### PR TITLE
Deduplicate miner registration and validator axon checks

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -14,8 +14,9 @@ from .helpers import (
     NETUID_DEFAULT,
     _connect_bittensor,
     _error,
-    _get_validator_axons,
     _load_config_value,
+    _require_registered,
+    _require_validator_axons,
     _resolve_endpoint,
     _status,
 )
@@ -59,16 +60,10 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
             sys.exit(1)
 
     # Verify miner is registered
-    if wallet.hotkey.ss58_address not in metagraph.hotkeys:
-        _error(f'Hotkey {wallet.hotkey.ss58_address[:16]}... is not registered on subnet {netuid}.', json_mode)
-        sys.exit(1)
+    _require_registered(wallet, metagraph, netuid, json_mode)
 
     # 3. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons, validator_uids = _get_validator_axons(metagraph)
-
-    if not validator_axons:
-        _error('No reachable validator axons found on the network.', json_mode)
-        sys.exit(1)
+    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode)
 
     # 4. Send check probes
     synapse = PatCheckSynapse()

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -78,3 +79,19 @@ def _error(msg: str, json_mode: bool) -> None:
         click.echo(json.dumps({'success': False, 'error': msg}))
     else:
         console.print(f'[red]Error: {msg}[/red]')
+
+
+def _require_registered(wallet, metagraph, netuid: int, json_mode: bool) -> None:
+    """Exit with error if wallet hotkey is not registered on the subnet."""
+    if wallet.hotkey.ss58_address not in metagraph.hotkeys:
+        _error(f'Hotkey {wallet.hotkey.ss58_address[:16]}... is not registered on subnet {netuid}.', json_mode)
+        sys.exit(1)
+
+
+def _require_validator_axons(metagraph, json_mode: bool) -> tuple[list, list]:
+    """Return validator (axons, uids), or exit with error if none found."""
+    validator_axons, validator_uids = _get_validator_axons(metagraph)
+    if not validator_axons:
+        _error('No reachable validator axons found on the network.', json_mode)
+        sys.exit(1)
+    return validator_axons, validator_uids

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -18,8 +18,9 @@ from gittensor.cli.miner_commands.helpers import (
     NETUID_DEFAULT,
     _connect_bittensor,
     _error,
-    _get_validator_axons,
     _load_config_value,
+    _require_registered,
+    _require_validator_axons,
     _resolve_endpoint,
     _status,
 )
@@ -96,16 +97,10 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
             sys.exit(1)
 
     # Verify miner is registered
-    if wallet.hotkey.ss58_address not in metagraph.hotkeys:
-        _error(f'Hotkey {wallet.hotkey.ss58_address[:16]}... is not registered on subnet {netuid}.', json_mode)
-        sys.exit(1)
+    _require_registered(wallet, metagraph, netuid, json_mode)
 
     # 4. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons, validator_uids = _get_validator_axons(metagraph)
-
-    if not validator_axons:
-        _error('No reachable validator axons found on the network.', json_mode)
-        sys.exit(1)
+    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode)
 
     # 5. Broadcast
     synapse = PatBroadcastSynapse(github_access_token=pat)


### PR DESCRIPTION
## Fixes: #493 

## Summary

Extract `_require_registered` and `_require_validator_axons` helpers into `gittensor/cli/miner_commands/helpers.py`, replacing identical validation blocks duplicated between `check.py` and `post.py`.
