### PR TITLE
Deactivate autoppia repos (deregistered)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -491,21 +491,6 @@
     "tier": "Bronze",
     "weight": 0.17
   },
-  "autoppia/autoppia_iwa": {
-    "additional_acceptable_branches": ["contribution/*"],
-    "tier": "Silver",
-    "weight": 5.33
-  },
-  "autoppia/autoppia_web_agents_subnet": {
-    "additional_acceptable_branches": ["dev", "dev-gittensor"],
-    "tier": "Silver",
-    "weight": 5.79
-  },
-  "autoppia/autoppia_webs_demo": {
-    "additional_acceptable_branches": ["feature/*", "fix/*"],
-    "tier": "Silver",
-    "weight": 5.2
-  },
   "autorope/donkeycar": {
     "tier": "Bronze",
     "weight": 0.16

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -491,6 +491,24 @@
     "tier": "Bronze",
     "weight": 0.17
   },
+  "autoppia/autoppia_iwa": {
+    "additional_acceptable_branches": ["contribution/*"],
+    "inactive_at": "2026-04-06T00:00:00Z",
+    "tier": "Silver",
+    "weight": 5.33
+  },
+  "autoppia/autoppia_web_agents_subnet": {
+    "additional_acceptable_branches": ["dev", "dev-gittensor"],
+    "inactive_at": "2026-04-06T00:00:00Z",
+    "tier": "Silver",
+    "weight": 5.79
+  },
+  "autoppia/autoppia_webs_demo": {
+    "additional_acceptable_branches": ["feature/*", "fix/*"],
+    "inactive_at": "2026-04-06T00:00:00Z",
+    "tier": "Silver",
+    "weight": 5.2
+  },
   "autorope/donkeycar": {
     "tier": "Bronze",
     "weight": 0.16


### PR DESCRIPTION
## Summary
- Deactivate deregistered autoppia repos in master_repositories.json by adding `inactive_at` timestamps:
  - `autoppia/autoppia_iwa`
  - `autoppia/autoppia_web_agents_subnet`
  - `autoppia/autoppia_webs_demo`