### PR TITLE
fix: improve scoring accuracy and validator reliability

### DIFF
--- a/gittensor/validator/evaluation/reward.py
+++ b/gittensor/validator/evaluation/reward.py
@@ -89,6 +89,9 @@ async def reward(
 
     score_pull_requests(miner_eval, master_repositories, programming_languages)
 
+    # Clear PAT after scoring to avoid storing sensitive data
+    miner_eval.github_pat = None
+
     bt.logging.info("*" * 50 + "\n")
     return miner_eval
 

--- a/gittensor/validator/evaluation/scoring.py
+++ b/gittensor/validator/evaluation/scoring.py
@@ -120,7 +120,7 @@ def calculate_merge_success_multiplier(miner_eval: MinerEvaluation) -> float:
     """Calculate multiplier based on PR merge success ratio."""
     total_prs = miner_eval.total_merged_prs + miner_eval.total_closed_prs
 
-    if (total_prs < MERGE_SUCCESS_RATIO_ATTEMPTS_THRESHOLD):
+    if total_prs <= 0 or total_prs < MERGE_SUCCESS_RATIO_ATTEMPTS_THRESHOLD:
         return 1.0
     
     merge_ratio = miner_eval.total_merged_prs / total_prs

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -391,8 +391,14 @@ class BaseValidatorNeuron(BaseNeuron):
         """Loads the state of the validator from a file."""
         bt.logging.info("Loading validator state.")
 
-        # Load the state of the validator from file.
-        state = np.load(self.config.neuron.full_path + "/state.npz")
-        self.step = state["step"]
-        self.scores = state["scores"]
-        self.hotkeys = state["hotkeys"]
+        state_path = self.config.neuron.full_path + "/state.npz"
+        try:
+            state = np.load(state_path)
+            self.step = int(state["step"])
+            self.scores = state["scores"]
+            self.hotkeys = list(state["hotkeys"])
+            bt.logging.success(f"Successfully loaded validator state from {state_path}")
+        except FileNotFoundError:
+            bt.logging.warning(f"No state file found at {state_path}, starting with fresh state")
+        except Exception as e:
+            bt.logging.error(f"Failed to load validator state from {state_path}: {e}. Starting with fresh state")


### PR DESCRIPTION
# Fix: Improve Validator Reliability

## Description

This PR addresses several reliability issues in the validator state management and scoring mechanism.

## Changes

### 1. Add Error Handling to `load_state()`

**File:** `neurons/base/validator.py`

**Problem:** The validator would crash on first run or if the state file was missing/corrupted, as there was no error handling around `np.load()`.

**Solution:** Added try/except handling for:
- `FileNotFoundError`: Logs warning and continues with fresh state
- General exceptions: Logs error and continues with fresh state

### 2. Add Division-by-Zero Guard

**File:** `gittensor/validator/evaluation/scoring.py`

**Problem:** Edge case where `total_prs` could be 0 in `calculate_merge_success_multiplier()`, causing a division-by-zero error.

**Solution:** Added explicit `total_prs <= 0` check before division.

### 3. Clear PAT After Scoring

**File:** `gittensor/validator/evaluation/reward.py`

**Problem:** The GitHub PAT was stored in `MinerEvaluation` objects which may be persisted to the database, unnecessarily retaining sensitive credentials.

**Solution:** Clear `github_pat` field after scoring is complete.

---