### PR TITLE
chore(deps): upgrade bittensor-cli from 9.17.0 to 9.18.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bittensor==10.1.0
-bittensor-cli==9.17.0
+bittensor-cli==9.18.1
 bittensor-commit-reveal==0.4.0
 bittensor-wallet==4.0.0
 levenshtein==0.27.3


### PR DESCRIPTION
Upgrades `bittensor-cli` from version 9.17.0 to 9.18.1 (minor version bump). No changelog was available, but as a minor release it should be backwards compatible.