### PR TITLE
refactor: remove dead verify_miner_registration and resolve_netuid_from_contract

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -287,34 +287,6 @@ def print_issue_submission_table(
     console.print(f'Showing {len(pull_requests)} submissions{suffix}')
 
 
-def resolve_netuid_from_contract(ws_endpoint: str, contract_addr: str) -> Optional[int]:
-    """Read the subnet netuid stored in the on-chain contract."""
-    # Keep this import local so CLI help can render without optional chain deps installed.
-    from substrateinterface import SubstrateInterface
-
-    substrate = SubstrateInterface(url=ws_endpoint)
-    packed = _read_contract_packed_storage(substrate, contract_addr)
-    if packed and packed.get('netuid') is not None:
-        return int(packed['netuid'])
-    return None
-
-
-def verify_miner_registration(ws_endpoint: str, contract_addr: str, hotkey_ss58: str) -> bool:
-    """Return whether the hotkey is registered on the subnet configured by the contract netuid."""
-    import bittensor as bt
-
-    netuid = resolve_netuid_from_contract(ws_endpoint, contract_addr)
-    if netuid is None:
-        return False
-
-    subtensor = bt.Subtensor(network=ws_endpoint)
-    try:
-        return bool(subtensor.is_hotkey_registered(netuid=netuid, hotkey_ss58=hotkey_ss58))
-    except TypeError:
-        # API compatibility fallback across bittensor versions.
-        return bool(subtensor.is_hotkey_registered(hotkey_ss58, netuid))
-
-
 # ---------------------------------------------------------------------------
 # Input validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Remove two dead functions from `gittensor/cli/issue_commands/helpers.py`:

- **`resolve_netuid_from_contract`** (line 290) — never called from any module. Its only caller was `verify_miner_registration` which is also dead.
- **`verify_miner_registration`** (line 302) — never imported or called anywhere in the codebase. Grep confirms zero references outside the definition.

Both functions were likely part of an earlier CLI workflow that has since been replaced.

## Related Issues
N/A (code cleanup)

## Type of Change
- [x] Refactoring (dead code removal)

## Testing
- [x] `ruff check` — 0 errors
- [x] `ruff format --check` — no diff
- [x] `pyright` — 0 errors
- [x] `pytest tests/ -v` — all pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No behavior change — removed code was unreachable

cc @anderdc @landyndev