### PR TITLE
treat transferred issues as closed in discovery scoring

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -132,7 +132,7 @@ class Issue:
 
     # Issue discovery fields
     author_github_id: Optional[str] = None  # Issue author's GitHub user ID (for miner matching)
-    is_transferred: bool = False
+    state_reason: Optional[str] = None  # "COMPLETED", "NOT_PLANNED", "TRANSFERRED", or None (legacy)
     updated_at: Optional[datetime] = None
     body_or_title_edited_at: Optional[datetime] = None
     discovery_base_score: float = 0.0
@@ -142,6 +142,11 @@ class Issue:
     discovery_time_decay_multiplier: float = 1.0
     discovery_credibility_multiplier: float = 1.0
     discovery_open_issue_spam_multiplier: float = 1.0
+
+    @property
+    def is_transferred(self) -> bool:
+        """Convenience accessor. Prefer gating on `state_reason` directly in new code."""
+        return self.state_reason == 'TRANSFERRED'
 
 
 @dataclass
@@ -289,7 +294,7 @@ class PullRequest:
                     author_github_id=str(author_db_id) if author_db_id else None,
                     updated_at=parse_github_timestamp_to_cst(issue['updatedAt']) if issue.get('updatedAt') else None,
                     body_or_title_edited_at=body_or_title_edited_at,
-                    is_transferred=(issue.get('stateReason') == 'TRANSFERRED'),
+                    state_reason=issue.get('stateReason'),
                 )
             )
 

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -289,6 +289,7 @@ class PullRequest:
                     author_github_id=str(author_db_id) if author_db_id else None,
                     updated_at=parse_github_timestamp_to_cst(issue['updatedAt']) if issue.get('updatedAt') else None,
                     body_or_title_edited_at=body_or_title_edited_at,
