### PR TITLE
refactor: use shared make_headers instead of inline GitHub header dicts

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from rich.table import Table
 
 from gittensor.constants import BASE_GITHUB_API_URL
+from gittensor.utils.github_api_tools import make_headers
 
 console = Console()
 
@@ -201,7 +202,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
 
 def _validate_pat_locally(pat: str) -> bool:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
-    headers = {'Authorization': f'token {pat}', 'Accept': 'application/vnd.github.v3+json'}
+    headers = make_headers(pat)
     try:
         # Check basic auth
         user_resp = requests.get(f'{BASE_GITHUB_API_URL}/user', headers=headers, timeout=15)

--- a/gittensor/validator/issue_discovery/repo_scan.py
+++ b/gittensor/validator/issue_discovery/repo_scan.py
@@ -18,6 +18,7 @@ import bittensor as bt
 import requests
 
 from gittensor.classes import Issue, MinerEvaluation
+from gittensor.utils.github_api_tools import make_headers
 from gittensor.constants import (
     BASE_GITHUB_API_URL,
     PR_LOOKBACK_DAYS,
@@ -202,7 +203,7 @@ async def _scan_repo(
 
 def _fetch_closed_issues(repo_name: str, since: str, token: str) -> List[dict]:
     """Fetch closed issues from a repo via REST API with pagination."""
-    headers = {'Authorization': f'token {token}', 'Accept': 'application/vnd.github.v3+json'}
+    headers = make_headers(token)
     all_issues: List[dict] = []
     page = 1
 


### PR DESCRIPTION
## Summary

Replace inline `{'Authorization': f'token {token}', 'Accept': ...}` header dicts with the existing `make_headers()` utility from `utils/github_api_tools.py`.

## Related Issues

N/A (code cleanup)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

No behavior change — `make_headers()` returns the identical dict that was previously inline.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
