### PR TITLE
fix: update NETUID_DEFAULT from 2 to 74 and show network default in help

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -19,7 +19,7 @@ console = Console()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
-@click.option('--network', default=None, help='Network name (local, test, finney).')
+@click.option('--network', default=None, help='Network name (local, test, finney). [default: finney]')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode):

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -19,14 +19,14 @@ from gittensor.constants import BASE_GITHUB_API_URL
 console = Console()
 
 # Shared CLI options for wallet/network configuration
-NETUID_DEFAULT = 2
+NETUID_DEFAULT = 74
 
 
 @click.command()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
-@click.option('--network', default=None, help='Network name (local, test, finney).')
+@click.option('--network', default=None, help='Network name (local, test, finney). [default: finney]')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
 @click.option(
     '--pat',


### PR DESCRIPTION
## Summary

Two CLI defaults that can mislead miners:

1. **`NETUID_DEFAULT = 2` → `74`** — The hardcoded default was a stale dev value. Mainnet is netuid 74 (testnet 422). Miners who omit `--netuid` would silently target the wrong subnet. The [docs](https://docs.gittensor.io/miner.html) always pass `--netuid 74` explicitly, but the code default should match.

2. **`--network` help text** — `_resolve_endpoint()` falls back to `finney`, but `--help` showed no default. Added `[default: finney]` to `--network` help in `post` and `check` commands so miners see the fallback.

### Files changed
- `gittensor/cli/miner_commands/post.py` — `NETUID_DEFAULT` 2→74, `--network` help text
- `gittensor/cli/miner_commands/check.py` — `--network` help text

### Impact
All three miner commands (`post`, `check`, `status`) import `NETUID_DEFAULT` from `post.py`, so all are fixed by this single change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Manually tested
- `ruff check` — all checks passed
- `ruff format` — all files formatted

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)