### PR TITLE
refactor: deduplicate Issue struct SCALE decoding into shared codec module

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -5,7 +5,6 @@
 Shared helper functions for issue commands
 """
 
-import hashlib
 import json
 import os
 import re
@@ -24,6 +23,7 @@ from rich.panel import Panel
 
 from gittensor.cli.issue_commands.tables import build_pr_table
 from gittensor.constants import CONTRACT_ADDRESS, NETWORK_MAP
+from gittensor.validator.issue_competitions.codec import compute_ink5_lazy_key, decode_issue_bytes
 
 # ALPHA token conversion
 ALPHA_DECIMALS = 9
@@ -708,24 +708,6 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
     }
 
 
-def _compute_ink5_lazy_key(root_key_hex: str, encoded_key: bytes) -> str:
-    """
-    Compute Ink! 5 lazy mapping storage key using blake2_128concat.
-
-    Args:
-        root_key_hex: Hex string of the mapping root key (e.g., '52789899')
-        encoded_key: SCALE-encoded key bytes
-
-    Returns:
-        Hex-encoded storage key
-    """
-    root_key = bytes.fromhex(root_key_hex.replace('0x', ''))
-    # Blake2_128Concat: blake2_128(root_key || encoded_key) || root_key || encoded_key
-    data = root_key + encoded_key
-    h = hashlib.blake2b(data, digest_size=16).digest()
-    return '0x' + (h + data).hex()
-
-
 def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool = False) -> List[Dict[str, Any]]:
     """
     Read all issues from contract child storage.
@@ -781,7 +763,7 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
     for issue_id in range(1, next_issue_id):
         # SCALE encode u64 as little-endian 8 bytes
         encoded_id = struct.pack('<Q', issue_id)
-        lazy_key = _compute_ink5_lazy_key('52789899', encoded_id)
+        lazy_key = compute_ink5_lazy_key('52789899', encoded_id)
 
         val_result = substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
         if not val_result.get('result'):
@@ -792,63 +774,24 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
         data = bytes.fromhex(val_result['result'].replace('0x', ''))
 
         try:
-            # Decode Issue struct:
-            # id: u64 (8 bytes)
-            # github_url_hash: [u8; 32] (32 bytes)
-            # repository_full_name: String (compact len + bytes)
-            # issue_number: u32 (4 bytes)
-            # bounty_amount: u128 (16 bytes)
-            # target_bounty: u128 (16 bytes)
-            # status: IssueStatus enum (1 byte)
-            # registered_at_block: u32 (4 bytes)
-
-            offset = 0
-            stored_issue_id = struct.unpack_from('<Q', data, offset)[0]
-            offset += 8
-            offset += 32  # Skip url_hash
-
-            # String: compact-encoded length then bytes
-            len_byte = data[offset]
-            if len_byte & 0x03 == 0:
-                str_len = len_byte >> 2
-                offset += 1
-            elif len_byte & 0x03 == 1:
-                # Two-byte length
-                str_len = (data[offset] | (data[offset + 1] << 8)) >> 2
-                offset += 2
-            else:
-                str_len = 0
-                offset += 1
-
-            repo_name = data[offset : offset + str_len].decode('utf-8', errors='replace')
-            offset += str_len
-
-            issue_number = struct.unpack_from('<I', data, offset)[0]
-            offset += 4
-
-            bounty_lo, bounty_hi = struct.unpack_from('<QQ', data, offset)
-            bounty_amount = bounty_lo + (bounty_hi << 64)
-            offset += 16
-
-            target_lo, target_hi = struct.unpack_from('<QQ', data, offset)
-            target_bounty = target_lo + (target_hi << 64)
-            offset += 16
-
-            status_byte = data[offset]
+            raw = decode_issue_bytes(data)
+            status_byte = raw['status_byte']
             status = status_names[status_byte] if status_byte < len(status_names) else 'Unknown'
 
             issues.append(
                 {
-                    'id': stored_issue_id,
-                    'repository_full_name': repo_name,
-                    'issue_number': issue_number,
-                    'bounty_amount': bounty_amount,
-                    'target_bounty': target_bounty,
+                    'id': raw['id'],
+                    'repository_full_name': raw['repository_full_name'],
+                    'issue_number': raw['issue_number'],
+                    'bounty_amount': raw['bounty_amount'],
+                    'target_bounty': raw['target_bounty'],
                     'status': status,
                 }
             )
             if verbose:
