### PR TITLE
fix: clean up stale miner data when hotkey re-links to new GitHub account

### DIFF
--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -16,6 +16,29 @@ WHERE github_id = %s
   AND (uid != %s OR hotkey != %s)
 """
 
+# Reverse cleanup: Remove stale data when a (uid, hotkey) re-links to a new github_id
+CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY = """
+DELETE FROM miner_evaluations
+WHERE uid = %s AND hotkey = %s
+  AND github_id != %s
+  AND github_id != '0'
+  AND created_at <= %s
+"""
+
+CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY = """
+DELETE FROM miner_tier_stats
+WHERE uid = %s AND hotkey = %s
+  AND github_id != %s
+  AND github_id != '0'
+"""
+
+CLEANUP_STALE_MINERS_BY_HOTKEY = """
+DELETE FROM miners
+WHERE uid = %s AND hotkey = %s
+  AND github_id != %s
+  AND github_id != '0'
+"""
+
 # Miner Queries
 SET_MINER = """
 INSERT INTO miners (uid, hotkey, github_id)

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -20,7 +20,10 @@ from .queries import (
     BULK_UPSERT_MINER_EVALUATION,
     BULK_UPSERT_PULL_REQUESTS,
     CLEANUP_STALE_MINER_EVALUATIONS,
+    CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY,
+    CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY,
     CLEANUP_STALE_MINERS,
+    CLEANUP_STALE_MINERS_BY_HOTKEY,
     SET_MINER,
 )
 
@@ -123,8 +126,16 @@ class Repository(BaseRepository):
         params = (evaluation.github_id, evaluation.uid, evaluation.hotkey)
         eval_params = params + (evaluation.evaluation_timestamp,)
 
+        # Clean up when same github_id re-registers on a new uid/hotkey
         self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS, eval_params)
         self.execute_command(CLEANUP_STALE_MINERS, params)
+
+        # Clean up when same (uid, hotkey) re-links to a new github_id
+        reverse_params = (evaluation.uid, evaluation.hotkey, evaluation.github_id)
+        reverse_eval_params = reverse_params + (evaluation.evaluation_timestamp,)
+        self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY, reverse_eval_params)
+        self.execute_command(CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY, reverse_params)
+        self.execute_command(CLEANUP_STALE_MINERS_BY_HOTKEY, reverse_params)
 
     def store_pull_requests_bulk(self, pull_requests: List[PullRequest]) -> int:
         """


### PR DESCRIPTION
## Summary
- Existing cleanup only handled one direction: same `github_id` re-registering on a new `(uid, hotkey)`
- Missing the reverse: same `(uid, hotkey)` linking to a new `github_id` — old GitHub's rows were never deleted
- This caused duplicate entries (e.g. [madelyngamble2](https://github.com/madelyngamble2)) showing stale data with same $/day but 0 score
- Added three reverse cleanup queries (`CLEANUP_STALE_*_BY_HOTKEY`) and call them in `cleanup_stale_miner_data()`

## Scenario
1. User registers [madelyngamble2](https://github.com/madelyngamble2), links wallet, gets hotkey
2. User stops mining with [madelyngamble2](https://github.com/madelyngamble2)
3. User registers [spider-yamet](https://github.com/spider-yamet) with the same wallet/hotkey
4. Old entry for [madelyngamble2](https://github.com/madelyngamble2) is never cleaned up → duplicate in UI

Related https://github.com/entrius/gittensor-ui/pull/124
![spider-yamet](https://github.com/user-attachments/assets/db4896b9-ed8c-43f1-bcb2-7ee54af22709)
![madelyngamble2](https://github.com/user-attachments/assets/8f6a08a4-05a4-4388-a75e-1b6422b44c53)
