### PR TITLE
fix: correct affine-cortex repository URL

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -15,7 +15,7 @@
   "Activiti/Activiti": {
     "weight": 0.32
   },
-  "AffineFoundation/affine": {
+  "AffineFoundation/affine-cortex": {
     "weight": 59.34
   },
   "Aider-AI/aider": {


### PR DESCRIPTION
# Fix: Correct affine-cortex Repository URL

## Description

Fixes incorrect repository name in `master_repositories.json`. The entry was `AffineFoundation/affine` but the correct repository is `AffineFoundation/affine-cortex`.

## Problem

Merged PRs to `affine-cortex` (e.g., [PR #214](https://github.com/AffineFoundation/affine-cortex/pull/214)) are not being recognized by validators because the master repository list has the wrong repo name.

## Changes

- **File:** `gittensor/validator/weights/master_repositories.json`
- **Change:** `AffineFoundation/affine` → `AffineFoundation/affine-cortex`

## Correct URL

https://github.com/AffineFoundation/affine-cortex
