### PR TITLE
fix: replace deprecated asyncio.get_event_loop() and deduplicate network init

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -45,22 +45,23 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 2. Set up bittensor objects
+    def _connect():
+        w = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+        st = bt.Subtensor(network=ws_endpoint)
+        mg = st.metagraph(netuid=netuid)
+        dd = bt.Dendrite(wallet=w)
+        return w, st, mg, dd
+
     if not json_mode:
         with console.status('[bold]Connecting to network...'):
             try:
-                wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-                subtensor = bt.Subtensor(network=ws_endpoint)
-                metagraph = subtensor.metagraph(netuid=netuid)
-                dendrite = bt.Dendrite(wallet=wallet)
+                wallet, subtensor, metagraph, dendrite = _connect()
             except Exception as e:
                 _error(f'Failed to initialize bittensor: {e}', json_mode)
                 sys.exit(1)
     else:
         try:
-            wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-            subtensor = bt.Subtensor(network=ws_endpoint)
-            metagraph = subtensor.metagraph(netuid=netuid)
-            dendrite = bt.Dendrite(wallet=wallet)
+            wallet, subtensor, metagraph, dendrite = _connect()
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)
@@ -85,25 +86,19 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
     # 4. Send check probes
     synapse = PatCheckSynapse()
 
+    async def _check():
+        return await dendrite(
+            axons=validator_axons,
+            synapse=synapse,
+            deserialize=False,
+            timeout=15.0,
+        )
+
     if not json_mode:
         with console.status(f'[bold]Checking {len(validator_axons)} validators...'):
-            responses = asyncio.get_event_loop().run_until_complete(
-                dendrite(
-                    axons=validator_axons,
-                    synapse=synapse,
-                    deserialize=False,
-                    timeout=15.0,
-                )
-            )
+            responses = asyncio.run(_check())
     else:
-        responses = asyncio.get_event_loop().run_until_complete(
-            dendrite(
-                axons=validator_axons,
-                synapse=synapse,
-                deserialize=False,
-                timeout=15.0,
-            )
-        )
+        responses = asyncio.run(_check())
 
     # 5. Collect results
     results = []

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -87,22 +87,23 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 3. Set up bittensor objects
+    def _connect():
+        w = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+        st = bt.Subtensor(network=ws_endpoint)
+        mg = st.metagraph(netuid=netuid)
+        dd = bt.Dendrite(wallet=w)
+        return w, st, mg, dd
+
     if not json_mode:
         with console.status('[bold]Connecting to network...'):
             try:
-                wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-                subtensor = bt.Subtensor(network=ws_endpoint)
-                metagraph = subtensor.metagraph(netuid=netuid)
-                dendrite = bt.Dendrite(wallet=wallet)
+                wallet, subtensor, metagraph, dendrite = _connect()
             except Exception as e:
                 _error(f'Failed to initialize bittensor: {e}', json_mode)
                 sys.exit(1)
     else:
         try:
-            wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-            subtensor = bt.Subtensor(network=ws_endpoint)
-            metagraph = subtensor.metagraph(netuid=netuid)
-            dendrite = bt.Dendrite(wallet=wallet)
+            wallet, subtensor, metagraph, dendrite = _connect()
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)
@@ -127,25 +128,19 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
     # 5. Broadcast
     synapse = PatBroadcastSynapse(github_access_token=pat)
 
+    async def _broadcast():
+        return await dendrite(
+            axons=validator_axons,
+            synapse=synapse,
+            deserialize=False,
+            timeout=30.0,
+        )
+
     if not json_mode:
         with console.status(f'[bold]Broadcasting to {len(validator_axons)} validators...'):
-            responses = asyncio.get_event_loop().run_until_complete(
-                dendrite(
-                    axons=validator_axons,
-                    synapse=synapse,
-                    deserialize=False,
-                    timeout=30.0,
-                )
-            )
+            responses = asyncio.run(_broadcast())
     else:
-        responses = asyncio.get_event_loop().run_until_complete(
-            dendrite(
-                axons=validator_axons,
-                synapse=synapse,
-                deserialize=False,
-                timeout=30.0,
-            )
-        )
+        responses = asyncio.run(_broadcast())
 
     # 6. Collect results
     results = []


### PR DESCRIPTION
## Problem

Both `miner_post` and `miner_check` CLI commands use `asyncio.get_event_loop().run_until_complete()` which is deprecated since Python 3.10 (emits `DeprecationWarning`) and raises `RuntimeError` in Python 3.12+ when no running event loop exists.

Additionally, both commands duplicate the bittensor initialization block (wallet, subtensor, metagraph, dendrite) — once inside `console.status()` and once outside for JSON mode — making the code fragile and harder to maintain.

## Solution

1. **Replace** `asyncio.get_event_loop().run_until_complete(coro)` with `asyncio.run(async_fn())` — the modern equivalent that properly creates and manages the event loop.
2. **Extract** `_connect()` helper to eliminate the duplicated 4-line init block in each command.
3. **Extract** `_broadcast()` / `_check()` async helpers to avoid repeating the dendrite call.

## Changes

### `post.py`
- Extract `_connect()` for wallet/subtensor/metagraph/dendrite init (−8 duplicated lines)
- Extract `_broadcast()` coroutine, replace 2× `asyncio.get_event_loop().run_until_complete()`

### `check.py`
- Same `_connect()` extraction (−8 duplicated lines)
- Extract `_check()` coroutine, replace 2× `asyncio.get_event_loop().run_until_complete()`

Net result: **+38 / −48 lines** (code reduction).

## Type of Change
- [x] Bug fix
- [x] Refactor

## Testing
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `pyright` passes (0 errors)
- [x] Self-reviewed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed

cc @anderdc @landyndev