### PR TITLE
fix: update package author metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/entrius/gittensor',
-    author='bittensor.com',  # TODO(developer): Change this value to your module subnet author name.
+    author='Entrius',
     packages=find_packages(),
     include_package_data=True,
     author_email='',


### PR DESCRIPTION
## Summary

Updates the package author metadata in setup.py.

## Changes

- Changed `author` field from `'bittensor.com'` to `'Entrius'`
- Removed the outdated TODO comment that was left over from the subnet template

## Rationale

The author field should reflect the actual maintainer of this subnet (Entrius/Gittensor), not the generic template value.

This is a minor metadata fix with no functional impact.