-                console.print(f'[dim]Debug: Decoded issue {stored_issue_id}: {repo_name}#{issue_number}[/dim]')
+                console.print(
+                    f'[dim]Debug: Decoded issue {raw["id"]}: {raw["repository_full_name"]}#{raw["issue_number"]}[/dim]'
+                )
         except Exception as e:
             if verbose:
                 console.print(f'[dim]Debug: Failed to decode issue {issue_id}: {e}[/dim]')

--- a/gittensor/validator/issue_competitions/codec.py
+++ b/gittensor/validator/issue_competitions/codec.py
@@ -1,0 +1,84 @@
+# The MIT License (MIT)
+# Copyright 2025 Entrius
+
+"""SCALE codec utilities for Issue Bounty contract storage."""
+
+import hashlib
+import struct
+from typing import Any, Dict
+
+
+def compute_ink5_lazy_key(root_key_hex: str, encoded_key: bytes) -> str:
+    """Compute Ink! 5 lazy mapping storage key using blake2_128concat."""
+    root_key = bytes.fromhex(root_key_hex.replace('0x', ''))
+    data = root_key + encoded_key
+    h = hashlib.blake2b(data, digest_size=16).digest()
+    return '0x' + (h + data).hex()
+
+
+def decode_issue_bytes(data: bytes) -> Dict[str, Any]:
+    """Decode a SCALE-encoded Issue struct from contract child storage.
+
+    Layout:
+        id: u64 (8 bytes)
+        github_url_hash: [u8; 32] (32 bytes)
+        repository_full_name: String (compact len + bytes)
+        issue_number: u32 (4 bytes)
+        bounty_amount: u128 (16 bytes)
+        target_bounty: u128 (16 bytes)
+        status: IssueStatus enum (1 byte)
+        registered_at_block: u32 (4 bytes)
+
+    Args:
+        data: Raw bytes from contract child storage.
+
+    Returns:
+        Dict with all decoded fields.
+    """
+    offset = 0
+    issue_id = struct.unpack_from('<Q', data, offset)[0]
+    offset += 8
+
+    github_url_hash = data[offset : offset + 32]
+    offset += 32
+
+    len_byte = data[offset]
+    if len_byte & 0x03 == 0:
+        str_len = len_byte >> 2
+        offset += 1
+    elif len_byte & 0x03 == 1:
+        str_len = (data[offset] | (data[offset + 1] << 8)) >> 2
+        offset += 2
+    else:
+        str_len = 0
+        offset += 1
+
+    repo_name = data[offset : offset + str_len].decode('utf-8', errors='replace')
+    offset += str_len
+
+    issue_number = struct.unpack_from('<I', data, offset)[0]
+    offset += 4
+
+    bounty_lo, bounty_hi = struct.unpack_from('<QQ', data, offset)
+    bounty_amount = bounty_lo + (bounty_hi << 64)
+    offset += 16
+
+    target_lo, target_hi = struct.unpack_from('<QQ', data, offset)
+    target_bounty = target_lo + (target_hi << 64)
+    offset += 16
+
+    status_byte = data[offset]
+    offset += 1
+
+    registered_at_block = struct.unpack_from('<I', data, offset)[0]
+
+    return {
+        'id': issue_id,
+        'github_url_hash': github_url_hash,
+        'repository_full_name': repo_name,
+        'issue_number': issue_number,
+        'bounty_amount': int(bounty_amount),
+        'target_bounty': int(target_bounty),
+        'status_byte': status_byte,
+        'registered_at_block': registered_at_block,
+    }

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -15,6 +15,8 @@ import bittensor as bt
 from substrateinterface import Keypair
 from substrateinterface.exceptions import ExtrinsicNotFound
 
+from gittensor.validator.issue_competitions.codec import compute_ink5_lazy_key, decode_issue_bytes
+
 # Bittensor uses async_substrate_interface which has its own exception type
 try:
     from async_substrate_interface.errors import ExtrinsicNotFound as AsyncExtrinsicNotFound
