### PR TITLE
fix: enforce documented 2.0x cap on issue multiplier

### DIFF
--- a/gittensor/validator/evaluation/scoring.py
+++ b/gittensor/validator/evaluation/scoring.py
@@ -481,6 +481,8 @@ def calculate_issue_multiplier(pr: PullRequest) -> float:
         age_ratio = math.sqrt(min(days_open, MAX_ISSUE_AGE_FOR_MAX_SCORE)) / math.sqrt(MAX_ISSUE_AGE_FOR_MAX_SCORE)
         age_bonus = MAX_ISSUE_AGE_BONUS * age_ratio
         total_bonus = age_bonus + maintainer_bonus
+        # Cap total multiplier at 2.0 as documented
+        total_bonus = min(total_bonus, 1.0)
         bt.logging.info(f'Issue #{issue.number} - Open for {days_open} days | bonus: {total_bonus:.2f}{maintainer_str}')
         return 1.0 + total_bonus
     except (ValueError, AttributeError) as e:


### PR DESCRIPTION
## Summary
Enforce the documented 2.0x maximum on the issue multiplier in `calculate_issue_multiplier()`.

## Problem
The [OSS contributions docs](https://docs.gittensor.io/oss-contributions.html) state:
> Max multiplier earned is 2.0x

However, the code computes `1.0 + age_bonus + maintainer_bonus` without capping the total. Currently the constants happen to sum to exactly 2.0 (`MAX_ISSUE_AGE_BONUS=0.75 + MAINTAINER_ISSUE_BONUS=0.25 = 1.0`), but if either constant is ever adjusted upward, the multiplier would silently exceed the documented 2.0x maximum.

## Fix
Add `total_bonus = min(total_bonus, 1.0)` before returning `1.0 + total_bonus`, ensuring the multiplier never exceeds 2.0x regardless of future constant changes.

## Testing
- No behavior change with current constants (already at exactly 2.0x max)
- Prevents future regressions if constants are tuned
