### PR TITLE
chore(weights): inactivate dify, lower allways-ui and gittensor-ui weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -197,13 +197,13 @@
     "weight": 1.0
   },
   "entrius/allways-ui": {
-    "weight": 1.0
+    "weight": 0.88
   },
   "entrius/gittensor": {
     "weight": 1.0
   },
   "entrius/gittensor-ui": {
-    "weight": 1.0
+    "weight": 0.88
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444
@@ -320,7 +320,8 @@
     "weight": 0.0615
   },
   "langgenius/dify": {
-    "weight": 0.0336
+    "weight": 0.0336,
+    "inactive_at": "2026-04-14T00:00:00Z"
   },
   "laravel/framework": {
     "weight": 0.0346


### PR DESCRIPTION
## Summary
- Inactivate `langgenius/dify` as of 2026-04-14 — causing nuisance
- Lower `entrius/allways-ui` weight from 1.0 to 0.88
- Lower `entrius/gittensor-ui` weight from 1.0 to 0.88

## Test plan
- [ ] Verify `load_weights.py` parses the updated JSON without errors
- [ ] Confirm dify is treated as inactive by the validator