### PR TITLE
feat: persist closed_at timestamp for pull requests (#396)

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -194,6 +194,7 @@ class PullRequest:
     issues: Optional[List[Issue]] = None
     description: Optional[str] = None
     last_edited_at: Optional[datetime] = None
+    closed_at: Optional[datetime] = None  # Set for CLOSED and MERGED PRs (GitHub sets closedAt on merge too)
     head_ref_oid: Optional[str] = None
     base_ref_oid: Optional[str] = None
 
@@ -266,6 +267,7 @@ class PullRequest:
         raw_edited_at = pr_data.get('lastEditedAt')
         last_edited_at = parse_github_timestamp_to_cst(raw_edited_at) if isinstance(raw_edited_at, str) else None
         merged_at = parse_github_timestamp_to_cst(pr_data['mergedAt']) if is_merged else None
+        closed_at = parse_github_timestamp_to_cst(pr_data['closedAt']) if pr_data.get('closedAt') else None
 
         return cls(
             number=pr_data['number'],
@@ -277,6 +279,7 @@ class PullRequest:
             author_login=pr_data['author']['login'],
             merged_at=merged_at,
             created_at=parse_github_timestamp_to_cst(pr_data['createdAt']),
+            closed_at=closed_at,
             pr_state=pr_state,
             additions=pr_data['additions'],
             deletions=pr_data['deletions'],

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -44,7 +44,7 @@ DO NOTHING
 BULK_UPSERT_PULL_REQUESTS = """
 INSERT INTO pull_requests (
     number, repository_full_name, uid, hotkey, github_id, title, author_login,
-    merged_at, pr_created_at, pr_state,
+    merged_at, pr_created_at, closed_at, pr_state,
     repo_weight_multiplier, base_score, issue_multiplier,
     open_pr_spam_multiplier, pioneer_dividend, pioneer_rank, time_decay_multiplier,
     credibility_multiplier, review_quality_multiplier,
@@ -60,6 +60,7 @@ DO UPDATE SET
     title = EXCLUDED.title,
     author_login = EXCLUDED.author_login,
     merged_at = EXCLUDED.merged_at,
+    closed_at = EXCLUDED.closed_at,
     pr_state = EXCLUDED.pr_state,
     repo_weight_multiplier = EXCLUDED.repo_weight_multiplier,
     base_score = EXCLUDED.base_score,

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -166,6 +166,7 @@ class Repository(BaseRepository):
                     pr.author_login,
                     pr.merged_at,
                     pr.created_at,
+                    pr.closed_at,
                     pr.pr_state.value,  # Convert PRState enum to string
                     pr.repo_weight_multiplier,
                     pr.base_score,

--- a/tests/validator/test_pull_request_closed_at.py
+++ b/tests/validator/test_pull_request_closed_at.py
@@ -1,0 +1,43 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for PullRequest.closed_at field parsing from GraphQL responses."""
+
+from gittensor.classes import PullRequest
+
+_BASE_PR_DATA = {
+    'number': 1,
+    'title': 'test',
+    'author': {'login': 'user'},
+    'createdAt': '2025-01-01T00:00:00Z',
+    'additions': 10,
+    'deletions': 5,
+    'repository': {'owner': {'login': 'owner'}, 'name': 'repo'},
+    'closingIssuesReferences': {'nodes': []},
+}
+
+
+def _parse(state: str, closed_at=None, merged_at=None) -> PullRequest:
+    data = {**_BASE_PR_DATA, 'state': state, 'closedAt': closed_at, 'mergedAt': merged_at}
+    if merged_at:
+        data['mergedBy'] = {'login': 'maintainer'}
+        data['commits'] = {'totalCount': 1}
+    return PullRequest.from_graphql_response(data, uid=1, hotkey='k', github_id='1')
+
+
+def test_closed_pr_has_closed_at():
+    pr = _parse('CLOSED', closed_at='2025-01-15T00:00:00Z')
+    assert pr.closed_at is not None
+    assert pr.merged_at is None
+
+
+def test_merged_pr_has_closed_at():
+    """GitHub sets closedAt when a PR is merged, so merged PRs should also have closed_at."""
+    pr = _parse('MERGED', closed_at='2025-01-20T00:00:00Z', merged_at='2025-01-20T00:00:00Z')
+    assert pr.closed_at is not None
+    assert pr.merged_at is not None
+
+
+def test_open_pr_has_no_closed_at():
+    pr = _parse('OPEN')
+    assert pr.closed_at is None


### PR DESCRIPTION
## Summary

Add `closed_at` field to the `PullRequest` dataclass and persist it to the database so the API can expose it to the frontend for 35-day evaluation window filtering.

The GraphQL query already fetches `closedAt` from GitHub, but it was only used during validation filtering in `try_add_open_or_closed_pr()` and never stored. This pipes the existing value through the dataclass into the bulk upsert query.

**Changes:**
- Add `closed_at: Optional[datetime]` field to `PullRequest` dataclass
- Parse `closedAt` from GraphQL response in `from_graphql_response()`
- Add `closed_at` column to `BULK_UPSERT_PULL_REQUESTS` INSERT and ON CONFLICT UPDATE
- Add `pr.closed_at` to the values tuple in `repository.py`
- Add unit tests covering CLOSED, MERGED, and OPEN PR states

**Migration required:**
```sql
ALTER TABLE pull_requests ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;
```
**Note:** GitHub sets `closedAt` for both CLOSED and MERGED PRs (merging closes a PR), so the field is populated for both states and `None` only for OPEN PRs.

## Related Issues

Fixes #396

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)