### PR TITLE
Merge test into main

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -8,7 +8,7 @@ from typing import DefaultDict, Dict, List, Optional, Set
 
 import bittensor as bt
 
-from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE
+from gittensor.constants import MAX_CODE_DENSITY_MULTIPLIER, MIN_TOKEN_SCORE_FOR_BASE_SCORE
 from gittensor.utils.utils import parse_repo_name
 
 GITHUB_DOMAIN = 'https://github.com/'
@@ -488,6 +488,14 @@ class ScoreBreakdown:
         )
 
 
+class ScoringCategory(Enum):
+    """Category of a scored file"""
+
+    SOURCE = 'source'  # Non-test code files scored via tree-diff
+    TEST = 'test'  # Test files (any scoring method)
+    NON_CODE = 'non_code'  # Everything else (line-count, skipped, binary, etc.)
+
+
 @dataclass
 class FileScoreResult:
     """Result of scoring a single file."""
@@ -500,18 +508,36 @@ class FileScoreResult:
     scoring_method: str  # 'tree-diff', 'line-count', 'skipped-*'
     breakdown: Optional[ScoreBreakdown] = None  # Only populated for tree-diff scoring
 
+    @property
+    def category(self) -> ScoringCategory:
+        if self.is_test_file:
+            return ScoringCategory.TEST
+        if self.scoring_method == 'tree-diff':
+            return ScoringCategory.SOURCE
+        return ScoringCategory.NON_CODE
+
 
 @dataclass
 class PrScoringResult:
-    """Result of scoring a pull request.
+    """Result of scoring a pull request
 
