### PR TITLE
fix: reapply lost PR #357 changes

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -104,7 +104,7 @@ INLINE_TEST_PATTERNS: Dict[str, re.Pattern] = {
 # Eligibility Gate (OSS Contributions)
 # =============================================================================
 MIN_VALID_MERGED_PRS = 5  # minimum "valid" merged PRs (token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE) to receive score
-MIN_CREDIBILITY = 0.90  # minimum credibility ratio to receive score
+MIN_CREDIBILITY = 0.80  # minimum credibility ratio to receive score
 CREDIBILITY_MULLIGAN_COUNT = 1  # number of closed PRs forgiven (erased from merged+closed counts entirely)
 
 # =============================================================================

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -25,13 +25,6 @@ WHERE uid = %s AND hotkey = %s
   AND created_at <= %s
 """
 
-CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY = """
-DELETE FROM miner_tier_stats
-WHERE uid = %s AND hotkey = %s
-  AND github_id != %s
-  AND github_id != '0'
-"""
-
 CLEANUP_STALE_MINERS_BY_HOTKEY = """
 DELETE FROM miners
 WHERE uid = %s AND hotkey = %s

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -21,7 +21,6 @@ from .queries import (
     BULK_UPSERT_PULL_REQUESTS,
     CLEANUP_STALE_MINER_EVALUATIONS,
     CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY,
-    CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY,
     CLEANUP_STALE_MINERS,
     CLEANUP_STALE_MINERS_BY_HOTKEY,
     SET_MINER,
@@ -134,7 +133,6 @@ class Repository(BaseRepository):
         reverse_params = (evaluation.uid, evaluation.hotkey, evaluation.github_id)
         reverse_eval_params = reverse_params + (evaluation.evaluation_timestamp,)
         self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY, reverse_eval_params)
-        self.execute_command(CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY, reverse_params)
         self.execute_command(CLEANUP_STALE_MINERS_BY_HOTKEY, reverse_params)
 
     def store_pull_requests_bulk(self, pull_requests: List[PullRequest]) -> int:

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -150,7 +150,8 @@ class TestHandlePatBroadcast:
         assert 'locked' in (result.rejection_reason or '').lower()
 
         # Original entry should be unchanged
-        entry = pat_storage.get_pat_by_uid(1) or {}
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
@@ -163,7 +164,8 @@ class TestHandlePatBroadcast:
         result = _run(handle_pat_broadcast(mock_validator, synapse))
 
         assert result.accepted is True
-        entry = pat_storage.get_pat_by_uid(1) or {}
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['pat'] == 'ghp_refreshed'
         assert entry['github_id'] == 'github_42'
 
@@ -177,7 +179,8 @@ class TestHandlePatBroadcast:
         result = _run(handle_pat_broadcast(mock_validator, synapse))
 
         assert result.accepted is True
-        entry = pat_storage.get_pat_by_uid(1) or {}
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['github_id'] == 'github_99'
         assert entry['hotkey'] == 'hotkey_1'
 


### PR DESCRIPTION
## Summary
- Re-applies changes from PR #357 which was merged but lost when `test` was rebased/force-pushed
- Removes stale `CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY` query (table no longer exists)
- Lowers `MIN_CREDIBILITY` from 0.90 → 0.80
- Fixes test assertions with proper `assert entry is not None` guards

## Test plan
- [x] ruff: all checks passed
- [x] pytest: 272 passed
- [x] pyright: no new errors (pre-existing numpy/psycopg2 import errors from missing local deps, pass in CI)