### PR TITLE
chore(deps): upgrade ruff from 0.14.10 to 0.15.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bittensor-commit-reveal==0.4.0
 bittensor-wallet==4.0.0
 levenshtein==0.27.3
 pytest==9.0.0
-ruff==0.14.10
+ruff==0.15.1
 tree-sitter==0.24.0
 tree-sitter-language-pack==0.7.2
 wandb==0.21.3


### PR DESCRIPTION
Upgrades `ruff` from version `0.14.10` to `0.15.1` (minor version bump).

This is a linting/formatting tool upgrade. Please verify that no new linting rules introduced in this version cause issues with the existing codebase by running `ruff check` and `ruff format` after the upgrade.