### PR TITLE
refactor: remove dead hash_url and get_available_issues from ContractClient

### DIFF
--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -120,11 +120,6 @@ class IssueCompetitionContractClient:
 
         bt.logging.debug(f'Contract client initialized: {self.contract_address}')
 
-    @staticmethod
-    def hash_url(url: str) -> bytes:
-        """Hash a URL for deduplication."""
-        return hashlib.sha256(url.encode()).digest()
-
     # =========================================================================
     # Query Functions (Read-only)
     # =========================================================================
@@ -211,10 +206,6 @@ class IssueCompetitionContractClient:
         except Exception as e:
             bt.logging.error(f'Error fetching issues by status: {e}')
             return []
-
-    def get_available_issues(self) -> List[ContractIssue]:
-        """Query contract for issues with status=Active."""
-        return self.get_issues_by_status(IssueStatus.ACTIVE)
 
     def get_issue(self, issue_id: int) -> Optional[ContractIssue]:
         """Get a specific issue by ID."""


### PR DESCRIPTION
## Summary
Remove two dead methods from `IssueCompetitionContractClient`:

- **`hash_url`** — static method defined at line 123, never called anywhere in the codebase. Grep confirms zero references outside its definition.
- **`get_available_issues`** — convenience wrapper defined at line 215, never called anywhere. Callers use `get_issues_by_status(IssueStatus.ACTIVE)` directly.

## Related Issues
N/A (code cleanup)

## Type of Change
- [x] Refactoring (dead code removal)

## Testing
- [x] `ruff check` — 0 errors
- [x] `ruff format --check` — no diff
- [x] `pyright` — 0 errors
- [x] `pytest tests/ -v` — all pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No behavior change — removed code was unreachable

cc @anderdc @landyndev