### PR TITLE
refactor: extract shared normalize_scores utility from duplicate normalize functions

### DIFF
--- a/gittensor/validator/issue_discovery/normalize.py
+++ b/gittensor/validator/issue_discovery/normalize.py
@@ -6,6 +6,7 @@ from typing import Dict
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
+from gittensor.validator.utils.normalize import normalize_scores
 
 
 def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
@@ -14,21 +15,18 @@ def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluati
     if not miner_evaluations:
         return {}
 
-    rewards: Dict[int, float] = {}
+    scores: Dict[int, float] = {}
     nonzero_count = 0
 
     for uid, evaluation in miner_evaluations.items():
-        rewards[uid] = evaluation.issue_discovery_score
-        if rewards[uid] > 0:
+        scores[uid] = evaluation.issue_discovery_score
+        if scores[uid] > 0:
             nonzero_count += 1
 
-    total = sum(rewards.values())
-    if total <= 0:
+    if sum(scores.values()) <= 0:
         bt.logging.info('Issue discovery: all scores are zero, returning empty rewards')
-        return rewards
-
-    normalized = {uid: score / total for uid, score in rewards.items()}
+        return scores
 
     bt.logging.info(f'Issue discovery: normalized {nonzero_count} miners with scores > 0')
 
-    return normalized
+    return normalize_scores(scores)

--- a/gittensor/validator/oss_contributions/normalize.py
+++ b/gittensor/validator/oss_contributions/normalize.py
@@ -3,6 +3,7 @@ from typing import Dict
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
+from gittensor.validator.utils.normalize import normalize_scores
 
 
 def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
@@ -12,24 +13,21 @@ def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> D
         bt.logging.warning('No miner evaluations provided for normalization')
         return {}
 
-    rewards: Dict[int, float] = {}
+    scores: Dict[int, float] = {}
     zero_reward_count = 0
 
     for uid, evaluation in miner_evaluations.items():
-        rewards[uid] = evaluation.total_score
-        if rewards[uid] > 0:
-            bt.logging.info(f'Final reward for uid {uid}: {rewards[uid]:.2f}')
+        scores[uid] = evaluation.total_score
+        if scores[uid] > 0:
+            bt.logging.info(f'Final reward for uid {uid}: {scores[uid]:.2f}')
         else:
             zero_reward_count += 1
 
     if zero_reward_count > 0:
         bt.logging.info(f'{zero_reward_count} miners have 0 reward')
 
-    total = sum(rewards.values())
-    if total <= 0:
+    if sum(scores.values()) <= 0:
         bt.logging.info('All scores are zero, returning original scores')
-        return rewards
+        return scores
 
-    normalized = {uid: score / total for uid, score in rewards.items()}
-
-    return normalized
+    return normalize_scores(scores)

--- a/gittensor/validator/utils/normalize.py
+++ b/gittensor/validator/utils/normalize.py
@@ -1,0 +1,20 @@
+# Entrius 2025
+
+"""Shared normalization utility for validator reward calculations."""
+
+from typing import Dict
+
+
+def normalize_scores(scores: Dict[int, float]) -> Dict[int, float]:
+    """Normalize a uid→score mapping to sum to 1.0, preserving ratios.
+
+    Returns the original dict unchanged if all scores are zero.
+    """
+    if not scores:
+        return {}
+
+    total = sum(scores.values())
+    if total <= 0:
+        return scores
+
+    return {uid: score / total for uid, score in scores.items()}


### PR DESCRIPTION
## Summary

`normalize_rewards_linear` (oss_contributions) and `normalize_issue_discovery_rewards` (issue_discovery) implement the same algorithm: build a uid→score map, check if total > 0, divide each score by total. The only difference is the field each pulls from (`evaluation.total_score` vs `evaluation.issue_discovery_score`).

This PR extracts the shared division logic into `gittensor/validator/utils/normalize.py` as `normalize_scores(scores: Dict[int, float]) -> Dict[int, float]` and has both functions delegate to it. All per-domain logic (field selection, logging) stays in each function.

## Test plan
- [ ] All 310 tests pass
- [ ] Pyright clean
- [ ] Ruff lint and format clean