### PR TITLE
Move duplicated ISO timestamp parser to shared datetime_utils

### DIFF
--- a/gittensor/validator/issue_discovery/repo_scan.py
+++ b/gittensor/validator/issue_discovery/repo_scan.py
@@ -18,6 +18,7 @@ import bittensor as bt
 import requests
 
 from gittensor.classes import Issue, MinerEvaluation
+from gittensor.validator.utils.datetime_utils import parse_iso
 from gittensor.constants import (
     BASE_GITHUB_API_URL,
     PR_LOOKBACK_DAYS,
@@ -182,7 +183,7 @@ async def _scan_repo(
             pr_number=pr_number or 0,
             repository_full_name=repo_name,
             title=issue_raw.get('title', ''),
-            created_at=_parse_iso(issue_raw.get('created_at')),
+            created_at=parse_iso(issue_raw.get('created_at')),
             author_login=user.get('login'),
             author_github_id=author_github_id,
             state='CLOSED',
@@ -190,7 +191,7 @@ async def _scan_repo(
 
         if solver_id is not None:
             # Case 2: solved by non-miner PR → positive credibility
-            issue.closed_at = _parse_iso(issue_raw.get('closed_at'))
+            issue.closed_at = parse_iso(issue_raw.get('closed_at'))
         else:
             # Case 3: closed without PR → negative credibility
             issue.closed_at = None
@@ -238,13 +239,3 @@ def _fetch_closed_issues(repo_name: str, since: str, token: str) -> List[dict]:
             break
 
     return all_issues
-
-
-def _parse_iso(value: Optional[str]) -> Optional[datetime]:
-    """Parse an ISO 8601 timestamp string to datetime."""
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace('Z', '+00:00'))
-    except (ValueError, AttributeError):
-        return None

--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 import pytz
 
@@ -20,3 +21,13 @@ def parse_github_timestamp_to_cst(timestamp_str: str) -> datetime:
     chicago_dt = utc_dt.astimezone(CHICAGO_TZ)
 
     return chicago_dt
+
+
+def parse_iso(value: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO 8601 timestamp string to datetime."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return None


### PR DESCRIPTION
### Description
- Extract `_parse_iso()` from `validator/issue_discovery/repo_scan.py` into `validator/utils/datetime_utils.py` as `parse_iso()`
- Import the shared function in `repo_scan.py`