### PR TITLE
Fix potential KeyError crash in uniqueness multiplier calculation

### DIFF
--- a/gittensor/validator/evaluation/scoring.py
+++ b/gittensor/validator/evaluation/scoring.py
@@ -142,7 +142,8 @@ def apply_cross_miner_multipliers_and_finalize(miner_evaluations: Dict[int, Mine
 
         for pr in evaluation.pull_requests:
             # Apply uniqueness multiplier (cross-miner dependent)
-            uniqueness_score = (total_contributing_miners - repo_counts[pr.repository_full_name] + 1) / total_contributing_miners
+            repo_count = repo_counts.get(pr.repository_full_name, 1)  # Default to 1 if repo not in counts
+            uniqueness_score = (total_contributing_miners - repo_count + 1) / total_contributing_miners
             uniqueness_multiplier = 1.0 + (uniqueness_score * UNIQUE_PR_BOOST)
             pr.repository_uniqueness_multiplier = uniqueness_multiplier
 


### PR DESCRIPTION
## Problem

The uniqueness multiplier calculation had a **critical KeyError bug** that could crash validators during score calculations.

**Buggy code (line 145):**
```python
uniqueness_score = (total_contributing_miners - repo_counts[pr.repository_full_name] + 1) / total_contributing_miners
```

**The Issue:**
Direct dictionary access `repo_counts[pr.repository_full_name]` raises `KeyError` if the repository is not in the counts dictionary.

## When This Crash Occurs

**Scenario 1: Mid-Scoring Repository Removal**
1. Scoring cycle starts with 10 repos in master_repositories
2. Admin removes a repo during scoring (e.g., repo became inactive)
3. Miner has PRs to that removed repo
4. `repo_counts` doesn't include the removed repo
5. **CRASH:** `KeyError: 'owner/removed-repo'`

**Scenario 2: Data Inconsistency**
1. PR data references repository "owner/repo"
2. That repo is filtered out earlier in the pipeline
3. `count_repository_contributors()` doesn't include it
4. **CRASH:** Validator stops, no scores calculated for any miner

**Scenario 3: Edge Cases**
- Race conditions during metagraph updates
- Corrupted PR data with invalid repo names
- Network issues causing partial data loads

## Impact

**Severity: CRITICAL**
- **Validator crash**: Entire scoring cycle fails
- **No rewards**: All miners get 0 rewards for that cycle
- **Network disruption**: Multiple validators could crash simultaneously
- **Poor user experience**: Validators need manual restart

## Fix (2 lines)

Added safe dictionary access with default fallback:

```python
# Before (UNSAFE):
uniqueness_score = (total_contributing_miners - repo_counts[pr.repository_full_name] + 1) / total_contributing_miners

# After (SAFE):
repo_count = repo_counts.get(pr.repository_full_name, 1)  # Default to 1 if repo not in counts
uniqueness_score = (total_contributing_miners - repo_count + 1) / total_contributing_miners
```

**Why default to 1?**
- Conservative: Treats unknown repos as single-contributor (maximum uniqueness bonus)
- Fair: Doesn't penalize miners for system inconsistencies
- Safe: Prevents validator crashes

## Testing

**Edge case verification:**
```python
# Missing repo - no longer crashes
repo_counts = {"owner/repo1": 5, "owner/repo2": 3}
pr.repository_full_name = "owner/unknown-repo"
repo_count = repo_counts.get(pr.repository_full_name, 1)  # Returns 1 ✅

# Normal case - works as before
pr.repository_full_name = "owner/repo1"
repo_count = repo_counts.get(pr.repository_full_name, 1)  # Returns 5 ✅
```

## Benefits

- **Stability**: Validators won't crash on edge cases
- **Reliability**: Scoring completes even with data inconsistencies
- **Minimal change**: 2-line fix, zero breaking changes
- **Fair fallback**: Unknown repos get maximum uniqueness bonus

Contribution by Gittensor, learn more at https://gittensor.io/
