### PR TITLE
fix(cli): return non-zero exit codes on runtime failures

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -96,8 +96,10 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
             print_error('Cancellation failed.')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @admin.command('payout-issue')
@@ -156,8 +158,10 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
             print_error('Payout failed.')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @admin.command('set-owner')
@@ -203,8 +207,10 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
             print_error('Ownership transfer failed.')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @admin.command('set-treasury')
@@ -258,8 +264,10 @@ def admin_set_treasury(
             print_error('Treasury hotkey update failed.')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @admin.command('add-vali')
@@ -311,8 +319,10 @@ def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, 
             console.print('  \u2022 Validator is already whitelisted')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @admin.command('remove-vali')
@@ -365,5 +375,7 @@ def admin_remove_validator(
             console.print('  \u2022 Validator is not in the whitelist')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -243,6 +243,7 @@ def issue_register(
     except ImportError as e:
         print_error(f'Missing dependency - {e}')
         console.print('[dim]Install with: uv sync[/dim]')
+        raise SystemExit(1)
     except Exception as e:
         error_msg = str(e)
         if 'ContractReverted' in error_msg:
@@ -253,6 +254,7 @@ def issue_register(
             console.print('  \u2022 Caller is not the contract owner')
         else:
             print_error(f'Error registering issue: {e}')
+        raise SystemExit(1)
 
 
 @click.command('harvest', cls=StyledCommand)
@@ -384,6 +386,7 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
     except ImportError as e:
         print_error(f'Missing dependency — {e}')
         console.print('[dim]Install with: uv sync[/dim]')
+        raise SystemExit(1)
     except Exception as e:
         import traceback
 
@@ -392,3 +395,4 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
             console.print(f'[dim]Full traceback:\n{traceback.format_exc()}[/dim]')
         else:
             console.print('[dim]Run with --verbose for full traceback.[/dim]')
+        raise SystemExit(1)

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -221,6 +221,7 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         console.print(f'[dim]Sum of bounty amounts from {len(issues)} issue(s)[/dim]')
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @click.command('pending-harvest', cls=StyledCommand)
@@ -282,8 +283,10 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         console.print(f'[green]Pending Harvest:[/green] {format_alpha(pending_harvest, 4)} ALPHA')
     except ImportError as e:
         print_error(f'Missing dependency — {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @click.command('info', cls=StyledCommand)
@@ -329,3 +332,4 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
             console.print('[dim]Try running with --verbose to see debug details.[/dim]')
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -142,8 +142,10 @@ def val_vote_solution(
             print_error('Vote failed.')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @vote.command('cancel')
@@ -200,8 +202,10 @@ def val_vote_cancel_issue(
             print_error('Cancel vote failed.')
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)
 
 
 @vote.command('list')
@@ -269,5 +273,7 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
 
     except ImportError as e:
         print_error(f'Missing dependency \u2014 {e}')
+        raise SystemExit(1)
     except Exception as e:
         print_error(str(e))
+        raise SystemExit(1)

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -644,3 +644,80 @@ class TestCliMissingContractConfig:
             )
         assert result.exit_code != 0
         assert 'Contract address not configured' in result.output
+
+
+class TestCliRuntimeExceptions:
+    """Ensure runtime/import failures exit non-zero for CLI commands."""
+
+    def test_admin_cancel_runtime_exception_exits_non_zero(self, cli_root, runner):
+        with (
+            patch(
+                'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.admin._make_contract_client',
+                side_effect=RuntimeError('boom-admin'),
+            ),
+        ):
+            result = runner.invoke(
+                cli_root,
+                ['admin', 'cancel-issue', '1'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'boom-admin' in result.output
+
+    def test_vote_solution_import_error_exits_non_zero(self, cli_root, runner):
+        with (
+            patch(
+                'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.vote._make_contract_client',
+                side_effect=ImportError('missing-dep'),
+            ),
+        ):
+            result = runner.invoke(
+                cli_root,
+                [
+                    'vote',
+                    'solution',
+                    '1',
+                    '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+                    '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+                    '1',
+                ],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'Missing dependency' in result.output
+
+    def test_harvest_runtime_exception_exits_non_zero(self, cli_root, runner):
+        with (
+            patch(
+                'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch('bittensor.Wallet', side_effect=RuntimeError('boom-harvest')),
+        ):
+            result = runner.invoke(
+                cli_root,
+                ['harvest'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'boom-harvest' in result.output


### PR DESCRIPTION
## Summary

Fixes incorrect success exit codes in issue CLI commands by raising `SystemExit(1)` when runtime/import failures occur, and adds regression tests to ensure failures return non-zero exit status.

## Related Issues

Closes #480

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
