### PR TITLE
fix: escape file paths in GraphQL queries and add batch-size limits

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -980,6 +980,28 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
         return None
 
 
+def _escape_graphql_expression(expression: str) -> str:
+    """Escape special characters in a GraphQL string literal.
+
+    File paths containing backslashes or double quotes break GraphQL query
+    syntax when interpolated directly. This escapes them so the query remains
+    valid.
+
+    Args:
+        expression: Raw string to embed inside a GraphQL double-quoted literal.
+
+    Returns:
+        Escaped string safe for embedding in GraphQL queries.
+    """
+    return expression.replace('\\', '\\\\').replace('"', '\\"')
+
+
+# Maximum files per GraphQL batch request. GitHub's GraphQL API has query
+# complexity limits; batching too many object lookups in a single request can
+# cause a 502/complexity error and lose all results.
+_MAX_FILES_PER_GRAPHQL_BATCH = 50
+
+
 def fetch_file_contents_batch(
     repo_owner: str,
     repo_name: str,
@@ -988,9 +1010,10 @@ def fetch_file_contents_batch(
     token: str,
 ) -> Dict[str, Optional[str]]:
     """
-    Fetch multiple file contents from a repository in a single GraphQL request.
+    Fetch multiple file contents from a repository in batched GraphQL requests.
 
-    Uses retry logic with exponential backoff for reliability.
+    Uses retry logic with exponential backoff for reliability. Batches files
+    to avoid exceeding GitHub's GraphQL complexity limits.
 
     Args:
         repo_owner: Repository owner
@@ -1005,47 +1028,53 @@ def fetch_file_contents_batch(
     if not file_paths:
         return {}
 
-    # Build GraphQL query with aliased file fields
-    file_fields = []
-    for i, path in enumerate(file_paths):
-        expression = f'{head_sha}:{path}'
-        file_fields.append(
-            f'file{i}: object(expression: "{expression}") {{ ... on Blob {{ text byteSize isBinary }} }}'
-        )
+    results: Dict[str, Optional[str]] = {}
 
-    query = f"""
-        query($owner: String!, $name: String!) {{
-            repository(owner: $owner, name: $name) {{
-                {' '.join(file_fields)}
+    # Process files in batches to avoid exceeding GraphQL complexity limits
+    for batch_start in range(0, len(file_paths), _MAX_FILES_PER_GRAPHQL_BATCH):
+        batch_paths = file_paths[batch_start : batch_start + _MAX_FILES_PER_GRAPHQL_BATCH]
+
+        # Build GraphQL query with aliased file fields
+        file_fields = []
+        for i, path in enumerate(batch_paths):
+            expression = _escape_graphql_expression(f'{head_sha}:{path}')
+            file_fields.append(
+                f'file{i}: object(expression: "{expression}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+            )
+
+        query = f"""
+            query($owner: String!, $name: String!) {{
+                repository(owner: $owner, name: $name) {{
+                    {' '.join(file_fields)}
+                }}
             }}
-        }}
-    """
+        """
 
-    variables = {'owner': repo_owner, 'name': repo_name}
+        variables = {'owner': repo_owner, 'name': repo_name}
 
-    # Execute with retry logic
-    data = execute_graphql_query(query, variables, token)
-    if data is None:
-        bt.logging.warning(f'Failed to fetch file contents for {repo_owner}/{repo_name}')
-        return {path: None for path in file_paths}
+        data = execute_graphql_query(query, variables, token)
+        if data is None:
+            bt.logging.warning(f'Failed to fetch file contents for {repo_owner}/{repo_name}')
+            for path in batch_paths:
+                results[path] = None
+            continue
 
-    if 'errors' in data:
-        bt.logging.warning(f'GraphQL errors fetching files: {data["errors"]}')
+        if 'errors' in data:
+            bt.logging.warning(f'GraphQL errors fetching files: {data["errors"]}')
 
-    repo_data = data.get('data', {}).get('repository', {})
-    results = {}
+        repo_data = data.get('data', {}).get('repository', {})
 
-    for i, path in enumerate(file_paths):
-        file_data = repo_data.get(f'file{i}')
+        for i, path in enumerate(batch_paths):
+            file_data = repo_data.get(f'file{i}')
 
-        if file_data is None:
-            results[path] = None
-        elif file_data.get('isBinary'):
-            results[path] = None
-        elif file_data.get('byteSize', 0) > MAX_FILE_SIZE_BYTES:
-            results[path] = None
-        else:
-            results[path] = file_data.get('text')
+            if file_data is None:
+                results[path] = None
+            elif file_data.get('isBinary'):
+                results[path] = None
+            elif file_data.get('byteSize', 0) > MAX_FILE_SIZE_BYTES:
+                results[path] = None
+            else:
+                results[path] = file_data.get('text')
 
     return results
 
@@ -1058,6 +1087,78 @@ class FileContentPair:
     new_content: Optional[str]  # None for deleted files
 
 
+def _fetch_file_contents_with_base_batch(
+    repo_owner: str,
+    repo_name: str,
+    base_sha: str,
+    head_sha: str,
+    file_changes: List['FileChangeType'],
+    token: str,
+) -> Dict[str, FileContentPair]:
+    """Fetch base and head file contents for a single batch of file changes.
+
+    Internal helper called by fetch_file_contents_with_base for each batch.
+    """
+    file_fields = []
+    for i, fc in enumerate(file_changes):
+        base_path = fc.previous_filename if fc.previous_filename else fc.filename
+        head_path = fc.filename
+
+        if fc.status != 'added':
+            base_expr = _escape_graphql_expression(f'{base_sha}:{base_path}')
+            file_fields.append(
+                f'base{i}: object(expression: "{base_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+            )
+
+        if fc.status != 'removed':
+            head_expr = _escape_graphql_expression(f'{head_sha}:{head_path}')
+            file_fields.append(
+                f'head{i}: object(expression: "{head_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+            )
+
+    if not file_fields:
+        return {}
+
+    query = f"""
+        query($owner: String!, $name: String!) {{
+            repository(owner: $owner, name: $name) {{
+                {' '.join(file_fields)}
+            }}
+        }}
+    """
+
+    variables = {'owner': repo_owner, 'name': repo_name}
+
+    data = execute_graphql_query(query, variables, token)
+    if data is None:
+        bt.logging.warning(f'Failed to fetch file contents for {repo_owner}/{repo_name}')
+        return {fc.filename: FileContentPair(None, None) for fc in file_changes}
+
+    if 'errors' in data:
+        bt.logging.warning(f'GraphQL errors fetching files: {data["errors"]}')
+
+    repo_data = data.get('data', {}).get('repository', {})
+    results: Dict[str, FileContentPair] = {}
+
+    for i, fc in enumerate(file_changes):
+        old_content = None
+        new_content = None
+
+        if fc.status != 'added':
+            base_data = repo_data.get(f'base{i}')
+            if base_data and not base_data.get('isBinary') and base_data.get('byteSize', 0) <= MAX_FILE_SIZE_BYTES:
+                old_content = base_data.get('text')
+
+        if fc.status != 'removed':
+            head_data = repo_data.get(f'head{i}')
+            if head_data and not head_data.get('isBinary') and head_data.get('byteSize', 0) <= MAX_FILE_SIZE_BYTES:
+                new_content = head_data.get('text')
+
+        results[fc.filename] = FileContentPair(old_content=old_content, new_content=new_content)
+
+    return results
+
+
 def fetch_file_contents_with_base(
     repo_owner: str,
     repo_name: str,
@@ -1067,7 +1168,11 @@ def fetch_file_contents_with_base(
     token: str,
 ) -> Dict[str, FileContentPair]:
     """
-    Fetch both base and head (old and new) versions of files in a single GraphQL request.
+    Fetch both base and head (old and new) versions of files via batched GraphQL requests.
+
+    Large PRs are split into batches to avoid exceeding GitHub's GraphQL query
+    complexity limits. File paths are escaped to prevent query syntax errors
+    from special characters.
 
     Args:
         repo_owner: Repository owner
@@ -1086,69 +1191,13 @@ def fetch_file_contents_with_base(
     if not file_changes:
         return {}
 
-    # Build GraphQL query with both base and head versions
-    file_fields = []
-    for i, fc in enumerate(file_changes):
-        # Determine the path to fetch for base version
-        # For renames, use previous_filename; otherwise use current filename
-        base_path = fc.previous_filename if fc.previous_filename else fc.filename
-        head_path = fc.filename
-
-        # Only fetch base version if file wasn't newly added
-        if fc.status != 'added':
-            base_expr = f'{base_sha}:{base_path}'
-            file_fields.append(
-                f'base{i}: object(expression: "{base_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
-            )
-
-        # Only fetch head version if file wasn't deleted
-        if fc.status != 'removed':
-            head_expr = f'{head_sha}:{head_path}'
-            file_fields.append(
-                f'head{i}: object(expression: "{head_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
-            )
-
-    if not file_fields:
-        return {}
-
-    query = f"""
-        query($owner: String!, $name: String!) {{
-            repository(owner: $owner, name: $name) {{
-                {' '.join(file_fields)}
-            }}
-        }}
-    """
-
-    variables = {'owner': repo_owner, 'name': repo_name}
-
-    # Execute with retry logic
-    data = execute_graphql_query(query, variables, token)
-    if data is None:
-        bt.logging.warning(f'Failed to fetch file contents for {repo_owner}/{repo_name}')
-        return {fc.filename: FileContentPair(None, None) for fc in file_changes}
-
-    if 'errors' in data:
-        bt.logging.warning(f'GraphQL errors fetching files: {data["errors"]}')
-
-    repo_data = data.get('data', {}).get('repository', {})
     results: Dict[str, FileContentPair] = {}
 
-    for i, fc in enumerate(file_changes):
-        old_content = None
-        new_content = None
-
-        # Extract base (old) content if applicable
-        if fc.status != 'added':
-            base_data = repo_data.get(f'base{i}')
-            if base_data and not base_data.get('isBinary') and base_data.get('byteSize', 0) <= MAX_FILE_SIZE_BYTES:
-                old_content = base_data.get('text')
-
-        # Extract head (new) content if applicable
-        if fc.status != 'removed':
-            head_data = repo_data.get(f'head{i}')
-            if head_data and not head_data.get('isBinary') and head_data.get('byteSize', 0) <= MAX_FILE_SIZE_BYTES:
-                new_content = head_data.get('text')
-
-        results[fc.filename] = FileContentPair(old_content=old_content, new_content=new_content)
+    for batch_start in range(0, len(file_changes), _MAX_FILES_PER_GRAPHQL_BATCH):
+        batch = file_changes[batch_start : batch_start + _MAX_FILES_PER_GRAPHQL_BATCH]
+        batch_results = _fetch_file_contents_with_base_batch(
+            repo_owner, repo_name, base_sha, head_sha, batch, token
+        )
+        results.update(batch_results)
 
     return results

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -914,6 +914,232 @@ def _make_graphql_response(pr_nodes):
     return mock_response
 
 
+_escape_graphql_expression = github_api_tools._escape_graphql_expression
+_MAX_FILES_PER_GRAPHQL_BATCH = github_api_tools._MAX_FILES_PER_GRAPHQL_BATCH
+fetch_file_contents_batch = github_api_tools.fetch_file_contents_batch
+fetch_file_contents_with_base = github_api_tools.fetch_file_contents_with_base
+FileContentPair = github_api_tools.FileContentPair
+
+
+# ============================================================================
+# GraphQL Expression Escaping Tests
+# ============================================================================
+
+
+class TestEscapeGraphQLExpression:
+    """Tests for _escape_graphql_expression helper."""
+
+    def test_plain_path_unchanged(self):
+        """Normal file paths pass through unmodified."""
+        assert _escape_graphql_expression('abc123:src/main.py') == 'abc123:src/main.py'
+
+    def test_double_quotes_escaped(self):
+        """Double quotes in paths are escaped to prevent query breakage."""
+        assert _escape_graphql_expression('abc123:path/with"quote.py') == 'abc123:path/with\\"quote.py'
+
+    def test_backslash_escaped(self):
+        """Backslashes in paths are escaped."""
+        assert _escape_graphql_expression('abc123:path\\file.py') == 'abc123:path\\\\file.py'
+
+    def test_both_quote_and_backslash(self):
+        """Paths with both special characters are fully escaped."""
+        result = _escape_graphql_expression('abc123:dir\\"file.py')
+        assert result == 'abc123:dir\\\\\\"file.py'
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        assert _escape_graphql_expression('') == ''
+
+
+# ============================================================================
+# File Contents Batch Tests
+# ============================================================================
+
+
+class TestFetchFileContentsBatch:
+    """Tests for fetch_file_contents_batch batching and escaping."""
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_empty_paths_returns_empty(self, mock_graphql):
+        """Empty file list returns empty dict without any API call."""
+        result = fetch_file_contents_batch('owner', 'repo', 'abc123', [], 'token')
+        assert result == {}
+        mock_graphql.assert_not_called()
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_small_batch_single_request(self, mock_graphql):
+        """Few files are fetched in a single GraphQL request."""
+        mock_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'file0': {'text': 'content_a', 'byteSize': 9, 'isBinary': False},
+                    'file1': {'text': 'content_b', 'byteSize': 9, 'isBinary': False},
+                }
+            }
+        }
+
+        result = fetch_file_contents_batch('owner', 'repo', 'abc123', ['a.py', 'b.py'], 'token')
+
+        assert mock_graphql.call_count == 1
+        assert result == {'a.py': 'content_a', 'b.py': 'content_b'}
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_large_batch_split_into_multiple_requests(self, mock_graphql):
+        """More files than _MAX_FILES_PER_GRAPHQL_BATCH triggers multiple requests."""
+        total_files = _MAX_FILES_PER_GRAPHQL_BATCH + 10
+        paths = [f'file_{i}.py' for i in range(total_files)]
+
+        def side_effect(query, variables, token):
+            # Count how many file aliases are in the query
+            count = query.count('... on Blob')
+            repo_data = {}
+            for i in range(count):
+                repo_data[f'file{i}'] = {'text': f'content', 'byteSize': 7, 'isBinary': False}
+            return {'data': {'repository': repo_data}}
+
+        mock_graphql.side_effect = side_effect
+
+        result = fetch_file_contents_batch('owner', 'repo', 'abc123', paths, 'token')
+
+        assert mock_graphql.call_count == 2, 'Should split into 2 batches'
+        assert len(result) == total_files
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_special_characters_in_path_escaped(self, mock_graphql):
+        """File paths with special characters are properly escaped in the query."""
+        mock_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'file0': {'text': 'ok', 'byteSize': 2, 'isBinary': False},
+                }
+            }
+        }
+
+        fetch_file_contents_batch('owner', 'repo', 'abc123', ['path/with"quote.py'], 'token')
+
+        query_arg = mock_graphql.call_args[0][0]
+        assert '\\"' in query_arg, 'Double quotes in path should be escaped in GraphQL query'
+        assert 'with"quote' not in query_arg, 'Unescaped double quote should not appear'
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_failed_batch_returns_none_for_affected_files(self, mock_graphql):
+        """Failed GraphQL request returns None for all files in that batch."""
+        mock_graphql.return_value = None
+
+        result = fetch_file_contents_batch('owner', 'repo', 'abc123', ['a.py', 'b.py'], 'token')
+
+        assert result == {'a.py': None, 'b.py': None}
+
+
+# ============================================================================
+# File Contents With Base Batch Tests
+# ============================================================================
+
+
+class TestFetchFileContentsWithBase:
+    """Tests for fetch_file_contents_with_base batching and escaping."""
+
+    @staticmethod
+    def _make_file_change(filename, status='modified', previous_filename=None):
+        """Create a mock FileChange object."""
+        fc = Mock()
+        fc.filename = filename
+        fc.status = status
+        fc.previous_filename = previous_filename
+        return fc
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_empty_file_changes_returns_empty(self, mock_graphql):
+        """Empty file changes returns empty dict."""
+        result = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', [], 'token')
+        assert result == {}
+        mock_graphql.assert_not_called()
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_escapes_special_characters_in_paths(self, mock_graphql):
+        """File paths with special characters are escaped in both base and head expressions."""
+        fc = self._make_file_change('path/with"quote.py')
+        mock_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'base0': {'text': 'old', 'byteSize': 3, 'isBinary': False},
+                    'head0': {'text': 'new', 'byteSize': 3, 'isBinary': False},
+                }
+            }
+        }
+
+        fetch_file_contents_with_base('owner', 'repo', 'base_sha', 'head_sha', [fc], 'token')
+
+        query_arg = mock_graphql.call_args[0][0]
+        assert 'with\\"quote' in query_arg, 'Double quotes should be escaped'
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_large_pr_batched(self, mock_graphql):
+        """PRs with many files are split into batches."""
+        total_files = _MAX_FILES_PER_GRAPHQL_BATCH + 5
+        file_changes = [self._make_file_change(f'file_{i}.py') for i in range(total_files)]
+
+        def side_effect(query, variables, token):
+            repo_data = {}
+            # Count base/head aliases in the query
+            for prefix in ('base', 'head'):
+                i = 0
+                while f'{prefix}{i}:' in query:
+                    repo_data[f'{prefix}{i}'] = {'text': 'content', 'byteSize': 7, 'isBinary': False}
+                    i += 1
+            return {'data': {'repository': repo_data}}
+
+        mock_graphql.side_effect = side_effect
+
+        result = fetch_file_contents_with_base(
+            'owner', 'repo', 'base_sha', 'head_sha', file_changes, 'token'
+        )
+
+        assert mock_graphql.call_count == 2, 'Should split into 2 batches'
+        assert len(result) == total_files
+        for fc in file_changes:
+            assert fc.filename in result
+            assert isinstance(result[fc.filename], FileContentPair)
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_added_file_no_base_fetch(self, mock_graphql):
+        """Added files should not fetch base content."""
+        fc = self._make_file_change('new_file.py', status='added')
+        mock_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'head0': {'text': 'new content', 'byteSize': 11, 'isBinary': False},
+                }
+            }
+        }
+
+        result = fetch_file_contents_with_base('owner', 'repo', 'base_sha', 'head_sha', [fc], 'token')
+
+        assert result['new_file.py'].old_content is None
+        assert result['new_file.py'].new_content == 'new content'
+        query_arg = mock_graphql.call_args[0][0]
+        assert 'base0' not in query_arg, 'Should not fetch base for added file'
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    def test_removed_file_no_head_fetch(self, mock_graphql):
+        """Removed files should not fetch head content."""
+        fc = self._make_file_change('deleted.py', status='removed')
+        mock_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'base0': {'text': 'old content', 'byteSize': 11, 'isBinary': False},
+                }
+            }
+        }
+
+        result = fetch_file_contents_with_base('owner', 'repo', 'base_sha', 'head_sha', [fc], 'token')
+
+        assert result['deleted.py'].old_content == 'old content'
+        assert result['deleted.py'].new_content is None
+        query_arg = mock_graphql.call_args[0][0]
+        assert 'head0' not in query_arg, 'Should not fetch head for removed file'
+
+
 class TestLoadMinersPrsErrorResilience:
     """Test that a single bad PR doesn't abort fetching for the entire miner."""
 


### PR DESCRIPTION
Fix two issues in the file content fetching functions used for token-based PR scoring:

1. **GraphQL injection from unescaped file paths**: File paths containing double quotes or backslashes are interpolated directly into GraphQL query strings, breaking query syntax and causing the entire file content fetch to fail silently. This means PRs touching files with special characters in their paths get scored as 0.
   - Add _escape_graphql_expression() helper that escapes \ and "
   - Apply escaping in both fetch_file_contents_batch and fetch_file_contents_with_base

2. **No batch-size limit for large PRs**: PRs with many files generate a single GraphQL query with one object lookup per file. GitHub's GraphQL API has query complexity limits, so large PRs can trigger 502 errors and lose all file contents for scoring.
   - Add _MAX_FILES_PER_GRAPHQL_BATCH = 50 constant
   - Split both fetch functions into batched requests
   - Extract _fetch_file_contents_with_base_batch() as internal helper

Tests added for escaping correctness, batch splitting behavior, special character handling, and edge cases (empty input, added/removed files, failed batches).

## Summary

<!-- Brief description of the changes -->

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [ ] Manually tested

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Changes are documented (if applicable)
