### PR TITLE
feat/pioneer reward mechanism

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -8,6 +8,7 @@ from typing import DefaultDict, Dict, List, Optional, Set
 
 import bittensor as bt
 
+from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE
 from gittensor.utils.utils import parse_repo_name
 from gittensor.validator.configurations.tier_config import Tier, TierConfig, TierStats
 
@@ -145,7 +146,8 @@ class PullRequest:
     title: str
     author_login: str
     merged_at: Optional[datetime]  # None for OPEN PRs
-    created_at: datetime
+    # Legacy rows may have null created_at; pioneer ordering treats nulls as last.
+    created_at: Optional[datetime]
 
     # PR state based fields
     pr_state: PRState
@@ -156,7 +158,9 @@ class PullRequest:
     base_score: float = 0.0
     issue_multiplier: float = 1.0
     open_pr_spam_multiplier: float = 1.0
-    repository_uniqueness_multiplier: float = 1.0
+    pioneer_multiplier: float = 1.0  # Persisted score multiplier for winning pioneer PRs.
+    pioneer_rank: int = 0  # Persisted per-repo pioneer rank (0 means non-pioneer).
+    is_untouched_in_lookback_window: bool = False  # Transient gate result for current scoring run.
     time_decay_multiplier: float = 1.0
     credibility_multiplier: float = 1.0
     raw_credibility: float = 1.0  # Before applying ^k scalar
@@ -188,13 +192,26 @@ class PullRequest:
         """Set the file changes for this pull request"""
         self.file_changes = file_changes
 
+    def is_pioneer_eligible(self) -> bool:
+        """Check base pioneer eligibility for this PR (history-agnostic).
+
+        Repository lookback/window checks are evaluated in scoring, where merged history is available.
+        """
+
+        return (
+            self.pr_state == PRState.MERGED
+            and self.merged_at is not None
+            and self.repository_tier_configuration is not None
+            and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        )
+
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers."""
         multipliers = {
             'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'spam': self.open_pr_spam_multiplier,
-            'unique': self.repository_uniqueness_multiplier,
+            'pioneer': self.pioneer_multiplier,
             'decay': self.time_decay_multiplier,
             'cred': self.credibility_multiplier,
         }

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -59,8 +59,15 @@ MAX_CONTRIBUTION_BONUS = 30
 DEFAULT_MAX_CONTRIBUTION_SCORE_FOR_FULL_BONUS = 2000
 
 # Boosts
-UNIQUE_PR_BOOST = 0.74
 MAX_CODE_DENSITY_MULTIPLIER = 3.0
+
+# Pioneer tuning guide:
+# - pioneer winner multiplier = 1 + PIONEER_BASE_BONUS
+# - reward is per winning PR (no cross-repo decay by uid)
+# - pioneer inactivity lookback reuses PR_LOOKBACK_DAYS
+# - base bonus 2.0 gives a meaningful first-win signal (3.0x)
+# - if untouched-repo breadth does not increase, raise BASE_BONUS in small steps (e.g. +0.25 / +0.5)
+PIONEER_BASE_BONUS = 2.0
 
 # Issue boosts
 MAX_ISSUE_CLOSE_WINDOW_DAYS = 1

--- a/gittensor/validator/evaluation/reward.py
+++ b/gittensor/validator/evaluation/reward.py
@@ -2,13 +2,15 @@
 # Copyright © 2025 Entrius
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Tuple
+from datetime import timedelta
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 import numpy as np
 from aiohttp import ClientConnectorError
 
-from gittensor.classes import MinerEvaluation
+from gittensor.classes import MinerEvaluation, PullRequest
+from gittensor.constants import PR_LOOKBACK_DAYS
 from gittensor.synapses import GitPatSynapse
 from gittensor.utils.github_api_tools import load_miners_prs
 from gittensor.validator.evaluation.dynamic_emissions import apply_dynamic_emissions_using_network_contributions
@@ -136,8 +138,11 @@ async def get_rewards(
     # Adjust scores for duplicate accounts
     detect_and_penalize_miners_sharing_github(miner_evaluations)
 
-    # Finalize scores: apply unique contribution multiplier, credibility, sum totals, deduct collateral
-    finalize_miner_scores(miner_evaluations)
+    # Load merged PR history used by pioneer lookback gating.
+    merged_history = _get_merged_history_for_cycle(self, miner_evaluations)
+
+    # Finalize scores: apply pioneer rewards, credibility, sum totals, deduct collateral
+    finalize_miner_scores(miner_evaluations, merged_history=merged_history)
 
     # Allocate emissions by tier: replace total_score with tier-weighted allocations
     allocate_emissions_by_tier(miner_evaluations)
@@ -155,3 +160,48 @@ async def get_rewards(
         np.array([final_rewards.get(uid, 0.0) for uid in sorted(uids)]),
         miner_evaluations,
     )
+
+
+def _get_merged_history_for_cycle(
+    self: Validator, miner_evaluations: Dict[int, MinerEvaluation]
+) -> Optional[List[PullRequest]]:
+    """Load merged PR history for repos touched by current cycle merged candidates.
+
+    Returns:
+        - `None` when DB is unavailable or history fetch fails (pioneer disabled)
+        - `[]` when history is available but empty
+        - populated list when history rows exist
+    """
+    db_storage = self.db_storage
+    if db_storage is None or not db_storage.is_enabled():
+        return None
+
+    cycle_candidates = [
+        pr
+        for evaluation in miner_evaluations.values()
+        for pr in evaluation.merged_pull_requests
+        if pr.repository_full_name and pr.merged_at is not None
+    ]
+    if not cycle_candidates:
+        return []
+
+    cycle_repos: Set[str] = {pr.repository_full_name for pr in cycle_candidates}
+    # Bound history to the minimum range required by lookback gating for this cycle.
+    merged_at_from = min(pr.merged_at for pr in cycle_candidates) - timedelta(days=PR_LOOKBACK_DAYS)
+    merged_at_to = max(pr.merged_at for pr in cycle_candidates)
+
+    try:
+        bt.logging.debug(
+            f'Pioneer history fetch | repos={len(cycle_repos)} '
+            f'merged_at_from={merged_at_from.isoformat()} merged_at_to={merged_at_to.isoformat()}'
+        )
+        history = db_storage.get_merged_pull_request_history_by_repos(
+            sorted(cycle_repos),
+            merged_at_from,
+            merged_at_to,
+        )
+        bt.logging.debug(f'Pioneer history fetch result | rows={len(history)}')
+        return history
+    except Exception as e:
+        bt.logging.warning(f'Pioneer history unavailable; rewards disabled: {e}')
+        return None

--- a/gittensor/validator/evaluation/scoring.py
+++ b/gittensor/validator/evaluation/scoring.py
@@ -2,8 +2,9 @@
 # Copyright © 2025 Entrius
 
 import math
-from datetime import datetime, timezone
-from typing import Dict, Optional
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional, Tuple
 
 import bittensor as bt
 
@@ -20,13 +21,14 @@ from gittensor.constants import (
     MAX_OPEN_PR_THRESHOLD,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     OPEN_PR_THRESHOLD_TOKEN_SCORE,
+    PIONEER_BASE_BONUS,
+    PR_LOOKBACK_DAYS,
     SECONDS_PER_DAY,
     SECONDS_PER_HOUR,
     TIME_DECAY_GRACE_PERIOD_HOURS,
     TIME_DECAY_MIN_MULTIPLIER,
     TIME_DECAY_SIGMOID_MIDPOINT,
     TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
-    UNIQUE_PR_BOOST,
 )
 from gittensor.utils.github_api_tools import (
     FileContentPair,
@@ -48,6 +50,27 @@ from gittensor.validator.evaluation.credibility import (
 )
 from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
+
+
+@dataclass
+class PioneerRepositoryTimeline:
+    """Chronological merged-PR timeline for one repository."""
+
+    merged_prs: list[PullRequest] = field(default_factory=list)
+    candidate_pr_numbers: set[int] = field(default_factory=set)
+
+    def add_history_pr(self, pr: PullRequest) -> None:
+        self.merged_prs.append(pr)
+
+    def add_candidate_pr(self, pr: PullRequest) -> None:
+        self.merged_prs.append(pr)
+        self.candidate_pr_numbers.add(pr.number)
+
+    def sorted_prs(self) -> list[PullRequest]:
+        return sorted(self.merged_prs, key=_pioneer_order_key)
+
+    def is_cycle_candidate(self, pr: PullRequest) -> bool:
+        return pr.number in self.candidate_pr_numbers
 
 
 def score_miner_prs(
@@ -226,25 +249,158 @@ def calculate_pr_multipliers(
         pr.credibility_multiplier = 1.0
 
 
-def count_repository_contributors(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[str, int]:
-    """
-    Count how many miners contribute to each repository and log statistics.
+def _pioneer_order_key(pr: PullRequest) -> Tuple[datetime, datetime, int, int]:
+    """Stable ordering key for pioneer event-time processing."""
+    merged_at = pr.merged_at or datetime.max.replace(tzinfo=timezone.utc)
+    created_at = pr.created_at or datetime.max.replace(tzinfo=timezone.utc)
+    return (merged_at, created_at, pr.number, pr.uid)
 
