### PR TITLE
feat: add erb file as new programming language

### DIFF
--- a/gittensor/validator/weights/programming_languages.json
+++ b/gittensor/validator/weights/programming_languages.json
@@ -28,6 +28,7 @@
   "dockerfile": { "weight": 1.0, "language": "dockerfile" },
   "elm": { "weight": 1.75, "language": "elm" },
   "env": { "weight": 0.25 },
+  "erb": { "weight": 1.25, "language": "ruby" },
   "erl": { "weight": 1.5, "language": "erlang" },
   "ex": { "weight": 1.5, "language": "elixir" },
   "exs": { "weight": 1.5, "language": "elixir" },


### PR DESCRIPTION
## Summary

Some of the gittensor silver repos such as [we-promise/sure](https://github.com/we-promise/sure) requires .erb file which stands for Embedded Ruby. It lets you mix HTML with Ruby code using <% %>.
Rails uses .erb files to generate dynamic HTML.
Currently only .rb file is scored and .erb is not.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)
