### PR TITLE
Require issues to be closed within 1 day of PR merged date

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -30,7 +30,7 @@ MAX_LINES_SCORED_FOR_MITIGATED_EXT = 300
 # Issue Scoring
 # =============================================================================
 MAX_ISSUES_SCORED_IN_SINGLE_PR = 2
-MAX_ISSUE_CLOSE_WINDOW_DAYS = 2
+MAX_ISSUE_CLOSE_WINDOW_DAYS = 1
 MAX_ISSUE_AGE_FOR_MAX_SCORE = 45  # days
 
 # =============================================================================


### PR DESCRIPTION
Updated to a maximum of 2 issues scored per PR.
Updated 5 day cushion to 1 day cushion for "issues closed requirement". In other words, Issue must be closed within 1 days of PR being merged in order to resolve the issue bonus.