+                    is_transferred=(issue.get('stateReason') == 'TRANSFERRED'),
                 )
             )
 

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -86,6 +86,7 @@ QUERY = """
                   number
                   title
                   state
+                  stateReason
                   createdAt
                   closedAt
                   updatedAt

--- a/gittensor/validator/issue_discovery/repo_scan.py
+++ b/gittensor/validator/issue_discovery/repo_scan.py
@@ -199,7 +199,7 @@ async def _scan_repo(
             author_login=user.get('login'),
             author_github_id=author_github_id,
             state='CLOSED',
-            is_transferred=(issue_raw.get('state_reason') == 'transferred'),
+            state_reason=(issue_raw.get('state_reason') or '').upper() or None,
         )
 
         if solver_id is not None:

--- a/gittensor/validator/issue_discovery/repo_scan.py
+++ b/gittensor/validator/issue_discovery/repo_scan.py
@@ -199,6 +199,7 @@ async def _scan_repo(
             author_login=user.get('login'),
             author_github_id=author_github_id,
             state='CLOSED',
+            is_transferred=(issue_raw.get('state_reason') == 'transferred'),
         )
 
         if solver_id is not None:

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -209,6 +209,14 @@ def _collect_issues_from_prs(
 
                 data = discoverer_data[discoverer_id]
 
+                # Anti-gaming: transferred issues count as closed, never as solved
+                if issue.is_transferred:
+                    bt.logging.info(
+                        f'Issue #{issue.number} transferred — 0 score, counts as closed'
+                    )
+                    data.closed_count += 1
+                    continue
+
                 # Classify: is this issue solved (merged PR closed it)?
                 is_solved = issue.state == 'CLOSED' and pr.merged_at is not None
 
@@ -277,6 +285,12 @@ def _merge_scan_issues(
 
         data = discoverer_data[github_id]
         for issue in issues:
+            if issue.is_transferred:
+                bt.logging.info(
+                    f'Scan issue #{issue.number} transferred — counts as closed'
+                )
+                data.closed_count += 1
+                continue
             if issue.state == 'CLOSED' and issue.closed_at:
                 # Case 2: solved by non-miner PR → positive credibility
                 data.solved_count += 1

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -209,10 +209,13 @@ def _collect_issues_from_prs(
 
                 data = discoverer_data[discoverer_id]
 
-                # Anti-gaming: transferred issues count as closed, never as solved
-                if issue.is_transferred:
+                # Anti-gaming: only explicitly COMPLETED closures count as solved.
+                # NOT_PLANNED, TRANSFERRED, and None all route to closed_count. None is
+                # effectively unreachable inside the 35-day lookback (GitHub auto-populates
+                # stateReason on close), but treating it as not-solved is the safer default.
+                if issue.state_reason != 'COMPLETED':
                     bt.logging.info(
-                        f'Issue #{issue.number} transferred — 0 score, counts as closed'
+                        f'Issue #{issue.number} state_reason={issue.state_reason} — 0 score, counts as closed'
                     )
                     data.closed_count += 1
                     continue
@@ -285,9 +288,11 @@ def _merge_scan_issues(
 
         data = discoverer_data[github_id]
         for issue in issues:
-            if issue.is_transferred:
+            # Anti-gaming: only explicitly COMPLETED closures count as solved.
+            # NOT_PLANNED, TRANSFERRED, and None all route to closed_count.
+            if issue.state_reason != 'COMPLETED':
                 bt.logging.info(
-                    f'Scan issue #{issue.number} transferred — counts as closed'
+                    f'Scan issue #{issue.number} state_reason={issue.state_reason} — counts as closed'
                 )
                 data.closed_count += 1
                 continue

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -291,9 +291,7 @@ def _merge_scan_issues(
             # Anti-gaming: only explicitly COMPLETED closures count as solved.
             # NOT_PLANNED, TRANSFERRED, and None all route to closed_count.
             if issue.state_reason != 'COMPLETED':
-                bt.logging.info(
-                    f'Scan issue #{issue.number} state_reason={issue.state_reason} — counts as closed'
-                )
+                bt.logging.info(f'Scan issue #{issue.number} state_reason={issue.state_reason} — counts as closed')
                 data.closed_count += 1
                 continue
             if issue.state == 'CLOSED' and issue.closed_at:

--- a/tests/validator/conftest.py
+++ b/tests/validator/conftest.py
@@ -137,13 +137,13 @@ class IssueBuilder:
         author_github_id: Optional[str] = '1001',
         author_login: str = 'alice',
         state: str = 'CLOSED',
-        is_transferred: bool = False,
+        state_reason: Optional[str] = 'COMPLETED',
         pr_number: int = 1,
         created_at: Optional[datetime] = None,
         closed_at: Optional[datetime] = None,
         updated_at: Optional[datetime] = None,
     ) -> Issue:
-        """Create a mock Issue with the given parameters."""
+        """Create a mock Issue with the given parameters. Defaults to COMPLETED (solved)."""
         if number is None:
             self._counter += 1
             number = self._counter
@@ -162,13 +162,25 @@ class IssueBuilder:
             author_login=author_login,
             author_github_id=author_github_id,
             state=state,
-            is_transferred=is_transferred,
+            state_reason=state_reason,
             updated_at=updated_at,
         )
 
+    def completed(self, **kwargs) -> Issue:
+        """Create a COMPLETED issue (solved)."""
+        return self.create(state_reason='COMPLETED', **kwargs)
+
     def transferred(self, **kwargs) -> Issue:
-        """Create a transferred issue."""
-        return self.create(is_transferred=True, **kwargs)
+        """Create a TRANSFERRED issue (counts as closed)."""
+        return self.create(state_reason='TRANSFERRED', **kwargs)
+
+    def not_planned(self, **kwargs) -> Issue:
+        """Create a NOT_PLANNED issue (counts as closed)."""
+        return self.create(state_reason='NOT_PLANNED', **kwargs)
+
+    def no_reason(self, **kwargs) -> Issue:
+        """Create an issue with no state_reason (legacy data — counts as closed)."""
+        return self.create(state_reason=None, **kwargs)
 
 
 @pytest.fixture

--- a/tests/validator/conftest.py
+++ b/tests/validator/conftest.py
@@ -14,7 +14,7 @@ from typing import List, Optional
 
 import pytest
 
-from gittensor.classes import PRState, PullRequest
+from gittensor.classes import Issue, PRState, PullRequest
 
 # ============================================================================
 # PR Factory Fixture
@@ -117,6 +117,64 @@ class PRBuilder:
 def pr_factory() -> PRBuilder:
     """Factory fixture for creating mock PRs."""
     return PRBuilder()
+
+
+# ============================================================================
+# Issue Factory Fixture
+# ============================================================================
+
+
+@dataclass
+class IssueBuilder:
+    """Builder for creating mock Issues with sensible defaults."""
+
+    _counter: int = 0
+
+    def create(
+        self,
+        number: Optional[int] = None,
+        repository_full_name: str = 'test/repo',
+        author_github_id: Optional[str] = '1001',
+        author_login: str = 'alice',
+        state: str = 'CLOSED',
+        is_transferred: bool = False,
+        pr_number: int = 1,
+        created_at: Optional[datetime] = None,
+        closed_at: Optional[datetime] = None,
+        updated_at: Optional[datetime] = None,
+    ) -> Issue:
+        """Create a mock Issue with the given parameters."""
+        if number is None:
+            self._counter += 1
+            number = self._counter
+        if created_at is None:
+            created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        if closed_at is None:
+            closed_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        return Issue(
+            number=number,
+            pr_number=pr_number,
+            repository_full_name=repository_full_name,
+            title=f'Test issue #{number}',
+            created_at=created_at,
+            closed_at=closed_at,
+            author_login=author_login,
+            author_github_id=author_github_id,
+            state=state,
+            is_transferred=is_transferred,
+            updated_at=updated_at,
+        )
+
+    def transferred(self, **kwargs) -> Issue:
+        """Create a transferred issue."""
+        return self.create(is_transferred=True, **kwargs)
+
+
+@pytest.fixture
+def issue_factory() -> IssueBuilder:
+    """Factory fixture for creating mock Issues."""
+    return IssueBuilder()
 
 
 # ============================================================================

--- a/tests/validator/test_issue_discovery_post_merge_edit.py
+++ b/tests/validator/test_issue_discovery_post_merge_edit.py
@@ -35,6 +35,7 @@ def _make_issue(
         closed_at=MERGED_AT,
         author_login='alice',
         state='CLOSED',
+        state_reason='COMPLETED',
         author_github_id=DISCOVERER_GH,
         updated_at=updated_at,
         body_or_title_edited_at=body_or_title_edited_at,

--- a/tests/validator/test_issue_discovery_repo_scan.py
+++ b/tests/validator/test_issue_discovery_repo_scan.py
@@ -27,24 +27,28 @@ def _make_raw(state_reason: Optional[str], number: int) -> dict:
 
 def _run_scan(monkeypatch, raw_issues):
     monkeypatch.setattr(
-        repo_scan, '_fetch_closed_issues',
+        repo_scan,
+        '_fetch_closed_issues',
         lambda repo_name, since, token: raw_issues,
     )
     monkeypatch.setattr(
-        repo_scan, 'find_solver_from_cross_references',
+        repo_scan,
+        'find_solver_from_cross_references',
         lambda repo, issue_number, token: (None, None),
     )
 
     result: dict = {}
-    asyncio.run(repo_scan._scan_repo(
-        repo_name='test/repo',
-        lookback_date='2026-01-01',
-        validator_pat='x',
-        miner_github_ids={'1001'},
-        known_issues=set(),
-        result=result,
-        lookup_cap=10,
-    ))
+    asyncio.run(
+        repo_scan._scan_repo(
+            repo_name='test/repo',
+            lookback_date='2026-01-01',
+            validator_pat='x',
+            miner_github_ids={'1001'},
+            known_issues=set(),
+            result=result,
+            lookup_cap=10,
+        )
+    )
     return result
 
 

--- a/tests/validator/test_issue_discovery_repo_scan.py
+++ b/tests/validator/test_issue_discovery_repo_scan.py
@@ -38,7 +38,7 @@ def _run_scan(monkeypatch, raw_issues):
     )
 
     result: dict = {}
-    asyncio.run(
+    asyncio.get_event_loop().run_until_complete(
         repo_scan._scan_repo(
             repo_name='test/repo',
             lookback_date='2026-01-01T00:00:00Z',

--- a/tests/validator/test_issue_discovery_repo_scan.py
+++ b/tests/validator/test_issue_discovery_repo_scan.py
@@ -1,0 +1,57 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for repo_scan: is_transferred population from REST state_reason."""
+
+import asyncio
+
+from gittensor.validator.issue_discovery import repo_scan
+
+
+def _make_raw(state_reason: str, number: int) -> dict:
+    return {
+        'number': number,
+        'title': f'issue {number}',
+        'created_at': '2026-01-01T00:00:00Z',
+        'closed_at': '2026-01-02T00:00:00Z',
+        'state': 'closed',
+        'state_reason': state_reason,
+        'user': {'login': 'alice', 'id': 1001},
+    }
+
+
+def _run_scan(monkeypatch, raw_issues):
+    monkeypatch.setattr(
+        repo_scan, '_fetch_closed_issues',
+        lambda repo_name, since, token: raw_issues,
+    )
+    monkeypatch.setattr(
+        repo_scan, 'find_solver_from_cross_references',
+        lambda repo, issue_number, token: (None, None),
+    )
+
+    result: dict = {}
+    asyncio.run(repo_scan._scan_repo(
+        repo_name='test/repo',
+        lookback_date='2026-01-01',
+        validator_pat='x',
+        miner_github_ids={'1001'},
+        known_issues=set(),
+        result=result,
+        lookup_cap=10,
+    ))
+    return result
+
+
+def test_scan_repo_sets_is_transferred_for_transferred_issue(monkeypatch):
+    result = _run_scan(monkeypatch, [_make_raw('transferred', 42)])
+
+    assert '1001' in result
+    assert result['1001'][0].is_transferred is True
+
+
+def test_scan_repo_is_transferred_false_for_completed_issue(monkeypatch):
+    result = _run_scan(monkeypatch, [_make_raw('completed', 43)])
+
+    assert '1001' in result
+    assert result['1001'][0].is_transferred is False

