### PR TITLE
feat: add additional_acceptable_branches for xinnan-tech/xiaozhi-esp32-server

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -5611,6 +5611,9 @@
     "weight": 0.19
   },
   "xinnan-tech/xiaozhi-esp32-server": {
+    "additional_acceptable_branches": [
+      "live2d-actions"
+    ],
     "tier": "Bronze",
     "weight": 0.3
   },


### PR DESCRIPTION
## Summary

Add `additional_acceptable_branches` configuration for `xinnan-tech/xiaozhi-esp32-server` repository to recognize PRs merged to the `live2d-actions` branch.

This change was requested by the xinnan-tech repository maintainers to support their branching workflow, allowing contributors to receive credit for PRs merged to feature branches beyond the default branch.

## Related Issues

<!-- Link to related issues if any -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed