### PR TITLE
Refactor/deduplicate config path constants

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -15,7 +15,6 @@ import urllib.error
 import urllib.request
 from contextlib import nullcontext
 from decimal import Decimal, InvalidOperation
-from pathlib import Path
 from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, TypeVar
 
 import click
@@ -23,7 +22,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from gittensor.cli.issue_commands.tables import build_pr_table
-from gittensor.constants import CONTRACT_ADDRESS, NETWORK_MAP
+from gittensor.constants import CONFIG_FILE, CONTRACT_ADDRESS, GITTENSOR_DIR, NETWORK_MAP
 
 # ALPHA token conversion
 ALPHA_DECIMALS = 9
@@ -43,10 +42,6 @@ STATUS_COLORS: Dict[str, str] = {
     'Cancelled': 'dim',
 }
 
-
-# Default paths
-GITTENSOR_DIR = Path.home() / '.gittensor'
-CONFIG_FILE = GITTENSOR_DIR / 'config.json'
 
 console = Console()
 

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -14,7 +14,6 @@ Usage:
 
 import json
 import os
-from pathlib import Path
 
 import click
 from click.shell_completion import get_completion_class
@@ -23,12 +22,9 @@ from rich.table import Table
 
 from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
+from gittensor.constants import CONFIG_FILE, GITTENSOR_DIR
 
 console = Console()
-
-# Config paths
-GITTENSOR_DIR = Path.home() / '.gittensor'
-CONFIG_FILE = GITTENSOR_DIR / 'config.json'
 
 
 @click.group(cls=StyledAliasGroup)

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -1,10 +1,14 @@
 # Entrius 2025
 import re
+from pathlib import Path
 from typing import Dict
 
 # =============================================================================
 # General
 # =============================================================================
+GITTENSOR_DIR = Path.home() / '.gittensor'
+CONFIG_FILE = GITTENSOR_DIR / 'config.json'
+
 SECONDS_PER_DAY = 86400
 SECONDS_PER_HOUR = 3600
 


### PR DESCRIPTION
## Summary

`GITTENSOR_DIR` and `CONFIG_FILE` were defined identically in two places:
- `cli/main.py:28-29`
- `cli/issue_commands/helpers.py:48-49`

Moves the canonical definition to `gittensor/constants.py`. Both files now import from there.
Also removes the now-unused `from pathlib import Path` import from `helpers.py`.

> `constants.py` is used as the shared home to avoid a circular import -
> `main.py` already imports from `issue_commands/__init__.py` → `helpers.py`.

## Test plan
- [x] `pytest tests/cli/ tests/utils/`, no new failures
