### PR TITLE
perf: eliminate a separate API call for requested_reviews

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -8,7 +8,7 @@ from typing import DefaultDict, Dict, List, Optional, Set
 
 import bittensor as bt
 
-from gittensor.constants import MAX_CODE_DENSITY_MULTIPLIER, MIN_TOKEN_SCORE_FOR_BASE_SCORE
+from gittensor.constants import MAINTAINER_ASSOCIATIONS, MAX_CODE_DENSITY_MULTIPLIER, MIN_TOKEN_SCORE_FOR_BASE_SCORE
 from gittensor.utils.utils import parse_repo_name
 
 GITHUB_DOMAIN = 'https://github.com/'
@@ -290,6 +290,13 @@ class PullRequest:
         last_edited_at = parse_github_timestamp_to_cst(raw_edited_at) if isinstance(raw_edited_at, str) else None
         merged_at = parse_github_timestamp_to_cst(pr_data['mergedAt']) if is_merged else None
 
+        changes_requested_count = 0
+        if is_merged:
+            cr_reviews = pr_data.get('changesRequestedReviews', {}).get('nodes', [])
+            changes_requested_count = sum(
+                1 for r in cr_reviews if r.get('authorAssociation') in MAINTAINER_ASSOCIATIONS
+            )
+
         # Extract last label from timeline events
         timeline_nodes = pr_data.get('timelineItems', {}).get('nodes', [])
         label = timeline_nodes[0]['label']['name'].lower() if timeline_nodes else None
@@ -315,6 +322,7 @@ class PullRequest:
             head_ref_oid=pr_data.get('headRefOid'),
             base_ref_oid=pr_data.get('baseRefOid'),
             label=label,
+            changes_requested_count=changes_requested_count,
         )
 
 

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -5,6 +5,7 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from math import ceil
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from gittensor.utils.utils import parse_repo_name
@@ -27,14 +28,18 @@ from gittensor.constants import (
     MAX_FILE_SIZE_BYTES,
     MAX_FILES_PER_GRAPHQL_BATCH,
     PR_LOOKBACK_DAYS,
+    REVIEW_PENALTY_RATE,
 )
 from gittensor.utils.models import PRInfo
 from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
+# Beyond this many CHANGES_REQUESTED reviews the quality multiplier is already 0
+_MAX_CHANGES_REQUESTED_REVIEWS = ceil(1 / REVIEW_PENALTY_RATE)
+
 # core github graphql query
 QUERY = """
-    query($userId: ID!, $limit: Int!, $cursor: String) {
+    query($userId: ID!, $limit: Int!, $cursor: String, $maxChangesRequestedReviews: Int!) {
       node(id: $userId) {
         ... on User {
           issues(states: [OPEN]) { totalCount }
@@ -112,6 +117,11 @@ QUERY = """
                   author {
                     login
                   }
+                }
+              }
+              changesRequestedReviews: reviews(first: $maxChangesRequestedReviews, states: CHANGES_REQUESTED) {
+                nodes {
+                  authorAssociation
                 }
               }
               timelineItems(itemTypes: [LABELED_EVENT], last: 1) {
@@ -365,88 +375,6 @@ def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -
         f'File changes request for PR #{pr_number} in {repository} failed after {max_attempts} attempts: {last_error}'
     )
     return []
