### PR TITLE
refactor: remove dead Repository dataclass and MinerEvaluationCache.invalidate

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -35,19 +35,6 @@ class Miner:
 
 
 @dataclass
-class Repository:
-    """Repository information"""
-
-    name: str
-    owner: str
-    weight: float
-
-    @property
-    def full_name(self) -> str:
-        return f'{self.owner}/{self.name}'
-
-
-@dataclass
 class FileChange:
     """Represents a single file change in a PR"""
 
@@ -639,12 +626,6 @@ class MinerEvaluationCache:
         bt.logging.debug(f'Cache hit for UID {uid} (cached at {cached.cached_at.isoformat()})')
 
         return deepcopy(cached.evaluation)
-
-    def invalidate(self, uid: int) -> None:
-        """Remove a cached evaluation for a specific UID."""
-        if uid in self._cache:
-            del self._cache[uid]
-            bt.logging.debug(f'Invalidated cache for UID {uid}')
 
     def clear(self) -> None:
         """Clear all cached evaluations."""


### PR DESCRIPTION
## Summary

Two dead code items removed from `gittensor/classes.py`:

- **`Repository` dataclass** (lines 37–48) — never imported or instantiated anywhere in production code or tests. All `from gittensor.classes import` statements reference other classes (`MinerEvaluation`, `PullRequest`, etc.). The active `Repository` in the codebase is a separate class in `gittensor/validator/storage/repository.py`.

- **`MinerEvaluationCache.invalidate(uid)`** (lines 643–647) — never called anywhere in production code or tests. The cache is cleared via `clear()` (which is called) or evicted naturally on identity mismatch in `get()`.

## Test plan

- [ ] Ruff lint/format clean
- [ ] Pyright passes
- [ ] Pytest passes