### PR TITLE
Correct the sn17's repo name

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,7 +7,7 @@
     "tier": "Silver",
     "weight": 6.52
   },
-  "404-Repo/three-gen-subnet": {
+  "404-Repo/404-gen-subnet": {
     "tier": "Gold",
     "weight": 44.58
   },


### PR DESCRIPTION
Ongoing development of SN 17 (404-GEN), their main repository altered from 'three-gen-subnet' to '404-gen-subnet'

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101099105