### PR TITLE
Low value PR Filtering

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -150,9 +150,10 @@ class PullRequest:
     merged_at: Optional[datetime]  # None for OPEN PRs
     created_at: datetime
 
-    # PR state for collateral system
+    # PR state based fields
     pr_state: PRState
     repository_tier_configuration: Optional[TierConfig] = None  # assigned when scoring PR
+    low_value_pr: bool = False
 
     # Score fields
     repo_weight_multiplier: float = 1.0

--- a/gittensor/validator/evaluation/credibility.py
+++ b/gittensor/validator/evaluation/credibility.py
@@ -32,7 +32,7 @@ def calculate_tier_stats(
         return None
 
     for pr in merged_prs:
-        if (tier := get_tier(pr)) and pr.earned_score > 0:
+        if (tier := get_tier(pr)) and not pr.low_value_pr:
             stats[tier].merged_count += 1
             if include_scoring_details:
                 stats[tier].earned_score += pr.earned_score

--- a/gittensor/validator/evaluation/scoring.py
+++ b/gittensor/validator/evaluation/scoring.py
@@ -102,11 +102,10 @@ def score_pull_request(
             return False
         pr.set_file_changes(file_changes)
 
-    base_score = calculate_base_score(pr, programming_languages)
-    if base_score == 0:
+    pr.base_score = calculate_base_score(pr, programming_languages)
+    if pr.low_value_pr:
         return False
 
-    pr.base_score = base_score
     calculate_pr_multipliers(pr, miner_eval, master_repositories)
 
     if pr.pr_state == PRState.MERGED:
@@ -132,7 +131,8 @@ def calculate_base_score(pr: PullRequest, programming_languages: Dict[str, float
     contribution_score, is_low_value_pr = pr.calculate_score_from_file_changes(programming_languages)
 
     if is_low_value_pr:
-        bt.logging.warning(f'PR #{pr.number} is low-value (>90% test/comment/typo changes) - base score = 0')
+        bt.logging.warning(f'PR #{pr.number} is low-value (>90% test/comment/typo changes), base score = 0')
+        pr.low_value_pr = is_low_value_pr
         return 0.0
 
     tier_config: TierConfig = pr.repository_tier_configuration

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -17,7 +17,7 @@ INSERT INTO pull_requests (
     open_pr_spam_multiplier, repository_uniqueness_multiplier, time_decay_multiplier,
     gittensor_tag_multiplier, credibility_multiplier, raw_credibility, credibility_scalar,
     earned_score, collateral_score,
-    additions, deletions, commits, total_lines_scored, gittensor_tagged,
+    additions, deletions, commits, total_lines_scored, gittensor_tagged, low_value_pr,
     merged_by_login, description, last_edited_at
 ) VALUES %s
 ON CONFLICT (number, repository_full_name)
@@ -45,6 +45,7 @@ DO UPDATE SET
     commits = EXCLUDED.commits,
     total_lines_scored = EXCLUDED.total_lines_scored,
     gittensor_tagged = EXCLUDED.gittensor_tagged,
+    low_value_pr = EXCLUDED.low_value_pr,
     merged_by_login = EXCLUDED.merged_by_login,
     description = EXCLUDED.description,
     last_edited_at = EXCLUDED.last_edited_at,

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -154,6 +154,7 @@ class Repository(BaseRepository):
                     pr.commits,
                     pr.total_lines_scored,
                     pr.gittensor_tagged,
+                    pr.low_value_pr,
                     pr.merged_by_login,
                     pr.description,
                     pr.last_edited_at,

--- a/gittensor/validator/storage/sql/pull_requests.sql
+++ b/gittensor/validator/storage/sql/pull_requests.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS pull_requests (
     commits                           INTEGER          DEFAULT 0,
     total_lines_scored                INTEGER          DEFAULT 0,
     gittensor_tagged                  BOOLEAN          DEFAULT FALSE,
+    low_value_pr                      BOOLEAN          DEFAULT FALSE,
     merged_by_login                   VARCHAR(255),
     description                       TEXT,
     last_edited_at                    TIMESTAMP,


### PR DESCRIPTION
- Low value PRs to not count towards tier unlock requirements or dynamic emissions
- Only merged PRs which are earnings score to count towards tier unlock requirements, commit [[here]](https://github.com/entrius/gittensor/pull/125/commits/a52eceb753aaaa6e4c782a2b08b552958d80876c)
- Bug Fix: Closed PRs to properly have tier configuration assigned so they can properly be accounted for in tier unlock requirements, commit [[here]](https://github.com/entrius/gittensor/pull/125/commits/e4620f4864de84c8a7cd9aa6ca59a9f975bd3852)