### PR TITLE
refactor: extract shared validator shutdown and storage error logging

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -184,12 +184,7 @@ class BaseValidatorNeuron(BaseNeuron):
         """
         Stops the validator's operations that are running in the background thread.
         """
-        if self.is_running:
-            bt.logging.debug('Stopping validator in background thread.')
-            self.should_exit = True
-            self.thread.join(5)
-            self.is_running = False
-            bt.logging.debug('Stopped')
+        self._stop_background_thread()
 
     def __enter__(self):
         self.run_in_background_thread()
@@ -208,6 +203,10 @@ class BaseValidatorNeuron(BaseNeuron):
             traceback: A traceback object encoding the stack trace.
                        None if the context was exited without an exception.
         """
+        self._stop_background_thread()
+
+    def _stop_background_thread(self):
+        """Gracefully stop validator when running in a background thread."""
         if self.is_running:
             bt.logging.debug('Stopping validator in background thread.')
             self.should_exit = True

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -124,9 +124,7 @@ class Validator(BaseValidatorNeuron):
                     successful_count += 1
                 else:
                     failed_uids.append(uid)
-                    bt.logging.warning(f'Storage partially failed for UID {uid}:')
-                    for error in storage_result.errors:
-                        bt.logging.warning(f'  - {error}')
+                    self._log_storage_partial_failure(uid, storage_result.errors)
             except Exception as e:
                 failed_uids.append(uid)
                 bt.logging.error(f'Error storing evaluation for UID {uid}: {e}')
@@ -151,12 +149,17 @@ class Validator(BaseValidatorNeuron):
                 if storage_result.success:
                     bt.logging.success(f'Successfully stored validation results for UID {uid} to DB.')
                 else:
-                    bt.logging.warning(f'Storage partially failed for UID {uid}:')
-                    for error in storage_result.errors:
-                        bt.logging.warning(f'  - {error}')
+                    self._log_storage_partial_failure(uid, storage_result.errors)
 
             except Exception as e:
                 bt.logging.error(f'Error when attempting to store miners evaluation for uid {uid}: {e}')
+
+    @staticmethod
+    def _log_storage_partial_failure(uid: int, errors: List[str]):
+        """Log storage errors for a single miner evaluation attempt."""
+        bt.logging.warning(f'Storage partially failed for UID {uid}:')
+        for error in errors:
+            bt.logging.warning(f'  - {error}')
 
     def store_or_use_cached_evaluation(self, miner_evaluations: Dict[int, MinerEvaluation]) -> Set[int]:
         """


### PR DESCRIPTION
## Summary
- Extract duplicated background-thread stop logic in `BaseValidatorNeuron` into `_stop_background_thread()`.
- Extract duplicated partial DB storage failure logging in `Validator` into `_log_storage_partial_failure()`.

## Why
- Reduces repeated logic across validator lifecycle and DB storage paths.
- Makes future updates less error-prone by centralizing shared behavior.
- Improves readability.

## Files changed
- `neurons/base/validator.py`
- `neurons/validator.py`