-    Returns:
-        Dict[str, int]: Dictionary mapping repository names to contributor counts
-    """
-    repo_counts: Dict[str, int] = {}
 
-    for evaluation in miner_evaluations.values():
-        for repo in evaluation.unique_repos_contributed_to:
-            repo_counts[repo] = repo_counts.get(repo, 0) + 1
+def _reset_lookback_inactivity_gate(candidates: list[PullRequest]) -> None:
+    """Default all candidates to non-untouched before gate evaluation."""
+    for pr in candidates:
+        pr.is_untouched_in_lookback_window = False
 
-    if repo_counts:
-        bt.logging.info(f'Repository contribution counts: {len(repo_counts)} total repositories')
-        for repo, count in sorted(repo_counts.items(), key=lambda x: -x[1]):
-            bt.logging.info(f'{repo}: {count}')
 
-    return repo_counts
+def _build_pioneer_timelines(
+    candidates: list[PullRequest], history: list[PullRequest]
+) -> Dict[str, PioneerRepositoryTimeline]:
+    """Build per-repo timelines from history and cycle-eligible candidates."""
+    eligible_candidates = [pr for pr in candidates if pr.is_pioneer_eligible()]
+    # Exclude cycle PRs while replaying historical merged rows.
+    candidate_keys = {(pr.repository_full_name, pr.number) for pr in candidates}
+
+    timelines_by_repo: Dict[str, PioneerRepositoryTimeline] = {}
+
+    def get_or_create_timeline(repo_full_name: str) -> PioneerRepositoryTimeline:
+        timeline = timelines_by_repo.get(repo_full_name)
+        if timeline is None:
+            timeline = PioneerRepositoryTimeline()
+            timelines_by_repo[repo_full_name] = timeline
+        return timeline
+
+    for pr in history:
+        if pr.pr_state != PRState.MERGED or pr.merged_at is None:
+            continue
+        if (pr.repository_full_name, pr.number) in candidate_keys:
+            continue
+        timeline = get_or_create_timeline(pr.repository_full_name)
+        timeline.add_history_pr(pr)
+
+    for pr in eligible_candidates:
+        timeline = get_or_create_timeline(pr.repository_full_name)
+        timeline.add_candidate_pr(pr)
+
+    return timelines_by_repo
+
+
+def _apply_lookback_inactivity_to_timeline(
+    timeline: PioneerRepositoryTimeline, lookback_delta: timedelta
+) -> None:
+    """Apply lookback inactivity gate to cycle candidates within one repo timeline."""
+    prior_repo_merge_at: datetime | None = None
+    for pr in timeline.sorted_prs():
+        if timeline.is_cycle_candidate(pr):
+            # Candidate is untouched when no prior repo merge exists inside the lookback window.
+            pr.is_untouched_in_lookback_window = (
+                prior_repo_merge_at is None or prior_repo_merge_at <= (pr.merged_at - lookback_delta)
+            )
+
+        # Any merged PR contributes to subsequent "last merge" state.
+        prior_repo_merge_at = pr.merged_at
+
+
+def _compute_lookback_inactivity_gate(candidates: list[PullRequest], history: list[PullRequest]) -> None:
+    """Set lookback inactivity gate result for candidate PRs."""
+    _reset_lookback_inactivity_gate(candidates)
+    timelines_by_repo = _build_pioneer_timelines(candidates, history)
+
+    lookback_delta = timedelta(days=PR_LOOKBACK_DAYS)
+    for timeline in timelines_by_repo.values():
+        _apply_lookback_inactivity_to_timeline(timeline, lookback_delta)
+
+
+def _rank_pioneer_candidates(candidates: list[PullRequest]) -> None:
+    """Rank pioneer candidates per repo with one representative PR per (repo, uid)."""
+    for pr in candidates:
+        pr.pioneer_rank = 0
+
+    # repo -> cycle PRs that passed lookback inactivity gate.
+    candidates_by_repo: Dict[str, list[PullRequest]] = {}
+
+    def get_or_create_repo_candidates(repo_full_name: str) -> list[PullRequest]:
+        repo_candidates = candidates_by_repo.get(repo_full_name)
+        if repo_candidates is None:
+            repo_candidates = []
+            candidates_by_repo[repo_full_name] = repo_candidates
+        return repo_candidates
+
+    for pr in candidates:
+        if not pr.is_untouched_in_lookback_window:
+            continue
+        get_or_create_repo_candidates(pr.repository_full_name).append(pr)
+
+    for repo_candidates in candidates_by_repo.values():
+        repo_candidates.sort(key=_pioneer_order_key)
+
+        representatives: list[PullRequest] = []
+        seen_uids: set[int] = set()
+        for pr in repo_candidates:
+            if pr.uid in seen_uids:
+                continue
+            seen_uids.add(pr.uid)
+            representatives.append(pr)
+
+        for rank, pr in enumerate(representatives, start=1):
+            pr.pioneer_rank = rank
+
+
+def _apply_pioneer_awards(candidates: list[PullRequest]) -> None:
+    """Apply pioneer multipliers for rank-1 repo winners."""
+    for pr in candidates:
+        pr.pioneer_multiplier = 1.0
+
+    # Reward each winning PR independently, without cross-repo decay per uid.
+    winner_multiplier = 1.0 + PIONEER_BASE_BONUS
+    for pr in candidates:
+        if pr.pioneer_rank == 1:
+            pr.pioneer_multiplier = winner_multiplier
+            bt.logging.info(
+                f'Pioneer winner | repo={pr.repository_full_name} uid={pr.uid} '
+                f'pr={pr.number} multiplier={pr.pioneer_multiplier:.2f}'
+            )
+
+
+def _get_cycle_merged_candidates(miner_evaluations: Dict[int, MinerEvaluation]) -> list[PullRequest]:
+    """Flatten merged PRs for this scoring cycle across all miners."""
+    return [pr for evaluation in miner_evaluations.values() for pr in evaluation.merged_pull_requests]
+
+
+def _reset_pioneer_fields(candidates: list[PullRequest]) -> None:
+    """Clear pioneer fields when lookback history is unavailable."""
+    for pr in candidates:
+        pr.pioneer_rank = 0
+        pr.pioneer_multiplier = 1.0
+        pr.is_untouched_in_lookback_window = False
+
+
+def apply_pioneer_mechanism(
+    miner_evaluations: Dict[int, MinerEvaluation], merged_history: list[PullRequest]
+) -> None:
+    """Apply pioneer gating, ranking, and awards to all merged PRs in cycle."""
+    cycle_candidates = _get_cycle_merged_candidates(miner_evaluations)
+
+    _compute_lookback_inactivity_gate(cycle_candidates, history=merged_history)
+    _rank_pioneer_candidates(cycle_candidates)
+    _apply_pioneer_awards(cycle_candidates)
+
+    repos_touched = {pr.repository_full_name for pr in cycle_candidates if pr.repository_full_name}
+    untouched_candidates = sum(1 for pr in cycle_candidates if pr.is_untouched_in_lookback_window)
+    winner_count = sum(1 for pr in cycle_candidates if pr.pioneer_rank == 1)
+    bt.logging.info(
+        f'Pioneer summary | repos={len(repos_touched)} candidates={len(cycle_candidates)} '
+        f'untouched={untouched_candidates} winners={winner_count} history_rows={len(merged_history)}'
+    )
 
 
 def calculate_open_pr_threshold(
@@ -304,12 +460,25 @@ def calculate_time_decay_multiplier(pr: PullRequest) -> float:
     return max(sigmoid, TIME_DECAY_MIN_MULTIPLIER)
 
 
-def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None:
-    """Finalize all miner scores: apply uniqueness multipliers, calculate totals, and deduct collateral."""
+def finalize_miner_scores(
+    miner_evaluations: Dict[int, MinerEvaluation],
+    merged_history: Optional[list[PullRequest]] = None,
+) -> None:
+    """Finalize all miner scores, including pioneer rewards, then deduct collateral.
+
+    `merged_history` semantics:
+    - None: history unavailable -> disable pioneer rewards (fail-closed)
+    - []: history available but empty -> apply pioneer against cycle-only events
+    """
     bt.logging.info('**Finalizing miner scores**')
 
-    repo_counts = count_repository_contributors(miner_evaluations)
-    total_contributing_miners = sum(1 for ev in miner_evaluations.values() if ev.unique_repos_contributed_to)
+    if merged_history is not None:
+        apply_pioneer_mechanism(miner_evaluations, merged_history=merged_history)
+    else:
+        bt.logging.warning(
+            'Pioneer rewards disabled: merged PR history unavailable for lookback gate.'
+        )
+        _reset_pioneer_fields(_get_cycle_merged_candidates(miner_evaluations))
 
     for uid, evaluation in miner_evaluations.items():
         if not evaluation:
@@ -348,10 +517,6 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
 
         # Process merged PRs
         for pr in evaluation.merged_pull_requests:
-            pr.repository_uniqueness_multiplier = calculate_uniqueness_multiplier(
-                pr.repository_full_name, repo_counts, total_contributing_miners
-            )
-
             # Apply spam multiplier (calculated once per miner based on unlocked tiers)
             pr.open_pr_spam_multiplier = spam_multiplier
 
@@ -429,18 +594,6 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
         )
 
     bt.logging.info('Finalization complete.')
-
-
-def calculate_uniqueness_multiplier(
-    repo_full_name: str, repo_counts: Dict[str, int], total_contributing_miners: int
-) -> float:
-    """Calculate repository uniqueness multiplier based on how many miners contribute to a repo."""
-    if total_contributing_miners == 0:
-        return 1.0
-    repo_count = repo_counts.get(repo_full_name, 0)
-    uniqueness_score = (total_contributing_miners - repo_count + 1) / total_contributing_miners
-    return 1.0 + (uniqueness_score * UNIQUE_PR_BOOST)
-
 
 def calculate_issue_multiplier(pr: PullRequest) -> float:
     """
