### PR TITLE
fix: use last_edited_at instead of updated_at for post-merge edit detection

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -237,7 +237,10 @@ def _collect_issues_from_prs(
                     continue  # No score for unsolved issues
 
                 # Anti-gaming: post-merge edit detection
-                if issue.updated_at and pr.merged_at and issue.updated_at > pr.merged_at:
+                # Use last_edited_at (body/title edits) instead of updated_at (any activity
+                # including comments, labels, and the closing event itself which always
+                # updates updated_at to >= merged_at, penalizing all solved issues)
+                if issue.last_edited_at and pr.merged_at and issue.last_edited_at > pr.merged_at:
                     bt.logging.info(
                         f'Issue #{issue.number} edited after PR #{pr.number} merge — 0 score, counts as closed'
                     )


### PR DESCRIPTION
## Summary

Fixes #372

The anti-gaming post-merge edit detection in issue discovery scoring uses `issue.updated_at > pr.merged_at`. However, GitHub's `updatedAt` reflects any activity on the issue (comments, label changes, and the closing event itself), not just content edits. Since closing an issue always updates `updatedAt` to >= `merged_at`, this check incorrectly penalizes nearly all legitimately solved issues by reclassifying them from `solved_count` to `closed_count`.

## Changes

**`gittensor/validator/issue_discovery/scoring.py`**: Replace `issue.updated_at` with `issue.last_edited_at` in the post-merge edit check (line 240). The `Issue` class already has `last_edited_at` populated from GitHub's `lastEditedAt` GraphQL field, which specifically tracks body/title edits by the author.

## Impact

Prevents legitimate issue discoveries from being incorrectly penalized. Without this fix, the anti-gaming check fires on nearly every solved issue because the closing event updates `updatedAt`.