### PR TITLE
Refactor: unify config loading by reusing load_config from helpers

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -14,6 +14,7 @@ import requests
 from rich.console import Console
 from rich.table import Table
 
+from gittensor.cli.issue_commands.helpers import load_config
 from gittensor.constants import BASE_GITHUB_API_URL
 
 console = Console()
@@ -229,16 +230,7 @@ def _validate_pat_locally(pat: str) -> bool:
 
 def _load_config_value(key: str):
     """Load a value from ~/.gittensor/config.json, or None."""
-    from pathlib import Path
-
-    config_file = Path.home() / '.gittensor' / 'config.json'
-    if not config_file.exists():
-        return None
-    try:
-        config = json.loads(config_file.read_text())
-        return config.get(key)
-    except (json.JSONDecodeError, OSError):
-        return None
+    return load_config().get(key)
 
 
 NETWORK_MAP = {

--- a/gittensor/validator/utils/issue_competitions.py
+++ b/gittensor/validator/utils/issue_competitions.py
@@ -3,22 +3,16 @@
 
 """Utility functions for Issue Bounties sub-mechanism."""
 
-import os
 from typing import Optional
 
 import bittensor as bt
 
-from gittensor.constants import CONTRACT_ADDRESS
+from gittensor.cli.issue_commands.helpers import get_contract_address as _get_contract_address
 
 
 def get_contract_address() -> Optional[str]:
-    """
-    Get contract address. Override via CONTRACT_ADDRESS env var for dev/testing.
-
-    Returns:
-        Contract address string (env var override or constants.py default)
-    """
-    return os.environ.get('CONTRACT_ADDRESS') or CONTRACT_ADDRESS
+    """Get contract address. CLI arg > env var > constants.py default."""
+    return _get_contract_address()
 
 
 def get_miner_coldkey(hotkey: str, subtensor: bt.Subtensor, netuid: int) -> Optional[str]:


### PR DESCRIPTION
### Summary
- Replace the standalone `_load_config_value()` in `cli/miner_commands/post.py` with a call to the existing `load_config()` from `cli/issue_commands/helpers.py`
- Replace the standalone `get_contract_address()` in `validator/utils/issue_competitions.py` with a call to the existing `get_contract_address()` from `cli/issue_commands/helpers.py`
- Same file paths, same error handling, just one implementation now