--- a/tests/validator/test_issue_discovery_repo_scan.py
+++ b/tests/validator/test_issue_discovery_repo_scan.py
@@ -1,14 +1,19 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-"""Tests for repo_scan: is_transferred population from REST state_reason."""
+"""Tests for repo_scan: state_reason population from REST state_reason field.
+
+REST returns lowercase (`transferred`, `not_planned`, `completed`); repo_scan
+normalizes to uppercase for a single gate with the GraphQL path.
+"""
 
 import asyncio
+from typing import Optional
 
 from gittensor.validator.issue_discovery import repo_scan
 
 
-def _make_raw(state_reason: str, number: int) -> dict:
+def _make_raw(state_reason: Optional[str], number: int) -> dict:
     return {
         'number': number,
         'title': f'issue {number}',
@@ -43,15 +48,34 @@ def _run_scan(monkeypatch, raw_issues):
     return result
 
 
-def test_scan_repo_sets_is_transferred_for_transferred_issue(monkeypatch):
+def test_scan_repo_sets_state_reason_for_transferred_issue(monkeypatch):
     result = _run_scan(monkeypatch, [_make_raw('transferred', 42)])
 
     assert '1001' in result
+    assert result['1001'][0].state_reason == 'TRANSFERRED'
     assert result['1001'][0].is_transferred is True
 
 
-def test_scan_repo_is_transferred_false_for_completed_issue(monkeypatch):
-    result = _run_scan(monkeypatch, [_make_raw('completed', 43)])
+def test_scan_repo_sets_state_reason_for_not_planned_issue(monkeypatch):
+    result = _run_scan(monkeypatch, [_make_raw('not_planned', 43)])
 
     assert '1001' in result
+    assert result['1001'][0].state_reason == 'NOT_PLANNED'
+    assert result['1001'][0].is_transferred is False
+
+
+def test_scan_repo_sets_state_reason_for_completed_issue(monkeypatch):
+    result = _run_scan(monkeypatch, [_make_raw('completed', 44)])
+
+    assert '1001' in result
+    assert result['1001'][0].state_reason == 'COMPLETED'
+    assert result['1001'][0].is_transferred is False
+
+
+def test_scan_repo_sets_state_reason_none_when_missing(monkeypatch):
+    """Legacy issues closed before GitHub rolled out state_reason return None."""
+    result = _run_scan(monkeypatch, [_make_raw(None, 45)])
+
+    assert '1001' in result
+    assert result['1001'][0].state_reason is None
     assert result['1001'][0].is_transferred is False

--- a/tests/validator/test_issue_discovery_repo_scan.py
+++ b/tests/validator/test_issue_discovery_repo_scan.py
@@ -41,7 +41,7 @@ def _run_scan(monkeypatch, raw_issues):
     asyncio.run(
         repo_scan._scan_repo(
             repo_name='test/repo',
-            lookback_date='2026-01-01',
+            lookback_date='2026-01-01T00:00:00Z',
             validator_pat='x',
             miner_github_ids={'1001'},
             known_issues=set(),

--- a/tests/validator/test_issue_discovery_scoring.py
+++ b/tests/validator/test_issue_discovery_scoring.py
@@ -28,7 +28,10 @@ def _run_pr_path(issue, pr):
     discoverer_data = {issue.author_github_id: _DiscovererData()}
 
     _collect_issues_from_prs(
-        miner_evaluations, github_id_to_uid, discoverer_data, {},
+        miner_evaluations,
+        github_id_to_uid,
+        discoverer_data,
+        {},
     )
     return discoverer_data[issue.author_github_id]
 
@@ -55,7 +58,8 @@ def test_completed_issue_in_pr_path_counts_as_solved(issue_factory, pr_factory):
 
 
 def test_transferred_issue_in_pr_path_counts_as_closed_not_solved(
-    issue_factory, pr_factory,
+    issue_factory,
+    pr_factory,
 ):
     issue = issue_factory.transferred()
     data = _run_pr_path(issue, pr_factory.merged())
@@ -64,7 +68,8 @@ def test_transferred_issue_in_pr_path_counts_as_closed_not_solved(
 
 
 def test_not_planned_issue_in_pr_path_counts_as_closed_not_solved(
-    issue_factory, pr_factory,
+    issue_factory,
+    pr_factory,
 ):
     issue = issue_factory.not_planned()
     data = _run_pr_path(issue, pr_factory.merged())
@@ -73,7 +78,8 @@ def test_not_planned_issue_in_pr_path_counts_as_closed_not_solved(
 
 
 def test_issue_with_no_state_reason_in_pr_path_counts_as_closed(
-    issue_factory, pr_factory,
+    issue_factory,
+    pr_factory,
 ):
     """Legacy data path: None state_reason routes to closed_count."""
     issue = issue_factory.no_reason()

--- a/tests/validator/test_issue_discovery_scoring.py
+++ b/tests/validator/test_issue_discovery_scoring.py
@@ -1,7 +1,11 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-"""Tests for issue discovery scoring: transfer-detection anti-gaming path."""
+"""Tests for issue discovery scoring: state_reason anti-gaming gate.
+
+Solved classification requires state_reason == 'COMPLETED'. Any other value
+(NOT_PLANNED, TRANSFERRED, None) routes to closed_count.
+"""
 
 from gittensor.classes import MinerEvaluation
 from gittensor.validator.issue_discovery.scoring import (
@@ -17,67 +21,96 @@ def _make_evaluation(pr) -> MinerEvaluation:
     return ev
 
 
+def _run_pr_path(issue, pr):
+    pr.issues = [issue]
+    miner_evaluations = {1: _make_evaluation(pr)}
+    github_id_to_uid = {issue.author_github_id: 1}
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+
+    _collect_issues_from_prs(
+        miner_evaluations, github_id_to_uid, discoverer_data, {},
+    )
+    return discoverer_data[issue.author_github_id]
+
+
+def _run_scan_path(issue):
+    scan_issues = {issue.author_github_id: [issue]}
+    github_id_to_uid = {issue.author_github_id: 1}
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+
+    _merge_scan_issues(scan_issues, github_id_to_uid, discoverer_data)
+    return discoverer_data[issue.author_github_id]
+
+
+# ---------------------------------------------------------------------------
+# PR-linked path (_collect_issues_from_prs)
+# ---------------------------------------------------------------------------
+
+
+def test_completed_issue_in_pr_path_counts_as_solved(issue_factory, pr_factory):
+    issue = issue_factory.completed()
+    data = _run_pr_path(issue, pr_factory.merged())
+    assert data.solved_count == 1
+    assert data.closed_count == 0
+
+
 def test_transferred_issue_in_pr_path_counts_as_closed_not_solved(
     issue_factory, pr_factory,
 ):
     issue = issue_factory.transferred()
-    pr = pr_factory.merged()
-    pr.issues = [issue]
-
-    miner_evaluations = {1: _make_evaluation(pr)}
-    github_id_to_uid = {issue.author_github_id: 1}
-    discoverer_data = {issue.author_github_id: _DiscovererData()}
-
-    _collect_issues_from_prs(
-        miner_evaluations, github_id_to_uid, discoverer_data, {},
-    )
-
-    data = discoverer_data[issue.author_github_id]
+    data = _run_pr_path(issue, pr_factory.merged())
     assert data.closed_count == 1
     assert data.solved_count == 0
 
 
-def test_non_transferred_issue_in_pr_path_counts_as_solved(
+def test_not_planned_issue_in_pr_path_counts_as_closed_not_solved(
     issue_factory, pr_factory,
 ):
-    issue = issue_factory.create()
-    pr = pr_factory.merged()
-    pr.issues = [issue]
+    issue = issue_factory.not_planned()
+    data = _run_pr_path(issue, pr_factory.merged())
+    assert data.closed_count == 1
+    assert data.solved_count == 0
 
-    miner_evaluations = {1: _make_evaluation(pr)}
-    github_id_to_uid = {issue.author_github_id: 1}
-    discoverer_data = {issue.author_github_id: _DiscovererData()}
 
-    _collect_issues_from_prs(
-        miner_evaluations, github_id_to_uid, discoverer_data, {},
-    )
+def test_issue_with_no_state_reason_in_pr_path_counts_as_closed(
+    issue_factory, pr_factory,
+):
+    """Legacy data path: None state_reason routes to closed_count."""
+    issue = issue_factory.no_reason()
+    data = _run_pr_path(issue, pr_factory.merged())
+    assert data.closed_count == 1
+    assert data.solved_count == 0
 
-    data = discoverer_data[issue.author_github_id]
+
+# ---------------------------------------------------------------------------
+# Scan path (_merge_scan_issues)
+# ---------------------------------------------------------------------------
+
+
+def test_completed_scan_issue_with_closed_at_counts_as_solved(issue_factory):
+    issue = issue_factory.completed()
+    data = _run_scan_path(issue)
     assert data.solved_count == 1
     assert data.closed_count == 0
 
 
 def test_transferred_scan_issue_counts_as_closed(issue_factory):
     issue = issue_factory.transferred()
-    scan_issues = {issue.author_github_id: [issue]}
-    github_id_to_uid = {issue.author_github_id: 1}
-    discoverer_data = {issue.author_github_id: _DiscovererData()}
-
-    _merge_scan_issues(scan_issues, github_id_to_uid, discoverer_data)
-
-    data = discoverer_data[issue.author_github_id]
+    data = _run_scan_path(issue)
     assert data.closed_count == 1
     assert data.solved_count == 0
 
 
-def test_non_transferred_scan_issue_with_closed_at_counts_as_solved(issue_factory):
-    issue = issue_factory.create()
-    scan_issues = {issue.author_github_id: [issue]}
-    github_id_to_uid = {issue.author_github_id: 1}
-    discoverer_data = {issue.author_github_id: _DiscovererData()}
+def test_not_planned_scan_issue_counts_as_closed(issue_factory):
+    issue = issue_factory.not_planned()
+    data = _run_scan_path(issue)
+    assert data.closed_count == 1
+    assert data.solved_count == 0
 
-    _merge_scan_issues(scan_issues, github_id_to_uid, discoverer_data)
 
-    data = discoverer_data[issue.author_github_id]
-    assert data.solved_count == 1
-    assert data.closed_count == 0
+def test_scan_issue_with_no_state_reason_counts_as_closed(issue_factory):
+    """Legacy data path: None state_reason routes to closed_count."""
+    issue = issue_factory.no_reason()
+    data = _run_scan_path(issue)
+    assert data.closed_count == 1
+    assert data.solved_count == 0

--- a/tests/validator/test_issue_discovery_scoring.py
+++ b/tests/validator/test_issue_discovery_scoring.py
@@ -1,0 +1,83 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for issue discovery scoring: transfer-detection anti-gaming path."""
+
+from gittensor.classes import MinerEvaluation
+from gittensor.validator.issue_discovery.scoring import (
+    _collect_issues_from_prs,
+    _DiscovererData,
+    _merge_scan_issues,
+)
+
+
+def _make_evaluation(pr) -> MinerEvaluation:
+    ev = MinerEvaluation(uid=1, hotkey='test_hotkey')
+    ev.merged_pull_requests = [pr]
+    return ev
+
+
+def test_transferred_issue_in_pr_path_counts_as_closed_not_solved(
+    issue_factory, pr_factory,
+):
+    issue = issue_factory.transferred()
+    pr = pr_factory.merged()
+    pr.issues = [issue]
+
+    miner_evaluations = {1: _make_evaluation(pr)}
+    github_id_to_uid = {issue.author_github_id: 1}
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+
+    _collect_issues_from_prs(
+        miner_evaluations, github_id_to_uid, discoverer_data, {},
+    )
+
+    data = discoverer_data[issue.author_github_id]
+    assert data.closed_count == 1
+    assert data.solved_count == 0
+
+
+def test_non_transferred_issue_in_pr_path_counts_as_solved(
+    issue_factory, pr_factory,
+):
+    issue = issue_factory.create()
+    pr = pr_factory.merged()
+    pr.issues = [issue]
+
+    miner_evaluations = {1: _make_evaluation(pr)}
+    github_id_to_uid = {issue.author_github_id: 1}
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+
+    _collect_issues_from_prs(
+        miner_evaluations, github_id_to_uid, discoverer_data, {},
+    )
+
+    data = discoverer_data[issue.author_github_id]
+    assert data.solved_count == 1
+    assert data.closed_count == 0
+
+
+def test_transferred_scan_issue_counts_as_closed(issue_factory):
+    issue = issue_factory.transferred()
+    scan_issues = {issue.author_github_id: [issue]}
+    github_id_to_uid = {issue.author_github_id: 1}
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+
+    _merge_scan_issues(scan_issues, github_id_to_uid, discoverer_data)
+
+    data = discoverer_data[issue.author_github_id]
+    assert data.closed_count == 1
+    assert data.solved_count == 0
+
+
+def test_non_transferred_scan_issue_with_closed_at_counts_as_solved(issue_factory):
+    issue = issue_factory.create()
+    scan_issues = {issue.author_github_id: [issue]}
+    github_id_to_uid = {issue.author_github_id: 1}
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+
+    _merge_scan_issues(scan_issues, github_id_to_uid, discoverer_data)
+
+    data = discoverer_data[issue.author_github_id]
+    assert data.solved_count == 1
+    assert data.closed_count == 0


### PR DESCRIPTION
closes #404
closes #405
 
## summary
 
transferred issues were being counted as solved in discovery scoring, so a miner could file an issue, have it transferred, and still collect emissions
repo_scan never populated is_transferred even though the rest response carries state_reason, and the pr-linked path never had the data because the graphql query didn't select stateReason
this adds stateReason to the closingIssuesReferences selection, sets is_transferred in both construction paths, and routes transferred issues to closed_count in _collect_issues_from_prs and _merge_scan_issues
 
## test plan
 
pytest covers transferred vs non-transferred in the pr-linked scoring path, the scan merge path, and the repo_scan field population from state_reason transferred/completed. ruff and pyright pass
 