@@ -541,7 +694,7 @@ def calculate_open_pr_collateral_score(pr: PullRequest) -> float:
 
     Applicable multipliers: repo_weight, issue
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
-                    uniqueness (cross-miner), open_pr_spam (not for collateral)
+                    pioneer (merged-only), open_pr_spam (not for collateral)
     """
     from math import prod
 

--- a/gittensor/validator/storage/migrations/20260304_add_pioneer_columns.sql
+++ b/gittensor/validator/storage/migrations/20260304_add_pioneer_columns.sql
@@ -1,0 +1,17 @@
+-- Add pioneer scoring columns to pull_requests (idempotent).
+-- Apply before deploying pioneer-scoring application code.
+
+ALTER TABLE pull_requests
+  ADD COLUMN IF NOT EXISTS pioneer_multiplier DOUBLE PRECISION NOT NULL DEFAULT 1.0;
+
+ALTER TABLE pull_requests
+  ADD COLUMN IF NOT EXISTS pioneer_rank INTEGER NOT NULL DEFAULT 0;
+
+-- Supports efficient pioneer inactivity lookups by repo + merged timestamp.
+CREATE INDEX IF NOT EXISTS idx_pull_requests_repo_merged_at
+  ON pull_requests (repository_full_name, merged_at DESC);
+
+-- WARNING: Destructive change.
+-- For safest rollout/rollback support, run this DROP in a later cleanup migration.
+-- ALTER TABLE pull_requests
+--   DROP COLUMN IF EXISTS repository_uniqueness_multiplier;

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -1,4 +1,4 @@
-# Storage Queries - Only SET/INSERT operations for writing data
+# Storage SQL queries (write + read)
 
 # Cleanup Queries - Remove stale data when a miner re-registers on a new uid/hotkey
 CLEANUP_STALE_MINER_EVALUATIONS = """
