### PR TITLE
refactor: extract shared normalization logic from duplicate normalize functions

### DIFF
--- a/gittensor/validator/issue_discovery/normalize.py
+++ b/gittensor/validator/issue_discovery/normalize.py
@@ -3,32 +3,10 @@
 
 from typing import Dict
 
-import bittensor as bt
-
 from gittensor.classes import MinerEvaluation
+from gittensor.validator.oss_contributions.normalize import _normalize_scores
 
 
 def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
-    """Normalize issue discovery scores to sum to 1.0, preserving ratios."""
-
-    if not miner_evaluations:
-        return {}
-
-    rewards: Dict[int, float] = {}
-    nonzero_count = 0
-
-    for uid, evaluation in miner_evaluations.items():
-        rewards[uid] = evaluation.issue_discovery_score
-        if rewards[uid] > 0:
-            nonzero_count += 1
-
-    total = sum(rewards.values())
-    if total <= 0:
-        bt.logging.info('Issue discovery: all scores are zero, returning empty rewards')
-        return rewards
-
-    normalized = {uid: score / total for uid, score in rewards.items()}
-
-    bt.logging.info(f'Issue discovery: normalized {nonzero_count} miners with scores > 0')
-
-    return normalized
+    """Normalize issue discovery scores to sum to 1.0."""
+    return _normalize_scores(miner_evaluations, lambda e: e.issue_discovery_score, 'Issue discovery')

--- a/gittensor/validator/oss_contributions/normalize.py
+++ b/gittensor/validator/oss_contributions/normalize.py
@@ -1,35 +1,38 @@
-from typing import Dict
+from typing import Callable, Dict
 
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
 
 
-def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
+def _normalize_scores(
+    miner_evaluations: Dict[int, MinerEvaluation],
+    score_getter: Callable[[MinerEvaluation], float],
+    label: str,
+) -> Dict[int, float]:
     """Normalize scores to sum to 1.0, preserving ratios."""
-
     if not miner_evaluations:
-        bt.logging.warning('No miner evaluations provided for normalization')
+        bt.logging.warning(f'{label}: no miner evaluations provided for normalization')
         return {}
 
     rewards: Dict[int, float] = {}
-    zero_reward_count = 0
+    nonzero_count = 0
 
     for uid, evaluation in miner_evaluations.items():
-        rewards[uid] = evaluation.total_score
+        rewards[uid] = score_getter(evaluation)
         if rewards[uid] > 0:
-            bt.logging.info(f'Final reward for uid {uid}: {rewards[uid]:.2f}')
-        else:
-            zero_reward_count += 1
-
-    if zero_reward_count > 0:
-        bt.logging.info(f'{zero_reward_count} miners have 0 reward')
+            nonzero_count += 1
 
     total = sum(rewards.values())
     if total <= 0:
-        bt.logging.info('All scores are zero, returning original scores')
+        bt.logging.info(f'{label}: all scores are zero, returning original scores')
         return rewards
 
     normalized = {uid: score / total for uid, score in rewards.items()}
-
+    bt.logging.info(f'{label}: normalized {nonzero_count} miners with scores > 0')
     return normalized
+
+
+def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
+    """Normalize OSS contribution scores to sum to 1.0."""
+    return _normalize_scores(miner_evaluations, lambda e: e.total_score, 'OSS contributions')


### PR DESCRIPTION
### Summary
- Create a generic `_normalize_scores()` function in `oss_contributions/normalize.py` that accepts a score getter and label
- Rewrite both `normalize_rewards_linear()` and `normalize_issue_discovery_rewards()` as thin wrappers around it

### Why
Both normalization functions had the same algorithm: extract scores from evaluations, sum them, divide each by the total. The only difference was which field they read (`total_score` vs `issue_discovery_score`) and the log messages.

### Test plan
- [x] All 301 tests pass
- [x] Pyright clean
- [x] Ruff lint and format clean