### PR TITLE
fix: clean up stale PR state when repo removed or PR merged to non-acceptable branch

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from math import prod
-from typing import DefaultDict, Dict, List, Optional, Set
+from typing import DefaultDict, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
@@ -314,6 +314,10 @@ class MinerEvaluation:
     open_pull_requests: List[PullRequest] = field(default_factory=list)
     closed_pull_requests: List[PullRequest] = field(default_factory=list)
     unique_repos_contributed_to: Set[str] = field(default_factory=set)
+
+    # PRs skipped during evaluation that still need their DB state updated
+    # Each entry is (pr_number, repository_full_name, github_state)
+    skipped_pr_state_updates: List[Tuple[int, str, str]] = field(default_factory=list)
 
     # Eligibility and credibility
     is_eligible: bool = False

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1071,6 +1071,9 @@ def load_miners_prs(
 
                     if should_skip:
                         bt.logging.debug(skip_reason or '')
+                        miner_eval.skipped_pr_state_updates.append(
+                            (pr_raw['number'], repository_full_name, pr_state)
+                        )
                         continue
 
                     miner_eval.add_merged_pull_request(pr_raw)

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -71,7 +71,8 @@ async def forward(self: 'Validator') -> None:
         issue_rewards = await issue_discovery(miner_evaluations, master_repositories, miner_uids)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
-        await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
+        active_repos = tuple(master_repositories.keys())
+        await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids, active_repos=active_repos)
 
         # 5. Blend 4 emission pools into final rewards
         rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -16,6 +16,21 @@ WHERE github_id = %s
   AND (uid != %s OR hotkey != %s)
 """
 
+# Cleanup stale pull requests from repositories no longer in master_repositories
+CLEANUP_STALE_PULL_REQUESTS = """
+DELETE FROM pull_requests
+WHERE uid = %s AND hotkey = %s
+  AND repository_full_name NOT IN %s
+"""
+
+# Update pr_state for PRs that were skipped during evaluation but have a new state on GitHub
+UPDATE_SKIPPED_PR_STATE = """
+UPDATE pull_requests
+SET pr_state = %s, updated_at = NOW()
+WHERE number = %s AND repository_full_name = %s
+  AND pr_state != %s
+"""
+
 # Reverse cleanup: Remove stale data when a (uid, hotkey) re-links to a new github_id
 CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY = """
 DELETE FROM miner_evaluations

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -23,7 +23,9 @@ from .queries import (
     CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY,
     CLEANUP_STALE_MINERS,
     CLEANUP_STALE_MINERS_BY_HOTKEY,
+    CLEANUP_STALE_PULL_REQUESTS,
     SET_MINER,
+    UPDATE_SKIPPED_PR_STATE,
 )
 
 T = TypeVar('T')
@@ -134,6 +136,37 @@ class Repository(BaseRepository):
         reverse_eval_params = reverse_params + (evaluation.evaluation_timestamp,)
         self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY, reverse_eval_params)
         self.execute_command(CLEANUP_STALE_MINERS_BY_HOTKEY, reverse_params)
+
+    def cleanup_stale_pull_requests(self, uid: int, hotkey: str, active_repos: tuple) -> bool:
+        """
+        Delete pull request records for repositories no longer tracked in master_repositories.
+
+        When a repository is removed from tracking, existing PR records in the database
+        retain their old pr_state indefinitely. This method removes those stale records.
+
+        Args:
+            uid: Miner UID
+            hotkey: Miner hotkey
+            active_repos: Tuple of currently tracked repository full names
+        """
+        if not active_repos:
+            return False
+        placeholders = ','.join(['%s'] * len(active_repos))
+        query = CLEANUP_STALE_PULL_REQUESTS.replace('IN %s', f'IN ({placeholders})')
+        return self.execute_command(query, (uid, hotkey) + active_repos)
+
+    def update_skipped_pr_states(self, state_updates: list) -> int:
+        """
+        Update pr_state for PRs that were skipped during evaluation but have a new state on GitHub.
+
+        Args:
+            state_updates: List of (pr_number, repository_full_name, github_state) tuples
+        """
+        count = 0
+        for pr_number, repo, state in state_updates:
+            if self.execute_command(UPDATE_SKIPPED_PR_STATE, (state, pr_number, repo, state)):
+                count += 1
+        return count
 
     def store_pull_requests_bulk(self, pull_requests: List[PullRequest]) -> int:
         """

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import bittensor as bt
 
@@ -28,12 +28,16 @@ class DatabaseStorage:
     def is_enabled(self) -> bool:
         return self.db_connection is not None
 
-    def store_evaluation(self, miner_eval: MinerEvaluation) -> StorageResult:
+    def store_evaluation(
+        self, miner_eval: MinerEvaluation, active_repos: Optional[Tuple[str, ...]] = None
+    ) -> StorageResult:
         """
         Store all evaluation data in an optimized manner with proper error handling.
 
         Args:
             miner_eval: Complete miner evaluation with all related data