@@ -37,7 +37,7 @@ INSERT INTO pull_requests (
     number, repository_full_name, uid, hotkey, github_id, title, author_login,
     merged_at, pr_created_at, pr_state,
     repo_weight_multiplier, base_score, issue_multiplier,
-    open_pr_spam_multiplier, repository_uniqueness_multiplier, time_decay_multiplier,
+    open_pr_spam_multiplier, pioneer_multiplier, pioneer_rank, time_decay_multiplier,
     credibility_multiplier, raw_credibility, credibility_scalar,
     earned_score, collateral_score,
     additions, deletions, commits, total_nodes_scored,
@@ -56,7 +56,8 @@ DO UPDATE SET
     base_score = EXCLUDED.base_score,
     issue_multiplier = EXCLUDED.issue_multiplier,
     open_pr_spam_multiplier = EXCLUDED.open_pr_spam_multiplier,
-    repository_uniqueness_multiplier = EXCLUDED.repository_uniqueness_multiplier,
+    pioneer_multiplier = EXCLUDED.pioneer_multiplier,
+    pioneer_rank = EXCLUDED.pioneer_rank,
     time_decay_multiplier = EXCLUDED.time_decay_multiplier,
     credibility_multiplier = EXCLUDED.credibility_multiplier,
     raw_credibility = EXCLUDED.raw_credibility,
@@ -76,6 +77,28 @@ DO UPDATE SET
     leaf_count = EXCLUDED.leaf_count,
     leaf_score = EXCLUDED.leaf_score,
     updated_at = NOW()
+"""
+
+# Keep ORDER BY in sync with scoring._pioneer_order_key for deterministic pioneer gating/ranking.
+GET_MERGED_PULL_REQUEST_HISTORY_BY_REPOS = """
+SELECT
+    repository_full_name,
+    merged_at,
+    pr_created_at,
+    number,
+    uid
+FROM pull_requests
+WHERE repository_full_name = ANY(%s)
+  AND pr_state = 'MERGED'
+  AND merged_at IS NOT NULL
+  AND merged_at >= %s
+  AND merged_at <= %s
+ORDER BY
+    repository_full_name,
+    merged_at,
+    pr_created_at NULLS LAST,
+    number,
+    uid
 """
 
 # Issue Queries

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -8,11 +8,12 @@ and miner evaluations.
 
 import logging
 from contextlib import contextmanager
+from datetime import datetime
 from typing import List, TypeVar
 
 import numpy as np
 
-from gittensor.classes import FileChange, Issue, Miner, MinerEvaluation, PullRequest
+from gittensor.classes import FileChange, Issue, Miner, MinerEvaluation, PRState, PullRequest
 from gittensor.validator.configurations.tier_config import Tier
 
 from .queries import (
@@ -24,6 +25,7 @@ from .queries import (
     CLEANUP_STALE_MINER_EVALUATIONS,
     CLEANUP_STALE_MINER_TIER_STATS,
     CLEANUP_STALE_MINERS,
+    GET_MERGED_PULL_REQUEST_HISTORY_BY_REPOS,
     SET_MINER,
 )
 
@@ -109,6 +111,48 @@ class Repository(BaseRepository):
         params = (miner.uid, miner.hotkey, miner.github_id)
         return self.set_entity(SET_MINER, params)
 
+    def get_merged_pull_request_history_by_repos(
+        self,
+        repository_full_names: List[str],
+        merged_at_from: datetime,
+        merged_at_to: datetime,
+    ) -> List[PullRequest]:
+        """
+        Fetch merged PR history for the provided repositories within a merge-time window.
+
+        Returns rows ordered by the same deterministic pioneer event key
+        (repo, merged_at, created_at nulls last, pr_number, uid).
+        """
+        if not repository_full_names:
+            return []
+
+        with self.get_cursor() as cursor:
+            cursor.execute(
+                GET_MERGED_PULL_REQUEST_HISTORY_BY_REPOS,
+                (repository_full_names, merged_at_from, merged_at_to),
+            )
+            rows = cursor.fetchall()
+
+        history: List[PullRequest] = []
+        for row in rows:
+            repo_full_name, merged_at, created_at, pr_number, uid = row
+            history.append(
+                PullRequest(
+                    number=int(pr_number),
+                    repository_full_name=repo_full_name,
+                    uid=int(uid),
+                    hotkey='',
+                    github_id='0',
+                    title='',
+                    author_login='',
+                    merged_at=merged_at,
+                    created_at=created_at,
+                    pr_state=PRState.MERGED,
+                )
+            )
+
+        return history
+
     def cleanup_stale_miner_data(self, evaluation: MinerEvaluation) -> None:
         """
         Remove stale evaluation data when a miner re-registers on a new uid/hotkey.
@@ -166,7 +210,8 @@ class Repository(BaseRepository):
                     pr.base_score,
                     pr.issue_multiplier,
                     pr.open_pr_spam_multiplier,
-                    pr.repository_uniqueness_multiplier,
+                    pr.pioneer_multiplier,
+                    pr.pioneer_rank,
                     pr.time_decay_multiplier,
                     pr.credibility_multiplier,
                     pr.raw_credibility,

--- a/gittensor/validator/test/simulation/run_scoring_simulation.py
+++ b/gittensor/validator/test/simulation/run_scoring_simulation.py
@@ -261,7 +261,9 @@ def run_scoring_simulation(
     print('\n[7/9] Finalizing scores...')
     sys.stdout.flush()
     time.sleep(0.1)
-    finalize_miner_scores(evals)
+    # No DB history in this standalone simulation; treat history as available-empty
+    # so pioneer logic still runs within the cycle.
+    finalize_miner_scores(evals, merged_history=[])
 
     # 8. Normalize & apply dynamic emissions
     print('\n[8/9] Normalizing & applying dynamic emissions...')

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Dict, List
 
 import bittensor as bt
 
-from gittensor.classes import Miner, MinerEvaluation
+from gittensor.classes import Miner, MinerEvaluation, PullRequest
 from gittensor.validator.storage.database import create_database_connection
 from gittensor.validator.storage.repository import Repository
 
@@ -83,6 +84,21 @@ class DatabaseStorage:
             self.logger.error(error_msg)
 
         return result
+
+    def get_merged_pull_request_history_by_repos(
+        self,
+        repository_full_names: List[str],
+        merged_at_from: datetime,
+        merged_at_to: datetime,
+    ) -> List[PullRequest]:
+        """Read merged PR history for pioneer inactivity gating within merge-time bounds."""
+        if not self.is_enabled() or self.repo is None:
+            return []
+        return self.repo.get_merged_pull_request_history_by_repos(
+            repository_full_names,
+            merged_at_from,
+            merged_at_to,
+        )
 
     def _log_storage_summary(self, counts: Dict[str, int]):
         """Log a summary of what was stored"""

--- a/tests/validator/test_pioneer_scoring.py
+++ b/tests/validator/test_pioneer_scoring.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gittensor.classes import MinerEvaluation, PRState, PullRequest
+from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE, PIONEER_BASE_BONUS
+from gittensor.validator.configurations.tier_config import TIERS, Tier
+from gittensor.validator.evaluation.scoring import apply_pioneer_mechanism, finalize_miner_scores
+
+
+def _dt(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _mk_pr(
+    *,
+    number: int,
+    repo: str,
+    uid: int,
+    merged_at: datetime,
+    created_at: datetime | None,
+    token_score: float = 50.0,
+    tier_ok: bool = True,
+    base_score: float = 10.0,
+) -> PullRequest:
+    return PullRequest(
+        number=number,
+        repository_full_name=repo,
+        uid=uid,
+        hotkey=f'hk-{uid}',
+        github_id=str(uid),
+        title=f'PR #{number}',
+        author_login=f'user-{uid}',
+        merged_at=merged_at,
+        created_at=created_at,
+        pr_state=PRState.MERGED,
+        repository_tier_configuration=TIERS[Tier.BRONZE] if tier_ok else None,
+        token_score=token_score,
+        base_score=base_score,
+    )
+
+
+def _evals_from_prs(prs: list[PullRequest]) -> dict[int, MinerEvaluation]:
+    grouped: dict[int, list[PullRequest]] = {}
+    for pr in prs:
+        grouped.setdefault(pr.uid, []).append(pr)
+
+    evals: dict[int, MinerEvaluation] = {}
+    for uid, uid_prs in grouped.items():
+        ev = MinerEvaluation(uid=uid, hotkey=f'hk-{uid}', github_id=str(uid), merged_pull_requests=uid_prs)
+        ev.unique_repos_contributed_to = {pr.repository_full_name for pr in uid_prs}
+        evals[uid] = ev
+    return evals
+
+
+def _pioneer_summary(evals: dict[int, MinerEvaluation]) -> list[tuple]:
+    rows: list[tuple] = []
+    for uid, ev in sorted(evals.items()):
+        for pr in sorted(ev.merged_pull_requests, key=lambda x: (x.repository_full_name, x.number)):
+            rows.append(
+                (
+                    uid,
+                    pr.repository_full_name,
+                    pr.number,
+                    pr.pioneer_rank,
+                    round(pr.pioneer_multiplier, 8),
+                    pr.is_untouched_in_lookback_window,
+                )
+            )
+    return rows
+
+
+# `is_untouched_in_lookback_window` is produced by deterministic merged-event replay:
+# later same-repo candidates in a cycle can become False once an earlier merge is observed.
+def test_first_on_untouched_repo_gets_bonus():
+    candidate = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=_dt(2026, 1, 10), created_at=_dt(2026, 1, 8))
+    evals = _evals_from_prs([candidate])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    assert candidate.is_untouched_in_lookback_window is True
+    assert candidate.pioneer_rank == 1
+    assert candidate.pioneer_multiplier == pytest.approx(1.0 + PIONEER_BASE_BONUS)
+
+
+def test_repo_not_untouched_when_recent_merge_exists():
+    t = _dt(2026, 1, 10)
+    candidate = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=t, created_at=t - timedelta(days=1))
+    history = [
+        _mk_pr(
+            number=100,
+            repo='o/r1',
+            uid=99,
+            merged_at=t - timedelta(days=10),
+            created_at=t - timedelta(days=11),
+        )
+    ]
+    evals = _evals_from_prs([candidate])
+
+    apply_pioneer_mechanism(evals, merged_history=history)
+
+    assert candidate.is_untouched_in_lookback_window is False
+    assert candidate.pioneer_rank == 0
+    assert candidate.pioneer_multiplier == 1.0
+
+
+def test_exact_90_day_boundary_is_eligible():
+    t = _dt(2026, 1, 10)
+    candidate = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=t, created_at=t - timedelta(days=1))
+    history = [
+        _mk_pr(
+            number=100,
+            repo='o/r1',
+            uid=99,
+            merged_at=t - timedelta(days=90),
+            created_at=t - timedelta(days=91),
+        )
+    ]
+    evals = _evals_from_prs([candidate])
+
+    apply_pioneer_mechanism(evals, merged_history=history)
+
+    assert candidate.is_untouched_in_lookback_window is True
+    assert candidate.pioneer_rank == 1
+
+
+def test_first_candidate_wins_when_merged_at_ties():
+    t = _dt(2026, 1, 10, 12, 0)
+    first = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=t, created_at=_dt(2026, 1, 9, 8))
+    second = _mk_pr(number=2, repo='o/r1', uid=2, merged_at=t, created_at=_dt(2026, 1, 9, 9))
+    evals = _evals_from_prs([first, second])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    assert first.is_untouched_in_lookback_window is True
+    assert second.is_untouched_in_lookback_window is False
+    assert first.pioneer_rank == 1
+    assert second.pioneer_rank == 0
+
+
+def test_null_created_at_sorts_last():
+    t = _dt(2026, 1, 10, 12, 0)
+    with_created_at = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=t, created_at=_dt(2026, 1, 9, 8))
+    without_created_at = _mk_pr(number=2, repo='o/r1', uid=2, merged_at=t, created_at=None)
+    evals = _evals_from_prs([with_created_at, without_created_at])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    assert with_created_at.is_untouched_in_lookback_window is True
+    assert without_created_at.is_untouched_in_lookback_window is False
+
+
+def test_low_quality_or_missing_tier_not_eligible():
+    t = _dt(2026, 1, 10)
+    low_quality = _mk_pr(
+        number=1,
+        repo='o/r1',
+        uid=1,
+        merged_at=t,
+        created_at=t - timedelta(days=1),
+        token_score=MIN_TOKEN_SCORE_FOR_BASE_SCORE - 0.01,
+    )
+    no_tier = _mk_pr(number=2, repo='o/r2', uid=1, merged_at=t, created_at=t - timedelta(days=1), tier_ok=False)
+    evals = _evals_from_prs([low_quality, no_tier])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    assert low_quality.is_untouched_in_lookback_window is False
+    assert no_tier.is_untouched_in_lookback_window is False
+    assert low_quality.pioneer_rank == 0
+    assert no_tier.pioneer_rank == 0
+
+
+def test_same_pr_row_in_history_is_ignored():
+    t = _dt(2026, 1, 10)
+    candidate = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=t, created_at=t - timedelta(days=1))
+    duplicate_in_history = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=t, created_at=t - timedelta(days=1))
+    evals = _evals_from_prs([candidate])
+
+    apply_pioneer_mechanism(evals, merged_history=[duplicate_in_history])
+
+    assert candidate.is_untouched_in_lookback_window is True
+    assert candidate.pioneer_rank == 1
+
+
+def test_one_representative_per_repo_uid():
+    first = _mk_pr(number=1, repo='o/r1', uid=1, merged_at=_dt(2026, 1, 1), created_at=_dt(2025, 12, 30))
+    later_same_uid = _mk_pr(number=2, repo='o/r1', uid=1, merged_at=_dt(2026, 5, 1), created_at=_dt(2026, 4, 28))
+    # Place this candidate beyond lookback from the prior merge so it remains untouched-eligible.
+    other_uid = _mk_pr(number=3, repo='o/r1', uid=2, merged_at=_dt(2026, 8, 5), created_at=_dt(2026, 8, 1))
+    evals = _evals_from_prs([first, later_same_uid, other_uid])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    assert first.pioneer_rank == 1
+    assert other_uid.pioneer_rank == 2
+    assert later_same_uid.pioneer_rank == 0
+
+
+def test_follower_stays_at_one():
+    t = _dt(2026, 1, 1, 12)
+    winner = _mk_pr(number=1, repo='o/repo-a', uid=1, merged_at=t, created_at=t - timedelta(days=1))
+    follower = _mk_pr(number=2, repo='o/repo-a', uid=2, merged_at=t + timedelta(hours=1), created_at=t)
+    evals = _evals_from_prs([winner, follower])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    assert winner.pioneer_rank == 1
+    assert winner.pioneer_multiplier == pytest.approx(1.0 + PIONEER_BASE_BONUS)
+    assert follower.pioneer_multiplier == 1.0
+
+
+def test_same_uid_wins_multiple_repos_gets_same_multiplier():
+    p1 = _mk_pr(number=1, repo='o/r1', uid=7, merged_at=_dt(2026, 1, 1), created_at=_dt(2025, 12, 30))
+    p2 = _mk_pr(number=2, repo='o/r2', uid=7, merged_at=_dt(2026, 1, 2), created_at=_dt(2025, 12, 31))
+    evals = _evals_from_prs([p1, p2])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    assert p1.pioneer_rank == 1
+    assert p2.pioneer_rank == 1
+    assert p1.pioneer_multiplier == pytest.approx(p2.pioneer_multiplier)
+
+
+def test_multiple_miners_can_pioneer_different_repos_in_same_cycle():
+    t = _dt(2026, 1, 1, 12)
+    miner1_repo1 = _mk_pr(number=1, repo='o/repo-a', uid=1, merged_at=t, created_at=t - timedelta(days=1))
+    miner2_repo2 = _mk_pr(number=2, repo='o/repo-b', uid=2, merged_at=t + timedelta(minutes=5), created_at=t)
+    evals = _evals_from_prs([miner1_repo1, miner2_repo2])
+
+    apply_pioneer_mechanism(evals, merged_history=[])
+
+    expected = 1.0 + PIONEER_BASE_BONUS
+    assert miner1_repo1.pioneer_rank == 1
+    assert miner2_repo2.pioneer_rank == 1
+    assert miner1_repo1.pioneer_multiplier == pytest.approx(expected)
+    assert miner2_repo2.pioneer_multiplier == pytest.approx(expected)
+
+
+def test_idempotent_and_order_independent():
+    t = _dt(2026, 1, 1, 12)
+    p1 = _mk_pr(number=1, repo='o/repo-a', uid=1, merged_at=t, created_at=t - timedelta(days=1))
+    p2 = _mk_pr(number=2, repo='o/repo-b', uid=1, merged_at=t + timedelta(hours=1), created_at=t)
+    p3 = _mk_pr(number=3, repo='o/repo-a', uid=2, merged_at=t + timedelta(hours=2), created_at=t)
+
+    run_a = _evals_from_prs(deepcopy([p1, p2, p3]))
+    run_b = _evals_from_prs(deepcopy([p3, p2, p1]))
+
+    apply_pioneer_mechanism(run_a, merged_history=[])
+    apply_pioneer_mechanism(run_b, merged_history=[])
+
+    assert _pioneer_summary(run_a) == _pioneer_summary(run_b)
+
+
+def test_finalize_miner_scores_disables_pioneer_when_history_unavailable(monkeypatch):
+    t = _dt(2026, 1, 1, 12)
+
+    monkeypatch.setattr(
+        'gittensor.validator.evaluation.scoring.calculate_credibility_per_tier',
+        lambda merged_prs, closed_prs: {tier: 1.0 for tier in Tier},
+    )
+
+    pioneer_candidate = _mk_pr(number=1, repo='o/repo-a', uid=1, merged_at=t, created_at=t - timedelta(days=1), base_score=10.0)
+    evals = _evals_from_prs([pioneer_candidate])
+
+    finalize_miner_scores(evals, merged_history=None)
+
+    assert pioneer_candidate.pioneer_rank == 0
+    assert pioneer_candidate.pioneer_multiplier == 1.0
+    assert pioneer_candidate.is_untouched_in_lookback_window is False
+    assert pioneer_candidate.earned_score == pytest.approx(10.0)