-
-
-def get_pull_request_maintainer_changes_requested_count(repository: str, pr_number: int, token: str) -> int:
-    """
-    Count CHANGES_REQUESTED reviews from maintainers for a PR.
-
-    Paginates with per_page=100 (GitHub max) to fetch ALL reviews.
-    Uses retry logic with exponential backoff for transient failures.
-    On error, returns 0 (fail-safe: no penalty applied).
-
-    Args:
-        repository (str): Repository in format 'owner/repo'
-        pr_number (int): PR number
-        token (str): Github pat
-    Returns:
-        int: Number of CHANGES_REQUESTED reviews from maintainers
-    """
-    max_attempts = 3
-    per_page = 100
-    headers = make_headers(token)
-
-    all_reviews: list = []
-    page = 1
-    attempt = 0
-    last_error = None
-
-    while attempt < max_attempts:
-        try:
-            response = requests.get(
-                f'{BASE_GITHUB_API_URL}/repos/{repository}/pulls/{pr_number}/reviews',
-                headers=headers,
-                params={'per_page': per_page, 'page': page},
-                timeout=15,
-            )
-            if response.status_code == 200:
-                reviews = response.json()
-                all_reviews.extend(reviews)
-
-                if len(reviews) < per_page:
-                    return sum(
-                        1
-                        for review in all_reviews
-                        if review.get('state') == 'CHANGES_REQUESTED'
-                        and review.get('author_association') in MAINTAINER_ASSOCIATIONS
-                    )
-
-                page += 1
-                continue
-
-            # Request failed — prepare retry
-            last_error = f'status {response.status_code}'
-            all_reviews = []
-            page = 1
-            attempt += 1
-
-            if attempt < max_attempts:
-                backoff_delay = min(5 * (2 ** (attempt - 1)), 30)
-                bt.logging.warning(
-                    f'Reviews request for PR #{pr_number} in {repository} failed with status {response.status_code} '
-                    f'(attempt {attempt}/{max_attempts}), retrying in {backoff_delay}s...'
-                )
-                time.sleep(backoff_delay)
-
-        except requests.exceptions.RequestException as e:
-            last_error = str(e)
-            all_reviews = []
-            page = 1
-            attempt += 1
-
-            if attempt < max_attempts:
-                backoff_delay = min(5 * (2 ** (attempt - 1)), 30)
-                bt.logging.warning(
-                    f'Reviews request error for PR #{pr_number} in {repository} '
-                    f'(attempt {attempt}/{max_attempts}): {e}, retrying in {backoff_delay}s...'
-                )
-                time.sleep(backoff_delay)
-
-    bt.logging.error(
-        f'Reviews request for PR #{pr_number} in {repository} failed after {max_attempts} attempts: {last_error}. '
-        f'Defaulting to 0 (no penalty).'
-    )
-    return 0
 
 
 # GraphQL fragment used by both issue submissions and solver detection.