@@ -157,13 +159,6 @@ class IssueCompetitionContractClient:
             bt.logging.debug(f'Error getting child storage key: {e}')
             return None
 
-    def compute_ink5_lazy_key(self, root_key_hex: str, encoded_key: bytes) -> str:
-        """Compute Ink! 5 lazy mapping storage key using blake2_128concat."""
-        root_key = bytes.fromhex(root_key_hex.replace('0x', ''))
-        data = root_key + encoded_key
-        h = hashlib.blake2b(data, digest_size=16).digest()
-        return '0x' + (h + data).hex()
-
     def _read_packed_storage(self) -> Optional[dict]:
         """Read the packed root storage from the contract"""
         child_key = self._get_child_storage_key()
@@ -216,61 +211,25 @@ class IssueCompetitionContractClient:
 
         try:
             encoded_id = struct.pack('<Q', issue_id)
-            lazy_key = self.compute_ink5_lazy_key('52789899', encoded_id)
+            lazy_key = compute_ink5_lazy_key('52789899', encoded_id)
 
             val_result = self.subtensor.substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
             if not val_result.get('result'):
                 return None
 
             data = bytes.fromhex(val_result['result'].replace('0x', ''))
-
-            offset = 0
-            stored_id = struct.unpack_from('<Q', data, offset)[0]
-            offset += 8
-
-            github_url_hash = data[offset : offset + 32]
-            offset += 32
-
-            len_byte = data[offset]
-            if len_byte & 0x03 == 0:
-                str_len = len_byte >> 2
-                offset += 1
-            elif len_byte & 0x03 == 1:
-                str_len = (data[offset] | (data[offset + 1] << 8)) >> 2
-                offset += 2
-            else:
-                str_len = 0
-                offset += 1
-
-            repo_name = data[offset : offset + str_len].decode('utf-8', errors='replace')
-            offset += str_len
-
-            issue_number = struct.unpack_from('<I', data, offset)[0]
-            offset += 4
-
-            bounty_lo, bounty_hi = struct.unpack_from('<QQ', data, offset)
-            bounty_amount = bounty_lo + (bounty_hi << 64)
-            offset += 16
-
-            target_lo, target_hi = struct.unpack_from('<QQ', data, offset)
-            target_bounty = target_lo + (target_hi << 64)
-            offset += 16
-
-            status_byte = data[offset]
-            offset += 1
-
-            registered_at_block = struct.unpack_from('<I', data, offset)[0]
+            raw = decode_issue_bytes(data)
 
             return ContractIssue(
-                id=stored_id,
-                github_url_hash=github_url_hash,
-                repository_full_name=repo_name,
-                issue_number=issue_number,
-                bounty_amount=int(bounty_amount),
-                target_bounty=int(target_bounty),
-                status=IssueStatus(status_byte),
-                registered_at_block=registered_at_block,
-                is_fully_funded=int(bounty_amount) >= int(target_bounty),
+                id=raw['id'],
+                github_url_hash=raw['github_url_hash'],
+                repository_full_name=raw['repository_full_name'],
+                issue_number=raw['issue_number'],
+                bounty_amount=raw['bounty_amount'],
+                target_bounty=raw['target_bounty'],
+                status=IssueStatus(raw['status_byte']),
+                registered_at_block=raw['registered_at_block'],
+                is_fully_funded=raw['bounty_amount'] >= raw['target_bounty'],
             )
         except Exception as e:
             bt.logging.debug(f'Error reading issue {issue_id}: {e}')