### PR DESCRIPTION
Closes #240

## Summary
Implemented a straightforward pioneer scoring rule: the first eligible merged PR on a repo with no merged PR in the 90-day lookback receives a fixed bonus, and later PRs on that repo continue scoring normally. 

The mechanism is intentionally simple to reason about and is designed to make untouched repos materially more attractive without introducing extra damping or decay logic.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

## Solution
This implementation uses a clear `gate -> rank -> award` flow:

#### 1. Gate:
- Build per-repo merged timelines from:
- current-cycle merged PR candidates
- merged PR history loaded from storage
- Mark `is_untouched_in_lookback_window=True` only when no prior merge exists within `PR_LOOKBACK_DAYS`.

#### 2. Rank:
- For untouched candidates, apply deterministic ordering:
  - `merged_at`, `created_at`, PR number, uid
- Keep one representative PR per `(repo, uid)`.
- Set `pioneer_rank` from this ordered representative list.

#### 3. Award:
- Apply `pioneer_multiplier = 1 + PIONEER_BASE_BONUS` only for `pioneer_rank == 1`.
- Followers keep `pioneer_multiplier = 1.0` (no penalty).

#### 4. Safety/failure behavior:
- If history is unavailable (`merged_history=None`), pioneer is disabled for that cycle (fail-closed).
- Quality guard remains in place via `is_pioneer_eligible()`:
  - merged state
  - non-null merge timestamp
  - tier config present
  - `token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE`

