### PR TITLE
Use `last_edited_at` instead of `updated_at` for post-merge edit detection

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -134,6 +134,7 @@ class Issue:
     author_github_id: Optional[str] = None  # Issue author's GitHub user ID (for miner matching)
     is_transferred: bool = False
     updated_at: Optional[datetime] = None
+    last_edited_at: Optional[datetime] = None
     discovery_base_score: float = 0.0
     discovery_earned_score: float = 0.0
     discovery_review_quality_multiplier: float = 1.0
@@ -259,6 +260,7 @@ class PullRequest:
                     author_association=issue.get('authorAssociation'),
                     author_github_id=str(author_db_id) if author_db_id else None,
                     updated_at=parse_github_timestamp_to_cst(issue['updatedAt']) if issue.get('updatedAt') else None,
+                    last_edited_at=parse_github_timestamp_to_cst(issue['lastEditedAt']) if issue.get('lastEditedAt') else None,
                 )
             )
 

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -90,6 +90,7 @@ QUERY = """
                   createdAt
                   closedAt
                   updatedAt
+                  lastEditedAt
                   author {
                     login
                     ... on User { databaseId }

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -237,7 +237,7 @@ def _collect_issues_from_prs(
                     continue  # No score for unsolved issues
 
                 # Anti-gaming: post-merge edit detection
-                if issue.updated_at and pr.merged_at and issue.updated_at > pr.merged_at:
+                if issue.last_edited_at and pr.merged_at and issue.last_edited_at > pr.merged_at:
                     bt.logging.info(
                         f'Issue #{issue.number} edited after PR #{pr.number} merge — 0 score, counts as closed'
                     )


### PR DESCRIPTION
## summary

closes #372
`issue.updated_at` reflects any issue activity including the close event itself, so every legitimately solved issue had `updated_at > pr.merged_at` and was incorrectly reclassified from `solved_count` to `closed_count`
the fix adds `lastEditedAt` to the GraphQL query for closing issues and uses `issue.last_edited_at` in the check, which only tracks actual body/title edits by the author

## test plan

existing 259 tests pass; no new fixture cases added as the scoring path has no unit tests covering this check