### PR TITLE
refactor: extract duplicated normalization logic into shared utility

### DIFF
--- a/gittensor/validator/issue_discovery/normalize.py
+++ b/gittensor/validator/issue_discovery/normalize.py
@@ -6,6 +6,7 @@ from typing import Dict
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
+from gittensor.validator.utils.normalize import normalize_scores
 
 
 def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
@@ -22,13 +23,9 @@ def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluati
         if rewards[uid] > 0:
             nonzero_count += 1
 
-    total = sum(rewards.values())
-    if total <= 0:
-        bt.logging.info('Issue discovery: all scores are zero, returning empty rewards')
-        return rewards
+    normalized = normalize_scores(rewards)
 
-    normalized = {uid: score / total for uid, score in rewards.items()}
-
-    bt.logging.info(f'Issue discovery: normalized {nonzero_count} miners with scores > 0')
+    if nonzero_count > 0:
+        bt.logging.info(f'Issue discovery: normalized {nonzero_count} miners with scores > 0')
 
     return normalized

--- a/gittensor/validator/oss_contributions/normalize.py
+++ b/gittensor/validator/oss_contributions/normalize.py
@@ -3,10 +3,11 @@ from typing import Dict
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
+from gittensor.validator.utils.normalize import normalize_scores
 
 
 def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
-    """Normalize scores to sum to 1.0, preserving ratios."""
+    """Normalize OSS contribution scores to sum to 1.0, preserving ratios."""
 
     if not miner_evaluations:
         bt.logging.warning('No miner evaluations provided for normalization')
@@ -25,11 +26,4 @@ def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> D
     if zero_reward_count > 0:
         bt.logging.info(f'{zero_reward_count} miners have 0 reward')
 
-    total = sum(rewards.values())
-    if total <= 0:
-        bt.logging.info('All scores are zero, returning original scores')
-        return rewards
-
-    normalized = {uid: score / total for uid, score in rewards.items()}
-
-    return normalized
+    return normalize_scores(rewards)

--- a/gittensor/validator/utils/normalize.py
+++ b/gittensor/validator/utils/normalize.py
@@ -1,0 +1,24 @@
+from typing import Dict
+
+import bittensor as bt
+
+
+def normalize_scores(scores: Dict[int, float]) -> Dict[int, float]:
+    """Normalize scores to sum to 1.0, preserving ratios.
+
+    Args:
+        scores: Mapping of uid to raw score.
+
+    Returns:
+        Mapping of uid to normalized score. Returns the original scores
+        unchanged when the total is zero or negative.
+    """
+    if not scores:
+        return {}
+
+    total = sum(scores.values())
+    if total <= 0:
+        bt.logging.info('All scores are zero, returning original scores')
+        return scores
+
+    return {uid: score / total for uid, score in scores.items()}

