### PR TITLE
enh: Cleaver label matching

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -166,7 +166,7 @@ class PullRequest:
     time_decay_multiplier: float = 1.0
     credibility_multiplier: float = 1.0
     review_quality_multiplier: float = 1.0  # Penalty for CHANGES_REQUESTED reviews from maintainers
-    label_multiplier: float = 1.0  # Multiplier based on PR label (feature, bug, enhancement, refactor)
+    label_multiplier: float = 1.0  # Multiplier based on PR label (exact match against known labels)
     label: Optional[str] = None  # Last label set on the PR
     changes_requested_count: int = 0  # Number of maintainer CHANGES_REQUESTED reviews
     earned_score: float = 0.0

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -74,12 +74,27 @@ CONTRIBUTION_SCORE_FOR_FULL_BONUS = 1500
 # Boosts
 MAX_CODE_DENSITY_MULTIPLIER = 1.5
 
-# Label multipliers — applied based on the last label set on the PR (requires triage+ access)
+# Label multipliers - applied based on the last label set on the PR (requires triage+ access)
 LABEL_MULTIPLIERS: dict[str, float] = {
+    # features
     'feature': 1.50,
+    'feat': 1.50,
+    # bug fixes
     'bug': 1.25,
+    'fix': 1.25,
+    'crash': 1.25,
+    'regression': 1.25,
+    'security': 1.25,
+    # enhancements
     'enhancement': 1.10,
+    'improve': 1.10,
+    'perf': 1.10,
+    # refactors
     'refactor': 1.00,
+    'cleanup': 1.00,
+    'polish': 1.00,
+    'debt': 1.00,
+    'chore': 1.00,
 }
 
 # Pioneer dividend — rewards the first quality contributor to each repository

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -1,0 +1,13 @@
+import pytest
+
+from gittensor.constants import LABEL_MULTIPLIERS
+
+
+@pytest.mark.parametrize('label,expected', list(LABEL_MULTIPLIERS.items()))
+def test_known_labels(label, expected):
+    assert LABEL_MULTIPLIERS.get(label, 1.0) == expected
+
+
+@pytest.mark.parametrize('label', ['docs', 'question', 'wontfix', 'kind/feature'])
+def test_unknown_labels_return_default(label):
+    assert LABEL_MULTIPLIERS.get(label, 1.0) == 1.0


### PR DESCRIPTION
Currently label multiplier only applies if there is exact match, which is not always the case considering the variety of labels in the wild.

The real-world example is: https://gittensor.io/miners/pr?repo=infiniflow%2Fragflow&number=14112

## Summary

- Now labels are matched by substring search.
- Added more labels to check, like `crash`, `perf`, `chore`, `feat` etc
- Added some tests to ensure everything works as expected.