### PR TITLE
chore: add additional acceptable branches to autoppia repos

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -490,9 +490,6 @@
     "weight": 0.29
   },
   "autoppia/autoppia_iwa": {
-    "additional_acceptable_branches": [
-      "feature/*"
-    ],
     "tier": "Silver",
     "weight": 4.25
   },


### PR DESCRIPTION
## Summary

Added additional acceptable branches to SN36 repos.

### Repos:
- autoppia_webs_demo
- autoppia_iwa

### Branch Pattern
"feature/*"

### Reason
The repos are related to web agents and owner wants to add more websites to make tasks difficult and to build general web agents across various kinds of websites. But one website takes long to develop and implement events and use_cases for task. So he wants to use additional branches for new website for each.
