### PR TITLE
feat: adding sn23 repo in the master repo list

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -10626,6 +10626,9 @@
   "trinodb/trino": {
     "weight": 0.17
   },
+  "trishoolai/trishool-subnet": {
+    "weight": 6.52
+  },
   "triton-inference-server/server": {
     "inactiveAt": "2025-11-29T17:45:38.525Z",
     "weight": 0.01


### PR DESCRIPTION
This PR adds sn23 subnet repo in the mast repo list.

### Weight
6.52 (from owner)

### Do they welcome community prs?

Yes - https://github.com/TrishoolAI/trishool-subnet?tab=readme-ov-file#contributing
