### PR TITLE
Fix incorrect skipping of PRs from forks with overlapping branch names

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -53,6 +53,12 @@ QUERY = """
                   name
                 }
               }
+              headRepository {
+                name
+                owner {
+                  login
+                }
+              }
               baseRefName
               headRefName
               author {
@@ -428,8 +434,16 @@ def _should_skip_merged_pr(
 
     # Skip if the source branch (headRef) is also an acceptable branch
     # This prevents PRs like "staging -> main" or "develop -> staging" where both are acceptable branches
+    # This check ONLY applies to internal PRs (same repository), as fork branch names are arbitrary.
     # Supports wildcard patterns (e.g., '*-dev' matches '3.0-dev', '3.1-dev', etc.)
-    if branch_matches_pattern(head_ref, acceptable_branches):
+    head_repo = pr_raw.get('headRepository')
+    is_internal_pr = False
+    if head_repo:
+        head_repo_full_name = f"{head_repo['owner']['login']}/{head_repo['name']}"
+        if head_repo_full_name.lower() == repository_full_name.lower():
+            is_internal_pr = True
+
+    if is_internal_pr and branch_matches_pattern(head_ref, acceptable_branches):
         return (
             True,
             f"Skipping PR #{pr_raw['number']} in {repository_full_name} - "


### PR DESCRIPTION
## Description
This PR fixes a bug in the validator's PR filtering logic where valid contributions from forks were being incorrectly skipped. 

### The Problem
The validator has a rule to prevent rewarding PRs that merge between "acceptable branches" (e.g., `staging` -> `main`, or `develop` -> `staging`). This is intended to avoid giving credit for internal maintenance tasks or branch syncing within a repository.

However, this check was being applied globally, regardless of whether the PR came from the same repository or a fork. If a miner named their branch in their fork `staging` and merged it into the main repository's `main` branch, the validator would see `staging` as an "acceptable branch" and skip the PR.

### The Fix
1.  **Updated GraphQL Query**: Added `headRepository` to the `QUERY` in `gittensor/utils/github_api_tools.py` to retrieve the source repository details for each PR.
2.  **Context-Aware Filtering**: Updated `_should_skip_merged_pr` to determine if a PR is "internal" by comparing the source repository (`headRepository`) with the target repository.
3.  **Scoped Branch Check**: The check that prevents merging between acceptable branches is now **only applied to internal PRs**. PRs from forks are no longer restricted by their source branch name.

## Impact
Miners can now use any branch name (including `staging`, `main`, etc.) in their forks without risk of their PRs being skipped by the validator.

## Verification Results
- The logic correctly identifies `is_internal_pr = True` only when the owner and name of both head and base repositories match.
- The `branch_matches_pattern` check for `head_ref` is now guarded by `is_internal_pr`.
- No linter errors introduced.