### PR TITLE
fix: add retry with backoff to _fetch_closed_issues for transient 5xx errors

### DIFF
--- a/gittensor/validator/issue_discovery/repo_scan.py
+++ b/gittensor/validator/issue_discovery/repo_scan.py
@@ -11,6 +11,7 @@ Uses the validator PAT for all API calls. Rate-limited by per-repo and global ca
 """
 
 import asyncio
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -201,40 +202,74 @@ async def _scan_repo(
 
 
 def _fetch_closed_issues(repo_name: str, since: str, token: str) -> List[dict]:
-    """Fetch closed issues from a repo via REST API with pagination."""
+    """Fetch closed issues from a repo via REST API with pagination and retry.
+
+    Retries transient 5xx errors and connection failures with exponential backoff,
+    matching the retry pattern used by other API functions in the codebase
+    (e.g. get_pull_request_file_changes, execute_graphql_query).
+    """
     headers = {'Authorization': f'token {token}', 'Accept': 'application/vnd.github.v3+json'}
     all_issues: List[dict] = []
     page = 1
+    max_retries = 3
 
     while True:
-        try:
-            response = requests.get(
-                f'{BASE_GITHUB_API_URL}/repos/{repo_name}/issues',
-                params={'state': 'closed', 'since': since, 'per_page': 100, 'page': page},
-                headers=headers,
-                timeout=30,
-            )
-            if response.status_code in (404, 422):
-                bt.logging.debug(f'Issue scan {repo_name} page {page}: HTTP {response.status_code}')
-                break
-            if response.status_code != 200:
-                bt.logging.warning(f'Issue scan {repo_name} page {page}: HTTP {response.status_code}')
-                break
+        last_error: Optional[str] = None
+        for attempt in range(max_retries):
+            try:
+                response = requests.get(
+                    f'{BASE_GITHUB_API_URL}/repos/{repo_name}/issues',
+                    params={'state': 'closed', 'since': since, 'per_page': 100, 'page': page},
+                    headers=headers,
+                    timeout=30,
+                )
 
-            issues = response.json()
-            if not issues:
-                break
+                if response.status_code == 200:
+                    issues = response.json()
+                    if not issues:
+                        return all_issues
+                    all_issues.extend(issues)
+                    last_error = None
+                    break  # Success, move to next page
 
-            all_issues.extend(issues)
-            page += 1
+                if response.status_code in (404, 422):
+                    bt.logging.debug(f'Issue scan {repo_name} page {page}: HTTP {response.status_code}')
+                    return all_issues
 
-            # Safety: don't paginate forever
-            if page > 100:
-                bt.logging.warning(f'Issue scan {repo_name}: hit 100-page limit')
-                break
+                # Retryable server error
+                last_error = f'HTTP {response.status_code}'
+                if response.status_code in (502, 503, 504) and attempt < max_retries - 1:
+                    backoff = min(5 * (2**attempt), 30)
+                    bt.logging.warning(
+                        f'Issue scan {repo_name} page {page}: {last_error} '
+                        f'(attempt {attempt + 1}/{max_retries}), retrying in {backoff}s...'
+                    )
+                    time.sleep(backoff)
+                    continue
 
-        except requests.RequestException as e:
-            bt.logging.warning(f'Issue scan {repo_name} page {page}: {e}')
+                bt.logging.warning(f'Issue scan {repo_name} page {page}: {last_error}')
+                return all_issues
+
+            except requests.RequestException as e:
+                last_error = str(e)
+                if attempt < max_retries - 1:
+                    backoff = min(5 * (2**attempt), 30)
+                    bt.logging.warning(
+                        f'Issue scan {repo_name} page {page}: {e} '
+                        f'(attempt {attempt + 1}/{max_retries}), retrying in {backoff}s...'
+                    )
+                    time.sleep(backoff)
+                    continue
+                bt.logging.warning(f'Issue scan {repo_name} page {page}: {last_error}')
+                return all_issues
+        else:
+            # All retries exhausted
+            bt.logging.warning(f'Issue scan {repo_name} page {page} failed after {max_retries} attempts: {last_error}')
+            return all_issues
+
+        page += 1
+        if page > 100:
+            bt.logging.warning(f'Issue scan {repo_name}: hit 100-page limit')
             break
 
     return all_issues

--- a/tests/validator/test_repo_scan_retry.py
+++ b/tests/validator/test_repo_scan_retry.py
@@ -1,0 +1,133 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Unit tests for _fetch_closed_issues retry logic in repo_scan module."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+repo_scan = pytest.importorskip('gittensor.validator.issue_discovery.repo_scan', reason='Requires gittensor package')
+_fetch_closed_issues = repo_scan._fetch_closed_issues
+
+
+def _mock_response(status_code: int, json_data=None):
+    """Create a mock requests.Response."""
+    resp = Mock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data if json_data is not None else []
+    return resp
+
+
+class TestFetchClosedIssuesRetry:
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_success_on_first_attempt(self, mock_get, mock_sleep):
+        issues = [{'number': 1, 'title': 'issue1'}]
+        mock_get.side_effect = [
+            _mock_response(200, issues),
+            _mock_response(200, []),  # empty = end pagination
+        ]
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == issues
+        mock_sleep.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_retry_on_502_then_success(self, mock_get, mock_sleep):
+        issues = [{'number': 1, 'title': 'issue1'}]
+        mock_get.side_effect = [
+            _mock_response(502),
+            _mock_response(200, issues),
+            _mock_response(200, []),
+        ]
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == issues
+        assert mock_sleep.call_count == 1
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_retry_on_503_then_success(self, mock_get, mock_sleep):
+        issues = [{'number': 2, 'title': 'issue2'}]
+        mock_get.side_effect = [
+            _mock_response(503),
+            _mock_response(503),
+            _mock_response(200, issues),
+            _mock_response(200, []),
+        ]
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == issues
+        assert mock_sleep.call_count == 2
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_all_retries_exhausted_returns_partial(self, mock_get, mock_sleep):
+        mock_get.side_effect = [
+            _mock_response(502),
+            _mock_response(502),
+            _mock_response(502),
+        ]
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == []
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_404_returns_immediately_no_retry(self, mock_get, mock_sleep):
+        mock_get.return_value = _mock_response(404)
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == []
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_422_returns_immediately_no_retry(self, mock_get, mock_sleep):
+        mock_get.return_value = _mock_response(422)
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == []
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_connection_error_retries(self, mock_get, mock_sleep):
+        import requests as req
+
+        issues = [{'number': 3, 'title': 'issue3'}]
+        mock_get.side_effect = [
+            req.ConnectionError('connection reset'),
+            _mock_response(200, issues),
+            _mock_response(200, []),
+        ]
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == issues
+        assert mock_sleep.call_count == 1
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_exponential_backoff_timing(self, mock_get, mock_sleep):
+        mock_get.side_effect = [
+            _mock_response(502),
+            _mock_response(502),
+            _mock_response(502),
+        ]
+        _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        # Backoff: 5*2^0=5, 5*2^1=10 (third attempt is last, no sleep after)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(5)
+        mock_sleep.assert_any_call(10)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_pagination_with_retry_on_second_page(self, mock_get, mock_sleep):
+        page1 = [{'number': 1}]
+        page2 = [{'number': 2}]
+        mock_get.side_effect = [
+            _mock_response(200, page1),  # page 1 OK
+            _mock_response(502),  # page 2 fail
+            _mock_response(200, page2),  # page 2 retry OK
+            _mock_response(200, []),  # page 3 empty = done
+        ]
+        result = _fetch_closed_issues('owner/repo', '2025-01-01T00:00:00Z', 'token')
+        assert result == page1 + page2
+        assert mock_sleep.call_count == 1


### PR DESCRIPTION
## Problem

`_fetch_closed_issues()` in `repo_scan.py` has no retry logic. A single transient 502/503/504 from GitHub causes the function to immediately `break` and return partial results, silently losing all issues from subsequent pages.

This is inconsistent with every other API function in the codebase:
- `get_pull_request_file_changes` — 3 retries with exponential backoff
- `get_pull_request_maintainer_changes_requested_count` — 3 retries
- `execute_graphql_query` — 8 retries with backoff
- `get_merge_base_sha` — 3 retries
- `get_github_user` — 6 retries

## Impact

When GitHub returns a transient 5xx during the issue discovery scan, the validator loses visibility into all remaining closed issues for that repo.

## Solution

Add retry logic with exponential backoff (3 attempts, capped at 30s) for 5xx errors and connection exceptions, matching the established pattern. Non-retryable errors (404, 422) still return immediately.

## Type of Change
- [x] Bug fix

## Testing
- [x] 9 unit tests in `tests/validator/test_repo_scan_retry.py`:
  - Success on first attempt (no sleep)
  - Retry on 502/503 with eventual success
  - All retries exhausted returns partial results
  - 404/422 return immediately without retry
  - ConnectionError triggers retry
  - Exponential backoff timing verification (5s, 10s)
  - Pagination continues after mid-page retry
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `pyright` passes
- [x] All existing tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added

cc @anderdc @landyndev