### PR TITLE
fix: exclude auto-close event from post-merge edit detection in issue discovery scoring

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -219,7 +219,12 @@ def _collect_issues_from_prs(
                     continue  # No score for unsolved issues
 
                 # Anti-gaming: post-merge edit detection
-                if issue.updated_at and pr.merged_at and issue.updated_at > pr.merged_at:
+                if (
+                    issue.updated_at
+                    and pr.merged_at
+                    and issue.updated_at > pr.merged_at
+                    and (not issue.closed_at or issue.updated_at > issue.closed_at)
+                ):
                     bt.logging.info(
                         f'Issue #{issue.number} edited after PR #{pr.number} merge — 0 score, counts as closed'
                     )


### PR DESCRIPTION
## Summary

Fix a false positive in the post-merge edit detection for issue discovery scoring. When a PR merge auto-closes a linked issue, GitHub sets the issue's `updated_at` to the close timestamp, which is always slightly after `merged_at`. The existing check treated this as a post-merge content edit, incorrectly flipping the issue from "solved" to "closed" — reducing the discoverer's `solved_count`, inflating `closed_count`, and dropping their credibility.

The fix adds a guard that compares `updated_at` against `closed_at`. The penalty now only fires when the issue was genuinely edited after the close event, not when the update was the close event itself.

## Related Issues

Fixes #443 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)


Manual testing performed:
- Verified that an issue auto-closed by a merged PR (where `updated_at == closed_at`) is correctly classified as "solved"
- Verified that an issue with `updated_at > closed_at` (genuine post-close edit) still triggers the penalty
- Verified that an issue with `closed_at = None` conservatively triggers the penalty

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed