### PR TITLE
Extract require_valid_issue_id and require_valid_ss58 CLI helpers

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -26,8 +26,8 @@ from .helpers import (
     print_error,
     print_network_header,
     print_success,
-    validate_issue_id,
-    validate_ss58_address,
+    require_valid_issue_id,
+    require_valid_ss58,
     with_network_contract_options,
     with_wallet_options,
 )
@@ -62,10 +62,7 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_issue_id(issue_id)
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
+    require_valid_issue_id(issue_id)
 
     print_network_header(network_name, contract_addr)
 
@@ -120,10 +117,7 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_issue_id(issue_id)
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
+    require_valid_issue_id(issue_id)
 
     print_network_header(network_name, contract_addr)
 
@@ -174,10 +168,7 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_ss58_address(new_owner, 'new_owner')
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
+    require_valid_ss58(new_owner, 'new_owner')
 
     print_network_header(network_name, contract_addr)
 
@@ -224,10 +215,7 @@ def admin_set_treasury(
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_ss58_address(new_treasury, 'new_treasury')
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
+    require_valid_ss58(new_treasury, 'new_treasury')
 
     print_network_header(network_name, contract_addr)
 
@@ -275,10 +263,7 @@ def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, 
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_ss58_address(hotkey, 'hotkey')
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
+    require_valid_ss58(hotkey, 'hotkey')
 
     print_network_header(network_name, contract_addr)
 
@@ -327,10 +312,7 @@ def admin_remove_validator(
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_ss58_address(hotkey, 'hotkey')
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
+    require_valid_ss58(hotkey, 'hotkey')
 
     print_network_header(network_name, contract_addr)
 

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -465,6 +465,22 @@ def validate_ss58_address(address: str, param_name: str = 'address') -> str:
     return address
 
 
+def require_valid_issue_id(value: int, param_name: str = 'issue_id') -> int:
+    """Validate an issue ID, raising ClickException on failure."""
+    try:
+        return validate_issue_id(value, param_name)
+    except click.BadParameter as e:
+        raise click.ClickException(str(e))
+
+
+def require_valid_ss58(address: str, param_name: str = 'address') -> str:
+    """Validate an SS58 address, raising ClickException on failure."""
+    try:
+        return validate_ss58_address(address, param_name)
+    except click.BadParameter as e:
+        raise click.ClickException(str(e))
+
+
 def load_config() -> Dict[str, Any]:
     """
     Load configuration from ~/.gittensor/config.json.

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -466,7 +466,11 @@ def validate_ss58_address(address: str, param_name: str = 'address') -> str:
 
 
 def require_valid_issue_id(value: int, param_name: str = 'issue_id') -> int:
-    """Validate an issue ID, raising ClickException on failure."""
+    """Validate an issue ID, raising ClickException on failure.
+
+    Returns:
+        The validated issue ID.
+    """
     try:
         return validate_issue_id(value, param_name)
     except click.BadParameter as e:
@@ -474,7 +478,11 @@ def require_valid_issue_id(value: int, param_name: str = 'issue_id') -> int:
 
 
 def require_valid_ss58(address: str, param_name: str = 'address') -> str:
-    """Validate an SS58 address, raising ClickException on failure."""
+    """Validate an SS58 address, raising ClickException on failure.
+
+    Returns:
+        The validated SS58 address string.
+    """
     try:
         return validate_ss58_address(address, param_name)
     except click.BadParameter as e:

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -26,6 +26,7 @@ from .helpers import (
     print_error,
     print_network_header,
     print_success,
+    require_valid_issue_id,
     validate_issue_id,
     validate_ss58_address,
     with_cli_behavior_options,
@@ -173,10 +174,7 @@ def val_vote_cancel_issue(
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_issue_id(issue_id)
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
+    require_valid_issue_id(issue_id)
 
     print_network_header(network_name, contract_addr)
 


### PR DESCRIPTION
## Fixes: #497

## Summary

Extract `require_valid_issue_id` and `require_valid_ss58` helpers into `gittensor/cli/issue_commands/helpers.py`, replacing 7 identical try/except/re-raise blocks across `admin.py` and `vote.py`.
