### PR TITLE
refactor: extract duplicate validator axon collection to shared helper

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -10,6 +10,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from .helpers import _get_validator_axons
 from .post import NETUID_DEFAULT, _error, _load_config_value, _resolve_endpoint
 
 console = Console()
@@ -72,12 +73,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         sys.exit(1)
 
     # 3. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons = []
-    validator_uids = []
-    for uid in range(metagraph.n):
-        if metagraph.validator_trust[uid] > 0.1 and metagraph.axons[uid].is_serving:
-            validator_axons.append(metagraph.axons[uid])
-            validator_uids.append(uid)
+    validator_axons, validator_uids = _get_validator_axons(metagraph)
 
     if not validator_axons:
         _error('No reachable validator axons found on the network.', json_mode)

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -1,0 +1,16 @@
+# Entrius 2025
+
+"""Shared helper utilities for miner CLI commands."""
+
+from __future__ import annotations
+
+
+def _get_validator_axons(metagraph) -> tuple[list, list]:
+    """Return (axons, uids) for all active validators (vtrust > 0.1, serving)."""
+    axons = []
+    uids = []
+    for uid in range(metagraph.n):
+        if metagraph.validator_trust[uid] > 0.1 and metagraph.axons[uid].is_serving:
+            axons.append(metagraph.axons[uid])
+            uids.append(uid)
+    return axons, uids

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -14,6 +14,7 @@ import requests
 from rich.console import Console
 from rich.table import Table
 
+from gittensor.cli.miner_commands.helpers import _get_validator_axons
 from gittensor.constants import BASE_GITHUB_API_URL, NETWORK_MAP
 
 console = Console()
@@ -114,12 +115,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         sys.exit(1)
 
     # 4. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons = []
-    validator_uids = []
-    for uid in range(metagraph.n):
-        if metagraph.validator_trust[uid] > 0.1 and metagraph.axons[uid].is_serving:
-            validator_axons.append(metagraph.axons[uid])
-            validator_uids.append(uid)
+    validator_axons, validator_uids = _get_validator_axons(metagraph)
 
     if not validator_axons:
         _error('No reachable validator axons found on the network.', json_mode)


### PR DESCRIPTION
The same 5-line loop — iterating over `metagraph.n` to collect axons and UIDs for validators with `vtrust > 0.1` — was copy-pasted across both `post.py` and `check.py`. Extracting it as `_get_validator_axons(metagraph)` in `post.py` means `check.py` (which already imports helpers from `post.py`) can simply call the shared function.

- Pyright clean
- Ruff lint and format clean