### PR TITLE
Add AffineIO/affine-cortex and AffineIO/affinetes to master repo list

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -51,6 +51,14 @@
     "tier": "Gold",
     "weight": 20.88
   },
+  "AffineIO/affine-cortex": {
+    "tier": "Gold",
+    "weight": 22.21
+  },
+  "AffineIO/affinetes": {
+    "tier": "Gold",
+    "weight": 20.88
+  },
   "aframevr/aframe": {
     "tier": "Bronze",
     "weight": 0.19


### PR DESCRIPTION
## Summary

Add **AffineIO/affine-cortex** and **AffineIO/affinetes** to the master repository list with the same tier and weights as the existing AffineFoundation entries. This lets miners contribute to the new Affine org locations while the previous org is being restored on GitHub.

- **AffineIO/affine-cortex** – Gold, weight 22.21 (same as AffineFoundation/affine-cortex)
- **AffineIO/affinetes** – Gold, weight 20.88 (same as AffineFoundation/affinetes)

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)