### PR TITLE
fix: exclude github organization member role

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -112,7 +112,7 @@ TOKEN_SCORE_RECYCLE_DECAY_RATE = 0.000012
 # =============================================================================
 # Spam & Gaming Mitigation
 # =============================================================================
-MAINTAINER_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR']
+MAINTAINER_ASSOCIATIONS = ['OWNER', 'COLLABORATOR']
 
 # Issue multiplier bonuses
 MAX_ISSUE_AGE_BONUS = 0.75  # Max bonus for issue age (scales with sqrt of days open)


### PR DESCRIPTION
## Summary
Currently there are some repositories which has temporarily creating a PR from the collaborators. Thus they invite to their organization who is willing to contribute to their repository.
We need to remove "Member" role so that PRs for such kind of repositories could still be in tier calculation so not to skip them.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)
