### PR TITLE
fix: use merge-base for tree-diff scoring to avoid inflated token scores

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -240,6 +240,62 @@ def get_github_account_age_days(token: str) -> Optional[int]:
         return None
 
 
+def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str) -> Optional[str]:
+    """
+    Get the merge-base commit SHA between two refs using GitHub's compare API.
+
+    The merge-base is the common ancestor commit — the correct "before" state
+    for computing a PR's own changes via tree-diff scoring.
+
+    Args:
+        repository: Repository in format 'owner/repo'
+        base_sha: Base branch ref OID
+        head_sha: Head branch ref OID
+        token: GitHub PAT
+
+    Returns:
+        Merge-base commit SHA, or None if the request fails
+    """
+    headers = make_headers(token)
+    max_attempts = 3
+
+    for attempt in range(max_attempts):
+        try:
+            response = requests.get(
+                f'{BASE_GITHUB_API_URL}/repos/{repository}/compare/{base_sha}...{head_sha}',
+                headers=headers,
+                timeout=15,
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                merge_base = (data.get('merge_base_commit') or {}).get('sha')
+                if merge_base:
+                    return merge_base
+                bt.logging.warning(f'Compare API returned 200 but no merge_base_commit for {repository}')
+                return None
+
+            if attempt < max_attempts - 1:
+                backoff_delay = min(5 * (2 ** (attempt)), 30)
+                bt.logging.warning(
+                    f'Compare API for {repository} failed with status {response.status_code} '
+                    f'(attempt {attempt + 1}/{max_attempts}), retrying in {backoff_delay}s...'
+                )
+                time.sleep(backoff_delay)
+
+        except requests.exceptions.RequestException as e:
+            if attempt < max_attempts - 1:
+                backoff_delay = min(5 * (2 ** (attempt)), 30)
+                bt.logging.warning(
+                    f'Compare API error for {repository} (attempt {attempt + 1}/{max_attempts}): {e}, '
+                    f'retrying in {backoff_delay}s...'
+                )
+                time.sleep(backoff_delay)
+
+    bt.logging.warning(f'Compare API for {repository} failed after {max_attempts} attempts. Will use base_ref_oid.')
+    return None
+
+
 def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -> Optional[List[FileChange]]:
     """
     Get the diff for a specific PR by repository name and PR number.

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -38,6 +38,7 @@ from gittensor.constants import (
 from gittensor.utils.github_api_tools import (
     FileContentPair,
     fetch_file_contents_with_base,
+    get_merge_base_sha,
     get_pull_request_file_changes,
     get_pull_request_maintainer_changes_requested_count,
 )
@@ -114,7 +115,16 @@ def score_pull_request(
 
 
 def fetch_file_contents_for_pr(pr: PullRequest, github_pat: str) -> Dict[str, FileContentPair]:
-    """Fetch both base and head file contents for all files in a PR using GraphQL batch fetch."""
+    """Fetch both base and head file contents for all files in a PR using GraphQL batch fetch.
+
+    Uses the merge-base commit (common ancestor) as the "before" state rather than
+    the base branch tip, so the tree-diff only scores the PR's own changes.
+
+    Returns:
+        Dict mapping filename to FileContentPair(old_content, new_content)
+        - old_content: File content before the PR (None for new files)
+        - new_content: File content after the PR (None for deleted files)
+    """
     if not pr.file_changes or not pr.head_ref_oid or not pr.base_ref_oid:
         return {}
 
@@ -125,9 +135,16 @@ def fetch_file_contents_for_pr(pr: PullRequest, github_pat: str) -> Dict[str, Fi
 
     owner, repo_name = parts
 
-    return fetch_file_contents_with_base(
-        owner, repo_name, pr.base_ref_oid, pr.head_ref_oid, pr.file_changes, github_pat
-    )
+    # Resolve merge-base to avoid scoring unrelated changes from the base branch.
+    # baseRefOid is the base branch tip, which may include commits not in this PR.
+    merge_base = get_merge_base_sha(pr.repository_full_name, pr.base_ref_oid, pr.head_ref_oid, github_pat)
+    base_sha = merge_base if merge_base else pr.base_ref_oid
+    if merge_base and merge_base != pr.base_ref_oid:
+        bt.logging.debug(
+            f'PR #{pr.number}: using merge-base {merge_base[:8]} instead of base_ref {pr.base_ref_oid[:8]}'
+        )
+
+    return fetch_file_contents_with_base(owner, repo_name, base_sha, pr.head_ref_oid, pr.file_changes, github_pat)
 
 
 def calculate_base_score(

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -30,6 +30,7 @@ get_github_graphql_query = github_api_tools.get_github_graphql_query
 get_github_id = github_api_tools.get_github_id
 get_github_account_age_days = github_api_tools.get_github_account_age_days
 get_pull_request_file_changes = github_api_tools.get_pull_request_file_changes
+get_merge_base_sha = github_api_tools.get_merge_base_sha
 find_prs_for_issue = github_api_tools.find_prs_for_issue
 execute_graphql_query = github_api_tools.execute_graphql_query
 
@@ -1448,6 +1449,199 @@ class TestFetchFileContentsWithBase:
         query_arg = mock_execute.call_args[0][0]
         assert 'base_sha:old_name.py' in query_arg
         assert 'head_sha:new_name.py' in query_arg
+
+
+# ============================================================================
+# Merge Base SHA Tests
+# ============================================================================
+
+
+class TestGetMergeBaseSha:
+    """Test suite for get_merge_base_sha using GitHub compare API."""
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    def test_returns_merge_base_sha_on_success(self, mock_get):
+        """Successful compare API call returns the merge_base_commit SHA."""
+        mock_response = Mock(status_code=200)
+        mock_response.json.return_value = {
+            'merge_base_commit': {'sha': 'abc123merge'},
+        }
+        mock_get.return_value = mock_response
+
+        result = get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token')
+
+        assert result == 'abc123merge'
+        assert mock_get.call_count == 1
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_retries_on_failure_then_succeeds(self, mock_logging, mock_sleep, mock_get):
+        """Retries on HTTP error and succeeds on second attempt."""
+        mock_500 = Mock(status_code=500, text='Internal Server Error')
+        mock_200 = Mock(status_code=200)
+        mock_200.json.return_value = {'merge_base_commit': {'sha': 'abc123merge'}}
+
+        mock_get.side_effect = [mock_500, mock_200]
+
+        result = get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token')
+
+        assert result == 'abc123merge'
+        assert mock_get.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_returns_none_after_all_attempts_fail(self, mock_logging, mock_sleep, mock_get):
+        """Returns None after 3 failed attempts."""
+        mock_500 = Mock(status_code=500, text='Internal Server Error')
+        mock_get.return_value = mock_500
+
+        result = get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token')
+
+        assert result is None
+        assert mock_get.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_returns_none_when_merge_base_commit_missing(self, mock_logging, mock_get):
+        """Returns None when response lacks merge_base_commit field."""
+        mock_response = Mock(status_code=200)
+        mock_response.json.return_value = {'status': 'ahead'}
+        mock_get.return_value = mock_response
+
+        result = get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token')
+
+        assert result is None
+        mock_logging.warning.assert_called()
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_retries_on_connection_error(self, mock_logging, mock_sleep, mock_get):
+        """Retries on connection errors and succeeds."""
+        import requests
+
+        mock_200 = Mock(status_code=200)
+        mock_200.json.return_value = {'merge_base_commit': {'sha': 'abc123merge'}}
+        mock_get.side_effect = [requests.exceptions.ConnectionError('refused'), mock_200]
+
+        result = get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token')
+
+        assert result == 'abc123merge'
+        assert mock_get.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_returns_none_after_all_connection_errors(self, mock_logging, mock_sleep, mock_get):
+        """Returns None after 3 connection errors."""
+        import requests
+
+        mock_get.side_effect = requests.exceptions.ConnectionError('refused')
+
+        result = get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token')
+
+        assert result is None
+        assert mock_get.call_count == 3
+
+
+# ============================================================================
+# fetch_file_contents_for_pr Merge Base Integration Tests
+# ============================================================================
+
+
+class TestFetchFileContentsForPrMergeBase:
+    """Test that fetch_file_contents_for_pr resolves merge-base instead of using base_ref_oid directly."""
+
+    @patch('gittensor.validator.oss_contributions.scoring.fetch_file_contents_with_base')
+    @patch('gittensor.validator.oss_contributions.scoring.get_merge_base_sha')
+    def test_uses_merge_base_when_available(self, mock_merge_base, mock_fetch):
+        """When merge-base resolves successfully, it should be used instead of base_ref_oid."""
+        from gittensor.classes import FileChange, PRState, PullRequest
+        from gittensor.validator.oss_contributions.scoring import fetch_file_contents_for_pr
+
+        mock_merge_base.return_value = 'merge_base_sha_123'
+        mock_fetch.return_value = {}
+
+        pr = PullRequest(
+            number=1,
+            repository_full_name='owner/repo',
+            uid=0,
+            hotkey='hk',
+            github_id='1',
+            title='test',
+            author_login='user',
+            merged_at=None,
+            created_at=__import__('datetime').datetime.now(__import__('datetime').timezone.utc),
+            pr_state=PRState.MERGED,
+            base_ref_oid='base_branch_tip_sha',
+            head_ref_oid='head_sha',
+            file_changes=[
+                FileChange(
+                    pr_number=1,
+                    repository_full_name='owner/repo',
+                    filename='test.py',
+                    status='modified',
+                    changes=5,
+                    additions=3,
+                    deletions=2,
+                ),
+            ],
+        )
+
+        fetch_file_contents_for_pr(pr, 'fake_token')
+
+        mock_merge_base.assert_called_once_with('owner/repo', 'base_branch_tip_sha', 'head_sha', 'fake_token')
+        # Verify merge-base SHA was passed, not the original base_ref_oid
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        assert call_args[0][2] == 'merge_base_sha_123', 'Should pass merge-base SHA as base_sha'
+
+    @patch('gittensor.validator.oss_contributions.scoring.fetch_file_contents_with_base')
+    @patch('gittensor.validator.oss_contributions.scoring.get_merge_base_sha')
+    def test_falls_back_to_base_ref_oid_when_merge_base_fails(self, mock_merge_base, mock_fetch):
+        """When merge-base resolution fails, should fall back to base_ref_oid."""
+        from gittensor.classes import FileChange, PRState, PullRequest
+        from gittensor.validator.oss_contributions.scoring import fetch_file_contents_for_pr
+
+        mock_merge_base.return_value = None
+        mock_fetch.return_value = {}
+
+        pr = PullRequest(
+            number=1,
+            repository_full_name='owner/repo',
+            uid=0,
+            hotkey='hk',
+            github_id='1',
+            title='test',
+            author_login='user',
+            merged_at=None,
+            created_at=__import__('datetime').datetime.now(__import__('datetime').timezone.utc),
+            pr_state=PRState.MERGED,
+            base_ref_oid='base_branch_tip_sha',
+            head_ref_oid='head_sha',
+            file_changes=[
+                FileChange(
+                    pr_number=1,
+                    repository_full_name='owner/repo',
+                    filename='test.py',
+                    status='modified',
+                    changes=5,
+                    additions=3,
+                    deletions=2,
+                ),
+            ],
+        )
+
+        fetch_file_contents_for_pr(pr, 'fake_token')
+
+        # Should fall back to base_ref_oid
+        call_args = mock_fetch.call_args
+        assert call_args[0][2] == 'base_branch_tip_sha', 'Should fall back to base_ref_oid'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

[fetch_file_contents_for_pr](cci:1://file:///https://github.com/entrius/gittensor/gittensor/validator/oss_contributions/scoring.py:124:0-155:114) used `baseRefOid` (base branch tip) to fetch the "before" file content for AST comparison. When the base branch had commits not in the PR, tree-diff scored unrelated changes, inflating `token_score`.

Now resolves the merge-base via GitHub's compare API and uses that as the "before" state. Falls back to `baseRefOid` if the compare API fails.

### Example: [sbt/sbt#9011](https://gittensor.io/miners/pr?repo=sbt%2Fsbt&number=9011) (+5/−1, 1 file)

The `develop` branch had 55 commits between the merge-base and tip, heavily touching the same file.

| | merge-base (fixed) | baseRefOid (old) |
|---|---|---|
| AST nodes diffed | 8 | 461 |
| token_score | 0.76 | 35.26 (46× inflated) |
| base_score | 0.01 | 90.53 |

A 1-line fix was getting `base_score=90` due to 460 phantom AST nodes from unrelated commits.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

8 new tests: merge-base resolution (success, retry, failure, null response, connection errors) and integration (merge-base used when available, fallback to baseRefOid). 465 tests pass, ruff lint + format clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)