### PR TITLE
patch api bug when fetching PRs

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -806,7 +806,9 @@ def load_miners_prs(
                     pr_state = pr_raw['state']
 
                     # Stop querying once we hit PRs older than the tier incentive start date
-                    pr_creation_time = datetime.fromisoformat(pr_raw['createdAt'].rstrip('Z')).replace(tzinfo=timezone.utc)
+                    pr_creation_time = datetime.fromisoformat(pr_raw['createdAt'].rstrip('Z')).replace(
+                        tzinfo=timezone.utc
+                    )
 
                     if pr_creation_time < TIER_BASED_INCENTIVE_MECHANISM_START_DATE:
                         bt.logging.info(

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -952,9 +952,9 @@ class TestLoadMinersPrsErrorResilience:
         load_miners_prs(miner_eval, master_repos)
 
         # Both good PRs should be collected; only the bad one is skipped
-        assert (
-            len(miner_eval.merged_pull_requests) == 2
-        ), f'Expected 2 merged PRs (skipping the bad one), got {len(miner_eval.merged_pull_requests)}'
+        assert len(miner_eval.merged_pull_requests) == 2, (
+            f'Expected 2 merged PRs (skipping the bad one), got {len(miner_eval.merged_pull_requests)}'
+        )
         collected_numbers = {pr.number for pr in miner_eval.merged_pull_requests}
         assert collected_numbers == {1, 3}, f'Expected PRs #1 and #3, got {collected_numbers}'
 


### PR DESCRIPTION
## Summary

- an error with affinefoundation api responses caused the miner PR processing loop to end early, causing miners to miss out and be evaluated at a lower score than what truly exists 
- patched by putting a try catch around PR processing so the early stopping does not occur and only the problematic PRs get tossed

## Related Issues

n/a

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
