### PR TITLE
Avoid apt npm dependency conflicts in setup_env.sh (Ubuntu 24.04)

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -15,7 +15,16 @@ sudo apt update -y
 sudo apt install -y \
     python3-pip \
     python3-venv \
-    npm
+    curl \
+    ca-certificates
+
+# Node.js / npm setup
+# NOTE: Installing `npm` via apt can fail on Ubuntu 24.04 due to dependency conflicts.
+# NodeSource Node.js packages include npm, so we install Node.js instead (only if needed).
+if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+    sudo apt install -y nodejs
+fi
 
 # Install process manager if not already installed
 if ! command -v pm2 &> /dev/null; then


### PR DESCRIPTION
- Problem: scripts/setup_env.sh installs npm via apt. On Ubuntu 24.04, this can fail due to dependency conflicts (especially when NodeSource repos are enabled), preventing environment setup.

- Change: Remove npm from apt dependencies. Ensure node and npm are present by installing Node.js 20 via NodeSource when missing (Node.js includes npm). PM2 installation continues using npm.

- Why safe: Existing systems with Node/npm already installed are unaffected; the script remains idempotent and works across Ubuntu versions.

- Tested: Ubuntu 24.04 (noble) on EC2.