### PR TITLE
chore(deps): upgrade bittensor from 10.0.1 to 10.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==10.0.1
+bittensor==10.1.0
 bittensor-cli==9.17.0
 bittensor-commit-reveal==0.4.0
 bittensor-wallet==4.0.0


### PR DESCRIPTION
Upgrades `bittensor` from version `10.0.1` to `10.1.0` (minor version bump).

No changelog was provided. As this is a minor version bump, it should be backwards compatible. No code changes were required beyond the version bump in `requirements.txt`.