### PR TITLE
fix: distinguish fetch failure from zero PRs in cache fallback

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -337,6 +337,7 @@ class MinerEvaluation:
     total_leaf_count: int = 0
     total_leaf_score: float = 0.0
     failed_reason: Optional[str] = None
+    github_fetch_failed: bool = False
     evaluation_timestamp: Optional[datetime] = None
     merged_pull_requests: List[PullRequest] = field(default_factory=list)
     open_pull_requests: List[PullRequest] = field(default_factory=list)

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1005,6 +1005,7 @@ def load_miners_prs(
 
             if not result.response:
                 bt.logging.warning('No response from github, breaking fetch loop...')
+                miner_eval.github_fetch_failed = True
                 break
 
             data: Dict = result.response.json()
@@ -1014,11 +1015,13 @@ def load_miners_prs(
                 non_resource_errors = [e for e in data['errors'] if e.get('type') != 'RESOURCE_LIMITS_EXCEEDED']
                 if non_resource_errors:
                     bt.logging.error(f'GraphQL errors: {non_resource_errors}')
+                    miner_eval.github_fetch_failed = True
                     break
 
             user_data: Dict = data.get('data', {}).get('node')
             if not user_data:
                 bt.logging.warning('User not found or no pull requests')
+                miner_eval.github_fetch_failed = True
                 break
 
             # Extract open issue count from first page (User-level field, not paginated)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -156,16 +156,16 @@ class Validator(BaseValidatorNeuron):
             if miner_eval.failed_reason is not None:
                 continue
 
-            # Successful evaluation with PRs - store to cache
-            if miner_eval.total_prs > 0:
+            # Successful evaluation - store to cache even if zero PRs
+            if not miner_eval.github_fetch_failed:
                 self.evaluation_cache.store(miner_eval)
                 continue
 
-            # if failure, try cache fallback
+            # Only use cache fallback when GitHub fetch actually failed
             cached_eval = self.evaluation_cache.get(uid, miner_eval.hotkey, miner_eval.github_id)
             if cached_eval is not None:
                 bt.logging.info(
-                    f'UID {uid}: GitHub returned no PRs, using cached evaluation '
+                    f'UID {uid}: GitHub fetch failed, using cached evaluation '
                     f'(merged={cached_eval.total_merged_prs}, open={cached_eval.total_open_prs}, '
                     f'closed={cached_eval.total_closed_prs})'
                 )


### PR DESCRIPTION
Fixes #515

## Problem
`store_or_use_cached_evaluation` used `total_prs == 0` as the signal
to fall back to cached data. This conflated two different states:
- GitHub fetch failed → cache fallback is correct
- GitHub fetch succeeded but miner genuinely has zero PRs → cache fallback is wrong

This caused stale cached evaluations to be reused for inactive miners,
distorting scores and rewards unfairly.

## Solution
Added `github_fetch_failed: bool = False` field to `MinerEvaluation`.
Set it to `True` only on actual fetch failures in `load_miners_prs`
(no response, GraphQL errors, user not found).
Updated `store_or_use_cached_evaluation` to check `github_fetch_failed`
instead of `total_prs == 0`.

## Files Changed
- `gittensor/classes.py` — added `github_fetch_failed` field to `MinerEvaluation`
- `gittensor/utils/github_api_tools.py` — set flag on all fetch failure paths in `load_miners_prs`
- `neurons/validator.py` — use `github_fetch_failed` instead of `total_prs == 0` in cache fallback logic