#### 5. Design scope:
- Adds no extra damping or decay to pioneer rewards intentionally.
- Pioneer is scoped to discovery selection only: gate -> rank -> award.
- Repeated pioneer wins can be an intended success case when a miner is genuinely contributing broadly across untouched repos.
- If that later produces excessive miner-level concentration in practice, it should be handled as a separate aggregate reward policy follow-up.
- That aggregate balancing is out of scope for this PR.

## Why Better
**Before (uniqueness reward)**
- Popularity-based adjustment, without explicit 90-day inactivity gating.
- Score gap between saturated and untouched repos was often too small to change behavior.

**After (pioneer reward)**
- History-backed inactivity gate (`PR_LOOKBACK_DAYS`) rewards true repo discovery, which directly reduces pile-on behavior on already active repos.
- First eligible merged PR on an untouched repo gets an immediate, predictable bonus, so exploration is worth more than joining crowded targets.
- Deterministic `gate -> rank -> award` with quality eligibility (`is_pioneer_eligible`) limits gaming/spam-style wins from low-quality or non-qualifying PRs.

## Scope of Changes
- Dataclass/model: `PullRequest` pioneer fields and eligibility helper in `gittensor/classes.py`.
- Constants: pioneer configuration in `gittensor/constants.py`.
- Scoring: pioneer gate/rank/award flow in `gittensor/validator/evaluation/scoring.py`.
- Reward orchestration: merged-history load and fail-closed wiring in `gittensor/validator/evaluation/reward.py`.
- Queries: pioneer read/write SQL updates and bounded merged-history read window in `gittensor/validator/storage/queries.py`.
- Storage/repository: merged-history read path in `gittensor/validator/storage/repository.py` and pass-through API in `gittensor/validator/utils/storage.py`.
- DB migration: `gittensor/validator/storage/migrations/20260304_add_pioneer_columns.sql`.
- Tests: `tests/validator/test_pioneer_scoring.py` covering core behavior and edge cases.
- Logging: pioneer summary/winner logs during finalization and bounded history-fetch diagnostics at debug level.

