### PR TITLE
chore(weights): add acceptable branch for uptime-kuma

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -3537,6 +3537,7 @@
     "weight": 0.01
   },
   "louislam/uptime-kuma": {
+    "additional_acceptable_branches": ["3.0.X"],
     "inactive_at": "2026-01-26T02:52:00.000Z",
     "tier": "Bronze",
     "weight": 0.19


### PR DESCRIPTION
## Summary

- Add `3.0.X` as an additional acceptable branch for `louislam/uptime-kuma`

## Related Issues

The `louislam/uptime-kuma` repository uses `3.0.X` as its active development branch alongside `master`. PRs merged into `3.0.X` (e.g., [#6595](https://github.com/louislam/uptime-kuma/pull/6595)) are currently skipped by the validator because only the default branch (`master`) is accepted. This adds `3.0.X` to the accepted branches so legitimate merged contributions are recognized.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe below)

Master repository configuration update — adds an additional acceptable branch.

## Testing

- [ ] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)