### PR TITLE
refactor: centralize GitHub API constants and deduplicate console.status pattern

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -17,6 +17,7 @@ from .helpers import (
     _get_validator_axons,
     _load_config_value,
     _resolve_endpoint,
+    _status,
 )
 
 console = Console()
@@ -50,18 +51,11 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 2. Set up bittensor objects
-    if not json_mode:
-        with console.status('[bold]Connecting to network...'):
-            try:
-                wallet, subtensor, metagraph, dendrite = _connect_bittensor(
-                    wallet_name, wallet_hotkey, ws_endpoint, netuid
-                )
-            except Exception as e:
-                _error(f'Failed to initialize bittensor: {e}', json_mode)
-                sys.exit(1)
-    else:
+    with _status('[bold]Connecting to network...', json_mode):
         try:
-            wallet, subtensor, metagraph, dendrite = _connect_bittensor(wallet_name, wallet_hotkey, ws_endpoint, netuid)
+            wallet, subtensor, metagraph, dendrite = _connect_bittensor(
+                wallet_name, wallet_hotkey, ws_endpoint, netuid
+            )
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)
@@ -89,10 +83,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
             timeout=15.0,
         )
 
-    if not json_mode:
-        with console.status(f'[bold]Checking {len(validator_axons)} validators...'):
-            responses = asyncio.run(_check())
-    else:
+    with _status(f'[bold]Checking {len(validator_axons)} validators...', json_mode):
         responses = asyncio.run(_check())
 
     # 5. Collect results

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -53,9 +53,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
     # 2. Set up bittensor objects
     with _status('[bold]Connecting to network...', json_mode):
         try:
-            wallet, subtensor, metagraph, dendrite = _connect_bittensor(
-                wallet_name, wallet_hotkey, ws_endpoint, netuid
-            )
+            wallet, subtensor, metagraph, dendrite = _connect_bittensor(wallet_name, wallet_hotkey, ws_endpoint, netuid)
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import nullcontext
 from pathlib import Path
 
 import click
@@ -64,6 +65,11 @@ def _connect_bittensor(wallet_name: str, wallet_hotkey: str, ws_endpoint: str, n
     mg = st.metagraph(netuid=netuid)
     dd = bt.Dendrite(wallet=w)
     return w, st, mg, dd
+
+
+def _status(message: str, json_mode: bool):
+    """Rich spinner in TTY mode, no-op in JSON mode."""
+    return nullcontext() if json_mode else console.status(message)
 
 
 def _error(msg: str, json_mode: bool) -> None:

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -21,6 +21,7 @@ from gittensor.cli.miner_commands.helpers import (
     _get_validator_axons,
     _load_config_value,
     _resolve_endpoint,
+    _status,
 )
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 
@@ -68,10 +69,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         pat = click.prompt('Enter your GitHub Personal Access Token', hide_input=True)
 
     # 1b. Validate PAT locally
-    if not json_mode:
-        with console.status('[bold]Validating PAT...'):
-            pat_valid = _validate_pat_locally(pat)
-    else:
+    with _status('[bold]Validating PAT...', json_mode):
         pat_valid = _validate_pat_locally(pat)
 
     if not pat_valid:
@@ -90,18 +88,11 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 3. Set up bittensor objects
-    if not json_mode:
-        with console.status('[bold]Connecting to network...'):
-            try:
-                wallet, subtensor, metagraph, dendrite = _connect_bittensor(
-                    wallet_name, wallet_hotkey, ws_endpoint, netuid
-                )
-            except Exception as e:
-                _error(f'Failed to initialize bittensor: {e}', json_mode)
-                sys.exit(1)
-    else:
+    with _status('[bold]Connecting to network...', json_mode):
         try:
-            wallet, subtensor, metagraph, dendrite = _connect_bittensor(wallet_name, wallet_hotkey, ws_endpoint, netuid)
+            wallet, subtensor, metagraph, dendrite = _connect_bittensor(
+                wallet_name, wallet_hotkey, ws_endpoint, netuid
+            )
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)
@@ -129,10 +120,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
             timeout=30.0,
         )
 
-    if not json_mode:
-        with console.status(f'[bold]Broadcasting to {len(validator_axons)} validators...'):
-            responses = asyncio.run(_broadcast())
-    else:
+    with _status(f'[bold]Broadcasting to {len(validator_axons)} validators...', json_mode):
         responses = asyncio.run(_broadcast())
 
     # 6. Collect results

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -22,7 +22,7 @@ from gittensor.cli.miner_commands.helpers import (
     _load_config_value,
     _resolve_endpoint,
 )
