### PR TITLE
chore: accept async-substrate-interface PRs merged to staging

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -3884,6 +3884,7 @@
     "weight": 0.16
   },
   "latent-to/async-substrate-interface": {
+    "additional_acceptable_branches": ["staging"],
     "tier": "Gold",
     "weight": 24.78
   },


### PR DESCRIPTION
Allow merged PRs targeting the `staging` branch in `latent-to/async-substrate-interface` to be counted by the validator.