-    Contains aggregate metrics for the PR, including total score and per-file details.
+    Contains aggregate metrics for the PR, including total score, per-file details,
+    and optional per-category breakdowns.
     """
 
     total_score: float
     total_nodes_scored: int  # Total AST nodes scored across all files
+    total_lines: int  # Total lines changed across all files
     file_results: List[FileScoreResult]
     score_breakdown: Optional[ScoreBreakdown] = None  # Aggregated breakdown across all files
+    by_category: Dict[ScoringCategory, 'PrScoringResult'] = field(default_factory=dict)
+
+    @property
+    def density(self) -> float:
+        """Code density (total_score / total_lines), capped at MAX_CODE_DENSITY_MULTIPLIER"""
+        if self.total_lines <= 0:
+            return 0.0
+        return min(self.total_score / self.total_lines, MAX_CODE_DENSITY_MULTIPLIER)
 
 
 @dataclass

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -10,7 +10,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from .post import NETUID_DEFAULT, _load_config_value, _resolve_endpoint
+from .post import NETUID_DEFAULT, _error, _load_config_value, _resolve_endpoint
 
 console = Console()
 
@@ -153,11 +153,3 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
 
         console.print(table)
         console.print(f'\n[bold]{valid_count}/{len(results)} validators have a valid PAT stored.[/bold]')
-
-
-def _error(msg: str, json_mode: bool):
-    """Print an error message in the appropriate format."""
-    if json_mode:
-        click.echo(json.dumps({'success': False, 'error': msg}))
-    else:
-        console.print(f'[red]Error: {msg}[/red]')

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -45,22 +45,23 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 2. Set up bittensor objects
+    def _connect():
+        w = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+        st = bt.Subtensor(network=ws_endpoint)
+        mg = st.metagraph(netuid=netuid)
+        dd = bt.Dendrite(wallet=w)
+        return w, st, mg, dd
+
     if not json_mode:
         with console.status('[bold]Connecting to network...'):
             try:
-                wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-                subtensor = bt.Subtensor(network=ws_endpoint)
-                metagraph = subtensor.metagraph(netuid=netuid)
-                dendrite = bt.Dendrite(wallet=wallet)
+                wallet, subtensor, metagraph, dendrite = _connect()
             except Exception as e:
                 _error(f'Failed to initialize bittensor: {e}', json_mode)
                 sys.exit(1)
     else:
         try:
-            wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-            subtensor = bt.Subtensor(network=ws_endpoint)
-            metagraph = subtensor.metagraph(netuid=netuid)
-            dendrite = bt.Dendrite(wallet=wallet)
+            wallet, subtensor, metagraph, dendrite = _connect()
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)
@@ -85,25 +86,19 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
     # 4. Send check probes
     synapse = PatCheckSynapse()
 
+    async def _check():
+        return await dendrite(
+            axons=validator_axons,
+            synapse=synapse,
+            deserialize=False,
+            timeout=15.0,
+        )
+
     if not json_mode:
         with console.status(f'[bold]Checking {len(validator_axons)} validators...'):
-            responses = asyncio.get_event_loop().run_until_complete(
-                dendrite(
-                    axons=validator_axons,
-                    synapse=synapse,
-                    deserialize=False,
-                    timeout=15.0,
-                )
-            )
+            responses = asyncio.run(_check())
     else:
-        responses = asyncio.get_event_loop().run_until_complete(
-            dendrite(
-                axons=validator_axons,
-                synapse=synapse,
-                deserialize=False,
-                timeout=15.0,
-            )
-        )
+        responses = asyncio.run(_check())
 
     # 5. Collect results
     results = []

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -19,7 +19,7 @@ from gittensor.constants import BASE_GITHUB_API_URL
 console = Console()
 
 # Shared CLI options for wallet/network configuration
-NETUID_DEFAULT = 2
+NETUID_DEFAULT = 74
 
 
 @click.command()

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -87,22 +87,23 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 3. Set up bittensor objects
+    def _connect():
+        w = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+        st = bt.Subtensor(network=ws_endpoint)
+        mg = st.metagraph(netuid=netuid)
+        dd = bt.Dendrite(wallet=w)
+        return w, st, mg, dd
+
     if not json_mode:
         with console.status('[bold]Connecting to network...'):
             try:
-                wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-                subtensor = bt.Subtensor(network=ws_endpoint)
-                metagraph = subtensor.metagraph(netuid=netuid)
-                dendrite = bt.Dendrite(wallet=wallet)
+                wallet, subtensor, metagraph, dendrite = _connect()
             except Exception as e:
                 _error(f'Failed to initialize bittensor: {e}', json_mode)
                 sys.exit(1)
     else:
         try:
-            wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
-            subtensor = bt.Subtensor(network=ws_endpoint)
-            metagraph = subtensor.metagraph(netuid=netuid)
-            dendrite = bt.Dendrite(wallet=wallet)
+            wallet, subtensor, metagraph, dendrite = _connect()
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)
@@ -127,25 +128,19 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
     # 5. Broadcast
     synapse = PatBroadcastSynapse(github_access_token=pat)
 
+    async def _broadcast():
+        return await dendrite(
+            axons=validator_axons,
+            synapse=synapse,
+            deserialize=False,
+            timeout=30.0,
+        )
+
     if not json_mode:
         with console.status(f'[bold]Broadcasting to {len(validator_axons)} validators...'):
-            responses = asyncio.get_event_loop().run_until_complete(
-                dendrite(
-                    axons=validator_axons,
-                    synapse=synapse,
-                    deserialize=False,
-                    timeout=30.0,
-                )
-            )
+            responses = asyncio.run(_broadcast())
     else:
-        responses = asyncio.get_event_loop().run_until_complete(
-            dendrite(
-                axons=validator_axons,
-                synapse=synapse,
-                deserialize=False,
-                timeout=30.0,
-            )
-        )
+        responses = asyncio.run(_broadcast())
 
     # 6. Collect results
     results = []

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -104,7 +104,7 @@ INLINE_TEST_PATTERNS: Dict[str, re.Pattern] = {
 # Eligibility Gate (OSS Contributions)
 # =============================================================================
 MIN_VALID_MERGED_PRS = 5  # minimum "valid" merged PRs (token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE) to receive score
-MIN_CREDIBILITY = 0.90  # minimum credibility ratio to receive score
+MIN_CREDIBILITY = 0.80  # minimum credibility ratio to receive score
 CREDIBILITY_MULLIGAN_COUNT = 1  # number of closed PRs forgiven (erased from merged+closed counts entirely)
 
 # =============================================================================

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -881,7 +881,19 @@ def try_add_open_or_closed_pr(
             bt.logging.warning(f'PR #{pr_raw["number"]} is CLOSED but missing closedAt timestamp.')
             return
 
+        created_at = pr_raw.get('createdAt')
+        if not created_at:
+            bt.logging.warning(f'PR #{pr_raw["number"]} is CLOSED but missing createdAt timestamp.')
+            return
+
         closed_dt = datetime.fromisoformat(closed_at.rstrip('Z')).replace(tzinfo=timezone.utc)
+        created_dt = datetime.fromisoformat(created_at.rstrip('Z')).replace(tzinfo=timezone.utc)
+
+        # Ignore stale PRs that were created before the scoring lookback window.
+        # This allows users to close old PRs without receiving a fresh credibility penalty.
+        if created_dt < lookback_date_filter:
+            return
+
         if closed_dt >= lookback_date_filter:
             miner_eval.add_closed_pull_request(pr_raw)
 

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -1,7 +1,6 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-import math
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
@@ -19,12 +18,8 @@ from gittensor.constants import (
     MIN_VALID_SOLVED_ISSUES,
     OPEN_ISSUE_SPAM_BASE_THRESHOLD,
     OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
-    SECONDS_PER_HOUR,
-    TIME_DECAY_GRACE_PERIOD_HOURS,
-    TIME_DECAY_MIN_MULTIPLIER,
-    TIME_DECAY_SIGMOID_MIDPOINT,
-    TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
 )
+from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
 
@@ -78,19 +73,6 @@ def check_issue_eligibility(solved_count: int, closed_count: int) -> Tuple[bool,
         return False, credibility, f'Issue credibility {credibility:.2f} < {MIN_ISSUE_CREDIBILITY}'
 
     return True, credibility, ''
-
-
-def _calculate_time_decay_from_merge(merged_at: datetime) -> float:
-    """Time decay anchored to a PR's merge date. Same sigmoid as OSS contributions."""
-    now = datetime.now(timezone.utc)
-    hours_since_merge = (now - merged_at).total_seconds() / SECONDS_PER_HOUR
-
-    if hours_since_merge < TIME_DECAY_GRACE_PERIOD_HOURS:
-        return 1.0
-
-    days_since_merge = hours_since_merge / 24
-    sigmoid = 1 / (1 + math.exp(TIME_DECAY_SIGMOID_STEEPNESS_SCALAR * (days_since_merge - TIME_DECAY_SIGMOID_MIDPOINT)))
-    return max(sigmoid, TIME_DECAY_MIN_MULTIPLIER)
 
 
 def score_discovered_issues(
@@ -267,7 +249,7 @@ def _collect_issues_from_prs(
                 repo_config = master_repositories.get(pr.repository_full_name)
                 issue.discovery_base_score = pr.base_score
                 issue.discovery_repo_weight_multiplier = round(repo_config.weight if repo_config else 0.01, 2)
-                issue.discovery_time_decay_multiplier = round(_calculate_time_decay_from_merge(pr.merged_at), 2)
+                issue.discovery_time_decay_multiplier = round(calculate_time_decay(pr.merged_at), 2)
                 issue.discovery_review_quality_multiplier = round(
                     calculate_issue_review_quality_multiplier(pr.changes_requested_count), 2
                 )

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -7,13 +7,19 @@ from typing import Dict, Tuple
 
 import bittensor as bt
 
-from gittensor.classes import Issue, MinerEvaluation, PrScoringResult, PRState, PullRequest
+from gittensor.classes import (
+    Issue,
+    MinerEvaluation,
+    PrScoringResult,
+    PRState,
+    PullRequest,
+    ScoringCategory,
+)
 from gittensor.constants import (
     CONTRIBUTION_SCORE_FOR_FULL_BONUS,
     EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
     MAINTAINER_ASSOCIATIONS,
     MAINTAINER_ISSUE_MULTIPLIER,
-    MAX_CODE_DENSITY_MULTIPLIER,
     MAX_CONTRIBUTION_BONUS,
     MAX_ISSUE_CLOSE_WINDOW_DAYS,
     MAX_OPEN_PR_THRESHOLD,
@@ -152,7 +158,7 @@ def calculate_base_score(
     token_config: TokenConfig,
     file_contents: Dict[str, FileContentPair],
 ) -> float:
-    """Calculate base score using code density scaling + contribution bonus."""
+    """Calculate base score using SOURCE density scaling + contribution bonus"""
     scoring_result: PrScoringResult = calculate_token_score_from_file_changes(
         pr.file_changes or [],
         file_contents,
@@ -160,44 +166,45 @@ def calculate_base_score(
         programming_languages,
     )
 
-    pr.total_nodes_scored = scoring_result.total_nodes_scored
     if scoring_result.score_breakdown:
         pr.token_score = scoring_result.score_breakdown.total_score
         pr.structural_count = scoring_result.score_breakdown.structural_count
         pr.structural_score = scoring_result.score_breakdown.structural_score
         pr.leaf_count = scoring_result.score_breakdown.leaf_count
         pr.leaf_score = scoring_result.score_breakdown.leaf_score
-
-    # Calculate total lines changed across all files
-    total_lines = sum(f.total_lines for f in scoring_result.file_results)
-
-    # Check minimum token score threshold for base score. PRs below threshold get 0 base score
-    if pr.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
-        code_density = 0.0
-        initial_base_score = 0.0
-    elif total_lines > 0:
-        code_density = min(pr.token_score / total_lines, MAX_CODE_DENSITY_MULTIPLIER)
-        initial_base_score = MERGED_PR_BASE_SCORE * code_density
+        # Only count AST nodes (tree-diff), not line-count "nodes"
+        pr.total_nodes_scored = (
+            scoring_result.score_breakdown.structural_count + scoring_result.score_breakdown.leaf_count
+        )
     else:
-        code_density = 0.0
-        initial_base_score = 0.0
+        pr.total_nodes_scored = 0
 
-    # Calculate contribution bonus, capped
+    # Threshold uses SOURCE category score only
+    source = scoring_result.by_category.get(ScoringCategory.SOURCE)
+    source_token_score = source.score_breakdown.total_score if source and source.score_breakdown else 0.0
+
+    # Density-scaled base score from SOURCE category only
+    source_density = source.density if source else 0.0
+    if source_token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        initial_base_score = 0.0
+    else:
+        initial_base_score = MERGED_PR_BASE_SCORE * source_density
+
+    # Contribution bonus from all categories, capped at MAX_CONTRIBUTION_BONUS
     bonus_percent = min(1.0, scoring_result.total_score / CONTRIBUTION_SCORE_FOR_FULL_BONUS)
     contribution_bonus = round(bonus_percent * MAX_CONTRIBUTION_BONUS, 2)
 
-    # Final base score = density-scaled base + contribution bonus
     base_score = round(initial_base_score + contribution_bonus, 2)
 
-    # Log with note if below token threshold
+    # Log with source density and bonus percentage
     threshold_note = (
         f' [below {MIN_TOKEN_SCORE_FOR_BASE_SCORE} token threshold]'
-        if pr.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        if source_token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE
         else ''
     )
     bt.logging.info(
-        f'Base score: {initial_base_score:.2f} (density {code_density:.2f}){threshold_note} + {contribution_bonus} bonus '
-        f'({bonus_percent * 100:.0f}% of max {MAX_CONTRIBUTION_BONUS}) = {base_score:.2f}'
+        f'Base score: {initial_base_score:.2f} (density {source_density:.2f}){threshold_note}'
+        f' + {contribution_bonus} bonus ({bonus_percent * 100:.0f}% of max {MAX_CONTRIBUTION_BONUS}) = {base_score:.2f}'
     )
 
     return base_score

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -1,8 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-import math
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, Tuple
 
 import bittensor as bt
@@ -33,12 +32,7 @@ from gittensor.constants import (
     PIONEER_DIVIDEND_RATE_REST,
     REVIEW_PENALTY_RATE,
     SECONDS_PER_DAY,
-    SECONDS_PER_HOUR,
     STANDARD_ISSUE_MULTIPLIER,
-    TIME_DECAY_GRACE_PERIOD_HOURS,
-    TIME_DECAY_MIN_MULTIPLIER,
-    TIME_DECAY_SIGMOID_MIDPOINT,
-    TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
 )
 from gittensor.utils.github_api_tools import (
     FileContentPair,
@@ -48,6 +42,7 @@ from gittensor.utils.github_api_tools import (
     get_pull_request_maintainer_changes_requested_count,
 )
 from gittensor.validator.oss_contributions.credibility import check_eligibility
+from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -267,18 +262,8 @@ def calculate_pr_spam_penalty_multiplier(total_open_prs: int, total_token_score:
 
 def calculate_time_decay_multiplier(pr: PullRequest) -> float:
     """Calculate time decay multiplier for a single PR based on merge date."""
-
     assert pr.merged_at is not None, f'PR #{pr.number} has no merged_at'
-    now = datetime.now(timezone.utc)
-    hours_since_merge = (now - pr.merged_at).total_seconds() / SECONDS_PER_HOUR
-
-    # No decay for PRs merged within the grace period
-    if hours_since_merge < TIME_DECAY_GRACE_PERIOD_HOURS:
-        return 1.0
-
-    days_since_merge = hours_since_merge / 24
-    sigmoid = 1 / (1 + math.exp(TIME_DECAY_SIGMOID_STEEPNESS_SCALAR * (days_since_merge - TIME_DECAY_SIGMOID_MIDPOINT)))
-    return max(sigmoid, TIME_DECAY_MIN_MULTIPLIER)
+    return calculate_time_decay(pr.merged_at)
 
 
 def calculate_pioneer_dividends(

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -25,13 +25,6 @@ WHERE uid = %s AND hotkey = %s
   AND created_at <= %s
 """
 
-CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY = """
-DELETE FROM miner_tier_stats
-WHERE uid = %s AND hotkey = %s
-  AND github_id != %s
-  AND github_id != '0'
-"""
-
 CLEANUP_STALE_MINERS_BY_HOTKEY = """
 DELETE FROM miners
 WHERE uid = %s AND hotkey = %s

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -21,7 +21,6 @@ from .queries import (
     BULK_UPSERT_PULL_REQUESTS,
     CLEANUP_STALE_MINER_EVALUATIONS,
     CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY,
-    CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY,
     CLEANUP_STALE_MINERS,
     CLEANUP_STALE_MINERS_BY_HOTKEY,
     SET_MINER,
@@ -134,7 +133,6 @@ class Repository(BaseRepository):
         reverse_params = (evaluation.uid, evaluation.hotkey, evaluation.github_id)
         reverse_eval_params = reverse_params + (evaluation.evaluation_timestamp,)
         self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY, reverse_eval_params)
-        self.execute_command(CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY, reverse_params)
         self.execute_command(CLEANUP_STALE_MINERS_BY_HOTKEY, reverse_params)
 
     def store_pull_requests_bulk(self, pull_requests: List[PullRequest]) -> int:

--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -1,6 +1,15 @@
-from datetime import datetime
+import math
+from datetime import datetime, timezone
 
 import pytz
+
+from gittensor.constants import (
+    SECONDS_PER_HOUR,
+    TIME_DECAY_GRACE_PERIOD_HOURS,
+    TIME_DECAY_MIN_MULTIPLIER,
+    TIME_DECAY_SIGMOID_MIDPOINT,
+    TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
+)
 
 CHICAGO_TZ = pytz.timezone('America/Chicago')
 
@@ -20,3 +29,16 @@ def parse_github_timestamp_to_cst(timestamp_str: str) -> datetime:
     chicago_dt = utc_dt.astimezone(CHICAGO_TZ)
 
     return chicago_dt
+
+
+def calculate_time_decay(merged_at: datetime) -> float:
+    """Calculate sigmoid-based time decay multiplier from a merge timestamp."""
+    now = datetime.now(timezone.utc)
+    hours_since_merge = (now - merged_at).total_seconds() / SECONDS_PER_HOUR
+
+    if hours_since_merge < TIME_DECAY_GRACE_PERIOD_HOURS:
+        return 1.0
+
+    days_since_merge = hours_since_merge / 24
+    sigmoid = 1 / (1 + math.exp(TIME_DECAY_SIGMOID_STEEPNESS_SCALAR * (days_since_merge - TIME_DECAY_SIGMOID_MIDPOINT)))
+    return max(sigmoid, TIME_DECAY_MIN_MULTIPLIER)

--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -10,6 +10,7 @@ from gittensor.classes import (
     FileScoreResult,
     PrScoringResult,
     ScoreBreakdown,
+    ScoringCategory,
 )
 from gittensor.constants import (
     COMMENT_NODE_TYPES,
@@ -245,67 +246,62 @@ def calculate_token_score_from_file_changes(
         programming_languages: Language weight mapping (for fallback/documentation files)
 
     Returns:
-        PrScoringResult with total score and per-file details
+        PrScoringResult with total score, per-file details, and per-category breakdowns
     """
     if not file_changes:
         return PrScoringResult(
             total_score=0.0,
             total_nodes_scored=0,
+            total_lines=0,
             file_results=[],
         )
 
     file_results: List[FileScoreResult] = []
+
+    # Per-category accumulators
+    cat_files: Dict[ScoringCategory, List[FileScoreResult]] = {}
+    cat_score: Dict[ScoringCategory, float] = {}
+    cat_nodes: Dict[ScoringCategory, int] = {}
+    cat_lines: Dict[ScoringCategory, int] = {}
+    cat_breakdowns: Dict[ScoringCategory, List[ScoreBreakdown]] = {}
+
     total_score = 0.0
-    total_nodes_scored = 0
+    total_nodes = 0
+    total_lines = 0
+    all_breakdowns: List[ScoreBreakdown] = []
 
     for file in file_changes:
         ext = file.file_extension or ''
         is_test_file = file.is_test_file()
         file_weight = TEST_FILE_CONTRIBUTION_WEIGHT if is_test_file else 1.0
 
-        # Skip deleted files
         if file.status == 'removed':
-            file_results.append(
-                FileScoreResult(
-                    filename=file.short_name,
-                    score=0.0,
-                    nodes_scored=0,
-                    total_lines=file.deletions,
-                    is_test_file=is_test_file,
-                    scoring_method='skipped',
-                )
+            file_result = FileScoreResult(
+                filename=file.short_name,
+                score=0.0,
+                nodes_scored=0,
+                total_lines=file.deletions,
+                is_test_file=is_test_file,
+                scoring_method='skipped',
             )
-            continue
-
-        # Handle non code extensions
-        if ext in NON_CODE_EXTENSIONS:
+        elif ext in NON_CODE_EXTENSIONS:
             lines_to_score = min(file.changes, MAX_LINES_SCORED_FOR_NON_CODE_EXT)
             lang_config = programming_languages.get(ext)
             lang_weight = lang_config.weight if lang_config else DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT
-            file_score = lang_weight * lines_to_score * file_weight
-
-            total_score += file_score
-
-            file_results.append(
-                FileScoreResult(
-                    filename=file.short_name,
-                    score=file_score,
-                    nodes_scored=lines_to_score,
-                    total_lines=file.changes,
-                    is_test_file=is_test_file,
-                    scoring_method='line-count',
-                )
+            file_result = FileScoreResult(
+                filename=file.short_name,
+                score=lang_weight * lines_to_score * file_weight,
+                nodes_scored=lines_to_score,
+                total_lines=file.changes,
+                is_test_file=is_test_file,
+                scoring_method='line-count',
             )
-            continue
+        else:
+            content_pair = file_contents.get(file.filename)
 
-        # Get file content pair (old and new versions)
-        content_pair = file_contents.get(file.filename)
-
-        # Handle missing/binary files - score 0
-        if content_pair is None or content_pair.new_content is None:
-            bt.logging.debug(f'  │   {file.short_name}: skipped (binary or fetch failed)')
-            file_results.append(
-                FileScoreResult(
+            if content_pair is None or content_pair.new_content is None:
+                bt.logging.debug(f'  │   {file.short_name}: skipped (binary or fetch failed)')
+                file_result = FileScoreResult(
                     filename=file.short_name,
                     score=0.0,
                     nodes_scored=0,
@@ -313,18 +309,9 @@ def calculate_token_score_from_file_changes(
                     is_test_file=is_test_file,
                     scoring_method='skipped-binary',
                 )
-            )
-            continue
-
-        # Extract old and new content for tree comparison
-        old_content = content_pair.old_content  # None for new files
-        new_content = content_pair.new_content
-
-        # Check file size - score 0 for large files
-        if len(new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES:
-            bt.logging.debug(f'  │   {file.short_name}: skipped (file too large, >{MAX_FILE_SIZE_BYTES} bytes)')
-            file_results.append(
-                FileScoreResult(
+            elif len(content_pair.new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES:
+                bt.logging.debug(f'  │   {file.short_name}: skipped (file too large, >{MAX_FILE_SIZE_BYTES} bytes)')
+                file_result = FileScoreResult(
                     filename=file.short_name,
                     score=0.0,
                     nodes_scored=0,
@@ -332,14 +319,9 @@ def calculate_token_score_from_file_changes(
                     is_test_file=is_test_file,
                     scoring_method='skipped-large',
                 )
-            )
-            continue
-
-        # Check if tree-sitter supports this extension
-        if not weights.supports_tree_sitter(ext):
-            bt.logging.debug(f'  │   {file.short_name}: skipped (extension .{ext} not supported)')
-            file_results.append(
-                FileScoreResult(
+            elif not weights.supports_tree_sitter(ext):
+                bt.logging.debug(f'  │   {file.short_name}: skipped (extension .{ext} not supported)')
+                file_result = FileScoreResult(
                     filename=file.short_name,
                     score=0.0,
                     nodes_scored=0,
@@ -347,64 +329,71 @@ def calculate_token_score_from_file_changes(
                     is_test_file=is_test_file,
                     scoring_method='skipped-unsupported',
                 )
-            )
-            continue
+            else:
+                # Tree diff scoring - compare old and new ASTs
+                old_content = content_pair.old_content
+                new_content = content_pair.new_content
+                file_breakdown = score_tree_diff(old_content, new_content, ext, weights)
 
-        # Use tree diff scoring - compare old and new ASTs
-        file_breakdown = score_tree_diff(old_content, new_content, ext, weights)
-        scoring_method = 'tree-diff'
+                lang_config = programming_languages.get(ext)
+                lang_weight = lang_config.weight if lang_config else 1.0
 
-        # Get language weight for this file type
-        lang_config = programming_languages.get(ext)
-        lang_weight = lang_config.weight if lang_config else 1.0
+                # For non-test files in inline-test languages, check if the current
+                # file contains inline tests and downweight the entire file if so
+                if not is_test_file and ext in INLINE_TEST_EXTENSIONS:
+                    if has_inline_tests(new_content, ext):
+                        is_test_file = True
+                        file_weight = TEST_FILE_CONTRIBUTION_WEIGHT
 
-        # For non-test files in inline-test languages, check if the current
-        # file contains inline tests and downweight the entire file if so.
-        if not is_test_file and ext in INLINE_TEST_EXTENSIONS:
-            if has_inline_tests(new_content, ext):
-                is_test_file = True
-                file_weight = TEST_FILE_CONTRIBUTION_WEIGHT
+                combined_weight = lang_weight * file_weight
+                file_breakdown = file_breakdown.with_weight(combined_weight)
+                nodes_scored = file_breakdown.added_count + file_breakdown.deleted_count
 
-        # Apply combined weight: language weight × test file weight
-        combined_weight = lang_weight * file_weight
-        file_breakdown = file_breakdown.with_weight(combined_weight)
-        file_score = file_breakdown.total_score
+                file_result = FileScoreResult(
+                    filename=file.short_name,
+                    score=file_breakdown.total_score,
+                    nodes_scored=nodes_scored,
+                    total_lines=file.changes,
+                    is_test_file=is_test_file,
+                    scoring_method='tree-diff',
+                    breakdown=file_breakdown,
+                )
 
-        # Track nodes scored for this file
-        nodes_scored = file_breakdown.added_count + file_breakdown.deleted_count
+        # Accumulate into results and per-category totals
+        file_results.append(file_result)
+        cat = file_result.category
+        cat_files.setdefault(cat, []).append(file_result)
+        cat_score[cat] = cat_score.get(cat, 0.0) + file_result.score
+        cat_nodes[cat] = cat_nodes.get(cat, 0) + file_result.nodes_scored
+        cat_lines[cat] = cat_lines.get(cat, 0) + file_result.total_lines
+        total_score += file_result.score
+        total_nodes += file_result.nodes_scored
+        total_lines += file_result.total_lines
+        if file_result.breakdown is not None:
+            cat_breakdowns.setdefault(cat, []).append(file_result.breakdown)
+            all_breakdowns.append(file_result.breakdown)
 
-        total_score += file_score
-        total_nodes_scored += nodes_scored
-
-        file_results.append(
-            FileScoreResult(
-                filename=file.short_name,
-                score=file_score,
-                nodes_scored=nodes_scored,
-                total_lines=file.changes,
-                is_test_file=is_test_file,
-                scoring_method=scoring_method,
-                breakdown=file_breakdown,
-            )
+    # Build per-category sub-results
+    by_category: Dict[ScoringCategory, PrScoringResult] = {}
+    for cat in cat_files:
+        bd = cat_breakdowns.get(cat)
+        by_category[cat] = PrScoringResult(
+            total_score=cat_score[cat],
+            total_nodes_scored=cat_nodes[cat],
+            total_lines=cat_lines[cat],
+            file_results=cat_files[cat],
+            score_breakdown=sum(bd, start=ScoreBreakdown()) if bd else None,
         )
 
-    # Compute total raw lines for logging
-    total_raw_lines = sum(f.total_lines for f in file_results)
-
-    # Compute aggregate breakdown from file_results
-    breakdowns = [r.breakdown for r in file_results if r.breakdown is not None]
-    total_breakdown = sum(breakdowns, start=ScoreBreakdown()) if breakdowns else None
-
-    log_scoring_results(
-        file_results,
-        total_score,
-        total_raw_lines,
-        total_breakdown,
-    )
-
-    return PrScoringResult(
+    result = PrScoringResult(
         total_score=total_score,
-        total_nodes_scored=total_nodes_scored,
+        total_nodes_scored=total_nodes,
+        total_lines=total_lines,
         file_results=file_results,
-        score_breakdown=total_breakdown,
+        score_breakdown=sum(all_breakdowns, start=ScoreBreakdown()) if all_breakdowns else None,
+        by_category=by_category,
     )
+
+    log_scoring_results(file_results, total_score, total_lines, result.score_breakdown)
+
+    return result

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -327,6 +327,9 @@
     "weight": 0.0346
   },
   "latent-to/async-substrate-interface": {
+    "additional_acceptable_branches": [
+      "staging"
+    ],
     "weight": 0.2764
   },
   "latent-to/bittensor": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -45,6 +45,7 @@
     "additional_acceptable_branches": [
       "contribution/*"
     ],
+    "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1259
   },
   "autoppia/autoppia_web_agents_subnet": {
@@ -52,6 +53,7 @@
       "dev",
       "dev-gittensor"
     ],
+    "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1321
   },
   "autoppia/autoppia_webs_demo": {
@@ -59,6 +61,7 @@
       "feature/*",
       "fix/*"
     ],
+    "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1239
   },
   "aws/aws-cli": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -197,13 +197,13 @@
     "weight": 1.0
   },
   "entrius/allways-ui": {
-    "weight": 1.0
+    "weight": 0.88
   },
   "entrius/gittensor": {
     "weight": 1.0
   },
   "entrius/gittensor-ui": {
-    "weight": 1.0
+    "weight": 0.88
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444
@@ -320,7 +320,8 @@
     "weight": 0.0615
   },
   "langgenius/dify": {
-    "weight": 0.0336
+    "weight": 0.0336,
+    "inactive_at": "2026-04-14T00:00:00Z"
   },
   "laravel/framework": {
     "weight": 0.0346

--- a/tests/validator/test_base_score.py
+++ b/tests/validator/test_base_score.py
@@ -1,0 +1,571 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Integration tests for calculate_base_score - verifying SOURCE-only density
+scaling and all-category contribution bonus using real tree-sitter scoring"""
+
+from typing import Dict, List, Optional
+
+import pytest
+
+from gittensor.classes import FileChange, PullRequest
+from gittensor.utils.github_api_tools import FileContentPair
+from gittensor.validator.oss_contributions.scoring import calculate_base_score
+from gittensor.validator.utils.load_weights import (
+    LanguageConfig,
+    TokenConfig,
+    load_programming_language_weights,
+    load_token_config,
+)
+from tests.validator.conftest import PRBuilder
+
+_SOURCE_CODE = """\
+def validate_input(value, min_val, max_val):
+    if not isinstance(value, (int, float)):
+        raise TypeError("Expected numeric value")
+    if value < min_val or value > max_val:
+        raise ValueError(f"Value {value} out of range [{min_val}, {max_val}]")
+    return True
+
+def clamp(value, low, high):
+    return max(low, min(high, value))
+
+class Processor:
+    def __init__(self, name):
+        self.name = name
+        self.results = []
+
+    def process(self, items):
+        for item in items:
+            if validate_input(item, 0, 100):
+                self.results.append(clamp(item, 0, 100))
+        return self.results
+"""
+
+_TEST_CODE = """\
+def test_validate_input_valid():
+    assert validate_input(5, 0, 10) is True
+
+def test_validate_input_type_error():
+    try:
+        validate_input("abc", 0, 10)
+        assert False
+    except TypeError:
+        pass
+
+def test_validate_input_range_error():
+    try:
+        validate_input(20, 0, 10)
+        assert False
+    except ValueError:
+        pass
+
+def test_clamp_within_range():
+    assert clamp(5, 0, 10) == 5
+
+def test_clamp_below():
+    assert clamp(-1, 0, 10) == 0
+
+def test_clamp_above():
+    assert clamp(15, 0, 10) == 10
+"""
+
+_LARGE_TEST_CODE = """\
+def test_processor_init():
+    p = Processor("test")
+    assert p.name == "test"
+    assert p.results == []
+
+def test_processor_process_valid():
+    p = Processor("test")
+    result = p.process([1, 50, 99])
+    assert result == [1, 50, 99]
+
+def test_processor_process_clamp():
+    p = Processor("test")
+    result = p.process([150, -10, 50])
+    assert result == [100, 0, 50]
+
+def test_validate_boundary():
+    assert validate_input(0, 0, 100) is True
+    assert validate_input(100, 0, 100) is True
+
+def test_clamp_boundary():
+    assert clamp(0, 0, 100) == 0
+    assert clamp(100, 0, 100) == 100
+"""
+
+# Same logic as _SOURCE_CODE but spread across more lines
+_VERBOSE_SOURCE = """\
+def validate_input(
+    value,
+    min_val,
+    max_val,
+):
+    if not isinstance(
+        value,
+        (int, float),
+    ):
+        raise TypeError(
+            "Expected numeric value"
+        )
+    if (
+        value < min_val
+        or value > max_val
+    ):
+        raise ValueError(
+            f"Value {value} out of range [{min_val}, {max_val}]"
+        )
+    return True
+
+def clamp(
+    value,
+    low,
+    high,
+):
+    return max(
+        low,
+        min(
+            high,
+            value,
+        ),
+    )
+
+class Processor:
+    def __init__(
+        self,
+        name,
+    ):
+        self.name = name
+        self.results = []
+
+    def process(
+        self,
+        items,
+    ):
+        for item in items:
+            if validate_input(
+                item,
+                0,
+                100,
+            ):
+                self.results.append(
+                    clamp(
+                        item,
+                        0,
+                        100,
+                    )
+                )
+        return self.results
+"""
+
+_SOURCE_CODE_V1 = """\
+def clamp(value, low, high):
+    return max(low, min(high, value))
+"""
+
+_SOURCE_CODE_V2 = """\
+def clamp(value, low, high):
+    if not isinstance(value, (int, float)):
+        raise TypeError("Expected numeric")
+    if low > high:
+        raise ValueError("low must be <= high")
+    return max(low, min(high, value))
+"""
+
+
+@pytest.fixture
+def token_config() -> TokenConfig:
+    return load_token_config()
+
+
+@pytest.fixture
+def programming_languages() -> Dict[str, LanguageConfig]:
+    return load_programming_language_weights()
+
+
+def _change(filename: str, content: str, status: str = 'added') -> FileChange:
+    lines: int = content.count('\n')
+    return FileChange(
+        pr_number=1,
+        repository_full_name='test/repo',
+        filename=filename,
+        changes=lines,
+        additions=lines if status != 'removed' else 0,
+        deletions=lines if status == 'removed' else 0,
+        status=status,
+    )
+
+
+def _contents(
+    filename: str, new_content: Optional[str], old_content: Optional[str] = None
+) -> tuple[str, FileContentPair]:
+    return filename, FileContentPair(old_content=old_content, new_content=new_content)
+
+
+def _score(
+    pr: PullRequest,
+    file_changes: List[FileChange],
+    file_contents: List[tuple[str, FileContentPair]],
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+) -> float:
+    """Set file_changes on PR and call calculate_base_score"""
+    pr.set_file_changes(file_changes)
+    return calculate_base_score(pr, programming_languages, token_config, dict(file_contents))
+
+
+def test_adding_tests_does_not_reduce_score(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """Adding test files to a source PR must never lower the base score"""
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+    test_change = _change('tests/test_main.py', _TEST_CODE)
+    test_content = _contents('tests/test_main.py', _TEST_CODE)
+
+    pr1 = pr_factory.merged()
+    score_without = _score(pr1, [source_change], [source_content], token_config, programming_languages)
+
+    pr2 = pr_factory.merged()
+    score_with = _score(
+        pr2,
+        [source_change, test_change],
+        [source_content, test_content],
+        token_config,
+        programming_languages,
+    )
+
+    assert score_with > score_without
+    assert score_without > 0
+
+
+def test_tests_contribute_modestly(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """Test files contribute via the contribution bonus (not density),
+    so even large test suites only produce a modest score increase"""
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+    small_test_change = _change('tests/test_a.py', _TEST_CODE)
+    small_test_content = _contents('tests/test_a.py', _TEST_CODE)
+    big_test = _TEST_CODE + _LARGE_TEST_CODE
+    big_test_change = _change('tests/test_a.py', big_test)
+    big_test_content = _contents('tests/test_a.py', big_test)
+
+    pr_base = pr_factory.merged()
+    score_without = _score(pr_base, [source_change], [source_content], token_config, programming_languages)
+
+    pr_small = pr_factory.merged()
+    score_small = _score(
+        pr_small,
+        [source_change, small_test_change],
+        [source_content, small_test_content],
+        token_config,
+        programming_languages,
+    )
+
+    pr_big = pr_factory.merged()
+    score_big = _score(
+        pr_big,
+        [source_change, big_test_change],
+        [source_content, big_test_content],
+        token_config,
+        programming_languages,
+    )
+
+    # Both increase over baseline
+    assert score_small > score_without
+    assert score_big > score_without
+
+    # Increases are modest relative to baseline (test weight is 0.05x)
+    assert (score_small - score_without) / score_without < 0.1
+    assert (score_big - score_without) / score_without < 0.1
+
+
+def test_tests_do_not_affect_threshold(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """A PR below the SOURCE token threshold stays near-zero even with
+    large test files - tests only contribute a tiny bonus, not density"""
+    tiny_change = _change('tiny.py', 'x = 1\n')
+    tiny_content = _contents('tiny.py', 'x = 1\n')
+    big_test = _TEST_CODE + _LARGE_TEST_CODE
+    big_test_change = _change('tests/test_a.py', big_test)
+    big_test_content = _contents('tests/test_a.py', big_test)
+
+    pr_tiny = pr_factory.merged(token_score=0.0)
+    score_tiny = _score(pr_tiny, [tiny_change], [tiny_content], token_config, programming_languages)
+
+    pr_tiny_with_tests = pr_factory.merged(token_score=0.0)
+    score_tiny_with_tests = _score(
+        pr_tiny_with_tests,
+        [tiny_change, big_test_change],
+        [tiny_content, big_test_content],
+        token_config,
+        programming_languages,
+    )
+
+    # Both below SOURCE threshold - only tiny contribution bonus
+    assert score_tiny < 1.0
+    assert score_tiny_with_tests < 1.0
+
+
+def test_non_code_contributes_modestly(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """Non-code files contribute via the contribution bonus, not density.
+    Larger non-code files score higher (more lines scored) but the overall
+    increase is modest relative to the source baseline"""
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+    small_yaml = 'key: value\n' * 5
+    small_yaml_change = _change('config.yaml', small_yaml)
+    small_yaml_content = _contents('config.yaml', small_yaml)
+    big_yaml = 'key: value\nlist:\n  - item1\n  - item2\n' * 50
+    big_yaml_change = _change('config.yaml', big_yaml)
+    big_yaml_content = _contents('config.yaml', big_yaml)
+
+    pr_base = pr_factory.merged()
+    score_without = _score(pr_base, [source_change], [source_content], token_config, programming_languages)
+
+    pr_small = pr_factory.merged()
+    score_small = _score(
+        pr_small,
+        [source_change, small_yaml_change],
+        [source_content, small_yaml_content],
+        token_config,
+        programming_languages,
+    )
+
+    pr_big = pr_factory.merged()
+    score_big = _score(
+        pr_big,
+        [source_change, big_yaml_change],
+        [source_content, big_yaml_content],
+        token_config,
+        programming_languages,
+    )
+
+    assert score_small > score_without
+    assert score_big > score_without
+    assert score_big >= score_small
+    # Increases are modest relative to baseline
+    assert (score_big - score_without) / score_without < 0.10
+
+
+def test_source_code_scores_much_higher_than_non_code(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """Tree-diff scored source code produces a much higher base score than
+    line-count scored non-code files"""
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+    big_yaml = 'key: value\nlist:\n  - item1\n  - item2\n' * 50
+    yaml_change = _change('config.yaml', big_yaml)
+    yaml_content = _contents('config.yaml', big_yaml)
+
+    pr_src = pr_factory.merged()
+    score_as_source = _score(pr_src, [source_change], [source_content], token_config, programming_languages)
+
+    pr_unc = pr_factory.merged()
+    score_as_non_code = _score(
+        pr_unc,
+        [yaml_change],
+        [yaml_content],
+        token_config,
+        programming_languages,
+    )
+
+    assert score_as_source > (score_as_non_code * 10)
+
+
+def test_non_code_does_not_bypass_threshold(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """A PR below the SOURCE token threshold stays far below a real PR
+    even with large non-code files - non-code only contributes via bonus"""
+    tiny_change = _change('tiny.py', 'x = 1\n')
+    tiny_content = _contents('tiny.py', 'x = 1\n')
+    big_yaml = 'key: value\nlist:\n  - item1\n  - item2\n' * 50
+    big_yaml_change = _change('config.yaml', big_yaml)
+    big_yaml_content = _contents('config.yaml', big_yaml)
+
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+
+    pr_tiny = pr_factory.merged(token_score=0.0)
+    score_tiny = _score(pr_tiny, [tiny_change], [tiny_content], token_config, programming_languages)
+
+    pr_tiny_with_yaml = pr_factory.merged(token_score=0.0)
+    score_tiny_with_yaml = _score(
+        pr_tiny_with_yaml,
+        [tiny_change, big_yaml_change],
+        [tiny_content, big_yaml_content],
+        token_config,
+        programming_languages,
+    )
+
+    pr_real = pr_factory.merged()
+    score_real = _score(pr_real, [source_change], [source_content], token_config, programming_languages)
+
+    # Both below SOURCE threshold - much less than a real source PR
+    assert score_tiny_with_yaml < score_real * 0.10
+    assert score_tiny < score_tiny_with_yaml
+
+
+def test_deleted_file_does_not_change_score(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """A deleted file contributes score=0 and must not reduce the base score"""
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+    deleted_change = _change('old.py', 'def old(): pass\n', status='removed')
+    deleted_content = _contents('old.py', None)
+
+    pr1 = pr_factory.merged()
+    score_without = _score(pr1, [source_change], [source_content], token_config, programming_languages)
+
+    pr2 = pr_factory.merged()
+    score_with = _score(
+        pr2,
+        [source_change, deleted_change],
+        [source_content, deleted_content],
+        token_config,
+        programming_languages,
+    )
+
+    assert score_without == score_with
+
+
+def test_unsupported_file_does_not_change_score(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """A file with an unsupported extension contributes score=0 and must
+    not reduce the base score"""
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+    unknown_change = _change('data.xyz', 'some unknown format\n' * 10)
+    unknown_content = _contents('data.xyz', 'some unknown format\n' * 10)
+
+    pr1 = pr_factory.merged()
+    score_without = _score(pr1, [source_change], [source_content], token_config, programming_languages)
+
+    pr2 = pr_factory.merged()
+    score_with = _score(
+        pr2,
+        [source_change, unknown_change],
+        [source_content, unknown_content],
+        token_config,
+        programming_languages,
+    )
+
+    assert score_without == score_with
+
+
+def test_verbose_formatting_decreases_score(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """Same logic reformatted across more lines produces a lower score
+    because density (token_score / lines) drops"""
+    compact_change = _change('main.py', _SOURCE_CODE)
+    compact_content = _contents('main.py', _SOURCE_CODE)
+    verbose_change = _change('main.py', _VERBOSE_SOURCE)
+    verbose_content = _contents('main.py', _VERBOSE_SOURCE)
+
+    pr_compact = pr_factory.merged()
+    score_compact = _score(pr_compact, [compact_change], [compact_content], token_config, programming_languages)
+
+    pr_verbose = pr_factory.merged()
+    score_verbose = _score(pr_verbose, [verbose_change], [verbose_content], token_config, programming_languages)
+
+    assert score_compact > score_verbose
+    assert score_verbose > 0
+
+
+def test_modified_file_scores_diff_only(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """A modified file scores only the AST diff between old and new content,
+    not the entire new file"""
+    new_change = _change('main.py', _SOURCE_CODE_V2)
+    new_content = _contents('main.py', _SOURCE_CODE_V2)
+    mod_change = _change('main.py', _SOURCE_CODE_V2, status='modified')
+    mod_content = _contents('main.py', _SOURCE_CODE_V2, old_content=_SOURCE_CODE_V1)
+
+    pr_new = pr_factory.merged()
+    score_new_file = _score(pr_new, [new_change], [new_content], token_config, programming_languages)
+
+    pr_mod = pr_factory.merged()
+    score_modified = _score(pr_mod, [mod_change], [mod_content], token_config, programming_languages)
+
+    assert score_new_file > score_modified
+    assert score_modified > 0
+
+
+def test_threshold_uses_source_category_only(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """Threshold check uses only SOURCE category score - substantial code
+    placed entirely in a test path gets near-zero score (only tiny bonus)"""
+    # Substantial code in a test directory - categorized as TEST, not SOURCE
+    test_change = _change('tests/test_main.py', _SOURCE_CODE)
+    test_content = _contents('tests/test_main.py', _SOURCE_CODE)
+
+    pr_test_only = pr_factory.merged()
+    score_test_only = _score(pr_test_only, [test_change], [test_content], token_config, programming_languages)
+
+    # Same code in a source path scores well above 0
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+
+    pr_source = pr_factory.merged()
+    score_source = _score(pr_source, [source_change], [source_content], token_config, programming_languages)
+
+    # SOURCE empty → no density score, only tiny bonus from test scores
+    assert score_test_only < 1.0
+    assert score_source > 0
+    assert score_source > score_test_only * 100
+
+
+def test_below_threshold_scores_less(
+    pr_factory: PRBuilder,
+    token_config: TokenConfig,
+    programming_languages: Dict[str, LanguageConfig],
+):
+    """A trivial change (below token score threshold) scores strictly less
+    than a substantial change (above threshold)"""
+    tiny_change = _change('tiny.py', 'x = 1\n')
+    tiny_content = _contents('tiny.py', 'x = 1\n')
+    source_change = _change('main.py', _SOURCE_CODE)
+    source_content = _contents('main.py', _SOURCE_CODE)
+
+    pr_below = pr_factory.merged(token_score=0.0)
+    score_below = _score(pr_below, [tiny_change], [tiny_content], token_config, programming_languages)
+
+    pr_above = pr_factory.merged()
+    score_above = _score(pr_above, [source_change], [source_content], token_config, programming_languages)
+
+    assert score_above > score_below

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -150,7 +150,8 @@ class TestHandlePatBroadcast:
         assert 'locked' in (result.rejection_reason or '').lower()
 
         # Original entry should be unchanged
-        entry = pat_storage.get_pat_by_uid(1) or {}
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
@@ -163,7 +164,8 @@ class TestHandlePatBroadcast:
         result = _run(handle_pat_broadcast(mock_validator, synapse))
 
         assert result.accepted is True
-        entry = pat_storage.get_pat_by_uid(1) or {}
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['pat'] == 'ghp_refreshed'
         assert entry['github_id'] == 'github_42'
 
@@ -177,7 +179,8 @@ class TestHandlePatBroadcast:
         result = _run(handle_pat_broadcast(mock_validator, synapse))
 
         assert result.accepted is True
-        entry = pat_storage.get_pat_by_uid(1) or {}
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['github_id'] == 'github_99'
         assert entry['hotkey'] == 'hotkey_1'
 

--- a/tests/validator/test_scoring_classes.py
+++ b/tests/validator/test_scoring_classes.py
@@ -1,0 +1,94 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Unit tests for FileScoreResult.category and PrScoringResult.density"""
+
+import pytest
+
+from gittensor.classes import FileScoreResult, PrScoringResult, ScoringCategory
+from gittensor.constants import MAX_CODE_DENSITY_MULTIPLIER
+
+
+def _file_result(is_test_file: bool = False, scoring_method: str = 'tree-diff') -> FileScoreResult:
+    return FileScoreResult(
+        filename='f.py',
+        score=1.0,
+        nodes_scored=1,
+        total_lines=10,
+        is_test_file=is_test_file,
+        scoring_method=scoring_method,
+    )
+
+
+class TestFileScoreResultCategory:
+    def test_tree_diff_non_test_is_source(self):
+        assert _file_result(is_test_file=False, scoring_method='tree-diff').category == ScoringCategory.SOURCE
+
+    def test_test_file_tree_diff_is_test(self):
+        assert _file_result(is_test_file=True, scoring_method='tree-diff').category == ScoringCategory.TEST
+
+    def test_test_file_line_count_is_test(self):
+        assert _file_result(is_test_file=True, scoring_method='line-count').category == ScoringCategory.TEST
+
+    def test_test_file_skipped_is_test(self):
+        assert _file_result(is_test_file=True, scoring_method='skipped').category == ScoringCategory.TEST
+
+    def test_line_count_non_test_is_non_code(self):
+        assert _file_result(is_test_file=False, scoring_method='line-count').category == ScoringCategory.NON_CODE
+
+    def test_skipped_is_non_code(self):
+        assert _file_result(is_test_file=False, scoring_method='skipped').category == ScoringCategory.NON_CODE
+
+    def test_skipped_binary_is_non_code(self):
+        assert _file_result(is_test_file=False, scoring_method='skipped-binary').category == ScoringCategory.NON_CODE
+
+    def test_skipped_large_is_non_code(self):
+        assert _file_result(is_test_file=False, scoring_method='skipped-large').category == ScoringCategory.NON_CODE
+
+    def test_skipped_unsupported_is_non_code(self):
+        assert (
+            _file_result(is_test_file=False, scoring_method='skipped-unsupported').category == ScoringCategory.NON_CODE
+        )
+
+    def test_is_test_takes_priority_over_scoring_method(self):
+        """is_test_file=True always routes to TEST regardless of scoring_method"""
+        for method in ('tree-diff', 'line-count', 'skipped', 'skipped-binary'):
+            assert _file_result(is_test_file=True, scoring_method=method).category == ScoringCategory.TEST
+
+
+def _pr_result(total_score: float, total_lines: int) -> PrScoringResult:
+    return PrScoringResult(
+        total_score=total_score,
+        total_nodes_scored=0,
+        total_lines=total_lines,
+        file_results=[],
+    )
+
+
+class TestPrScoringResultDensity:
+    def test_basic_density(self):
+        assert _pr_result(total_score=10.0, total_lines=20).density == pytest.approx(0.5)
+
+    def test_zero_lines_returns_zero(self):
+        assert _pr_result(total_score=10.0, total_lines=0).density == 0.0
+
+    def test_negative_lines_returns_zero(self):
+        assert _pr_result(total_score=10.0, total_lines=-1).density == 0.0
+
+    def test_capped_at_max(self):
+        """Density is capped at MAX_CODE_DENSITY_MULTIPLIER even if ratio is higher"""
+        result = _pr_result(total_score=100.0, total_lines=1)
+        assert result.density == MAX_CODE_DENSITY_MULTIPLIER
+
+    def test_exactly_at_cap(self):
+        result = _pr_result(total_score=MAX_CODE_DENSITY_MULTIPLIER * 10, total_lines=10)
+        assert result.density == pytest.approx(MAX_CODE_DENSITY_MULTIPLIER)
+
+    def test_just_below_cap(self):
+        score = (MAX_CODE_DENSITY_MULTIPLIER - 0.01) * 10
+        result = _pr_result(total_score=score, total_lines=10)
+        assert result.density == pytest.approx(score / 10)
+        assert result.density < MAX_CODE_DENSITY_MULTIPLIER
+
+    def test_zero_score_returns_zero(self):
+        assert _pr_result(total_score=0.0, total_lines=10).density == 0.0


### PR DESCRIPTION
## Summary

- **Scoring tests**: added dedicated test suites for base score and scoring classes (`test_base_score.py`, `test_scoring_classes.py`)
- **Fix stale closed PRs**: ignore stale closed PRs in the lookback window to avoid incorrect credibility penalties
- **Restore NETUID_DEFAULT**: fix regression that changed NETUID_DEFAULT from 74
- **Fix deprecated asyncio**: replace deprecated `asyncio.get_event_loop()` and deduplicate network init
- **Refactor time decay**: extract duplicated time decay calculation to shared `datetime_utils`
- **Refactor check.py**: remove duplicated `_error` function
- **Weights adjustments**: inactivate dify, lower allways-ui and gittensor-ui weights
- **async-substrate-interface**: allow PRs merged to staging branch
- **Reapply PR #357**: lower MIN_CREDIBILITY to 0.80, remove stale `CLEANUP_STALE_MINER_TIER_STATS_BY_HOTKEY` query, fix pyright errors in pat_handler tests