### PR TITLE
chore(weights): add 2 repos, adjust 1391 weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1535,8 +1535,8 @@
     "weight": 26.91
   },
   "entrius/venth": {
-    "tier": "Gold",
-    "weight": 20.26,
+    "tier": "Silver",
+    "weight": 3.52,
     "inactive_at": "2026-03-14"
   },
   "envoyproxy/envoy": {


### PR DESCRIPTION
## Purpose

Operation Laser Beam & Additional Target Adjustments

## Changes Summary

| Metric | 🥇 Gold | 🥈 Silver | 🥉 Bronze | Total |
|--------|---------|-----------|-----------|-------|
| Repositories Added | 0 | 3 | 0 | 3 |
| Repositories Removed/Inactivated | 0 | 2 | 4 | 6 |
| Weights Modified | 12 | 54 | 1325 | 1391 |

## Added Repositories

| Repository | Tier | Branch | Weight |
|------------|------|--------|--------|
| `qwibitai/nanoclaw` | 🥈 silver | `main` | 20.00 |
| `paperclipai/paperclip` | 🥈 silver | `main` | 20.00 |
| `Desearch-ai/linkedin-dms` | 🥈 silver | `main` | (median) |

## Additional Targeted Updates
- **Removed**: `openssl/openssl`
- **Inactivated**: `entrius/venth` (effective 3/14/2026)
- **Inactivated**: All `frappe` organization repos (`frappe/frappe`, `frappe/erpnext`, `frappe/hrms`, `frappe/gantt`) (effective 3/14/2026)
