### PR TITLE
feat(cli): add submissions and predict commands for merge predictions

### DIFF
--- a/gittensor/cli/issue_commands/__init__.py
+++ b/gittensor/cli/issue_commands/__init__.py
@@ -8,6 +8,8 @@ Command structure:
     gitt issues (alias: i)       - Issue management commands
         list [--id <ID>]             List issues or view a specific issue
         register                     Register a new issue bounty
+        submissions --id <N>         List open PRs for a bountied issue
+        predict --id <N>             Predict merge probabilities for PRs
         bounty-pool                  View total bounty pool
         pending-harvest              View pending emissions
     gitt harvest                 - Harvest emissions (top-level)
@@ -39,6 +41,7 @@ from .mutations import (
     issue_harvest,
     issue_register,
 )
+from .predictions import issues_predict, issues_submissions
 from .view import admin_info, issues_bounty_pool, issues_list, issues_pending_harvest
 from .vote import vote
 
@@ -51,6 +54,8 @@ def issues_group():
     Commands:
         list              List issues or view a specific issue
         register          Register a new issue bounty
+        submissions       List open PRs for a bountied issue
+        predict           Predict merge probabilities for PRs
         bounty-pool       View total bounty pool
         pending-harvest   View pending emissions
     """
@@ -59,6 +64,8 @@ def issues_group():
 
 issues_group.add_command(issues_list, name='list')
 issues_group.add_command(issue_register, name='register')
+issues_group.add_command(issues_submissions, name='submissions')
+issues_group.add_command(issues_predict, name='predict')
 issues_group.add_command(issues_bounty_pool, name='bounty-pool')
 issues_group.add_command(issues_pending_harvest, name='pending-harvest')
 
@@ -90,6 +97,8 @@ __all__ = [
     'admin',
     'issue_register',
     'issue_harvest',
+    'issues_submissions',
+    'issues_predict',
     # Helpers
     'console',
     'load_config',

--- a/gittensor/cli/issue_commands/predictions.py
+++ b/gittensor/cli/issue_commands/predictions.py
@@ -1,0 +1,482 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""
+Miner-facing prediction commands for issue CLI
+
+Commands:
+    gitt issues submissions --id <N>
+    gitt issues predict --id <N>
+"""
+
+import json as json_mod
+import os
+
+import click
+from rich.panel import Panel
+from rich.table import Table
+
+from .helpers import (
+    _is_interactive,
+    console,
+    fetch_open_prs_for_issue,
+    get_contract_address,
+    print_error,
+    print_network_header,
+    print_success,
+    read_issues_from_contract,
+    resolve_network,
+    validate_issue_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_issue_and_prs(issue_id, network, rpc_url, contract, verbose):
+    """Resolve on-chain issue data and fetch open PRs from GitHub.
+
+    Returns (issue_dict, prs_list, ws_endpoint, network_name, contract_addr)
+    or raises click.ClickException on failure.
+    """
+    contract_addr = get_contract_address(contract)
+    ws_endpoint, network_name = resolve_network(network, rpc_url)
+
+    if not contract_addr:
+        raise click.ClickException(
+            'Contract address not configured. Set via: gitt config set contract_address <ADDR>.'
+        )
+
+    try:
+        validate_issue_id(issue_id)
+    except click.BadParameter as e:
+        raise click.ClickException(str(e))
+
+    with console.status('[bold cyan]Reading issue from contract...', spinner='dots'):
+        issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
+
+    issue = next((i for i in issues if i['id'] == issue_id), None)
+    if not issue:
+        raise click.ClickException(f'Issue {issue_id} not found on contract.')
+
+    status = issue.get('status', '')
+    if isinstance(status, str):
+        status = status.capitalize()
+    if status not in ('Active', 'Registered'):
+        raise click.ClickException(
+            f'Issue {issue_id} is not in an active/bountied state (status: {status}).'
+        )
+
+    repo_full = issue.get('repository_full_name', '')
+    issue_number = issue.get('issue_number', 0)
+    if not repo_full or '/' not in repo_full:
+        raise click.ClickException(f'Issue {issue_id} has invalid repository: {repo_full}')
+
+    owner, repo = repo_full.split('/', 1)
+
+    with console.status('[bold cyan]Fetching open PRs from GitHub...', spinner='dots'):
+        prs = fetch_open_prs_for_issue(owner, repo, issue_number, verbose)
+
+    return issue, prs, ws_endpoint, network_name, contract_addr
+
+
+def _build_pr_table(prs):
+    """Build a Rich Table from a list of PR dicts."""
+    table = Table(show_header=True, header_style='bold magenta')
+    table.add_column('PR #', style='cyan', justify='right')
+    table.add_column('Title', style='green')
+    table.add_column('Author', style='yellow')
+    table.add_column('Created', style='dim')
+    table.add_column('Review', justify='center')
+    table.add_column('URL', style='dim')
+
+    for pr in prs:
+        review = pr.get('review_status', 'UNKNOWN')
+        review_styled = {
+            'APPROVED': '[green]APPROVED[/green]',
+            'CHANGES_REQUESTED': '[red]CHANGES_REQ[/red]',
+            'REVIEW_REQUIRED': '[yellow]REVIEW_REQ[/yellow]',
+            'PENDING': '[yellow]PENDING[/yellow]',
+        }.get(review, f'[dim]{review}[/dim]')
+
+        created = pr.get('created_at', '')[:10]  # date part only
+
+        table.add_row(
+            str(pr['number']),
+            pr.get('title', '')[:60],
+            pr.get('author', 'unknown'),
+            created,
+            review_styled,
+            pr.get('url', ''),
+        )
+    return table
+
+
+# ---------------------------------------------------------------------------
+# submissions command
+# ---------------------------------------------------------------------------
+
+
+@click.command('submissions')
+@click.option(
+    '--id',
+    'issue_id',
+    required=True,
+    type=int,
+    help='On-chain issue ID',
+)
+@click.option(
+    '--network',
+    '-n',
+    default=None,
+    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
+    help='Network (finney/test/local)',
+)
+@click.option(
+    '--rpc-url',
+    default=None,
+    help='Subtensor RPC endpoint (overrides --network)',
+)
+@click.option(
+    '--contract',
+    default='',
+    help='Contract address (uses config if empty)',
+)
+@click.option('--verbose', '-v', is_flag=True, help='Show debug output')
+@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting')
+def issues_submissions(issue_id: int, network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
+    """List open PRs (submissions) for a bountied issue.
+
+    Displays all open pull requests that reference a given on-chain
+    bountied issue. Uses GITTENSOR_MINER_PAT for authenticated GitHub
+    API calls when set, otherwise falls back to unauthenticated endpoints.
+
+    \b
+    Examples:
+        gitt issues submissions --id 42
+        gitt i submissions --id 42
+        gitt i submissions --id 42 --json
+    """
+    issue, prs, ws_endpoint, network_name, contract_addr = _resolve_issue_and_prs(
+        issue_id, network, rpc_url, contract, verbose,
+    )
+
+    repo_full = issue.get('repository_full_name', '')
+    issue_number = issue.get('issue_number', 0)
+
+    if as_json:
+        console.print(json_mod.dumps({
+            'issue_id': issue_id,
+            'repository': repo_full,
+            'issue_number': issue_number,
+            'submissions': prs,
+        }, indent=2, default=str))
+        return
+
+    print_network_header(network_name, contract_addr)
+    console.print(
+        f'[bold cyan]Submissions for Issue #{issue_id}[/bold cyan] '
+        f'({repo_full}#{issue_number})\n'
+    )
+
+    if prs:
+        console.print(_build_pr_table(prs))
+        console.print(f'\n[dim]{len(prs)} open PR(s) found[/dim]')
+    else:
+        console.print('[yellow]No open PRs found for this issue.[/yellow]')
+
+
+# ---------------------------------------------------------------------------
+# predict command
+# ---------------------------------------------------------------------------
+
+
+def _validate_probability(value):
+    """Validate a probability value is in [0.0, 1.0]. Returns float."""
+    try:
+        p = float(value)
+    except (TypeError, ValueError):
+        raise click.BadParameter(f'Invalid probability: {value} (must be a float in [0.0, 1.0])')
+    if p < 0.0 or p > 1.0:
+        raise click.BadParameter(f'Probability must be in [0.0, 1.0] (got {p})')
+    return p
+
+
+def _validate_pr_belongs_to_issue(pr_number, prs):
+    """Validate that pr_number exists in the list of open PRs."""
+    pr_numbers = {pr['number'] for pr in prs}
+    if pr_number not in pr_numbers:
+        raise click.ClickException(
+            f'PR #{pr_number} is not an open PR for this issue. '
+            f'Valid PRs: {sorted(pr_numbers)}'
+        )
+
+
+@click.command('predict')
+@click.option(
+    '--id',
+    'issue_id',
+    required=True,
+    type=int,
+    help='On-chain issue ID',
+)
+@click.option(
+    '--pr',
+    'pr_number',
+    default=None,
+    type=int,
+    help='PR number (non-interactive single prediction)',
+)
+@click.option(
+    '--probability',
+    default=None,
+    type=float,
+    help='Merge probability for --pr (0.0 to 1.0)',
+)
+@click.option(
+    '--json-input',
+    'json_input',
+    default=None,
+    type=str,
+    help='Batch predictions as JSON: \'{"101": 0.85, "103": 0.10}\'',
+)
+@click.option(
+    '--wallet-name',
+    '--wallet.name',
+    '--wallet',
+    default='default',
+    help='Wallet name',
+)
+@click.option(
+    '--wallet-hotkey',
+    '--wallet.hotkey',
+    '--hotkey',
+    default='default',
+    help='Hotkey name',
+)
+@click.option(
+    '--network',
+    '-n',
+    default=None,
+    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
+    help='Network (finney/test/local)',
+)
+@click.option(
+    '--rpc-url',
+    default=None,
+    help='Subtensor RPC endpoint (overrides --network)',
+)
+@click.option(
+    '--contract',
+    default='',
+    help='Contract address (uses config if empty)',
+)
+@click.option(
+    '--yes',
+    '-y',
+    is_flag=True,
+    help='Skip confirmation prompt (non-interactive/CI)',
+)
+@click.option('--verbose', '-v', is_flag=True, help='Show debug output')
+@click.option('--json', 'as_json', is_flag=True, help='Output result as JSON')
+def issues_predict(
+    issue_id: int,
+    pr_number: int,
+    probability: float,
+    json_input: str,
+    wallet_name: str,
+    wallet_hotkey: str,
+    network: str,
+    rpc_url: str,
+    contract: str,
+    yes: bool,
+    verbose: bool,
+    as_json: bool,
+):
+    """Predict merge probabilities for PRs on a bountied issue.
+
+    Interactive mode (default): prompts you to assign probabilities to
+    each open PR. Non-interactive modes available via --pr/--probability
+    or --json-input for scripting.
+
+    \b
+    Examples:
+        gitt i predict --id 42
+        gitt i predict --id 42 --pr 101 --probability 0.85
+        gitt i predict --id 42 --json-input '{"101": 0.85, "103": 0.10}'
+        gitt i predict --id 42 --json-input '{"101": 0.85}' -y
+    """
+    # --- Resolve issue and PRs ---
+    issue, prs, ws_endpoint, network_name, contract_addr = _resolve_issue_and_prs(
+        issue_id, network, rpc_url, contract, verbose,
+    )
+
+    repo_full = issue.get('repository_full_name', '')
+
+    if not prs:
+        raise click.ClickException('No open PRs found for this issue. Nothing to predict.')
+
+    # --- Load miner identity ---
+    pat = os.environ.get('GITTENSOR_MINER_PAT', '').strip()
+    if not pat and not as_json:
+        console.print('[yellow]Warning: GITTENSOR_MINER_PAT not set. Wallet verification only.[/yellow]')
+
+    miner_hotkey_addr = None
+    try:
+        import bittensor as bt
+
+        wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+        miner_hotkey_addr = wallet.hotkey.ss58_address
+        if verbose and not as_json:
+            console.print(f'[dim]Miner hotkey: {miner_hotkey_addr}[/dim]')
+
+        # Verify the hotkey is registered on the subnet
+        subtensor = bt.Subtensor(network=ws_endpoint)
+        netuid = 47  # gittensor subnet
+        metagraph = subtensor.metagraph(netuid)
+        if miner_hotkey_addr not in metagraph.hotkeys:
+            raise click.ClickException(
+                f'Hotkey {miner_hotkey_addr} is not a registered miner on subnet {netuid}.'
+            )
+        if verbose and not as_json:
+            console.print('[dim]Miner registration verified.[/dim]')
+    except ImportError:
+        if not as_json:
+            console.print('[yellow]Warning: bittensor not installed — skipping wallet verification.[/yellow]')
+    except click.ClickException:
+        raise
+    except Exception as e:
+        if not as_json:
+            console.print(f'[yellow]Warning: Could not verify miner registration: {e}[/yellow]')
+
+    # --- Build predictions dict ---
+    predictions = {}  # {pr_number: probability}
+
+    if json_input is not None:
+        # Batch mode via --json-input
+        try:
+            raw = json_mod.loads(json_input)
+        except json_mod.JSONDecodeError as e:
+            raise click.ClickException(f'Invalid JSON input: {e}')
+        if not isinstance(raw, dict):
+            raise click.ClickException('--json-input must be a JSON object: {"pr_number": probability, ...}')
+        for k, v in raw.items():
+            try:
+                pr_num = int(k)
+            except ValueError:
+                raise click.ClickException(f'Invalid PR number in JSON: {k}')
+            prob = _validate_probability(v)
+            _validate_pr_belongs_to_issue(pr_num, prs)
+            predictions[pr_num] = prob
+
+    elif pr_number is not None:
+        # Single non-interactive mode
+        if probability is None:
+            raise click.ClickException('--probability is required when using --pr.')
+        prob = _validate_probability(probability)
+        _validate_pr_belongs_to_issue(pr_number, prs)
+        predictions[pr_number] = prob
+
+    else:
+        # Interactive mode
+        if not as_json:
+            print_network_header(network_name, contract_addr)
+            console.print(
+                f'[bold cyan]Predict Merge Probabilities[/bold cyan] — '
+                f'Issue #{issue_id} ({repo_full})\n'
+            )
+            console.print(_build_pr_table(prs))
+            console.print()
+
+        running_total = 0.0
+        for pr in prs:
+            pr_num = pr['number']
+            while True:
+                raw_input = click.prompt(
+                    f'  PR #{pr_num} ({pr["title"][:40]}) probability [0.0-1.0, Enter to skip]',
+                    default='',
+                    show_default=False,
+                )
+                if raw_input.strip() == '':
+                    break
+                try:
+                    prob = _validate_probability(raw_input)
+                except click.BadParameter as e:
+                    console.print(f'  [red]{e}[/red]')
+                    continue
+
+                new_total = running_total + prob
+                if new_total > 1.0:
+                    console.print(
+                        f'  [red]Sum would exceed 1.0 ({new_total:.4f}). '
+                        f'Current total: {running_total:.4f}. Try again.[/red]'
+                    )
+                    continue
+
+                predictions[pr_num] = prob
+                running_total = new_total
+                if running_total > 0.9:
+                    console.print(f'  [yellow]Running total: {running_total:.4f} (approaching 1.0)[/yellow]')
+                else:
+                    console.print(f'  [dim]Running total: {running_total:.4f}[/dim]')
+                break
+
+        if not predictions:
+            console.print('[yellow]No predictions entered. Aborting.[/yellow]')
+            return
+
+    # --- Validate sum <= 1.0 ---
+    total = sum(predictions.values())
+    if total > 1.0:
+        raise click.ClickException(
+            f'Sum of probabilities ({total:.4f}) exceeds 1.0. Predictions rejected.'
+        )
+
+    # --- Build payload ---
+    payload = {
+        'issue_id': issue_id,
+        'repository': repo_full,
+        'predictions': {int(k): float(v) for k, v in predictions.items()},
+    }
+
+    # --- Confirmation ---
+    if as_json:
+        console.print(json_mod.dumps(payload, indent=2, default=str))
+        return
+
+    pred_lines = '\n'.join(
+        f'  PR #{pr_num}: {prob:.4f}' for pr_num, prob in sorted(predictions.items())
+    )
+    console.print(
+        Panel(
+            f'[cyan]Issue ID:[/cyan] {issue_id}\n'
+            f'[cyan]Repository:[/cyan] {repo_full}\n'
+            f'[cyan]Total probability:[/cyan] {total:.4f}\n'
+            f'[cyan]Predictions:[/cyan]\n{pred_lines}',
+            title='Prediction Summary',
+            border_style='blue',
+        )
+    )
+
+    skip_confirm = yes or not _is_interactive()
+    if not skip_confirm and not click.confirm('\nSubmit prediction?', default=True):
+        console.print('[yellow]Prediction cancelled.[/yellow]')
+        return
+
+    # TODO: Broadcast prediction via synapse to validators.
+    # The validated payload is structured and ready for a future synapse
+    # to consume. Replace the stub below with the actual network call.
+    print_success('Prediction validated and ready to broadcast!')
+    console.print(
+        Panel(
+            json_mod.dumps(payload, indent=2, default=str),
+            title='[bold green]Validated Payload (broadcast stub)[/bold green]',
+            border_style='green',
+        )
+    )
+    console.print(
+        '[dim]Network broadcast is not yet implemented. '
+        'The payload above shows exactly what would be sent.[/dim]'
+    )

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -7,6 +7,10 @@ Gittensor CLI - Main entry point
 Usage:
     gitt config              - Show/set CLI configuration
     gitt issues ...          - Issue management (alias: i)
+        list                     List issues or view a specific issue
+        register                 Register a new issue bounty
+        submissions --id <N>     List open PRs for a bountied issue
+        predict --id <N>         Predict merge probabilities for PRs
     gitt harvest             - Harvest emissions
     gitt vote ...            - Validator vote commands
     gitt admin ...           - Owner commands (alias: a)

--- a/tests/cli/test_predictions.py
+++ b/tests/cli/test_predictions.py
@@ -1,0 +1,599 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""
+Unit tests for the submissions and predict CLI commands.
+
+Covers: submissions display, JSON output, predict validation (interactive,
+non-interactive, batch), probability validation, and CLI wiring.
+All tests mock network/contract calls — no live APIs.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from gittensor.cli.issue_commands.helpers import (
+    _get_pr_review_status,
+    _github_headers,
+    fetch_open_prs_for_issue,
+)
+from gittensor.cli.issue_commands.predictions import (
+    _build_pr_table,
+    _resolve_issue_and_prs,
+    _validate_pr_belongs_to_issue,
+    _validate_probability,
+    issues_predict,
+    issues_submissions,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+FAKE_CONTRACT = '5FakeContractAddress1234567890123456789012'
+
+FAKE_ISSUES = [
+    {
+        'id': 42,
+        'repository_full_name': 'owner/repo',
+        'issue_number': 100,
+        'bounty_amount': 100_000_000_000,
+        'target_bounty': 100_000_000_000,
+        'status': 'Active',
+    },
+    {
+        'id': 99,
+        'repository_full_name': 'owner/repo',
+        'issue_number': 200,
+        'bounty_amount': 50_000_000_000,
+        'target_bounty': 100_000_000_000,
+        'status': 'Completed',
+    },
+]
+
+FAKE_PRS = [
+    {
+        'number': 101,
+        'title': 'Fix the bug',
+        'author': 'alice',
+        'created_at': '2025-06-01T12:00:00Z',
+        'review_status': 'APPROVED',
+        'url': 'https://github.com/owner/repo/pull/101',
+        'html_url': 'https://github.com/owner/repo/pull/101',
+    },
+    {
+        'number': 103,
+        'title': 'Another approach',
+        'author': 'bob',
+        'created_at': '2025-06-02T12:00:00Z',
+        'review_status': 'PENDING',
+        'url': 'https://github.com/owner/repo/pull/103',
+        'html_url': 'https://github.com/owner/repo/pull/103',
+    },
+]
+
+
+def _get_cli_root():
+    try:
+        from gittensor.cli.main import cli
+        return cli
+    except ImportError:
+        from gittensor.cli.issue_commands import register_commands
+        root = click.Group()
+        register_commands(root)
+        return root
+
+
+@pytest.fixture
+def cli_root():
+    return _get_cli_root()
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _patch_resolve():
+    """Return context managers that mock contract + GitHub calls."""
+    return (
+        patch(
+            'gittensor.cli.issue_commands.predictions.get_contract_address',
+            return_value=FAKE_CONTRACT,
+        ),
+        patch(
+            'gittensor.cli.issue_commands.predictions.resolve_network',
+            return_value=('wss://fake', 'test'),
+        ),
+        patch(
+            'gittensor.cli.issue_commands.predictions.read_issues_from_contract',
+            return_value=FAKE_ISSUES,
+        ),
+        patch(
+            'gittensor.cli.issue_commands.predictions.fetch_open_prs_for_issue',
+            return_value=FAKE_PRS,
+        ),
+    )
+
+
+# =============================================================================
+# _validate_probability
+# =============================================================================
+
+
+class TestValidateProbability:
+    def test_valid_zero(self):
+        assert _validate_probability(0.0) == 0.0
+
+    def test_valid_one(self):
+        assert _validate_probability(1.0) == 1.0
+
+    def test_valid_mid(self):
+        assert _validate_probability(0.5) == 0.5
+
+    def test_string_input(self):
+        assert _validate_probability('0.85') == 0.85
+
+    def test_negative_rejected(self):
+        with pytest.raises(click.BadParameter) as exc_info:
+            _validate_probability(-0.1)
+        assert '0.0' in str(exc_info.value) or '1.0' in str(exc_info.value)
+
+    def test_over_one_rejected(self):
+        with pytest.raises(click.BadParameter):
+            _validate_probability(1.1)
+
+    def test_invalid_string_rejected(self):
+        with pytest.raises(click.BadParameter):
+            _validate_probability('abc')
+
+
+# =============================================================================
+# _validate_pr_belongs_to_issue
+# =============================================================================
+
+
+class TestValidatePrBelongsToIssue:
+    def test_valid_pr(self):
+        _validate_pr_belongs_to_issue(101, FAKE_PRS)  # should not raise
+
+    def test_invalid_pr(self):
+        with pytest.raises(click.ClickException) as exc_info:
+            _validate_pr_belongs_to_issue(999, FAKE_PRS)
+        assert '999' in str(exc_info.value)
+
+
+# =============================================================================
+# _build_pr_table
+# =============================================================================
+
+
+class TestBuildPrTable:
+    def test_builds_table_with_rows(self):
+        table = _build_pr_table(FAKE_PRS)
+        assert table.row_count == 2
+
+    def test_empty_prs(self):
+        table = _build_pr_table([])
+        assert table.row_count == 0
+
+
+# =============================================================================
+# _github_headers
+# =============================================================================
+
+
+class TestGithubHeaders:
+    def test_with_pat(self):
+        with patch.dict('os.environ', {'GITTENSOR_MINER_PAT': 'ghp_test123'}):
+            headers = _github_headers()
+        assert headers['Authorization'] == 'token ghp_test123'
+        assert 'Accept' in headers
+
+    def test_without_pat(self):
+        with patch.dict('os.environ', {}, clear=True):
+            headers = _github_headers()
+        assert 'Authorization' not in headers
+        assert 'Accept' in headers
+
+
+# =============================================================================
+# submissions CLI command
+# =============================================================================
+
+
+class TestSubmissionsCommand:
+    def test_submissions_displays_prs(self, cli_root, runner):
+        p1, p2, p3, p4 = _patch_resolve()
+        with p1, p2, p3, p4:
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'submissions', '--id', '42'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert '101' in result.output
+        assert '103' in result.output
+        assert 'Fix the bug' in result.output
+
+    def test_submissions_json_output(self, cli_root, runner):
+        p1, p2, p3, p4 = _patch_resolve()
+        with p1, p2, p3, p4:
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'submissions', '--id', '42', '--json'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data['issue_id'] == 42
+        assert data['repository'] == 'owner/repo'
+        assert len(data['submissions']) == 2
+
+    def test_submissions_alias_i(self, cli_root, runner):
+        p1, p2, p3, p4 = _patch_resolve()
+        with p1, p2, p3, p4:
+            result = runner.invoke(
+                cli_root,
+                ['i', 'submissions', '--id', '42'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert '101' in result.output
+
+    def test_submissions_issue_not_found(self, cli_root, runner):
+        p1, p2, p3, p4 = _patch_resolve()
+        with p1, p2, p3, p4:
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'submissions', '--id', '999'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'not found' in result.output
+
+    def test_submissions_completed_issue_rejected(self, cli_root, runner):
+        p1, p2, p3, p4 = _patch_resolve()
+        with p1, p2, p3, p4:
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'submissions', '--id', '99'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'not in an active' in result.output
+
+    def test_submissions_missing_contract(self, cli_root, runner):
+        with patch(
+            'gittensor.cli.issue_commands.predictions.get_contract_address',
+            return_value='',
+        ):
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'submissions', '--id', '42'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'Contract address not configured' in result.output
+
+    def test_submissions_no_prs_found(self, cli_root, runner):
+        with (
+            patch(
+                'gittensor.cli.issue_commands.predictions.get_contract_address',
+                return_value=FAKE_CONTRACT,
+            ),
+            patch(
+                'gittensor.cli.issue_commands.predictions.resolve_network',
+                return_value=('wss://fake', 'test'),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.predictions.read_issues_from_contract',
+                return_value=FAKE_ISSUES,
+            ),
+            patch(
+                'gittensor.cli.issue_commands.predictions.fetch_open_prs_for_issue',
+                return_value=[],
+            ),
+        ):
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'submissions', '--id', '42'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert 'No open PRs' in result.output
+
+
+# =============================================================================
+# predict CLI command - non-interactive modes
+# =============================================================================
+
+
+class TestPredictCommandNonInteractive:
+    def _invoke_predict(self, runner, cli_root, extra_args):
+        p1, p2, p3, p4 = _patch_resolve()
+        with (
+            p1, p2, p3, p4,
+            patch.dict('os.environ', {'GITTENSOR_MINER_PAT': 'ghp_fake'}),
+            patch('gittensor.cli.issue_commands.predictions.bt', create=True) as mock_bt,
+        ):
+            # Mock bittensor wallet + subtensor
+            mock_wallet = MagicMock()
+            mock_wallet.hotkey.ss58_address = '5FakeHotkey'
+            mock_bt.Wallet.return_value = mock_wallet
+            mock_subtensor = MagicMock()
+            mock_metagraph = MagicMock()
+            mock_metagraph.hotkeys = ['5FakeHotkey']
+            mock_subtensor.metagraph.return_value = mock_metagraph
+            mock_bt.Subtensor.return_value = mock_subtensor
+
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'predict'] + extra_args,
+                catch_exceptions=False,
+            )
+        return result
+
+    def test_single_pr_prediction(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--pr', '101', '--probability', '0.85', '-y'],
+        )
+        assert result.exit_code == 0
+        assert 'Prediction validated' in result.output
+        assert '101' in result.output
+        assert '0.85' in result.output
+
+    def test_batch_json_input(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--json-input', '{"101": 0.6, "103": 0.3}', '-y'],
+        )
+        assert result.exit_code == 0
+        assert 'Prediction validated' in result.output
+
+    def test_json_output(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--pr', '101', '--probability', '0.5', '--json'],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data['issue_id'] == 42
+        assert data['predictions']['101'] == 0.5
+
+    def test_missing_probability_rejected(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--pr', '101', '-y'],
+        )
+        assert result.exit_code != 0
+        assert 'probability' in result.output.lower()
+
+    def test_invalid_pr_number_rejected(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--pr', '999', '--probability', '0.5', '-y'],
+        )
+        assert result.exit_code != 0
+        assert '999' in result.output
+
+    def test_sum_exceeds_one_rejected(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--json-input', '{"101": 0.8, "103": 0.3}', '-y'],
+        )
+        assert result.exit_code != 0
+        assert 'exceeds 1.0' in result.output
+
+    def test_probability_over_one_rejected(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--pr', '101', '--probability', '1.5', '-y'],
+        )
+        assert result.exit_code != 0
+
+    def test_invalid_json_input_rejected(self, cli_root, runner):
+        result = self._invoke_predict(
+            runner, cli_root,
+            ['--id', '42', '--json-input', 'not-json', '-y'],
+        )
+        assert result.exit_code != 0
+        assert 'Invalid JSON' in result.output
+
+    def test_no_open_prs_rejected(self, cli_root, runner):
+        with (
+            patch(
+                'gittensor.cli.issue_commands.predictions.get_contract_address',
+                return_value=FAKE_CONTRACT,
+            ),
+            patch(
+                'gittensor.cli.issue_commands.predictions.resolve_network',
+                return_value=('wss://fake', 'test'),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.predictions.read_issues_from_contract',
+                return_value=FAKE_ISSUES,
+            ),
+            patch(
+                'gittensor.cli.issue_commands.predictions.fetch_open_prs_for_issue',
+                return_value=[],
+            ),
+            patch.dict('os.environ', {'GITTENSOR_MINER_PAT': 'ghp_fake'}),
+            patch('gittensor.cli.issue_commands.predictions.bt', create=True) as mock_bt,
+        ):
+            mock_wallet = MagicMock()
+            mock_wallet.hotkey.ss58_address = '5FakeHotkey'
+            mock_bt.Wallet.return_value = mock_wallet
+            mock_subtensor = MagicMock()
+            mock_metagraph = MagicMock()
+            mock_metagraph.hotkeys = ['5FakeHotkey']
+            mock_subtensor.metagraph.return_value = mock_metagraph
+            mock_bt.Subtensor.return_value = mock_subtensor
+
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'predict', '--id', '42', '--pr', '101', '--probability', '0.5', '-y'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'No open PRs' in result.output
+
+
+# =============================================================================
+# predict CLI - interactive mode
+# =============================================================================
+
+
+class TestPredictCommandInteractive:
+    def test_interactive_with_input(self, cli_root, runner):
+        p1, p2, p3, p4 = _patch_resolve()
+        with (
+            p1, p2, p3, p4,
+            patch.dict('os.environ', {'GITTENSOR_MINER_PAT': 'ghp_fake'}),
+            patch('gittensor.cli.issue_commands.predictions.bt', create=True) as mock_bt,
+        ):
+            mock_wallet = MagicMock()
+            mock_wallet.hotkey.ss58_address = '5FakeHotkey'
+            mock_bt.Wallet.return_value = mock_wallet
+            mock_subtensor = MagicMock()
+            mock_metagraph = MagicMock()
+            mock_metagraph.hotkeys = ['5FakeHotkey']
+            mock_subtensor.metagraph.return_value = mock_metagraph
+            mock_bt.Subtensor.return_value = mock_subtensor
+
+            # Input: 0.6 for first PR, skip second, then confirm
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'predict', '--id', '42'],
+                input='0.6\n\ny\n',
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert 'Prediction validated' in result.output
+
+    def test_interactive_skip_all_aborts(self, cli_root, runner):
+        p1, p2, p3, p4 = _patch_resolve()
+        with (
+            p1, p2, p3, p4,
+            patch.dict('os.environ', {'GITTENSOR_MINER_PAT': 'ghp_fake'}),
+            patch('gittensor.cli.issue_commands.predictions.bt', create=True) as mock_bt,
+        ):
+            mock_wallet = MagicMock()
+            mock_wallet.hotkey.ss58_address = '5FakeHotkey'
+            mock_bt.Wallet.return_value = mock_wallet
+            mock_subtensor = MagicMock()
+            mock_metagraph = MagicMock()
+            mock_metagraph.hotkeys = ['5FakeHotkey']
+            mock_subtensor.metagraph.return_value = mock_metagraph
+            mock_bt.Subtensor.return_value = mock_subtensor
+
+            # Skip both PRs
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'predict', '--id', '42'],
+                input='\n\n',
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert 'No predictions entered' in result.output
+
+
+# =============================================================================
+# fetch_open_prs_for_issue (helper)
+# =============================================================================
+
+
+class TestFetchOpenPrsForIssue:
+    def test_returns_prs(self):
+        search_response = json.dumps({
+            'items': [
+                {
+                    'number': 10,
+                    'title': 'PR title',
+                    'user': {'login': 'alice'},
+                    'created_at': '2025-01-01',
+                    'html_url': 'https://github.com/o/r/pull/10',
+                    'pull_request': {'html_url': 'https://github.com/o/r/pull/10'},
+                },
+                {
+                    'number': 11,
+                    'title': 'Not a PR',
+                    'user': {'login': 'bob'},
+                    'created_at': '2025-01-02',
+                    'html_url': 'https://github.com/o/r/issues/11',
+                    # no 'pull_request' key — this is an issue
+                },
+            ]
+        }).encode()
+
+        reviews_response = json.dumps([]).encode()
+
+        call_count = {'n': 0}
+        def mock_urlopen(req, timeout=None):
+            call_count['n'] += 1
+            resp = MagicMock()
+            if call_count['n'] == 1:
+                resp.read.return_value = search_response
+            else:
+                resp.read.return_value = reviews_response
+            return resp
+
+        with patch('urllib.request.urlopen', side_effect=mock_urlopen):
+            result = fetch_open_prs_for_issue('o', 'r', 5)
+
+        assert len(result) == 1
+        assert result[0]['number'] == 10
+        assert result[0]['author'] == 'alice'
+
+    def test_handles_api_error(self):
+        import urllib.error
+        with patch('urllib.request.urlopen', side_effect=urllib.error.HTTPError(
+            'url', 403, 'Forbidden', {}, None
+        )):
+            result = fetch_open_prs_for_issue('o', 'r', 5)
+        assert result == []
+
+
+# =============================================================================
+# _get_pr_review_status
+# =============================================================================
+
+
+class TestGetPrReviewStatus:
+    def test_approved(self):
+        reviews = json.dumps([
+            {'state': 'APPROVED', 'user': {'login': 'reviewer'}},
+        ]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = reviews
+        with patch('urllib.request.urlopen', return_value=mock_resp):
+            status = _get_pr_review_status('o', 'r', 1, {})
+        assert status == 'APPROVED'
+
+    def test_changes_requested(self):
+        reviews = json.dumps([
+            {'state': 'CHANGES_REQUESTED', 'user': {'login': 'reviewer'}},
+        ]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = reviews
+        with patch('urllib.request.urlopen', return_value=mock_resp):
+            status = _get_pr_review_status('o', 'r', 1, {})
+        assert status == 'CHANGES_REQUESTED'
+
+    def test_no_reviews(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps([]).encode()
+        with patch('urllib.request.urlopen', return_value=mock_resp):
+            status = _get_pr_review_status('o', 'r', 1, {})
+        assert status == 'REVIEW_REQUIRED'
+
+    def test_api_error_returns_unknown(self):
+        with patch('urllib.request.urlopen', side_effect=Exception('timeout')):
+            status = _get_pr_review_status('o', 'r', 1, {})
+        assert status == 'UNKNOWN'


### PR DESCRIPTION
Closes #223

## Summary
Add two new CLI commands under `gitt issues` that form the miner-facing interface for the upcoming prediction feature.

### 1. `gitt issues submissions --id <N>`
Read-only. Displays all open PRs for a given bountied issue in a rich table.
- Reads on-chain issue data via `read_issues_from_contract`
- Validates issue exists and is active/bountied
- Uses `GITTENSOR_MINER_PAT` for authenticated GitHub API calls (falls back to unauthenticated)
- Rich table with: PR #, title, author, created date, review status, URL
- `--json` flag for scripting

### 2. `gitt issues predict --id <N>`
Interactive + scriptable. Lets a miner assign merge probabilities to PRs.
- **Interactive mode** (default): displays PR table, prompts for probabilities, running total with warnings
- **Single PR**: `--pr <N> --probability <float>`
- **Batch**: `--json-input '{"101": 0.85, "103": 0.10}'`
- **Wallet verification**: loads wallet via `--wallet`/`--hotkey`, verifies miner registration on subnet
- **Validation**: issue exists on-chain, PRs exist on GitHub, probabilities in [0.0, 1.0], sum <= 1.0
- **Broadcast stub**: prints validated payload with clear TODO boundary for future synapse
- Confirmation panel before sending (like `issue_register`)
- `--yes`/`-y` to skip confirmation, `--json` for machine-readable output

## Implementation Details

### New files
- `gittensor/cli/issue_commands/predictions.py` — Both commands with shared helpers
- `tests/cli/test_predictions.py` — 37 unit tests

### Modified files
- `gittensor/cli/issue_commands/helpers.py` — Added `_github_headers()`, `fetch_open_prs_for_issue()`, `_get_pr_review_status()` (GitHub Search API with retry)
- `gittensor/cli/issue_commands/__init__.py` — Registered commands, updated docstring and `__all__`
- `gittensor/cli/main.py` — Updated module docstring

### Design decisions
- Reuses existing patterns (`read_issues_from_contract`, `_is_interactive`, Rich output)
- `GITTENSOR_MINER_PAT` is the existing env var — no new config introduced
- Prediction payload structured as `{"issue_id": int, "repository": str, "predictions": {pr: prob}}`
- Code is modular so it can be driven programmatically by external agents/scripts

## Tests
- **37 new tests**, all passing
- **103 total CLI tests** (66 existing + 37 new), zero regressions
- Covers: validation, JSON output, interactive mode, batch mode, error paths, CLI wiring, alias support