### PR TITLE
refactor: remove dead store_evaluation and unused WANDB_API_KEY

### DIFF
--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -7,7 +7,6 @@ VALIDATOR_STEPS_INTERVAL = 120  # 2 hours, every time a scoring round happens
 
 # required env vars
 GITTENSOR_VALIDATOR_PAT = os.getenv('GITTENSOR_VALIDATOR_PAT')
-WANDB_API_KEY = os.getenv('WANDB_API_KEY')
 WANDB_PROJECT = os.getenv('WANDB_PROJECT', 'gittensor-validators')
 WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -139,25 +139,6 @@ class Validator(BaseValidatorNeuron):
         if failed_uids:
             bt.logging.warning(f'Failed to store {len(failed_uids)} UIDs: {failed_uids}')
 
-    async def store_evaluation(self, uid: int, miner_eval: MinerEvaluation):
-        """
-        Stores the miner eval if DB storage is enabled via STORE_DB_RESULTS=true in .env.
-        """
-
-        if self.db_storage is not None:
-            try:
-                storage_result = self.db_storage.store_evaluation(miner_eval)
-
-                if storage_result.success:
-                    bt.logging.success(f'Successfully stored validation results for UID {uid} to DB.')
-                else:
-                    bt.logging.warning(f'Storage partially failed for UID {uid}:')
-                    for error in storage_result.errors:
-                        bt.logging.warning(f'  - {error}')
-
-            except Exception as e:
-                bt.logging.error(f'Error when attempting to store miners evaluation for uid {uid}: {e}')
-
     def store_or_use_cached_evaluation(self, miner_evaluations: Dict[int, MinerEvaluation]) -> Set[int]:
         """
         Handle evaluation cache: store successful evals, fallback to cache for GitHub failures.


### PR DESCRIPTION
## Summary
Remove two pieces of dead code from the validator module:

- **`Validator.store_evaluation`** (`neurons/validator.py`, line 142) — async method never called anywhere. The codebase uses `bulk_store_evaluation` (line 101, called from `forward.py:74`) instead. The only `store_evaluation` calls in the codebase target `self.db_storage.store_evaluation()` (a different class: `DatabaseStorage`), not this Validator method.

- **`WANDB_API_KEY`** (`gittensor/validator/utils/config.py`, line 10) — constant assigned from `os.getenv('WANDB_API_KEY')` but never imported or referenced anywhere else. The sibling constants `WANDB_PROJECT` and `WANDB_VALIDATOR_NAME` are both imported and used in `neurons/validator.py`, but `WANDB_API_KEY` is not. The wandb library reads the environment variable directly.

## Related Issues
N/A (code cleanup)

## Type of Change
- [x] Refactoring (dead code removal)

## Testing
- [x] `ruff check` — 0 errors
- [x] `ruff format --check` — no diff
- [x] `pyright` — 0 errors
- [x] `pytest tests/ -v` — all pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No behavior change — removed code was unreachable

cc @anderdc @landyndev