### PR TITLE
fix: change the inactivate date

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1421,23 +1421,23 @@
     "weight": 1.03
   },
   "TheAlgorithms/C-Plus-Plus": {
-    "inactiveAt": "2025-11-10T16:39:22.045Z",
+    "inactiveAt": "2025-11-12T00:00:00.000Z",
     "weight": 1.0
   },
   "TheAlgorithms/C-Sharp": {
-    "inactiveAt": "2025-11-10T16:39:22.045Z",
+    "inactiveAt": "2025-11-12T00:00:00.000Z",
     "weight": 1.0
   },
   "TheAlgorithms/Java": {
-    "inactiveAt": "2025-11-10T16:39:22.045Z",
+    "inactiveAt": "2025-11-12T00:00:00.000Z",
     "weight": 1.0
   },
   "TheAlgorithms/JavaScript": {
-    "inactiveAt": "2025-11-10T16:39:22.045Z",
+    "inactiveAt": "2025-11-12T00:00:00.000Z",
     "weight": 1.0
   },
   "TheAlgorithms/Python": {
-    "inactiveAt": "2025-11-10T16:39:22.045Z",
+    "inactiveAt": "2025-11-12T00:00:00.000Z",
     "weight": 1.0
   },
   "TheLastBen/fast-stable-diffusion": {


### PR DESCRIPTION
### description
changed the inactivate date for some repos to 12/11 instead of 10 because owner mentioned this at 11/11

Contribution by Gittensor, learn more at https://gittensor.io/