### PR TITLE
refactor: remove dead ScoreBreakdown.added_score and .deleted_score properties

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -479,19 +479,9 @@ class ScoreBreakdown:
         return self.structural_added_count + self.leaf_added_count
 
     @property
-    def added_score(self) -> float:
-        """Total score from additions."""
-        return self.structural_added_score + self.leaf_added_score
-
-    @property
     def deleted_count(self) -> int:
         """Total deleted nodes (structural + leaf)."""
         return self.structural_deleted_count + self.leaf_deleted_count
-
-    @property
-    def deleted_score(self) -> float:
-        """Total score from deletions."""
-        return self.structural_deleted_score + self.leaf_deleted_score
 
     def with_weight(self, weight: float) -> 'ScoreBreakdown':
         """Return new ScoreBreakdown with scores multiplied by weight (counts unchanged)."""

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -636,11 +636,6 @@ class MinerEvaluationCache:
             del self._cache[uid]
             bt.logging.debug(f'Invalidated cache for UID {uid}')
 
-    def clear(self) -> None:
-        """Clear all cached evaluations."""
-        self._cache.clear()
-        bt.logging.info('Cleared evaluation cache')
-
     def create_lightweight_copy(self, evaluation: 'MinerEvaluation') -> 'MinerEvaluation':
         """Create a memory-efficient copy, stripping file patches."""
         light_eval = deepcopy(evaluation)


### PR DESCRIPTION
## Summary

Remove two unused properties (`added_score` and `deleted_score`) from the `ScoreBreakdown` dataclass and the unused `clear()` method from `MinerEvaluationCache` in `gittensor/classes.py`. None of these have any callers in the codebase.
 
Closes #488 
Closes #486
 

## Test Plan

- Ruff lint/format passes
- Pyright type checking passes
- Pytest test suite passes
