### PR TITLE
Adjust label multipliers and lower gittensor-ui weight

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -78,8 +78,8 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.5
 LABEL_MULTIPLIERS: dict[str, float] = {
     'feature': 1.50,
     'bug': 1.25,
-    'enhancement': 1.15,
-    'refactor': 1.05,
+    'enhancement': 1.10,
+    'refactor': 1.00,
 }
 
 # Pioneer dividend — rewards the first quality contributor to each repository

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -206,7 +206,7 @@
     "weight": 1.0
   },
   "entrius/gittensor-ui": {
-    "weight": 0.88
+    "weight": 0.74
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444


### PR DESCRIPTION
## Summary
- Label multipliers: enhancement 1.15 → 1.10, refactor 1.05 → 1.00
- Repository weight: gittensor-ui 0.88 → 0.74
- Feature (1.50) and bug (1.25) unchanged

## Test plan
- [ ] Verify scoring picks up new label multipliers
- [ ] Verify gittensor-ui PRs score with updated weight