### PR TITLE
refactor: extract duplicated time decay calculation to shared util

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -1,7 +1,6 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-import math
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
@@ -19,12 +18,8 @@ from gittensor.constants import (
     MIN_VALID_SOLVED_ISSUES,
     OPEN_ISSUE_SPAM_BASE_THRESHOLD,
     OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
-    SECONDS_PER_HOUR,
-    TIME_DECAY_GRACE_PERIOD_HOURS,
-    TIME_DECAY_MIN_MULTIPLIER,
-    TIME_DECAY_SIGMOID_MIDPOINT,
-    TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
 )
+from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
 
@@ -80,17 +75,6 @@ def check_issue_eligibility(solved_count: int, closed_count: int) -> Tuple[bool,
     return True, credibility, ''
 
 
-def _calculate_time_decay_from_merge(merged_at: datetime) -> float:
-    """Time decay anchored to a PR's merge date. Same sigmoid as OSS contributions."""
-    now = datetime.now(timezone.utc)
-    hours_since_merge = (now - merged_at).total_seconds() / SECONDS_PER_HOUR
-
-    if hours_since_merge < TIME_DECAY_GRACE_PERIOD_HOURS:
-        return 1.0
-
-    days_since_merge = hours_since_merge / 24
-    sigmoid = 1 / (1 + math.exp(TIME_DECAY_SIGMOID_STEEPNESS_SCALAR * (days_since_merge - TIME_DECAY_SIGMOID_MIDPOINT)))
-    return max(sigmoid, TIME_DECAY_MIN_MULTIPLIER)
 
 
 def score_discovered_issues(
@@ -267,7 +251,7 @@ def _collect_issues_from_prs(
                 repo_config = master_repositories.get(pr.repository_full_name)
                 issue.discovery_base_score = pr.base_score
                 issue.discovery_repo_weight_multiplier = round(repo_config.weight if repo_config else 0.01, 2)
-                issue.discovery_time_decay_multiplier = round(_calculate_time_decay_from_merge(pr.merged_at), 2)
+                issue.discovery_time_decay_multiplier = round(calculate_time_decay(pr.merged_at), 2)
                 issue.discovery_review_quality_multiplier = round(
                     calculate_issue_review_quality_multiplier(pr.changes_requested_count), 2
                 )

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -75,8 +75,6 @@ def check_issue_eligibility(solved_count: int, closed_count: int) -> Tuple[bool,
     return True, credibility, ''
 
 
-
-
 def score_discovered_issues(
     miner_evaluations: Dict[int, MinerEvaluation],
     master_repositories: Dict[str, RepositoryConfig],

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -1,7 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, Tuple
 
 import bittensor as bt

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -1,7 +1,6 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-import math
 from datetime import datetime, timezone
 from typing import Dict, Tuple
 
@@ -33,12 +32,7 @@ from gittensor.constants import (
     PIONEER_DIVIDEND_RATE_REST,
     REVIEW_PENALTY_RATE,
     SECONDS_PER_DAY,
-    SECONDS_PER_HOUR,
     STANDARD_ISSUE_MULTIPLIER,
-    TIME_DECAY_GRACE_PERIOD_HOURS,
-    TIME_DECAY_MIN_MULTIPLIER,
-    TIME_DECAY_SIGMOID_MIDPOINT,
-    TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
 )
 from gittensor.utils.github_api_tools import (
     FileContentPair,
@@ -48,6 +42,7 @@ from gittensor.utils.github_api_tools import (
     get_pull_request_maintainer_changes_requested_count,
 )
 from gittensor.validator.oss_contributions.credibility import check_eligibility
+from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -267,18 +262,8 @@ def calculate_pr_spam_penalty_multiplier(total_open_prs: int, total_token_score:
 
 def calculate_time_decay_multiplier(pr: PullRequest) -> float:
     """Calculate time decay multiplier for a single PR based on merge date."""
-
     assert pr.merged_at is not None, f'PR #{pr.number} has no merged_at'
-    now = datetime.now(timezone.utc)
-    hours_since_merge = (now - pr.merged_at).total_seconds() / SECONDS_PER_HOUR
-
-    # No decay for PRs merged within the grace period
-    if hours_since_merge < TIME_DECAY_GRACE_PERIOD_HOURS:
-        return 1.0
-
-    days_since_merge = hours_since_merge / 24
-    sigmoid = 1 / (1 + math.exp(TIME_DECAY_SIGMOID_STEEPNESS_SCALAR * (days_since_merge - TIME_DECAY_SIGMOID_MIDPOINT)))
-    return max(sigmoid, TIME_DECAY_MIN_MULTIPLIER)
+    return calculate_time_decay(pr.merged_at)
 
 
 def calculate_pioneer_dividends(

--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -1,6 +1,15 @@
-from datetime import datetime
+import math
+from datetime import datetime, timezone
 
 import pytz
+
+from gittensor.constants import (
+    SECONDS_PER_HOUR,
+    TIME_DECAY_GRACE_PERIOD_HOURS,
+    TIME_DECAY_MIN_MULTIPLIER,
+    TIME_DECAY_SIGMOID_MIDPOINT,
+    TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
+)
 
 CHICAGO_TZ = pytz.timezone('America/Chicago')
 
@@ -20,3 +29,16 @@ def parse_github_timestamp_to_cst(timestamp_str: str) -> datetime:
     chicago_dt = utc_dt.astimezone(CHICAGO_TZ)
 
     return chicago_dt
+
+
+def calculate_time_decay(merged_at: datetime) -> float:
+    """Calculate sigmoid-based time decay multiplier from a merge timestamp."""
+    now = datetime.now(timezone.utc)
+    hours_since_merge = (now - merged_at).total_seconds() / SECONDS_PER_HOUR
+
+    if hours_since_merge < TIME_DECAY_GRACE_PERIOD_HOURS:
+        return 1.0
+
+    days_since_merge = hours_since_merge / 24
+    sigmoid = 1 / (1 + math.exp(TIME_DECAY_SIGMOID_STEEPNESS_SCALAR * (days_since_merge - TIME_DECAY_SIGMOID_MIDPOINT)))
+    return max(sigmoid, TIME_DECAY_MIN_MULTIPLIER)


### PR DESCRIPTION
### Summary
- Move the identical sigmoid-based time decay logic from `oss_contributions/scoring.py` and `issue_discovery/scoring.py` into a single `calculate_time_decay()` function in `validator/utils/datetime_utils.py`
- Both callers now import and use the shared function instead of maintaining their own copy

### Why
The same time decay formula (grace period check, sigmoid curve, min multiplier) was copy-pasted across two scoring modules. Any future change to the decay logic would need to be applied in both places, which is error-prone.

### Test plan
- [x] All 301 tests pass
- [x] Pyright clean
- [x] Ruff lint and format clean