### PR TITLE
refactor: remove dead stop_run_thread from BaseValidatorNeuron

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -180,17 +180,6 @@ class BaseValidatorNeuron(BaseNeuron):
             self.is_running = True
             bt.logging.debug('Started')
 
-    def stop_run_thread(self):
-        """
-        Stops the validator's operations that are running in the background thread.
-        """
-        if self.is_running:
-            bt.logging.debug('Stopping validator in background thread.')
-            self.should_exit = True
-            self.thread.join(5)
-            self.is_running = False
-            bt.logging.debug('Stopped')
-
     def __enter__(self):
         self.run_in_background_thread()
         return self


### PR DESCRIPTION
## Summary
Remove the dead `stop_run_thread` method from `BaseValidatorNeuron` in `neurons/base/validator.py`.

This method is never called anywhere in the codebase. The `__exit__` context manager (line 198) already inlines the exact same logic:

```python
# __exit__ (kept):
if self.is_running:
    bt.logging.debug('Stopping validator in background thread.')
    self.should_exit = True
    self.thread.join(5)
    self.is_running = False
    bt.logging.debug('Stopped')
```

The duplicated `stop_run_thread` method is unreachable dead code.

## Related Issues
N/A (code cleanup)

## Type of Change
- [x] Refactoring (dead code removal)

## Testing
- [x] `ruff check` — 0 errors
- [x] `ruff format --check` — no diff
- [x] `pyright` — 0 errors
- [x] `pytest tests/ -v` — all pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No behavior change — removed code was unreachable

cc @anderdc @landyndev