### PR TITLE
Improve CLI help output and shared option decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ target/
 **/*.rs.bk
 *.lock
 !uv.lock
+
+**/.venv/

--- a/gittensor/cli/issue_commands/__init__.py
+++ b/gittensor/cli/issue_commands/__init__.py
@@ -24,6 +24,7 @@ Command structure:
 import click
 
 from .admin import admin
+from .help import StyledGroup
 
 # Re-export helpers
 from .helpers import (
@@ -45,18 +46,9 @@ from .view import admin_info, issues_bounty_pool, issues_list, issues_pending_ha
 from .vote import vote
 
 
-@click.group(name='issues')
+@click.group(name='issues', cls=StyledGroup)
 def issues_group():
-    """Issue management commands.
-
-    \b
-    Commands:
-        list              List issues or view a specific issue
-        submissions       List open PR submissions for an issue
-        register          Register a new issue bounty
-        bounty-pool       View total bounty pool
-        pending-harvest   View pending emissions
-    """
+    """Manage issue bounties, submissions, and predictions."""
     pass
 
 

--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -27,6 +27,8 @@ from .helpers import (
     resolve_network,
     validate_issue_id,
     validate_ss58_address,
+    with_network_contract_options,
+    with_wallet_options,
 )
 
 
@@ -41,37 +43,8 @@ def admin():
 
 @admin.command('cancel-issue')
 @click.argument('issue_id', type=int)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address (uses config if empty)')
 def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Cancel an issue (owner only).
 
@@ -144,37 +117,8 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
 
 @admin.command('payout-issue')
 @click.argument('issue_id', type=int)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address (uses config if empty)')
 def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Manual payout fallback (owner only).
 
@@ -248,37 +192,8 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
 
 @admin.command('set-owner')
 @click.argument('new_owner', type=str)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address',
-)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address')
 def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Transfer contract ownership (owner only).
 
@@ -339,37 +254,8 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
 
 @admin.command('set-treasury')
 @click.argument('new_treasury', type=str)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address',
-)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address')
 def admin_set_treasury(
     new_treasury: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str
 ):
@@ -438,37 +324,8 @@ def admin_set_treasury(
 
 @admin.command('add-vali')
 @click.argument('hotkey', type=str)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address',
-)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address')
 def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Add a validator to the voting whitelist (owner only).
 
@@ -535,37 +392,8 @@ def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, 
 
 @admin.command('remove-vali')
 @click.argument('hotkey', type=str)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address',
-)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address')
 def admin_remove_validator(
     hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str
 ):

--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -16,6 +16,7 @@ Commands:
 import click
 from rich.panel import Panel
 
