### PR TITLE
Min stake

### DIFF
--- a/gittensor/utils/config.py
+++ b/gittensor/utils/config.py
@@ -143,7 +143,7 @@ def add_miner_args(cls, parser):
         "--blacklist.min_stake",
         type=int,
         help="Minimum stake required for a validator to query this miner.",
-        default=15000,
+        default=12500,
     )
 
     parser.add_argument(


### PR DESCRIPTION
- default `min_stake` to query a miner was `30,000`, lowering to `12,500` to make validating the subnet more accessible but still require capital investment
- will require miners to update