### PR TITLE
refactor: extract should_exclude_maintainer_pr helper

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -828,6 +828,18 @@ def _has_resource_limit_errors(data: Dict) -> bool:
     return any(isinstance(e, dict) and e.get('type') == 'RESOURCE_LIMITS_EXCEEDED' for e in errors)
 
 
+def should_exclude_maintainer_pr(author_association: Optional[str]) -> bool:
+    """Return True when a PR should be excluded from scoring due to a maintainer author.
+
+    Maintainers can merge directly, so their PRs aren't valid scoring targets.
+    DEV_MODE bypasses the check so local testing works against repos where
+    contributors are predominantly maintainers.
+    """
+    if os.environ.get('DEV_MODE'):
+        return False
+    return author_association in MAINTAINER_ASSOCIATIONS
+
+
 def try_add_open_or_closed_pr(
     miner_eval: MinerEvaluation,
     pr_raw: Dict,
@@ -843,8 +855,7 @@ def try_add_open_or_closed_pr(
         pr_state: GitHub PR state (OPEN, CLOSED, MERGED)
         lookback_date_filter: Date filter for lookback period
     """
-    # Ignore all maintainer contributions
-    if not os.environ.get('DEV_MODE') and pr_raw.get('authorAssociation') in MAINTAINER_ASSOCIATIONS:
+    if should_exclude_maintainer_pr(pr_raw.get('authorAssociation')):
         return
 
     if pr_state == PRState.OPEN.value:
@@ -904,9 +915,8 @@ def should_skip_merged_pr(
             f'Skipping PR #{pr_raw["number"]} in {repository_full_name} - merged before {PR_LOOKBACK_DAYS}-day lookback window',
         )
 
-    # Skip if PR author is a maintainer
     author_association = pr_raw.get('authorAssociation')
-    if not os.environ.get('DEV_MODE') and author_association in MAINTAINER_ASSOCIATIONS:
+    if should_exclude_maintainer_pr(author_association):
         return (
             True,
             f'Skipping PR #{pr_raw["number"]} in {repository_full_name} - author is {author_association} (has direct merge capabilities)',

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -26,12 +26,16 @@ github_api_tools = pytest.importorskip(
     'gittensor.utils.github_api_tools', reason='Requires gittensor package with all dependencies'
 )
 
+# Safe after the importorskip above: github_api_tools transitively imports gittensor.constants.
+from gittensor.constants import MAINTAINER_ASSOCIATIONS  # noqa: E402
+
 get_github_graphql_query = github_api_tools.get_github_graphql_query
 get_github_id = github_api_tools.get_github_id
 get_pull_request_file_changes = github_api_tools.get_pull_request_file_changes
 get_merge_base_sha = github_api_tools.get_merge_base_sha
 find_prs_for_issue = github_api_tools.find_prs_for_issue
 execute_graphql_query = github_api_tools.execute_graphql_query
+should_exclude_maintainer_pr = github_api_tools.should_exclude_maintainer_pr
 
 
 # ============================================================================
@@ -1511,6 +1515,37 @@ class TestFetchFileContentsForPrMergeBase:
         # Should fall back to base_ref_oid
         call_args = mock_fetch.call_args
         assert call_args[0][2] == 'base_branch_tip_sha', 'Should fall back to base_ref_oid'
+
+
+# ============================================================================
+# Maintainer-author exclusion tests
+# ============================================================================
+
+
+class TestShouldExcludeMaintainerPr:
+    """Test suite for should_exclude_maintainer_pr."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_dev_mode(self, monkeypatch):
+        monkeypatch.delenv('DEV_MODE', raising=False)
+
+    @pytest.mark.parametrize('association', MAINTAINER_ASSOCIATIONS)
+    def test_maintainer_associations_are_excluded(self, association):
+        assert should_exclude_maintainer_pr(association) is True
+
+    @pytest.mark.parametrize('association', ['CONTRIBUTOR', 'FIRST_TIME_CONTRIBUTOR', 'NONE', 'MANNEQUIN', '', None])
+    def test_non_maintainer_associations_are_not_excluded(self, association):
+        assert should_exclude_maintainer_pr(association) is False
+
+    @pytest.mark.parametrize('association', MAINTAINER_ASSOCIATIONS)
+    def test_dev_mode_bypasses_exclusion(self, association, monkeypatch):
+        monkeypatch.setenv('DEV_MODE', '1')
+        assert should_exclude_maintainer_pr(association) is False
+
+    def test_empty_dev_mode_does_not_bypass(self, monkeypatch):
+        """An empty DEV_MODE env var is falsy and must not bypass the check."""
+        monkeypatch.setenv('DEV_MODE', '')
+        assert should_exclude_maintainer_pr('OWNER') is True
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

The maintainer-author exclusion predicate (`MAINTAINER_ASSOCIATIONS` membership plus the `DEV_MODE` bypass) was inlined identically in `try_add_open_or_closed_pr` and `should_skip_merged_pr`. Pulling it into `should_exclude_maintainer_pr(author_association)` collapses the duplication and gives the rule a single source of truth, so future changes to the bypass policy or the association list only need to touch one place.

The reviewer-side maintainer check in `get_pull_request_maintainer_changes_requested_count` is intentionally left untouched: it reads the REST `author_association` field, has no `DEV_MODE` bypass, and consolidating it would change behavior.

## Related Issues

N/A

## Type of Change

- [x] Refactor

## Testing

- [x] Tests added/updated
- [x] Manually tested

New `TestShouldExcludeMaintainerPr` class in `tests/utils/test_github_api_tools.py` covers:

- All three maintainer associations (`OWNER`, `MEMBER`, `COLLABORATOR`) return `True`
- Non-maintainer values (`CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `NONE`, `MANNEQUIN`, `''`, `None`) return `False`
- `DEV_MODE` set to a truthy value bypasses the check for every maintainer association
- Empty `DEV_MODE` still applies the check (Python truthiness behavior preserved)

Local verification:

- `ruff check`: clean
- `ruff format --check`: clean
- `pyright`: 0 errors
- `pytest tests/`: 322 passed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
