### PR TITLE
Added new branch on hect0x7

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -5701,7 +5701,8 @@
     "weight": 0.01
   },
   "hect0x7/JMComic-Crawler-Python": {
-    "weight": 0.35
+    "weight": 0.35,
+    "additional_acceptable_branches": ["dev"]
   },
   "hectorqin/reader": {
     "inactiveAt": "2025-11-29T17:45:38.525Z",


### PR DESCRIPTION
### Summary
Adds `dev` as an additional acceptable branch for `hect0x7/JMComic-Crawler-Python` in the master repositories configuration.

### Changes
- Added `additional_acceptable_branches: ["dev"]` to `hect0x7/JMComic-Crawler-Python` in `master_repositories.json`

### Impact
PRs merged to the `dev` branch (in addition to the default branch) will now be considered valid for miner evaluation and scoring.

### Repository Details
- Repository: `hect0x7/JMComic-Crawler-Python`
- Weight: 0.35 (unchanged)
- New acceptable branch: `dev`

Example: https://github.com/hect0x7/JMComic-Crawler-Python/pull/496

Contribution by Gittensor, learn more at https://gittensor.io/