--- a/tests/validator/test_normalize.py
+++ b/tests/validator/test_normalize.py
@@ -1,0 +1,127 @@
+"""
+Tests for the shared normalize_scores utility and its callers.
+
+Run tests:
+    pytest tests/validator/test_normalize.py -v
+"""
+
+from unittest.mock import MagicMock
+
+from gittensor.validator.utils.normalize import normalize_scores
+
+
+class TestNormalizeScores:
+    """Tests for the shared normalize_scores function."""
+
+    def test_empty_dict_returns_empty(self):
+        """Empty input returns empty dict."""
+        assert normalize_scores({}) == {}
+
+    def test_single_miner_normalizes_to_one(self):
+        """A single positive score normalizes to 1.0."""
+        result = normalize_scores({0: 5.0})
+        assert result == {0: 1.0}
+
+    def test_equal_scores_normalize_evenly(self):
+        """Equal scores produce equal normalized values."""
+        result = normalize_scores({0: 10.0, 1: 10.0})
+        assert result == {0: 0.5, 1: 0.5}
+
+    def test_unequal_scores_preserve_ratios(self):
+        """Unequal scores preserve their original ratios."""
+        result = normalize_scores({0: 30.0, 1: 10.0})
+        assert result[0] == 0.75
+        assert result[1] == 0.25
+
+    def test_sum_equals_one(self):
+        """Normalized scores sum to 1.0."""
+        result = normalize_scores({0: 3.0, 1: 7.0, 2: 5.0})
+        assert abs(sum(result.values()) - 1.0) < 1e-9
+
+    def test_all_zeros_returns_original(self):
+        """All-zero scores are returned unchanged."""
+        scores = {0: 0.0, 1: 0.0}
+        result = normalize_scores(scores)
+        assert result == {0: 0.0, 1: 0.0}
+
+    def test_mix_of_zero_and_positive(self):
+        """Zero-score miners get 0.0 in normalized output."""
+        result = normalize_scores({0: 0.0, 1: 10.0})
+        assert result[0] == 0.0
+        assert result[1] == 1.0
+
+    def test_preserves_uid_keys(self):
+        """All original UIDs appear in the output."""
+        scores = {5: 1.0, 10: 2.0, 15: 3.0}
+        result = normalize_scores(scores)
+        assert set(result.keys()) == {5, 10, 15}
+
+
+class TestNormalizeRewardsLinearDelegation:
+    """Verify normalize_rewards_linear delegates to normalize_scores."""
+
+    def test_delegates_normalization(self):
+        """normalize_rewards_linear uses normalize_scores for the math."""
+        from gittensor.validator.oss_contributions.normalize import normalize_rewards_linear
+
+        eval_a = MagicMock()
+        eval_a.total_score = 30.0
+        eval_b = MagicMock()
+        eval_b.total_score = 10.0
+
+        result = normalize_rewards_linear({0: eval_a, 1: eval_b})
+        assert result[0] == 0.75
+        assert result[1] == 0.25
+
+    def test_empty_evaluations_returns_empty(self):
+        """Empty input returns empty dict."""
+        from gittensor.validator.oss_contributions.normalize import normalize_rewards_linear
+
+        assert normalize_rewards_linear({}) == {}
+
+    def test_all_zero_scores_returns_zeros(self):
+        """All-zero evaluations return zero scores."""
+        from gittensor.validator.oss_contributions.normalize import normalize_rewards_linear
+
+        eval_a = MagicMock()
+        eval_a.total_score = 0.0
+        eval_b = MagicMock()
+        eval_b.total_score = 0.0
+
+        result = normalize_rewards_linear({0: eval_a, 1: eval_b})
+        assert result == {0: 0.0, 1: 0.0}
+
+
+class TestNormalizeIssueDiscoveryRewardsDelegation:
+    """Verify normalize_issue_discovery_rewards delegates to normalize_scores."""
+
+    def test_delegates_normalization(self):
+        """normalize_issue_discovery_rewards uses normalize_scores for the math."""
+        from gittensor.validator.issue_discovery.normalize import normalize_issue_discovery_rewards
+
+        eval_a = MagicMock()
+        eval_a.issue_discovery_score = 20.0
+        eval_b = MagicMock()
+        eval_b.issue_discovery_score = 80.0
+
+        result = normalize_issue_discovery_rewards({0: eval_a, 1: eval_b})
+        assert result[0] == 0.2
+        assert result[1] == 0.8
+
+    def test_empty_evaluations_returns_empty(self):
+        """Empty input returns empty dict."""
+        from gittensor.validator.issue_discovery.normalize import normalize_issue_discovery_rewards
+
+        assert normalize_issue_discovery_rewards({}) == {}
+
+    def test_all_zero_scores_returns_zeros(self):
+        """All-zero evaluations return zero scores."""
+        from gittensor.validator.issue_discovery.normalize import normalize_issue_discovery_rewards
+
+        eval_a = MagicMock()
+        eval_a.issue_discovery_score = 0.0
+        eval_b = MagicMock()
+        eval_b.issue_discovery_score = 0.0
+
+        result = normalize_issue_discovery_rewards({0: eval_a, 1: eval_b})
+        assert result == {0: 0.0, 1: 0.0}


### PR DESCRIPTION
## Summary

`normalize_rewards_linear` (OSS contributions) and `normalize_issue_discovery_rewards` (issue discovery) implemented the same "normalize scores to sum to 1.0" algorithm independently. Extracted the shared math into `normalize_scores()` in `validator/utils/normalize.py`. Both callers now delegate to it while preserving their domain-specific field extraction and logging.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