--- a/tests/validator/test_issue_codec.py
+++ b/tests/validator/test_issue_codec.py
@@ -1,0 +1,102 @@
+# The MIT License (MIT)
+# Copyright 2025 Entrius
+
+"""Tests for Issue contract codec functions."""
+
+import hashlib
+import struct
+
+from gittensor.validator.issue_competitions.codec import compute_ink5_lazy_key, decode_issue_bytes
+
+
+def _build_issue_bytes(
+    issue_id: int = 1,
+    url_hash: bytes = b'\x00' * 32,
+    repo_name: str = 'entrius/gittensor',
+    issue_number: int = 42,
+    bounty_amount: int = 1_000_000_000,
+    target_bounty: int = 2_000_000_000,
+    status_byte: int = 1,
+    registered_at_block: int = 100,
+) -> bytes:
+    """Build a SCALE-encoded Issue struct for testing."""
+    buf = bytearray()
+    buf += struct.pack('<Q', issue_id)
+    buf += url_hash
+    name_bytes = repo_name.encode('utf-8')
+    name_len = len(name_bytes)
+    if name_len < 64:
+        buf += bytes([name_len << 2])
+    else:
+        buf += struct.pack('<H', (name_len << 2) | 1)
+    buf += name_bytes
+    buf += struct.pack('<I', issue_number)
+    buf += struct.pack('<QQ', bounty_amount & ((1 << 64) - 1), bounty_amount >> 64)
+    buf += struct.pack('<QQ', target_bounty & ((1 << 64) - 1), target_bounty >> 64)
+    buf += bytes([status_byte])
+    buf += struct.pack('<I', registered_at_block)
+    return bytes(buf)
+
+
+class TestDecodeIssueBytes:
+    def test_round_trip(self):
+        data = _build_issue_bytes()
+        result = decode_issue_bytes(data)
+        assert result['id'] == 1
+        assert result['github_url_hash'] == b'\x00' * 32
+        assert result['repository_full_name'] == 'entrius/gittensor'
+        assert result['issue_number'] == 42
+        assert result['bounty_amount'] == 1_000_000_000
+        assert result['target_bounty'] == 2_000_000_000
+        assert result['status_byte'] == 1
+        assert result['registered_at_block'] == 100
+
+    def test_long_repo_name_two_byte_compact(self):
+        long_name = 'org/' + 'a' * 100
+        data = _build_issue_bytes(repo_name=long_name)
+        result = decode_issue_bytes(data)
+        assert result['repository_full_name'] == long_name
+
+    def test_empty_repo_name(self):
+        data = _build_issue_bytes(repo_name='')
+        result = decode_issue_bytes(data)
+        assert result['repository_full_name'] == ''
+
+    def test_large_u128_bounty(self):
+        large = (1 << 127) + 42
+        data = _build_issue_bytes(bounty_amount=large)
+        result = decode_issue_bytes(data)
+        assert result['bounty_amount'] == large
+
+    def test_all_status_values(self):
+        for status in range(4):
+            data = _build_issue_bytes(status_byte=status)
+            result = decode_issue_bytes(data)
+            assert result['status_byte'] == status
+
+    def test_url_hash_preserved(self):
+        url_hash = hashlib.sha256(b'https://github.com/entrius/gittensor/issues/42').digest()
+        data = _build_issue_bytes(url_hash=url_hash)
+        result = decode_issue_bytes(data)
+        assert result['github_url_hash'] == url_hash
+
+
+class TestComputeInk5LazyKey:
+    def test_deterministic(self):
+        key1 = compute_ink5_lazy_key('52789899', struct.pack('<Q', 1))
+        key2 = compute_ink5_lazy_key('52789899', struct.pack('<Q', 1))
+        assert key1 == key2
+
+    def test_different_ids_produce_different_keys(self):
+        key1 = compute_ink5_lazy_key('52789899', struct.pack('<Q', 1))
+        key2 = compute_ink5_lazy_key('52789899', struct.pack('<Q', 2))
+        assert key1 != key2
+
+    def test_starts_with_0x(self):
+        key = compute_ink5_lazy_key('52789899', struct.pack('<Q', 1))
+        assert key.startswith('0x')
+
+    def test_0x_prefix_in_root_key_stripped(self):
+        key1 = compute_ink5_lazy_key('0x52789899', struct.pack('<Q', 1))
+        key2 = compute_ink5_lazy_key('52789899', struct.pack('<Q', 1))
+        assert key1 == key2


### PR DESCRIPTION
## Summary

the Issue struct binary decoding (~23 lines) and `compute_ink5_lazy_key` (3 lines) were copy-pasted between `contract_client.py` and `cli/issue_commands/helpers.py`. extracted both into `issue_competitions/codec.py` as pure functions — `decode_issue_bytes(data) -> dict` and `compute_ink5_lazy_key(root_key_hex, encoded_key) -> str`. both callers now import from there. zero behavior change.

## Related Issues

Closes #440

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
