### PR TITLE
Remove home-assistant and esphome repositories from master_repositories

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -2229,10 +2229,6 @@
     "tier": "Bronze",
     "weight": 0.32
   },
-  "esphome/esphome": {
-    "tier": "Bronze",
-    "weight": 0.28
-  },
   "espnet/espnet": {
     "tier": "Bronze",
     "weight": 0.17
@@ -2843,19 +2839,6 @@
   "hiyouga/LLaMA-Factory": {
     "tier": "Bronze",
     "weight": 0.24
-  },
-  "home-assistant/core": {
-    "additional_acceptable_branches": ["dev"],
-    "tier": "Gold",
-    "weight": 48.92
-  },
-  "home-assistant/frontend": {
-    "tier": "Silver",
-    "weight": 5.85
-  },
-  "home-assistant/home-assistant.io": {
-    "tier": "Bronze",
-    "weight": 0.22
   },
   "honza/vim-snippets": {
     "tier": "Silver",


### PR DESCRIPTION
Hi 👋,

I'm working for the Open Home Foundation. We would like to request that the **home-assistant** and **esphome** repositories be removed from your listing.

While we appreciate the visibility, we have noticed that being listed has led to a significant increase in low-quality and AI-generated pull requests. Unfortunately, It is making it difficult for our maintainers to focus on contributions from our actual user base.

We want to ensure our attention remains on contributors who are genuinely invested in the project's long-term health. 

Thank you for your understanding.