### PR TITLE
Fix issue multiplier to use validated issues list

### DIFF
--- a/gittensor/validator/evaluation/scoring.py
+++ b/gittensor/validator/evaluation/scoring.py
@@ -187,12 +187,12 @@ def calculate_issue_multiplier(pr: PullRequest) -> float:
         bt.logging.info(f"PR #{pr.number} - found no valid issues")
         return 1.0
 
-    num_issues = min(len(pr.issues), MAX_ISSUES_SCORED_IN_SINGLE_PR)
+    num_issues = min(len(valid_issues), MAX_ISSUES_SCORED_IN_SINGLE_PR)
     bt.logging.info(f"Calculating issue multiplier for PR #{pr.number} with {num_issues} issues")
 
     total_issue_multiplier = 0.0
     for i in range(num_issues):
-        issue = pr.issues[i]
+        issue = valid_issues[i]
         issue_num = getattr(issue, 'number', i + 1)
 
         if not (issue.created_at and issue.closed_at):


### PR DESCRIPTION
Bug: calculate_issue_multiplier() was using the unfiltered pr.issues list instead of the filtered valid_issues list, allowing invalid issues (self-created, wrong timing, etc.) to be scored.

Impact: Miners could game the system by adding self-created issues to their PRs and still receive issue bonus multipliers.

Fix: Changed 2 lines to use valid_issues instead of pr.issues:
- Line 190: num_issues = min(len(valid_issues), ...)
- Line 195: issue = valid_issues[i]

This ensures only issues that pass _is_valid_issue() validation are scored, preventing gaming and maintaining fairness.

Contribution by Gittensor, learn more at https://gittensor.io/