### PR TITLE
refactor: remove dead code across neurons and cli modules

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -35,19 +35,6 @@ class Miner:
 
 
 @dataclass
-class Repository:
-    """Repository information"""
-
-    name: str
-    owner: str
-    weight: float
-
-    @property
-    def full_name(self) -> str:
-        return f'{self.owner}/{self.name}'
-
-
-@dataclass
 class FileChange:
     """Represents a single file change in a PR"""
 
@@ -639,12 +626,6 @@ class MinerEvaluationCache:
         bt.logging.debug(f'Cache hit for UID {uid} (cached at {cached.cached_at.isoformat()})')
 
         return deepcopy(cached.evaluation)
-
-    def invalidate(self, uid: int) -> None:
-        """Remove a cached evaluation for a specific UID."""
-        if uid in self._cache:
-            del self._cache[uid]
-            bt.logging.debug(f'Invalidated cache for UID {uid}')
 
     def clear(self) -> None:
         """Clear all cached evaluations."""

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -287,34 +287,6 @@ def print_issue_submission_table(
     console.print(f'Showing {len(pull_requests)} submissions{suffix}')
 
 
-def resolve_netuid_from_contract(ws_endpoint: str, contract_addr: str) -> Optional[int]:
-    """Read the subnet netuid stored in the on-chain contract."""
-    # Keep this import local so CLI help can render without optional chain deps installed.
-    from substrateinterface import SubstrateInterface
-
-    substrate = SubstrateInterface(url=ws_endpoint)
-    packed = _read_contract_packed_storage(substrate, contract_addr)
-    if packed and packed.get('netuid') is not None:
-        return int(packed['netuid'])
-    return None
-
-
-def verify_miner_registration(ws_endpoint: str, contract_addr: str, hotkey_ss58: str) -> bool:
-    """Return whether the hotkey is registered on the subnet configured by the contract netuid."""
-    import bittensor as bt
-
-    netuid = resolve_netuid_from_contract(ws_endpoint, contract_addr)
-    if netuid is None:
-        return False
-
-    subtensor = bt.Subtensor(network=ws_endpoint)
-    try:
-        return bool(subtensor.is_hotkey_registered(netuid=netuid, hotkey_ss58=hotkey_ss58))
-    except TypeError:
-        # API compatibility fallback across bittensor versions.
-        return bool(subtensor.is_hotkey_registered(hotkey_ss58, netuid))
-
-
 # ---------------------------------------------------------------------------
 # Input validation
 # ---------------------------------------------------------------------------

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -139,25 +139,6 @@ class Validator(BaseValidatorNeuron):
         if failed_uids:
             bt.logging.warning(f'Failed to store {len(failed_uids)} UIDs: {failed_uids}')
 
-    async def store_evaluation(self, uid: int, miner_eval: MinerEvaluation):
-        """
-        Stores the miner eval if DB storage is enabled via STORE_DB_RESULTS=true in .env.
-        """
-
-        if self.db_storage is not None:
-            try:
-                storage_result = self.db_storage.store_evaluation(miner_eval)
-
-                if storage_result.success:
-                    bt.logging.success(f'Successfully stored validation results for UID {uid} to DB.')
-                else:
-                    bt.logging.warning(f'Storage partially failed for UID {uid}:')
-                    for error in storage_result.errors:
-                        bt.logging.warning(f'  - {error}')
-
-            except Exception as e:
-                bt.logging.error(f'Error when attempting to store miners evaluation for uid {uid}: {e}')
-
     def store_or_use_cached_evaluation(self, miner_evaluations: Dict[int, MinerEvaluation]) -> Set[int]:
         """
         Handle evaluation cache: store successful evals, fallback to cache for GitHub failures.


### PR DESCRIPTION
## Summary

- **`Validator.store_evaluation`** (`neurons/validator.py`) — never called; `bulk_store_evaluation` is the only storage path used from `forward.py`
- **`resolve_netuid_from_contract` + `verify_miner_registration`** (`cli/issue_commands/helpers.py`) — never called or imported anywhere; speculative feature that was never wired up to any CLI command
- **`Repository` dataclass** (`classes.py`) — never imported anywhere in production code or tests; superseded by the separate `Repository` class in `gittensor/validator/storage/repository.py`
- **`MinerEvaluationCache.invalidate`** (`classes.py`) — never called anywhere; cache is cleared via `clear()` or natural eviction in `get()`

## Test plan

- [ ] Ruff lint/format clean
- [ ] Pyright passes
- [ ] Pytest passes