+from .help import StyledGroup
 from .helpers import (
     console,
     format_alpha,
@@ -29,21 +30,11 @@ from .helpers import (
 )
 
 
-@click.group(name='admin')
+@click.group(name='admin', cls=StyledGroup)
 def admin():
     """Owner-only administrative commands.
 
     These commands require the contract owner wallet.
-
-    \b
-    Commands:
-        info           View contract configuration
-        cancel-issue   Cancel an issue
-        payout-issue   Manual payout fallback
-        set-owner      Transfer ownership
-        set-treasury   Change treasury hotkey
-        add-vali       Add a validator to the whitelist
-        remove-vali    Remove a validator from the whitelist
     """
     pass
 
@@ -84,17 +75,16 @@ def admin():
 def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Cancel an issue (owner only).
 
-    Immediately cancels an issue without requiring validator consensus.
-    Bounty funds are returned to the alpha pool.
+    [dim]Immediately cancels an issue without validator consensus. Bounty funds are returned to the alpha pool.[/dim]
 
-    \b
-    Arguments:
+    [dim]Arguments:
         ISSUE_ID: On-chain issue ID to cancel
+    [/dim]
 
-    \b
-    Examples:
-        gitt admin cancel-issue 1
-        gitt a cancel-issue 5 --network test
+    [dim]Examples:
+        $ gitt admin cancel-issue 1
+        $ gitt a cancel-issue 5 --network test
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -188,17 +178,17 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
 def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Manual payout fallback (owner only).
 
-    Pays out a completed issue bounty to the solver. The solver address
-    is determined by validator consensus and stored in the contract.
+    [dim]Pays out a completed issue bounty to the solver.
+    The solver address is determined by validator consensus and stored in the contract.[/dim]
 
-    \b
-    Arguments:
+    [dim]Arguments:
         ISSUE_ID: On-chain ID of a completed issue
+    [/dim]
 
-    \b
-    Examples:
-        gitt admin payout-issue 1
-        gitt a payout-issue 3 --network test
+    [dim]Examples:
+        $ gitt admin payout-issue 1
+        $ gitt a payout-issue 3 --network test
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -292,13 +282,13 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
 def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Transfer contract ownership (owner only).
 
-    \b
-    Arguments:
+    [dim]Arguments:
         NEW_OWNER: SS58 address of the new owner
+    [/dim]
 
-    \b
-    Examples:
-        gitt admin set-owner 5Hxxx...
+    [dim]Examples:
+        $ gitt admin set-owner 5Hxxx...
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -385,17 +375,16 @@ def admin_set_treasury(
 ):
     """Change treasury hotkey (owner only).
 
-    The treasury hotkey receives staking emissions that fund bounty payouts.
-    Changing the treasury resets all Active/Registered issue bounty amounts
-    to 0 (they will be re-funded on next harvest from the new treasury).
+    [dim]The treasury hotkey receives staking emissions that fund bounty payouts. Changing the treasury resets all
+    Active/Registered issue bounty amounts to 0 (they will be re-funded on the next harvest from the new treasury).[/dim]
 
-    \b
-    Arguments:
+    [dim]Arguments:
         NEW_TREASURY: SS58 address of the new treasury hotkey
+    [/dim]
 
-    \b
-    Examples:
-        gitt admin set-treasury 5Hxxx...
+    [dim]Examples:
+        $ gitt admin set-treasury 5Hxxx...
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -483,17 +472,16 @@ def admin_set_treasury(
 def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
     """Add a validator to the voting whitelist (owner only).
 
-    Whitelisted validators can vote on solutions and issue cancellations.
-    The consensus threshold adjusts automatically: simple majority after
-    3 validators are added.
+    [dim]Whitelisted validators can vote on solutions and issue cancellations.
+    The consensus threshold adjusts automatically to a simple majority after 3 validators are added.[/dim]
 
-    \b
-    Arguments:
+    [dim]Arguments:
         HOTKEY: SS58 address of the validator hotkey to whitelist
+    [/dim]
 
-    \b
-    Examples:
-        gitt admin add-vali 5Hxxx...
+    [dim]Examples:
+        $ gitt admin add-vali 5Hxxx...
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -583,15 +571,15 @@ def admin_remove_validator(
 ):
     """Remove a validator from the voting whitelist (owner only).
 
-    The consensus threshold adjusts automatically after removal.
+    [dim]The consensus threshold adjusts automatically after removal.[/dim]
 
-    \b
-    Arguments:
+    [dim]Arguments:
         HOTKEY: SS58 address of the validator hotkey to remove
+    [/dim]
 
-    \b
-    Examples:
-        gitt admin remove-vali 5Hxxx...
+    [dim]Examples:
+        $ gitt admin remove-vali 5Hxxx...
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -21,7 +21,6 @@ from typing import Any, ContextManager, Dict, List, Optional, Tuple
 import click
 from rich.console import Console
 from rich.panel import Panel
-from substrateinterface import SubstrateInterface
 
 from gittensor.cli.issue_commands.tables import build_pr_table
 from gittensor.constants import CONTRACT_ADDRESS
@@ -195,6 +194,8 @@ def print_issue_submission_table(
 
 def resolve_netuid_from_contract(ws_endpoint: str, contract_addr: str) -> Optional[int]:
     """Read the subnet netuid stored in the on-chain contract."""
+    # Keep this import local so CLI help can render without optional chain deps installed.
+    from substrateinterface import SubstrateInterface
 
     substrate = SubstrateInterface(url=ws_endpoint)
     packed = _read_contract_packed_storage(substrate, contract_addr)

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -16,7 +16,7 @@ import urllib.request
 from contextlib import nullcontext
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, ContextManager, Dict, List, Optional, Tuple
+from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, TypeVar
 
 import click
 from rich.console import Console
@@ -49,6 +49,110 @@ GITTENSOR_DIR = Path.home() / '.gittensor'
 CONFIG_FILE = GITTENSOR_DIR / 'config.json'
 
 console = Console()
+
+CommandFunc = TypeVar('CommandFunc', bound=Callable[..., Any])
+NETWORK_CHOICE = click.Choice(['finney', 'test', 'local'], case_sensitive=False)
+
+
+def apply_click_options(*decorators: Callable[[CommandFunc], CommandFunc]) -> Callable[[CommandFunc], CommandFunc]:
+    """Apply Click decorators in the declared display order."""
+
+    def wrapper(func: CommandFunc) -> CommandFunc:
+        for decorator in reversed(decorators):
+            func = decorator(func)
+        return func
+
+    return wrapper
+
+
+def with_wallet_options(
+    wallet_default: str = 'default', hotkey_default: str = 'default'
+) -> Callable[[CommandFunc], CommandFunc]:
+    """Add the standard wallet name/hotkey options."""
+    return apply_click_options(
+        click.option(
+            '--wallet-name',
+            '--wallet.name',
+            '--wallet',
+            default=wallet_default,
+            help='Wallet name',
+        ),
+        click.option(
+            '--wallet-hotkey',
+            '--wallet.hotkey',
+            '--hotkey',
+            default=hotkey_default,
+            help='Hotkey name',
+        ),
+    )
+
+
+def with_network_contract_options(
+    contract_help: str,
+) -> Callable[[CommandFunc], CommandFunc]:
+    """Add the standard network / rpc / contract option bundle."""
+    return apply_click_options(
+        click.option(
+            '--network',
+            '-n',
+            default=None,
+            type=NETWORK_CHOICE,
+            help='Network (finney/test/local)',
+        ),
+        click.option(
+            '--rpc-url',
+            default=None,
+            help='Subtensor RPC endpoint (overrides --network)',
+        ),
+        click.option(
+            '--contract',
+            default='',
+            help=contract_help,
+        ),
+    )
+
+
+def with_cli_behavior_options(
+    *,
+    include_verbose: bool = False,
+    include_json: bool = False,
+    include_yes: bool = False,
+    verbose_help: str = 'Show debug output',
+    json_help: str = 'Output as JSON for scripting',
+    yes_help: str = 'Skip confirmation prompt (non-interactive/CI)',
+) -> Callable[[CommandFunc], CommandFunc]:
+    """Add common CLI behavior options such as verbose, JSON, and confirmation controls."""
+    decorators: list[Callable[[CommandFunc], CommandFunc]] = []
+
+    if include_verbose:
+        decorators.append(
+            click.option(
+                '--verbose',
+                '-v',
+                is_flag=True,
+                help=verbose_help,
+            )
+        )
+    if include_json:
+        decorators.append(
+            click.option(
+                '--json',
+                'as_json',
+                is_flag=True,
+                help=json_help,
+            )
+        )
+    if include_yes:
+        decorators.append(
+            click.option(
+                '--yes',
+                '-y',
+                is_flag=True,
+                help=yes_help,
+            )
+        )
+
+    return apply_click_options(*decorators)
 
 
 def format_alpha(raw_amount: int, decimals: int = 2) -> str:

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import click
 from rich.panel import Panel
 
+from .help import StyledCommand
 from .helpers import (
     MAX_ISSUE_NUMBER,
     _is_interactive,
@@ -31,7 +32,7 @@ from .helpers import (
 )
 
 
-@click.command('register')
+@click.command('register', cls=StyledCommand)
 @click.option(
     '--repo',
     required=True,
@@ -101,21 +102,20 @@ def issue_register(
     """
     Register a new issue with a bounty (OWNER ONLY).
 
-    This command registers a GitHub issue on the smart contract
-    with a target bounty amount. Only the contract owner can
-    register new issues.
+    [dim]This command registers a GitHub issue on the smart contract with a target bounty amount.
+    Only the contract owner can register new issues.[/dim]
 
-    \b
-    Arguments:
+    [dim]Arguments:
         --repo: Repository in owner/repo format
         --issue: GitHub issue number
         --bounty: Target bounty amount in ALPHA
+    [/dim]
 
-    \b
-    Examples:
-        gitt issues register --repo latent-to/btcli --issue 144 --bounty 100
-        gitt i reg --repo tensorflow/tensorflow --issue 12345 --bounty 50
-        gitt i reg --repo owner/repo --issue 1 --bounty 10 -y
+    [dim]Examples:
+        $ gitt issues register --repo latent-to/btcli --issue 144 --bounty 100
+        $ gitt i reg --repo tensorflow/tensorflow --issue 12345 --bounty 50
+        $ gitt i reg --repo owner/repo --issue 1 --bounty 10 -y
+    [/dim]
     """
     console.print('\n[bold cyan]Register Issue for Bounty[/bold cyan]\n')
 
@@ -256,7 +256,7 @@ def issue_register(
             print_error(f'Error registering issue: {e}')
 
 
-@click.command('harvest')
+@click.command('harvest', cls=StyledCommand)
 @click.option(
     '--wallet-name',
     '--wallet.name',
@@ -293,14 +293,14 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
     """
     Manually trigger emission harvest from contract treasury.
 
-    This command is permissionless - any wallet can trigger it.
-    The contract handles emission collection and distribution internally.
+    [dim]This command is permissionless - any wallet can trigger it.
+    The contract handles emission collection and distribution internally.[/dim]
 
-    \b
-    Examples:
-        gitt harvest
-        gitt harvest --verbose
-        gitt harvest --wallet-name mywallet --wallet-hotkey mykey
+    [dim]Examples:
+        $ gitt harvest
+        $ gitt harvest --verbose
+        $ gitt harvest --wallet-name mywallet --wallet-hotkey mykey
+    [/dim]
     """
     console.print('\n[bold cyan]Manual Emission Harvest[/bold cyan]\n')
 

--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -20,6 +20,8 @@ from .helpers import (
     print_warning,
     resolve_network,
     validate_issue_id,
+    with_cli_behavior_options,
+    with_network_contract_options,
 )
 
 
@@ -31,25 +33,8 @@ from .helpers import (
     type=int,
     help='On-chain issue ID',
 )
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses default if empty)',
-)
-@click.option('--verbose', '-v', is_flag=True, help='Show debug output')
-@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting')
+@with_cli_behavior_options(include_verbose=True, include_json=True)
+@with_network_contract_options('Contract address (uses default if empty)')
 def issues_submissions(
     issue_id: int,
     network: str | None,

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -31,6 +31,8 @@ from .helpers import (
     print_network_header,
     read_issues_from_contract,
     resolve_network,
+    with_cli_behavior_options,
+    with_network_contract_options,
 )
 
 
@@ -42,25 +44,12 @@ from .helpers import (
     type=int,
     help='View a specific issue by ID',
 )
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
+@with_cli_behavior_options(
+    include_verbose=True,
+    include_json=True,
+    verbose_help='Show debug output for contract reads',
 )
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses default if empty)',
-)
-@click.option('--verbose', '-v', is_flag=True, help='Show debug output for contract reads')
-@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting')
+@with_network_contract_options('Contract address (uses default if empty)')
 def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """List issues or view a specific issue.
 
@@ -189,25 +178,8 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
 
 
 @click.command('bounty-pool', cls=StyledCommand)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
-@click.option('--verbose', '-v', is_flag=True, help='Show debug output')
-@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting')
+@with_cli_behavior_options(include_verbose=True, include_json=True)
+@with_network_contract_options('Contract address (uses config if empty)')
 def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """View total bounty pool (sum of all issue bounty amounts).
 
@@ -256,25 +228,8 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
 
 
 @click.command('pending-harvest', cls=StyledCommand)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
-@click.option('--verbose', '-v', is_flag=True, help='Show debug output')
-@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting')
+@with_cli_behavior_options(include_verbose=True, include_json=True)
+@with_network_contract_options('Contract address (uses config if empty)')
 def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """View pending harvest (treasury stake minus allocated bounties).
 
@@ -340,25 +295,8 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
 
 
 @click.command('info', cls=StyledCommand)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
-@click.option('--verbose', '-v', is_flag=True, help='Show debug output')
-@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting')
+@with_cli_behavior_options(include_verbose=True, include_json=True)
+@with_network_contract_options('Contract address (uses config if empty)')
 def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """View contract configuration.
 

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -18,6 +18,7 @@ import click
 from rich.panel import Panel
 from rich.table import Table
 
+from .help import StyledCommand
 from .helpers import (
     _read_contract_packed_storage,
     _read_issues_from_child_storage,
@@ -33,7 +34,7 @@ from .helpers import (
 )
 
 
-@click.command('list')
+@click.command('list', cls=StyledCommand)
 @click.option(
     '--id',
     'issue_id',
@@ -63,12 +64,12 @@ from .helpers import (
 def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """List issues or view a specific issue.
 
-    \b
-    Examples:
-        gitt issues list
-        gitt i list --network test
-        gitt i list --id 1
-        gitt i list --json
+    [dim]Examples:
+        $ gitt issues list
+        $ gitt i list --network test
+        $ gitt i list --id 1
+        $ gitt i list --json
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -187,7 +188,7 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
         console.print('[dim]Register an issue: gitt issues register --repo owner/repo --issue 1 --bounty 100[/dim]')
 
 
-@click.command('bounty-pool')
+@click.command('bounty-pool', cls=StyledCommand)
 @click.option(
     '--network',
     '-n',
@@ -210,10 +211,10 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
 def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """View total bounty pool (sum of all issue bounty amounts).
 
-    \b
-    Examples:
-        gitt issues bounty-pool
-        gitt i bounty-pool --json
+    [dim]Examples:
+        $ gitt issues bounty-pool
+        $ gitt i bounty-pool --json
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -254,7 +255,7 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         print_error(str(e))
 
 
-@click.command('pending-harvest')
+@click.command('pending-harvest', cls=StyledCommand)
 @click.option(
     '--network',
     '-n',
@@ -277,10 +278,10 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
 def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """View pending harvest (treasury stake minus allocated bounties).
 
-    \b
-    Examples:
-        gitt issues pending-harvest
-        gitt i pending-harvest --json
+    [dim]Examples:
+        $ gitt issues pending-harvest
+        $ gitt i pending-harvest --json
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -338,7 +339,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         print_error(str(e))
 
 
-@click.command('info')
+@click.command('info', cls=StyledCommand)
 @click.option(
     '--network',
     '-n',
@@ -361,10 +362,10 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
 def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
     """View contract configuration.
 
-    \b
-    Examples:
-        gitt admin info
-        gitt a info --json
+    [dim]Examples:
+        $ gitt admin info
+        $ gitt a info --json
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -17,6 +17,7 @@ import click
 from rich.panel import Panel
 from rich.table import Table
 
+from .help import StyledGroup
 from .helpers import (
     console,
     get_contract_address,
@@ -56,17 +57,11 @@ def parse_pr_number(pr_input: str) -> int:
     raise ValueError(f'Cannot parse PR number from: {pr_input}')
 
 
-@click.group(name='vote')
+@click.group(name='vote', cls=StyledGroup)
 def vote():
     """Validator consensus operations.
 
     These commands are used by validators to manage issue bounty payouts.
-
-    \b
-    Commands:
-        solution   Vote for a solver on an active issue
-        cancel     Vote to cancel an issue
-        list       List whitelisted validators
     """
     pass
 
@@ -120,17 +115,17 @@ def val_vote_solution(
 ):
     """Vote for a solution on an active issue (triggers auto-payout on consensus).
 
-    \b
-    Arguments:
+    [dim]Arguments:
         ISSUE_ID: On-chain issue ID to vote on
         SOLVER_HOTKEY: SS58 address of the solver's hotkey
         SOLVER_COLDKEY: SS58 address of the solver's coldkey (payout destination)
         PR_NUMBER_OR_URL: PR number or full GitHub PR URL
+    [/dim]
 
-    \b
-    Examples:
-        gitt vote solution 1 5Hxxx... 5Hyyy... 123
-        gitt vote solution 1 5Hxxx... 5Hyyy... https://github.com/.../pull/123
+    [dim]Examples:
+        $ gitt vote solution 1 5Hxxx... 5Hyyy... 123
+        $ gitt vote solution 1 5Hxxx... 5Hyyy... https://github.com/.../pull/123
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -237,15 +232,15 @@ def val_vote_cancel_issue(
 ):
     """Vote to cancel an issue (works on Registered or Active).
 
-    \b
-    Arguments:
+    [dim]Arguments:
         ISSUE_ID: On-chain issue ID to cancel
         REASON: Reason for cancellation
+    [/dim]
 
-    \b
-    Examples:
-        gitt vote cancel 1 "External solution found"
-        gitt vote cancel 42 "Issue invalid"
+    [dim]Examples:
+        $ gitt vote cancel 1 "External solution found"
+        $ gitt vote cancel 42 "Issue invalid"
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
@@ -316,11 +311,11 @@ def val_vote_cancel_issue(
 def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: bool):
     """List whitelisted validators and consensus threshold.
 
-    \b
-    Examples:
-        gitt vote list
-        gitt vote list --network test
-        gitt vote list --json
+    [dim]Examples:
+        $ gitt vote list
+        $ gitt vote list --network test
+        $ gitt vote list --json
+    [/dim]
     """
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -27,6 +27,9 @@ from .helpers import (
     resolve_network,
     validate_issue_id,
     validate_ss58_address,
+    with_cli_behavior_options,
+    with_network_contract_options,
+    with_wallet_options,
 )
 
 
@@ -71,37 +74,8 @@ def vote():
 @click.argument('solver_hotkey', type=str)
 @click.argument('solver_coldkey', type=str)
 @click.argument('pr_number_or_url', type=str)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address (uses config if empty)')
 def val_vote_solution(
     issue_id: int,
     solver_hotkey: str,
@@ -190,37 +164,8 @@ def val_vote_solution(
 @vote.command('cancel')
 @click.argument('issue_id', type=int)
 @click.argument('reason', type=str)
-@click.option(
-    '--wallet-name',
-    '--wallet.name',
-    '--wallet',
-    default='default',
-    help='Wallet name',
-)
-@click.option(
-    '--wallet-hotkey',
-    '--wallet.hotkey',
-    '--hotkey',
-    default='default',
-    help='Hotkey name',
-)
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
+@with_wallet_options()
+@with_network_contract_options('Contract address (uses config if empty)')
 def val_vote_cancel_issue(
     issue_id: int,
     reason: str,
@@ -290,24 +235,8 @@ def val_vote_cancel_issue(
 
 
 @vote.command('list')
-@click.option(
-    '--network',
-    '-n',
-    default=None,
-    type=click.Choice(['finney', 'test', 'local'], case_sensitive=False),
-    help='Network (finney/test/local)',
-)
-@click.option(
-    '--rpc-url',
-    default=None,
-    help='Subtensor RPC endpoint (overrides --network)',
-)
-@click.option(
-    '--contract',
-    default='',
-    help='Contract address (uses config if empty)',
-)
-@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting')
+@with_cli_behavior_options(include_json=True)
+@with_network_contract_options('Contract address (uses config if empty)')
 def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: bool):
     """List whitelisted validators and consensus threshold.
 

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -19,6 +19,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands import register_commands
 
 console = Console()
@@ -28,64 +29,17 @@ GITTENSOR_DIR = Path.home() / '.gittensor'
 CONFIG_FILE = GITTENSOR_DIR / 'config.json'
 
 
-class AliasGroup(click.Group):
-    """Click Group that supports command aliases without duplicate help entries."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._aliases = {}  # alias -> canonical name
-
-    def add_alias(self, name, alias):
-        """Register an alias for an existing command."""
-        self._aliases[alias] = name
-
-    def get_command(self, ctx, cmd_name):
-        # Resolve alias to canonical name
-        canonical = self._aliases.get(cmd_name, cmd_name)
-        return super().get_command(ctx, canonical)
-
-    def format_commands(self, ctx, formatter):
-        """Write the help text, appending aliases to command descriptions."""
-        # Build reverse map: canonical -> list of aliases
-        alias_map = {}
-        for alias, canonical in self._aliases.items():
-            alias_map.setdefault(canonical, []).append(alias)
-
-        commands = []
-        for subcommand in self.list_commands(ctx):
-            cmd = self.commands.get(subcommand)
-            if cmd is None or cmd.hidden:
-                continue
-            help_text = cmd.get_short_help_str(limit=150)
-            aliases = alias_map.get(subcommand)
-            if aliases:
-                alias_str = ', '.join(sorted(aliases))
-                subcommand = f'{subcommand}, {alias_str}'
-            commands.append((subcommand, help_text))
-
-        if commands:
-            with formatter.section('Commands'):
-                formatter.write_dl(commands)
-
-
-@click.group(cls=AliasGroup)
+@click.group(cls=StyledAliasGroup)
 @click.version_option(version='3.2.0', prog_name='gittensor')
 def cli():
     """Gittensor CLI - Manage issue bounties and validator operations"""
     pass
 
 
-@click.group(name='config', invoke_without_command=True)
+@click.group(name='config', cls=StyledGroup, invoke_without_command=True)
 @click.pass_context
 def config_group(ctx):
-    """CLI configuration management.
-
-    Show current configuration (default) or set config values.
-
-    \b
-    Subcommands:
-        set <key> <value>    Set a config value
-    """
+    """Show current configuration (default) or set configuration values."""
     # If no subcommand, show config
     if ctx.invoked_subcommand is None:
         show_config()
@@ -129,19 +83,21 @@ def show_config():
 def config_set(key: str, value: str):
     """Set a configuration value.
 
-    \b
-    Common keys:
+    [dim]Use this command to override values stored in `~/.gittensor/config.json`.[/dim]
+
+    [dim]Common keys:
         wallet              Wallet name
         hotkey              Hotkey name
         contract_address    Contract address
         ws_endpoint         WebSocket endpoint
         network             Network (local, test, finney)
+    [/dim]
 
-    \b
-    Examples:
-        gitt config set wallet alice
-        gitt config set contract_address 5Cxxx...
-        gitt config set network local
+    [dim]Examples:
+        $ gitt config set wallet alice
+        $ gitt config set contract_address 5Cxxx...
+        $ gitt config set network local
+    [/dim]
     """
     # Ensure config directory exists
     GITTENSOR_DIR.mkdir(parents=True, exist_ok=True)

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -19,8 +19,8 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands import register_commands
+from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 
 console = Console()
 

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -113,3 +113,16 @@ def test_submissions_human_no_open_prs_message(cli_root, runner, sample_issue):
 
     assert result.exit_code == 0
     assert 'No open submissions available' in result.output
+
+
+def test_submissions_help_via_issue_alias_routes_to_command_help(cli_root, runner):
+    result = runner.invoke(
+        cli_root,
+        ['i', 'submissions', '--help'],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert 'On-chain issue ID' in result.output
+    assert '--id' in result.output
+    assert '--logging.debug' not in result.output


### PR DESCRIPTION
## Summary
Fix CLI help output, improve help presentation, and clean up shared command option handling.

## Done
### Fix broken CLI help output
**Root cause**: optional miner and chain runtime dependencies were imported on the help path.

**Solution**: move optional imports to execution paths so help rendering does not require runtime-only dependencies.

**Screenshots**:
- Before
<img width="1847" height="580" alt="image" src="https://github.com/user-attachments/assets/ccb56fe6-ab9b-4d82-8a8f-5f1f747b7e06" />


- After
<img width="1201" height="633" alt="image" src="https://github.com/user-attachments/assets/be45be5a-2b0f-4bd4-9f3e-643b2f26b647" />


### Improve CLI help presentation

Aligned all command help output with the BTCLI-style, production-grade format.

**Screenshots**:
<img width="1218" height="1202" alt="image" src="https://github.com/user-attachments/assets/109b7538-3fcc-40b2-b0e6-23070f7eae80" />

<img width="1246" height="882" alt="image" src="https://github.com/user-attachments/assets/75b3a202-5537-4aa4-a324-142ce2bc8a3a" />

<img width="1245" height="736" alt="image" src="https://github.com/user-attachments/assets/a219ec03-3f6f-4901-8d74-7918d55c4cd1" />

<img width="1218" height="850" alt="image" src="https://github.com/user-attachments/assets/ac6bcfc2-c03b-4d7f-aa88-a6b036f75efa" />

<img width="1256" height="871" alt="image" src="https://github.com/user-attachments/assets/8c037d2d-3e6a-44e4-b4bd-2a7d3ddd5f28" />

...

### Clean up shared command option handling

Extracted shared Click option bundles to reduce repetition and keep command definitions easier to read.

## Tests
```bash
uv run pytest -q tests/utils
# 53 passed in 1.09s
```