### PR TITLE
fix: exclude ineligible miners from pioneer dividend calculation

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -287,6 +287,8 @@ def calculate_pioneer_dividends(
     repo_contributions: Dict[str, Dict[int, Tuple[datetime, int, float]]] = {}
 
     for evaluation in miner_evaluations.values():
+        if not evaluation.is_eligible:
+            continue
         for pr in evaluation.merged_pull_requests:
             if not pr.is_pioneer_eligible():
                 continue
@@ -327,7 +329,13 @@ def calculate_pioneer_dividends(
 
         pioneer_uid = sorted_uids[0][0]
         pioneer_pr_number = sorted_uids[0][1][1]
-        pioneer_pr = next(pr for pr in pr_index[repo][pioneer_uid] if pr.number == pioneer_pr_number)
+        pioneer_pr = next(
+            (pr for pr in pr_index[repo][pioneer_uid] if pr.number == pioneer_pr_number),
+            None,
+        )
+        if pioneer_pr is None:
+            bt.logging.warning(f'Pioneer PR #{pioneer_pr_number} not found in index for {repo}')
+            continue
         max_dividend = pioneer_pr.earned_score * PIONEER_DIVIDEND_MAX_RATIO
         capped = min(dividend, max_dividend)
         pioneer_pr.pioneer_dividend = round(capped, 2)

--- a/tests/validator/test_pioneer_dividend.py
+++ b/tests/validator/test_pioneer_dividend.py
@@ -66,6 +66,7 @@ class TestPioneerDividendCalculation:
         """Helper to create a MinerEvaluation with given merged PRs."""
         eval_ = MinerEvaluation(uid=uid, hotkey=f'hotkey_{uid}')
         eval_.merged_pull_requests = prs
+        eval_.is_eligible = True
         return eval_
 
     def test_single_contributor_no_dividend(self, builder):
@@ -229,3 +230,196 @@ class TestPioneerDividendCalculation:
 
         # Ineligible follower doesn't count
         assert pioneer_pr.pioneer_dividend == 0.0
+
+
+# ==========================================================================
+# TestPioneerDividendEligibility
+# ==========================================================================
+
+
+class TestPioneerDividendEligibility:
+    """Tests that miner-level eligibility gate is enforced in pioneer dividends.
+
+    The eligibility gate (5+ valid merged PRs, 80%+ credibility) must be
+    checked in addition to the PR-level quality gate (is_pioneer_eligible).
+    Ineligible miners must not claim the pioneer slot or occupy follower
+    positions, as their earned_score is 0 and they would waste dividends
+    or dilute position rates.
+    """
+
+    def _make_eval(self, uid, prs, is_eligible=True):
+        """Helper to create a MinerEvaluation with eligibility flag."""
+        eval_ = MinerEvaluation(uid=uid, hotkey=f'hotkey_{uid}')
+        eval_.merged_pull_requests = prs
+        eval_.is_eligible = is_eligible
+        return eval_
+
+    def test_ineligible_pioneer_excluded_eligible_gets_dividend(self, builder):
+        """Ineligible first contributor is skipped; eligible second contributor becomes pioneer."""
+        now = datetime.now(timezone.utc)
+        # Miner A: first contributor but ineligible (e.g. only 3 valid PRs)
+        ineligible_pr = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            merged_at=now - timedelta(days=10),
+            earned_score=0.0,  # Never calculated — ineligible miners skip Phase 1
+        )
+        # Miner B: second contributor, eligible — should become pioneer
+        eligible_pioneer_pr = builder.create(
+            state=PRState.MERGED,
+            uid=2,
+            repo='test/repo',
+            merged_at=now - timedelta(days=5),
+            earned_score=100.0,
+        )
+        # Miner C: third contributor, eligible — follower
+        follower_pr = builder.create(
+            state=PRState.MERGED,
+            uid=3,
+            repo='test/repo',
+            merged_at=now - timedelta(days=1),
+            earned_score=80.0,
+        )
+        evals = {
+            1: self._make_eval(1, [ineligible_pr], is_eligible=False),
+            2: self._make_eval(2, [eligible_pioneer_pr], is_eligible=True),
+            3: self._make_eval(3, [follower_pr], is_eligible=True),
+        }
+        calculate_pioneer_dividends(evals)
+
+        # Miner A excluded — no rank, no dividend
+        assert ineligible_pr.pioneer_rank == 0
+        assert ineligible_pr.pioneer_dividend == 0.0
+
+        # Miner B becomes pioneer (rank 1) and gets dividend from Miner C
+        assert eligible_pioneer_pr.pioneer_rank == 1
+        expected_dividend = min(80.0 * PIONEER_DIVIDEND_RATE_1ST, 100.0 * PIONEER_DIVIDEND_MAX_RATIO)
+        assert eligible_pioneer_pr.pioneer_dividend == round(expected_dividend, 2)
+
+        # Miner C is follower (rank 2)
+        assert follower_pr.pioneer_rank == 2
+
+    def test_ineligible_follower_excluded_from_positions(self, builder):
+        """Ineligible follower doesn't occupy a position slot or dilute rates."""
+        now = datetime.now(timezone.utc)
+        # Miner A: eligible pioneer
+        pioneer_pr = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            merged_at=now - timedelta(days=10),
+            earned_score=100.0,
+        )
+        # Miner B: ineligible follower (would be position 1 without fix)
+        ineligible_follower_pr = builder.create(
+            state=PRState.MERGED,
+            uid=2,
+            repo='test/repo',
+            merged_at=now - timedelta(days=5),
+            earned_score=0.0,
+        )
+        # Miner C: eligible follower — should be 1st follower (30% rate)
+        eligible_follower_pr = builder.create(
+            state=PRState.MERGED,
+            uid=3,
+            repo='test/repo',
+            merged_at=now - timedelta(days=1),
+            earned_score=80.0,
+        )
+        evals = {
+            1: self._make_eval(1, [pioneer_pr], is_eligible=True),
+            2: self._make_eval(2, [ineligible_follower_pr], is_eligible=False),
+            3: self._make_eval(3, [eligible_follower_pr], is_eligible=True),
+        }
+        calculate_pioneer_dividends(evals)
+
+        # Miner B excluded entirely
+        assert ineligible_follower_pr.pioneer_rank == 0
+        assert ineligible_follower_pr.pioneer_dividend == 0.0
+
+        # Miner C is 1st follower (position 0 → 30% rate), not 2nd (20% rate)
+        assert eligible_follower_pr.pioneer_rank == 2
+        expected_dividend = min(80.0 * PIONEER_DIVIDEND_RATE_1ST, 100.0 * PIONEER_DIVIDEND_MAX_RATIO)
+        assert pioneer_pr.pioneer_dividend == round(expected_dividend, 2)
+
+    def test_all_ineligible_no_dividend_no_crash(self, builder):
+        """When all miners are ineligible, no dividends are awarded and no crash occurs."""
+        now = datetime.now(timezone.utc)
+        pr_a = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            merged_at=now - timedelta(days=5),
+            earned_score=0.0,
+        )
+        pr_b = builder.create(
+            state=PRState.MERGED,
+            uid=2,
+            repo='test/repo',
+            merged_at=now - timedelta(days=1),
+            earned_score=0.0,
+        )
+        evals = {
+            1: self._make_eval(1, [pr_a], is_eligible=False),
+            2: self._make_eval(2, [pr_b], is_eligible=False),
+        }
+
+        # Should not raise
+        calculate_pioneer_dividends(evals)
+
+        assert pr_a.pioneer_rank == 0
+        assert pr_a.pioneer_dividend == 0.0
+        assert pr_b.pioneer_rank == 0
+        assert pr_b.pioneer_dividend == 0.0
+
+    def test_mixed_eligibility_across_repos(self, builder):
+        """Eligibility filter applies independently per repo."""
+        now = datetime.now(timezone.utc)
+        # Repo A: Miner 1 ineligible pioneer, Miner 2 eligible
+        pr_1a = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo-a',
+            merged_at=now - timedelta(days=10),
+            earned_score=0.0,
+        )
+        pr_2a = builder.create(
+            state=PRState.MERGED,
+            uid=2,
+            repo='test/repo-a',
+            merged_at=now - timedelta(days=5),
+            earned_score=100.0,
+        )
+        pr_3a = builder.create(
+            state=PRState.MERGED,
+            uid=3,
+            repo='test/repo-a',
+            merged_at=now - timedelta(days=1),
+            earned_score=60.0,
+        )
+        # Repo B: Miner 1 is the only contributor (ineligible) — no dividend
+        pr_1b = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo-b',
+            merged_at=now - timedelta(days=3),
+            earned_score=0.0,
+        )
+        evals = {
+            1: self._make_eval(1, [pr_1a, pr_1b], is_eligible=False),
+            2: self._make_eval(2, [pr_2a], is_eligible=True),
+            3: self._make_eval(3, [pr_3a], is_eligible=True),
+        }
+        calculate_pioneer_dividends(evals)
+
+        # Repo A: Miner 1 excluded, Miner 2 is pioneer with dividend from Miner 3
+        assert pr_1a.pioneer_rank == 0
+        assert pr_2a.pioneer_rank == 1
+        assert pr_3a.pioneer_rank == 2
+        expected = min(60.0 * PIONEER_DIVIDEND_RATE_1ST, 100.0 * PIONEER_DIVIDEND_MAX_RATIO)
+        assert pr_2a.pioneer_dividend == round(expected, 2)
+
+        # Repo B: Miner 1 excluded (ineligible), no eligible contributors
+        assert pr_1b.pioneer_rank == 0
+        assert pr_1b.pioneer_dividend == 0.0