-from gittensor.constants import BASE_GITHUB_API_URL
+from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 
 console = Console()
 
@@ -192,17 +192,17 @@ def _validate_pat_locally(pat: str) -> bool:
     headers = {'Authorization': f'token {pat}', 'Accept': 'application/vnd.github.v3+json'}
     try:
         # Check basic auth
-        user_resp = requests.get(f'{BASE_GITHUB_API_URL}/user', headers=headers, timeout=15)
+        user_resp = requests.get(f'{BASE_GITHUB_API_URL}/user', headers=headers, timeout=GITHUB_HTTP_TIMEOUT_SECONDS)
         if user_resp.status_code != 200:
             return False
 
         # Check GraphQL access (same test the validator runs during PAT broadcast)
-        gql_headers = {'Authorization': f'bearer {pat}', 'Accept': 'application/json'}
+        gql_headers = {'Authorization': f'Bearer {pat}', 'Accept': 'application/json'}
         gql_resp = requests.post(
             f'{BASE_GITHUB_API_URL}/graphql',
-            json={'query': '{ viewer { login } }'},
+            json={'query': GRAPHQL_VIEWER_QUERY},
             headers=gql_headers,
-            timeout=15,
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
         if gql_resp.status_code != 200:
             console.print(

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -90,9 +90,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
     # 3. Set up bittensor objects
     with _status('[bold]Connecting to network...', json_mode):
         try:
-            wallet, subtensor, metagraph, dendrite = _connect_bittensor(
-                wallet_name, wallet_hotkey, ws_endpoint, netuid
-            )
+            wallet, subtensor, metagraph, dendrite = _connect_bittensor(wallet_name, wallet_hotkey, ws_endpoint, netuid)
         except Exception as e:
             _error(f'Failed to initialize bittensor: {e}', json_mode)
             sys.exit(1)

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -21,6 +21,8 @@ NETWORK_MAP = {
 # GitHub API
 # =============================================================================
 BASE_GITHUB_API_URL = 'https://api.github.com'
+GITHUB_HTTP_TIMEOUT_SECONDS = 15
+GRAPHQL_VIEWER_QUERY = '{ viewer { login } }'
 # 1MB max file size for github api file fetches. Files exceeding this get no score.
 MAX_FILE_SIZE_BYTES = 1_000_000
 # Too many object lookups in one GraphQL query can trigger 502 errors and lose all results.

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import bittensor as bt
 import requests
 
-from gittensor.constants import BASE_GITHUB_API_URL
+from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.validator import pat_storage
 from gittensor.validator.utils.github_validation import validate_github_credentials
@@ -157,22 +157,19 @@ async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-_TEST_GRAPHQL_QUERY = '{ viewer { login } }'
-
-
 def _test_pat_against_repo(pat: str) -> Optional[str]:
     """Run a test GraphQL call to verify the PAT has the access scoring requires.
 
     Scoring uses the GraphQL API to fetch miner PRs, so this mirrors the real path.
     Returns an error string on failure, None on success.
     """
-    headers = {'Authorization': f'bearer {pat}', 'Accept': 'application/json'}
+    headers = {'Authorization': f'Bearer {pat}', 'Accept': 'application/json'}
     try:
         response = requests.post(
             f'{BASE_GITHUB_API_URL}/graphql',
-            json={'query': _TEST_GRAPHQL_QUERY},
+            json={'query': GRAPHQL_VIEWER_QUERY},
             headers=headers,
-            timeout=15,
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
         if response.status_code != 200:
             return f'GitHub GraphQL API returned {response.status_code}'

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -157,6 +157,7 @@ async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+
 def _test_pat_against_repo(pat: str) -> Optional[str]:
     """Run a test GraphQL call to verify the PAT has the access scoring requires.
 


### PR DESCRIPTION
## Summary

Centralize duplicated GitHub API values into named constants and eliminate repeated `if not json_mode: with console.status(...) else: ...` blocks in the miner CLI.

- Add `GITHUB_HTTP_TIMEOUT_SECONDS` and `GRAPHQL_VIEWER_QUERY` to `gittensor/constants.py`, replacing magic values hardcoded in `post.py` and `pat_handler.py`
- Remove module-level `_TEST_GRAPHQL_QUERY` duplicate from `pat_handler.py` in favor of the shared constant
- Add `_status()` helper to `miner_commands/helpers.py` using `contextlib.nullcontext`, replacing 5 duplicated conditional blocks across `post.py` (3 sites) and `check.py` (2 sites)
- Normalize `bearer` → `Bearer` in authorization headers to match RFC 6750 and the rest of the codebase

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)