### PR TITLE
chore(weights): add 1 repo

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -3044,6 +3044,10 @@
     "tier": "Bronze",
     "weight": 0.21
   },
+  "lyogavin/airllm": {
+    "weight": 3.89,
+    "tier": "Silver"
+  },
   "lyswhut/lx-music-desktop": {
     "tier": "Bronze",
     "weight": 0.22


### PR DESCRIPTION
## Purpose

Add AirLLM 70B inference with single 4GB GPU

## Changes Summary

| Metric | 🥇 Gold | 🥈 Silver | 🥉 Bronze | Total |
|--------|---------|-----------|-----------|-------|
| Repositories Added | 0 | 1 | 0 | 1 |
| Net Weight Change | +0.00 | +3.89 | +0.00 | +3.89 |

## Added Repositories

| Repository | Tier | Branch | Weight |
|------------|------|--------|--------|
| `lyogavin/airllm` | 🥈 silver | `main` | 3.89 |
