### PR TITLE
chore(weights): add 2 repos from sn36

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1392,7 +1392,7 @@
   },
   "autoppia/autoppia_iwa": {
     "tier": "Silver",
-    "weight": 6.46
+    "weight": 4.25
   },
   "autoppia/autoppia_web_agents_subnet": {
     "tier": "Silver",
@@ -1400,7 +1400,7 @@
   },
   "autoppia/autoppia_webs_demo": {
     "tier": "Silver",
-    "weight": 6.46
+    "weight": 4.25
   },
   "autorope/donkeycar": {
     "tier": "Bronze",


### PR DESCRIPTION
### Summary

#### Added 2 repos related to subnet 36.

- [autoppia/autoppia_iwa](https://github.com/autoppia/autoppia_iwa)
- [autoppia/autoppia_webs_demo](https://github.com/autoppia/autoppia_webs_demo)