### PR TITLE
fix: update subnet repsitories

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7732,6 +7732,9 @@
   "mmistakes/minimal-mistakes": {
     "weight": 0.27
   },
+  "mobiusfund/etf": {
+    "weight": 6.52
+  },
   "moby/moby": {
     "weight": 0.29
   },


### PR DESCRIPTION
This PR updates subnet and opentensor repositories based on current subnet identities

Branch added:
opentensor/bittensor -> SDKv10 (staging branch is to be deprecated soon and SDKv10 should be the base branch according to maintainer's [comment](https://github.com/opentensor/bittensor/pull/3166#issuecomment-3600136494))

Repos Added:
SN118: mobiusfund/etf

Repos Changed:
SN6: niels-ma/infinite_games -> numinouslabs/numinous
SN8: taoshidev/proprietary-trading-network -> taoshidev/vanta-network
SN66: Oceans-Subnet/oceans_subnet -> AlphaCoreBittensor/alphacore

Repos removed:
SN16: BitKoopLabs/BitKoop -> FirstTensorLabs/BitAds (still private repository, thus not added)
SN25: macrocosm-os/mainframe (discontinued according to [accounce](https://discord.com/channels/799672011265015819/1234881153832321024/1432769639938789488))
SN115: SentiVerse-AI/soulx (repo is copy of ex-SN86 and discord channel removed)

Contribution by Gittensor, learn more at https://gittensor.io/