### PR TITLE
refactor: remove duplicated _error function from check.py

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -10,7 +10,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from .post import NETUID_DEFAULT, _load_config_value, _resolve_endpoint
+from .post import NETUID_DEFAULT, _error, _load_config_value, _resolve_endpoint
 
 console = Console()
 
@@ -158,11 +158,3 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
 
         console.print(table)
         console.print(f'\n[bold]{valid_count}/{len(results)} validators have a valid PAT stored.[/bold]')
-
-
-def _error(msg: str, json_mode: bool):
-    """Print an error message in the appropriate format."""
-    if json_mode:
-        click.echo(json.dumps({'success': False, 'error': msg}))
-    else:
-        console.print(f'[red]Error: {msg}[/red]')


### PR DESCRIPTION
### Summary
- Remove the duplicate `_error()` function from `cli/miner_commands/check.py`
- Import it from `cli/miner_commands/post.py` where the identical function already exists

### Why
Both `post.py` and `check.py` had the exact same `_error()` function for printing errors in JSON or Rich format. `check.py` already imports other helpers from `post.py`, so this is a natural consolidation.

### Test plan
- [x] All 301 tests pass
- [x] Pyright clean
- [x] Ruff lint and format clean