@@ -758,6 +686,7 @@ def get_github_graphql_query(
             'userId': global_user_id,
             'limit': limit,
             'cursor': cursor,
+            'maxChangesRequestedReviews': _MAX_CHANGES_REQUESTED_REVIEWS,
         }
         try:
             response = requests.post(

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -40,7 +40,6 @@ from gittensor.utils.github_api_tools import (
     fetch_file_contents_with_base,
     get_merge_base_sha,
     get_pull_request_file_changes,
-    get_pull_request_maintainer_changes_requested_count,
 )
 from gittensor.validator.oss_contributions.credibility import check_eligibility
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
@@ -102,12 +101,6 @@ def score_pull_request(
     file_contents = fetch_file_contents_for_pr(pr, miner_eval.github_pat)
 
     pr.base_score = calculate_base_score(pr, programming_languages, token_config, file_contents)
-
-    # Fetch review data before multiplier calculation (only for merged PRs)
-    if pr.pr_state == PRState.MERGED:
-        pr.changes_requested_count = get_pull_request_maintainer_changes_requested_count(
-            pr.repository_full_name, pr.number, miner_eval.github_pat
-        )
 
     calculate_pr_multipliers(pr, miner_eval, master_repositories)
 

--- a/tests/validator/test_review_quality_multiplier.py
+++ b/tests/validator/test_review_quality_multiplier.py
@@ -8,17 +8,15 @@ Tests for PR review quality multiplier (issue #303).
 Covers:
 - calculate_review_quality_multiplier standalone function
 - review_quality_multiplier field on PullRequest and its effect on earned_score
-- get_pull_request_maintainer_changes_requested_count GitHub API function
 """
 
-from unittest.mock import Mock, patch
+from math import ceil
 
 import pytest
-import requests
 
-from gittensor.classes import PRState
-from gittensor.constants import MAINTAINER_ASSOCIATIONS, REVIEW_PENALTY_RATE
-from gittensor.utils.github_api_tools import get_pull_request_maintainer_changes_requested_count
+from gittensor.classes import PRState, PullRequest
+from gittensor.constants import REVIEW_PENALTY_RATE
+from gittensor.utils.github_api_tools import _MAX_CHANGES_REQUESTED_REVIEWS
 from gittensor.validator.oss_contributions.scoring import calculate_review_quality_multiplier
 from tests.validator.conftest import PRBuilder
 
@@ -30,15 +28,6 @@ from tests.validator.conftest import PRBuilder
 @pytest.fixture
 def builder():
     return PRBuilder()
-
-
-# ============================================================================
-# Helpers
-# ============================================================================
-
-
-def _make_review(state: str, association: str) -> dict:
-    return {'state': state, 'author_association': association}
 
 
 # ============================================================================
@@ -146,126 +135,53 @@ class TestReviewQualityMultiplierOnPullRequest:
 
 
 # ============================================================================
-# TestGetPullRequestMaintainerChangesRequestedCount
+# TestChangesRequestedCountFromGraphQL
 # ============================================================================
 
 
-class TestGetPullRequestMaintainerChangesRequestedCount:
-    """Tests for the GitHub API function that counts CHANGES_REQUESTED reviews from maintainers."""
+def _make_graphql_pr(state: str, changes_requested_reviews: list, merged_at: str = '2025-06-01T00:00:00Z') -> dict:
+    """Build minimal GraphQL PR response data for from_graphql_response"""
+    return {
+        'number': 1,
+        'title': 'Test PR',
+        'state': state,
+        'additions': 10,
+        'deletions': 5,
+        'createdAt': '2025-06-01T00:00:00Z',
+        'mergedAt': merged_at if state == 'MERGED' else None,
+        'author': {'login': 'testuser'},
+        'repository': {'name': 'repo', 'owner': {'login': 'owner'}},
+        'changesRequestedReviews': {'nodes': changes_requested_reviews},
+    }
 
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_no_reviews_returns_zero(self, mock_get):
-        mock_get.return_value = Mock(status_code=200, **{'json.return_value': []})
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == 0
 
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_counts_changes_requested_from_maintainers(self, mock_get):
-        reviews = [_make_review('CHANGES_REQUESTED', assoc) for assoc in MAINTAINER_ASSOCIATIONS]
-        mock_get.return_value = Mock(status_code=200, **{'json.return_value': reviews})
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == len(
-            MAINTAINER_ASSOCIATIONS
+class TestChangesRequestedCountFromGraphQL:
+    """Tests that from_graphql_response correctly parses changesRequestedReviews into changes_requested_count"""
+
+    def test_merged_pr_counts_only_maintainer_reviews(self):
+        pr_data = _make_graphql_pr(
+            'MERGED',
+            [
+                {'authorAssociation': 'OWNER'},
+                {'authorAssociation': 'CONTRIBUTOR'},
+                {'authorAssociation': 'COLLABORATOR'},
+                {'authorAssociation': 'NONE'},
+            ],
         )
+        pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='hk', github_id='123')
+        assert pr.changes_requested_count == 2
 
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_ignores_non_maintainer_changes_requested(self, mock_get):
-        reviews = [
-            _make_review('CHANGES_REQUESTED', 'CONTRIBUTOR'),
-            _make_review('CHANGES_REQUESTED', 'NONE'),
-            _make_review('CHANGES_REQUESTED', 'OWNER'),  # only this counts
-        ]
-        mock_get.return_value = Mock(status_code=200, **{'json.return_value': reviews})
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == 1
+    def test_non_merged_pr_does_not_parse_reviews(self):
+        pr_data = _make_graphql_pr('OPEN', [{'authorAssociation': 'OWNER'}])
+        pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='hk', github_id='123')
+        assert pr.changes_requested_count == 0
 
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_ignores_non_changes_requested_states(self, mock_get):
-        reviews = [
-            _make_review('APPROVED', 'OWNER'),
-            _make_review('COMMENTED', 'COLLABORATOR'),
-            _make_review('DISMISSED', 'OWNER'),
-            _make_review('CHANGES_REQUESTED', 'OWNER'),  # only this counts
-        ]
-        mock_get.return_value = Mock(status_code=200, **{'json.return_value': reviews})
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == 1
 
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_multiple_reviews_from_same_maintainer_count_separately(self, mock_get):
-        reviews = [
-            _make_review('CHANGES_REQUESTED', 'OWNER'),
-            _make_review('CHANGES_REQUESTED', 'OWNER'),
-            _make_review('CHANGES_REQUESTED', 'OWNER'),
-        ]
-        mock_get.return_value = Mock(status_code=200, **{'json.return_value': reviews})
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == 3
-
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    @patch('gittensor.utils.github_api_tools.time.sleep')
-    @patch('gittensor.utils.github_api_tools.bt.logging')
-    def test_api_error_returns_zero(self, mock_logging, mock_sleep, mock_get):
-        """Fail-safe: any non-200 response returns 0 (no penalty applied)."""
-        mock_get.return_value = Mock(status_code=500)
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == 0
-
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    @patch('gittensor.utils.github_api_tools.time.sleep')
-    @patch('gittensor.utils.github_api_tools.bt.logging')
-    def test_request_exception_returns_zero(self, mock_logging, mock_sleep, mock_get):
-        """Fail-safe: network errors return 0 (no penalty applied)."""
-        mock_get.side_effect = requests.exceptions.RequestException('timeout')
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == 0
-
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_uses_per_page_100_and_page_param(self, mock_get):
-        """Ensures pagination parameters are sent on each request."""
-        mock_get.return_value = Mock(status_code=200, **{'json.return_value': []})
-        get_pull_request_maintainer_changes_requested_count('owner/repo', 42, 'token')
-        _, kwargs = mock_get.call_args
-        assert kwargs.get('params', {}).get('per_page') == 100
-        assert kwargs.get('params', {}).get('page') == 1
-
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_paginates_across_multiple_pages(self, mock_get):
-        """Fetches all pages when reviews exceed per_page and accumulates counts."""
-        page1 = [_make_review('CHANGES_REQUESTED', 'OWNER')] * 100  # full page
-        page2 = [
-            _make_review('CHANGES_REQUESTED', 'COLLABORATOR'),
-            _make_review('APPROVED', 'OWNER'),
-        ]
-        mock_get.side_effect = [
-            Mock(status_code=200, **{'json.return_value': page1}),
-            Mock(status_code=200, **{'json.return_value': page2}),
-        ]
-        result = get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token')
-        assert result == 101  # 100 from page1 + 1 from page2
-        assert mock_get.call_count == 2
-        # Verify page param increments
-        assert mock_get.call_args_list[0][1]['params']['page'] == 1
-        assert mock_get.call_args_list[1][1]['params']['page'] == 2
-
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    @patch('gittensor.utils.github_api_tools.time.sleep')
-    @patch('gittensor.utils.github_api_tools.bt.logging')
-    def test_pagination_resets_on_retry(self, mock_logging, mock_sleep, mock_get):
-        """On failure mid-pagination, retries from page 1."""
-        page1 = [_make_review('CHANGES_REQUESTED', 'OWNER')] * 100
-        mock_get.side_effect = [
-            Mock(status_code=200, **{'json.return_value': page1}),  # page 1 OK
-            Mock(status_code=500),  # page 2 fails
-            Mock(status_code=200, **{'json.return_value': page1}),  # retry page 1
-            Mock(
-                status_code=200, **{'json.return_value': [_make_review('CHANGES_REQUESTED', 'OWNER')]}
-            ),  # retry page 2
-        ]
-        result = get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token')
-        assert result == 101
-
-    @patch('gittensor.utils.github_api_tools.requests.get')
-    def test_contributor_association_not_counted(self, mock_get):
-        """CONTRIBUTOR is not in MAINTAINER_ASSOCIATIONS and should not be counted."""
-        reviews = [
-            _make_review('CHANGES_REQUESTED', 'CONTRIBUTOR'),
-        ]
-        mock_get.return_value = Mock(status_code=200, **{'json.return_value': reviews})
-        assert get_pull_request_maintainer_changes_requested_count('owner/repo', 1, 'token') == 0
+def test_max_changes_requested_reviews_matches_penalty_rate():
+    # Tripwire: the GraphQL fetch cap must stay aligned with REVIEW_PENALTY_RATE so that any
+    # review beyond the cap is already forced to a 0.0 multiplier by calculate_review_quality_multiplier
+    assert _MAX_CHANGES_REQUESTED_REVIEWS == ceil(1 / REVIEW_PENALTY_RATE)
+    assert calculate_review_quality_multiplier(_MAX_CHANGES_REQUESTED_REVIEWS) == 0.0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Eliminates 1 REST API call per merged PR by fetching `CHANGES_REQUESTED` reviews inline via the existing GraphQL PR query
- Amount of elements to fetch now calculated dynamically depending on penalty constant: `ceil(1 / REVIEW_PENALTY_RATE)` (no reason to fetch more, as it'll result in 0.0 multiplier anyway)
- Remove the now-unused `get_pull_request_maintainer_changes_requested_count` function and its tests

## Tests

Added several tests to ensure it still fills correctly. 

You can also manually verify that this data is available using GraphQL:

```
# Single PR with known CHANGES_REQUESTED review
gh api graphql -f query='
  query {
    repository(owner: "Entrius", name: "gittensor") {
      pullRequest(number: 487) {
        number
        title
        state
        reviews(first: 3, states: APPROVED) {
          nodes { author { login } }
        }
        changesRequestedReviews: reviews(first: 7, states: CHANGES_REQUESTED) {
          nodes { authorAssociation }
        }
      }
    }
  }'
```

And compare it with REST:

```
gh api repos/Entrius/gittensor/pulls/487/reviews --jq '[.[] | select(.state == "CHANGES_REQUESTED") | {state, author_association}]'
```