+            active_repos: Tuple of currently tracked repository names. If provided,
+                          PR records for repos not in this set are deleted.
 
         Returns:
             StorageResult with success status, errors, and counts
@@ -65,6 +69,14 @@ class DatabaseStorage:
             result.stored_counts['file_changes'] = self.repo.store_file_changes_bulk(miner_eval.get_all_file_changes())
             # Clean up stale data if this github_id was previously registered under a different uid/hotkey
             self.repo.cleanup_stale_miner_data(miner_eval)
+
+            # Clean up PR records from repositories no longer in master_repositories
+            if active_repos:
+                self.repo.cleanup_stale_pull_requests(miner_eval.uid, miner_eval.hotkey, active_repos)
+
+            # Update pr_state for PRs skipped during evaluation (e.g., merged to non-acceptable branch)
+            if miner_eval.skipped_pr_state_updates:
+                self.repo.update_skipped_pr_states(miner_eval.skipped_pr_state_updates)
 
             result.stored_counts['evaluations'] = 1 if self.repo.set_miner_evaluation(miner_eval) else 0
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -98,12 +98,18 @@ class Validator(BaseValidatorNeuron):
         bt.logging.info('load_state()')
         self.load_state()
 
-    async def bulk_store_evaluation(self, miner_evals: Dict[int, MinerEvaluation], skip_uids: Set[int] = None):
+    async def bulk_store_evaluation(
+        self,
+        miner_evals: Dict[int, MinerEvaluation],
+        skip_uids: Set[int] = None,
+        active_repos: tuple = None,
+    ):
         """Store all miner evaluations, log summary rather than per-UID.
 
         Args:
             miner_evals: Dict of UID -> MinerEvaluation to store.
             skip_uids: Set of UIDs to skip (e.g. cached evaluations that were already stored previously).
+            active_repos: Tuple of currently tracked repo names for stale PR cleanup.
         """
         if self.db_storage is None:
             return
@@ -119,7 +125,7 @@ class Validator(BaseValidatorNeuron):
                 continue
 
             try:
-                storage_result = self.db_storage.store_evaluation(evaluation)
+                storage_result = self.db_storage.store_evaluation(evaluation, active_repos=active_repos)
                 if storage_result.success:
                     successful_count += 1
                 else:


### PR DESCRIPTION
When a repository is removed from `master_repositories.json`, existing PR records in the database kept their old `pr_state` indefinitely. Similarly, PRs merged to non-acceptable branches were skipped during evaluation, leaving stale `OPEN` state in the DB.

Two cleanup mechanisms added:
- **Scenario 1 (repo removed):** DELETE PR records for repos no longer in `master_repositories`
- **Scenario 2 (non-acceptable branch):** UPDATE `pr_state` for skipped merged PRs to reflect actual GitHub state

## Related Issues

Fixes #398

## Type of Change

- [x] Bug fix

## Testing

- [x] Tests added/updated
- [x] Manually tested

10 tests added in `tests/validator/test_stale_pr_cleanup.py`:
- 6 SQL logic tests (SQLite in-memory) covering both scenarios
- 4 Python unit tests (mocked DB) for Repository methods

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)