### PR TITLE
refactor: remove dead `Miner.__str__` and unused `WANDB_API_KEY

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -30,9 +30,6 @@ class Miner:
     hotkey: str
     github_id: str
 
-    def __str__(self) -> str:
-        return f'Miner(uid={self.uid}, hotkey={self.hotkey[:8]}..., github_id={self.github_id})'
-
 
 @dataclass
 class FileChange:

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -7,7 +7,6 @@ VALIDATOR_STEPS_INTERVAL = 120  # 2 hours, every time a scoring round happens
 
 # required env vars
 GITTENSOR_VALIDATOR_PAT = os.getenv('GITTENSOR_VALIDATOR_PAT')
-WANDB_API_KEY = os.getenv('WANDB_API_KEY')
 WANDB_PROJECT = os.getenv('WANDB_PROJECT', 'gittensor-validators')
 WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 


### PR DESCRIPTION
### What this does

Removes two small pieces of dead code:

- **`Miner.__str__`** - Nobody ever calls `str(miner)` or prints a `Miner` instance. The only place a `Miner` is created (`storage.py`) immediately passes it to `set_miner()`, which reads `.uid`, `.hotkey`, `.github_id` directly. The `@dataclass` already generates a `__repr__` that covers debug output, so this custom `__str__` is redundant.

- **`WANDB_API_KEY`** - This loads `os.getenv('WANDB_API_KEY')` into a Python variable, but nothing ever imports or reads that variable. The wandb SDK picks up the env var on its own. The other wandb constants in the same file (`WANDB_PROJECT`, `WANDB_VALIDATOR_NAME`) are actually imported in `neurons/validator.py` - this one isn't.


### Test plan

- [X] `uv run pytest` passes
- [X] `uv run ruff check` passes
- [X] `uv run pyright` passes
