### PR TITLE
fix: ignore stale closed PRs in lookback window

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -881,7 +881,19 @@ def try_add_open_or_closed_pr(
             bt.logging.warning(f'PR #{pr_raw["number"]} is CLOSED but missing closedAt timestamp.')
             return
 
+        created_at = pr_raw.get('createdAt')
+        if not created_at:
+            bt.logging.warning(f'PR #{pr_raw["number"]} is CLOSED but missing createdAt timestamp.')
+            return
+
         closed_dt = datetime.fromisoformat(closed_at.rstrip('Z')).replace(tzinfo=timezone.utc)
+        created_dt = datetime.fromisoformat(created_at.rstrip('Z')).replace(tzinfo=timezone.utc)
+
+        # Ignore stale PRs that were created before the scoring lookback window.
+        # This allows users to close old PRs without receiving a fresh credibility penalty.
+        if created_dt < lookback_date_filter:
+            return
+
         if closed_dt >= lookback_date_filter:
             miner_eval.add_closed_pull_request(pr_raw)
 


### PR DESCRIPTION
## Summary

Fixes closed-PR lookback filtering so stale PRs are not counted against miner credibility.

Previously, CLOSED PRs were counted when `closedAt` was within the lookback window, even if the PR had been created before the window. This could penalize miners for closing old backlog PRs.

## Related Issues

Fixes #277 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

Validated behavior with existing test suite/lint/type checks in local dev environment.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)