### PR TITLE
fix: move valid_solved_count increment past same-account guard

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -245,13 +245,15 @@ def _collect_issues_from_prs(
                     data.closed_count += 1
                     continue
 
-                # Count valid solved (PR quality gate only — independent of same-account/one-per-PR)
-                if pr.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
-                    data.valid_solved_count += 1
-
                 # Same-account: discoverer == solver → 0 score but credibility counts
                 if discoverer_id == pr.github_id:
                     continue
+
+                # Count valid solved (PR quality gate only — independent of same-account/one-per-PR)
+                # NOTE: must be after same-account guard so self-solved issues don't
+                # falsely count toward the eligibility threshold for the reward pool.
+                if pr.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+                    data.valid_solved_count += 1
 
                 # One-issue-per-PR: only the first (earliest-created) issue gets scored
                 pr_key = (pr.repository_full_name, pr.number)


### PR DESCRIPTION
## Summary

Move the `data.valid_solved_count += 1` increment to **after** the same-account guard in `_collect_issues_from_prs`. Previously, self-solved issues (where discoverer == solver) were counted toward `valid_solved_count` before the guard could skip them, allowing a miner to falsely satisfy the eligibility gate for the issue discovery reward pool.

@anderdc @LandynDev

## Related Issues

Fixes #386

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

All 272 existing tests pass (`pytest tests/ -x -q`).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)