## Notes
- The legacy `repository_uniqueness_multiplier` DROP is intentionally commented in migration for safer rollout.
- Please uncomment and run it in target environments after PR validation.

## Verification
- Added behavioral tests for scoring logic covering happy-path, edge, and essential scenarios.
```bash
pytest tests/validator/test_pioneer_scoring.py -v
# 13 passed
```
- All validator tests passed:
```bash
pytest tests/validator -q
# 200 passed
```

<img width="1195" height="523" alt="image" src="https://github.com/user-attachments/assets/c548e4ba-9d39-434f-b839-fb8006777f6d" />

### Simulation
I included a small simulation page to make the scoring change easy to audit on a fixed synthetic dataset.
It is useful to check:
- it compares the old uniqueness logic and the new pioneer mechanism on the exact same scoring snapshot
- all PR quality inputs are held constant, so the visible change comes from the scoring rule itself
- it shows the outcome at the distribution level, which is the real product goal of this issue

#### How to read it:
- `Simulation Dataset` explains the fixed mock snapshot and why the hot repo is not pioneer-eligible
- `Summary Table` shows the before/after metrics directly
- `Step-by-Step Math` shows how the old and new totals are calculated
- `Show Dataset` and `Show Before vs After Distribution` let reviewers inspect the mock rows and repo-level score shift