### PR DESCRIPTION
## Summary

- Filter out ineligible miners (`is_eligible=False`) in `calculate_pioneer_dividends()` so
  they cannot claim the pioneer slot or occupy follower positions
- Add safe `next()` default to prevent `StopIteration` crash on data inconsistency
- Add tests verifying ineligible miners are excluded from pioneer/follower rankings

Closes #526

## Problem

`calculate_pioneer_dividends()` checks `pr.is_pioneer_eligible()` (PR-level gate) but not
`evaluation.is_eligible` (miner-level gate). An ineligible miner with the earliest merge
date on a repo becomes the pioneer. Since their `earned_score` is 0.0, the dividend cap
(`earned_score × PIONEER_DIVIDEND_MAX_RATIO = 0.0`) wastes the entire computed dividend.
The first eligible contributor is demoted to follower and loses their pioneer reward.

## Test plan

- [ ] `test_ineligible_pioneer_excluded_eligible_gets_dividend` - ineligible first contributor
      is skipped, eligible second contributor gets pioneer dividend
- [ ] `test_ineligible_follower_excluded_from_positions` - ineligible followers don't dilute
      position rates for eligible followers
- [ ] `test_all_ineligible_no_dividend` - all ineligible miners produce no dividends, no crash
- [ ] Existing pioneer dividend tests still pass
