### PR TITLE
fix: restore inactive_at on autoppia repos (regression from #356)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -45,6 +45,7 @@
     "additional_acceptable_branches": [
       "contribution/*"
     ],
+    "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1259
   },
   "autoppia/autoppia_web_agents_subnet": {
@@ -52,6 +53,7 @@
       "dev",
       "dev-gittensor"
     ],
+    "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1321
   },
   "autoppia/autoppia_webs_demo": {
@@ -59,6 +61,7 @@
       "feature/*",
       "fix/*"
     ],
+    "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1239
   },
   "aws/aws-cli": {


### PR DESCRIPTION
## Summary

Restores the `inactive_at: "2026-04-06T00:00:00Z"` field on the three autoppia repos, reapplying PR #347 which was silently undone by commit `faa5673` ("Issue discovery", PR #356).

- `autoppia/autoppia_iwa`
- `autoppia/autoppia_web_agents_subnet`
- `autoppia/autoppia_webs_demo`

## Background — what happened

**Merged 2026-04-07 (PR #347)**: `inactive_at` markers were added to the 3 autoppia repos to deregister them.

**Merged 2026-04-09 (PR #356 / commit `faa5673`)**: the issue-discovery feature rewrote `master_repositories.json` to rescale weights for the new emission pool math. That rewrite kept the 3 autoppia entries in the file but **silently stripped the `inactive_at` field**, returning them to active scoring status.

Diff evidence from `git show faa5673 -- gittensor/validator/weights/master_repositories.json`:

```diff
-  "autoppia/autoppia_iwa": {
-    "additional_acceptable_branches": ["contribution/*"],
-    "inactive_at": "2026-04-06T00:00:00Z",
-    "tier": "Silver",
-    "weight": 5.33
+  "autoppia/autoppia_iwa": {
+    "additional_acceptable_branches": ["contribution/*"],
+    "weight": 0.1259
```

Same pattern for `autoppia_web_agents_subnet` and `autoppia_webs_demo`. The result is that since 2026-04-09, the three deregistered autoppia repos have been silently scoring like any other active repo, for roughly a week of scoring rounds.

## Impact

For the full lookback window since `faa5673` landed, any miner with autoppia PRs has been earning rewards from a deregistered subnet team's repos. This is a live regression — PR #347's intent (stop rewarding work on deregistered repos) has not been in effect.

Re-adding `inactive_at` triggers the existing enforcement paths:

- `gittensor/utils/github_api_tools.py:1050-1062` — `load_miners_prs` skips any PR created on/after `inactive_at`
- `gittensor/validator/issue_discovery/repo_scan.py:81` — filters inactive repos out of the issue-discovery scan

## Scope of this PR

**This PR only restores the 3 autoppia entries.** The same commit (`faa5673`) also stripped `inactive_at` from ~36 other repos; many of those were also fully removed from the file (intentional), but a full audit to identify any other "kept-in-file-but-lost-inactive_at" regressions should be done as a follow-up.

## Test plan

- [x] `pytest tests/validator/test_load_weights.py` passes (16 tests). This suite explicitly asserts that known deregistered orgs have `inactive_at` set, so it's directly relevant coverage.
- [x] JSON syntax validated with `python3 -c "import json; json.load(...)"`
- [x] Diff is 3 lines, same timestamp as original PR #347 (`2026-04-06T00:00:00Z`)

## Related

- Reapplies: #347
- Caused by: #356 (commit `faa5673`)
- Similar pattern previously hit PR #357, reapplied as PR #362 and commit `7b2df54` ("fix: reapply lost PR #357 changes (v2)")