### PR TITLE
refactor: extract mulligan ratio and reward normalization helpers

### DIFF
--- a/gittensor/validator/issue_discovery/normalize.py
+++ b/gittensor/validator/issue_discovery/normalize.py
@@ -6,6 +6,7 @@ from typing import Dict
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
+from gittensor.validator.utils.reward_normalization import normalize_reward_ratios
 
 
 def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
@@ -27,7 +28,7 @@ def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluati
         bt.logging.info('Issue discovery: all scores are zero, returning empty rewards')
         return rewards
 
-    normalized = {uid: score / total for uid, score in rewards.items()}
+    normalized = normalize_reward_ratios(rewards)
 
     bt.logging.info(f'Issue discovery: normalized {nonzero_count} miners with scores > 0')
 

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -9,7 +9,6 @@ import bittensor as bt
 
 from gittensor.classes import Issue, MinerEvaluation
 from gittensor.constants import (
-    CREDIBILITY_MULLIGAN_COUNT,
     ISSUE_REVIEW_CLEAN_BONUS,
     ISSUE_REVIEW_PENALTY_RATE,
     MAX_OPEN_ISSUE_THRESHOLD,
@@ -19,6 +18,7 @@ from gittensor.constants import (
     OPEN_ISSUE_SPAM_BASE_THRESHOLD,
     OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
 )
+from gittensor.validator.utils.credibility_math import mulligan_success_ratio
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
@@ -52,11 +52,7 @@ def calculate_issue_credibility(solved_count: int, closed_count: int) -> float:
 
     credibility = solved / (solved + max(0, closed - mulligan))
     """
-    adjusted_closed = max(0, closed_count - CREDIBILITY_MULLIGAN_COUNT)
-    total = solved_count + adjusted_closed
-    if total == 0:
-        return 0.0
-    return solved_count / total
+    return mulligan_success_ratio(solved_count, closed_count)
 
 
 def check_issue_eligibility(solved_count: int, closed_count: int) -> Tuple[bool, float, str]:

--- a/gittensor/validator/oss_contributions/credibility.py
+++ b/gittensor/validator/oss_contributions/credibility.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING, List, Tuple
 import bittensor as bt
 
 from gittensor.constants import (
-    CREDIBILITY_MULLIGAN_COUNT,
     MIN_CREDIBILITY,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     MIN_VALID_MERGED_PRS,
 )
+from gittensor.validator.utils.credibility_math import mulligan_success_ratio
 
 if TYPE_CHECKING:
     from gittensor.classes import PullRequest
@@ -24,14 +24,7 @@ def calculate_credibility(merged_prs: List['PullRequest'], closed_prs: List['Pul
 
     Returns credibility in [0.0, 1.0], or 0.0 if no attempts after mulligan.
     """
-    merged_count = len(merged_prs)
-    closed_count = max(0, len(closed_prs) - CREDIBILITY_MULLIGAN_COUNT)
-    total_attempts = merged_count + closed_count
-
-    if total_attempts == 0:
-        return 0.0
-
-    return merged_count / total_attempts
+    return mulligan_success_ratio(len(merged_prs), len(closed_prs))
 
 
 def check_eligibility(merged_prs: List['PullRequest'], closed_prs: List['PullRequest']) -> Tuple[bool, float, str]:

--- a/gittensor/validator/oss_contributions/normalize.py
+++ b/gittensor/validator/oss_contributions/normalize.py
@@ -3,6 +3,7 @@ from typing import Dict
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
+from gittensor.validator.utils.reward_normalization import normalize_reward_ratios
 
 
 def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
@@ -30,6 +31,4 @@ def normalize_rewards_linear(miner_evaluations: Dict[int, MinerEvaluation]) -> D
         bt.logging.info('All scores are zero, returning original scores')
         return rewards
 
-    normalized = {uid: score / total for uid, score in rewards.items()}
-
-    return normalized
+    return normalize_reward_ratios(rewards)

--- a/gittensor/validator/utils/credibility_math.py
+++ b/gittensor/validator/utils/credibility_math.py
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Shared credibility math used by OSS and issue discovery scoring."""
+
+from gittensor.constants import CREDIBILITY_MULLIGAN_COUNT
+
+
+def mulligan_success_ratio(
+    successes: int, failures: int, *, mulligan: int = CREDIBILITY_MULLIGAN_COUNT
+) -> float:
+    """Ratio successes / (successes + max(0, failures - mulligan)).
+
+    Used for PR credibility (merged vs closed) and issue discovery (solved vs closed).
+    Returns a value in [0.0, 1.0], or 0.0 when the denominator is zero.
+    """
+    adjusted_failures = max(0, failures - mulligan)
+    denominator = successes + adjusted_failures
+    if denominator == 0:
+        return 0.0
+    return successes / denominator

--- a/gittensor/validator/utils/reward_normalization.py
+++ b/gittensor/validator/utils/reward_normalization.py
@@ -1,0 +1,20 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Shared linear normalization for validator reward dicts."""
+
+from typing import Dict
+
+
+def normalize_reward_ratios(rewards: Dict[int, float]) -> Dict[int, float]:
+    """Scale scores so they sum to 1.0, preserving ratios.
+
+    If ``rewards`` is empty or the sum of values is non-positive, returns ``rewards``
+    unchanged (caller handles logging for those cases).
+    """
+    if not rewards:
+        return rewards
+    total = sum(rewards.values())
+    if total <= 0:
+        return rewards
+    return {uid: score / total for uid, score in rewards.items()}

--- a/tests/validator/test_credibility_math_and_reward_norm.py
+++ b/tests/validator/test_credibility_math_and_reward_norm.py
@@ -1,0 +1,43 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Unit tests for shared credibility and reward normalization helpers."""
+
+import pytest
+
+from gittensor.constants import CREDIBILITY_MULLIGAN_COUNT
+from gittensor.validator.utils.credibility_math import mulligan_success_ratio
+from gittensor.validator.utils.reward_normalization import normalize_reward_ratios
+
+
+class TestMulliganSuccessRatio:
+    def test_matches_legacy_oss_formula(self):
+        merged, closed_raw = 5, 3
+        expected = merged / (merged + max(0, closed_raw - CREDIBILITY_MULLIGAN_COUNT))
+        assert mulligan_success_ratio(merged, closed_raw) == pytest.approx(expected)
+
+    def test_matches_legacy_issue_formula(self):
+        solved, closed_raw = 7, 4
+        expected = solved / (solved + max(0, closed_raw - CREDIBILITY_MULLIGAN_COUNT))
+        assert mulligan_success_ratio(solved, closed_raw) == pytest.approx(expected)
+
+    def test_zero_attempts(self):
+        assert mulligan_success_ratio(0, 0) == 0.0
+
+    def test_custom_mulligan(self):
+        assert mulligan_success_ratio(2, 5, mulligan=2) == pytest.approx(2 / (2 + 3))
+
+
+class TestNormalizeRewardRatios:
+    def test_empty(self):
+        assert normalize_reward_ratios({}) == {}
+
+    def test_all_zero_returns_unchanged(self):
+        raw = {1: 0.0, 2: 0.0}
+        assert normalize_reward_ratios(raw) is raw
+
+    def test_normalizes_to_unit_sum(self):
+        out = normalize_reward_ratios({10: 2.0, 20: 3.0})
+        assert sum(out.values()) == pytest.approx(1.0)
+        assert out[10] == pytest.approx(0.4)
+        assert out[20] == pytest.approx(0.6)


### PR DESCRIPTION
## Summary
Centralizes two repeated patterns: mulligan-adjusted success ratio (OSS PR credibility vs issue discovery) and linear reward normalization (OSS total score vs issue discovery score). Public scoring behavior and logging are unchanged; logic lives in small gittensor.validator.utils helpers with unit tests.

## Changes

- gittensor/validator/utils/credibility_math.py — mulligan_success_ratio(successes, failures, mulligan=...) implementing
- successes / (successes + max(0, failures - mulligan)).
- gittensor/validator/utils/reward_normalization.py — normalize_reward_ratios to scale a {uid: score} map to sum to 1.0 when the total is positive; otherwise returns the dict unchanged (callers keep existing empty/zero-sum logging).
- gittensor/validator/oss_contributions/credibility.py — calculate_credibility uses mulligan_success_ratio.
- gittensor/validator/issue_discovery/scoring.py — calculate_issue_credibility uses mulligan_success_ratio (drops redundant CREDIBILITY_MULLIGAN_COUNT import from this file).
- gittensor/validator/oss_contributions/normalize.py and gittensor/validator/issue_discovery/normalize.py — call normalize_reward_ratios after existing guards/logging.
- tests/validator/test_credibility_math_and_reward_norm.py — covers equivalence to the previous formulas and basic normalization cases.
