### PR TITLE
fix: exclude deleted files from code_density calculation

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -168,8 +168,9 @@ def calculate_base_score(
         pr.leaf_count = scoring_result.score_breakdown.leaf_count
         pr.leaf_score = scoring_result.score_breakdown.leaf_score
 
-    # Calculate total lines changed across all files
-    total_lines = sum(f.total_lines for f in scoring_result.file_results)
+    # Calculate total lines changed across scored files (exclude deleted files which
+    # contribute 0 to token_score but would artificially deflate code_density)
+    total_lines = sum(f.total_lines for f in scoring_result.file_results if f.scoring_method != 'skipped')
 
     # Check minimum token score threshold for base score. PRs below threshold get 0 base score
     if pr.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:


### PR DESCRIPTION
## Summary

When a PR deletes files, the deleted files are correctly scored at 0 (`scoring_method='skipped'`) in `tree_sitter_scoring.py`, but their `total_lines` (set to `file.deletions`) are still included in the `total_lines` sum in `scoring.py:172`.

Since `code_density = token_score / total_lines`, deleted files inflate the denominator without contributing to the numerator, artificially deflating code_density and reducing the base_score for all miners whose PRs include file deletions.

This fix filters out skipped (deleted) files from the `total_lines` calculation so that code_density accurately reflects only the scored content.

**Example:** A PR with 50 lines of dense code (token_score=80) that also removes a 200-line file would get `code_density = 80/250 = 0.32` instead of the correct `80/50 = 1.6` — a 5x penalty.

## Type of Change
- [x] Bug fix

## Testing
- [x] `ruff check` passes
- [x] `pyright` passes
- [x] Self-reviewed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed

cc @anderdc @landyndev