#### What it demonstrates:
- under the old uniqueness approach, score remains more concentrated on the already-active repo
- under the pioneer approach, untouched repos become materially more competitive
- this is the intended behavior change for issue #240: reduce pile-on pressure on active repos and make first contributions to untouched repos more attractive

#### Bonus (PIONEER_BASE_BONUS) calibration note:
- repo distribution in the fixed PR snapshot:
  - baseline `66.83%` Top-5 share
  - bonus `1.2` -> `58.75%`
  - bonus `1.5` -> `57.14%`
  - bonus `2.0` -> `55.00%`
- equal-throughput case (`3` pioneer wins vs `3` normal PRs):
  - `1.2` -> explorer `68.8%`
  - `1.5` -> explorer `71.4%`
  - `2.0` -> explorer `75.0%`
- concentration case (`4` pioneer wins vs `8` miners with `1` normal PR each):
  - `1.2` -> leader `52.4%`
  - `1.5` -> leader `55.6%`
  - `2.0` -> leader `60.0%`

Based on this simple synthetic sweep, `2.0` is a strong initial base bonus: it most clearly shifts incentives toward untouched repos. It is more aggressive than `1.2` or `1.5`, but repeated pioneer wins across many repos are not easy in practice, so this PR treats `2.0` as a reasonable starting point and leaves any later aggregate balancing to follow-up tuning if rollout data justifies it.

#### Screenshots

<img width="2377" height="1154" alt="image" src="https://github.com/user-attachments/assets/18e39032-5832-491f-9bae-323927d950e7" />
<img width="1192" height="762" alt="image" src="https://github.com/user-attachments/assets/cb9c4c89-ef4d-443f-b75a-edba96ff9940" />

<img width="1196" height="921" alt="image" src="https://github.com/user-attachments/assets/80cb7b93-85b8-4293-baff-cb8a638d422b" />
<img width="1189" height="603" alt="image" src="https://github.com/user-attachments/assets/c0d551e0-f291-4d1a-b74f-3cfd2589ef2e" />
