### PR TITLE
fix: resolve pyright errors in pat_handler and tests

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -66,8 +66,8 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     if test_error:
         return _reject(f'PAT test query failed: {test_error}')
 
-    # 5. Store PAT
-    pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=github_id)
+    # 5. Store PAT (github_id guaranteed non-None after validate_github_credentials success)
+    pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=github_id or '0')
 
     # Clear PAT from response so it isn't echoed back
     synapse.github_access_token = ''

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -150,7 +150,7 @@ class TestHandlePatBroadcast:
         assert 'locked' in (result.rejection_reason or '').lower()
 
         # Original entry should be unchanged
-        entry = pat_storage.get_pat_by_uid(1)
+        entry = pat_storage.get_pat_by_uid(1) or {}
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
@@ -163,7 +163,7 @@ class TestHandlePatBroadcast:
         result = _run(handle_pat_broadcast(mock_validator, synapse))
 
         assert result.accepted is True
-        entry = pat_storage.get_pat_by_uid(1)
+        entry = pat_storage.get_pat_by_uid(1) or {}
         assert entry['pat'] == 'ghp_refreshed'
         assert entry['github_id'] == 'github_42'
 
@@ -177,7 +177,7 @@ class TestHandlePatBroadcast:
         result = _run(handle_pat_broadcast(mock_validator, synapse))
 
         assert result.accepted is True
-        entry = pat_storage.get_pat_by_uid(1)
+        entry = pat_storage.get_pat_by_uid(1) or {}
         assert entry['github_id'] == 'github_99'
         assert entry['hotkey'] == 'hotkey_1'
 


### PR DESCRIPTION
- Use `or '0'` fallback for `github_id` in `pat_handler.save_pat` call to satisfy pyright's `str | None` check
- Use `or {}` fallback on `get_pat_by_uid()` calls in tests to fix `reportOptionalSubscript` errors