### PR TITLE
fix: restore NETUID_DEFAULT to 74 (regression)

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -19,7 +19,7 @@ from gittensor.constants import BASE_GITHUB_API_URL
 console = Console()
 
 # Shared CLI options for wallet/network configuration
-NETUID_DEFAULT = 2
+NETUID_DEFAULT = 74
 
 
 @click.command()


### PR DESCRIPTION
## Summary

`NETUID_DEFAULT` in `gittensor/cli/miner_commands/post.py` is currently set to `2` instead of `74`. This was originally fixed in #358 by @eureka0928, but the fix was lost during the reapply series (#361–#363). As a result, miners running `gitt miner post` or `gitt miner check` without explicitly passing `--netuid 74` silently target the wrong subnet.

This one-line fix restores the correct default.

## Related Issues

Regression of #358

## Type of Change
- [x] Bug fix

## Testing
- [x] Manually tested — verified `gitt miner post --help` shows `[default: 74]`
- [x] `ruff check` passes
- [x] `pyright` passes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed

cc @anderdc @landyndev