### PR TITLE
fix: use GraphQL variables for file content expressions instead of f-string interpolation

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1210,37 +1210,40 @@ def _fetch_file_contents_with_base_batch(
         Dict mapping file paths to FileContentPair (old_content, new_content)
     """
     file_fields = []
+    var_declarations = []
+    variables: Dict[str, str] = {'owner': repo_owner, 'name': repo_name}
+
     for i, fc in enumerate(batch_changes):
-        # Renames need the old path for the base version
         base_path = fc.previous_filename if fc.previous_filename else fc.filename
         head_path = fc.filename
 
-        # New files have no base version to fetch
         if fc.status != 'added':
-            base_expr = f'{base_sha}:{base_path}'
+            var_name = f'base{i}'
+            var_declarations.append(f'${var_name}: String!')
+            variables[var_name] = f'{base_sha}:{base_path}'
             file_fields.append(
-                f'base{i}: object(expression: "{base_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+                f'{var_name}: object(expression: ${var_name}) {{ ... on Blob {{ text byteSize isBinary }} }}'
             )
 
-        # Deleted files have no head version to fetch
         if fc.status != 'removed':
-            head_expr = f'{head_sha}:{head_path}'
+            var_name = f'head{i}'
+            var_declarations.append(f'${var_name}: String!')
+            variables[var_name] = f'{head_sha}:{head_path}'
             file_fields.append(
-                f'head{i}: object(expression: "{head_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+                f'{var_name}: object(expression: ${var_name}) {{ ... on Blob {{ text byteSize isBinary }} }}'
             )
 
     if not file_fields:
         return {}
 
+    extra_vars = ', '.join(var_declarations)
     query = f"""
-        query($owner: String!, $name: String!) {{
+        query($owner: String!, $name: String!, {extra_vars}) {{
             repository(owner: $owner, name: $name) {{
                 {' '.join(file_fields)}
             }}
         }}
     """
-
-    variables = {'owner': repo_owner, 'name': repo_name}
 
     data = execute_graphql_query(query, variables, token)
     if data is None:


### PR DESCRIPTION
### Summary

Move the `expression` arguments in `_fetch_file_contents_with_base_batch` from f-string interpolation into proper GraphQL `$variables`. Filenames containing `"`, `\`, or newlines currently break out of the GraphQL string literal and either produce a malformed query or silently drop the file's score.

### Why

The existing code builds each `object(expression: "...")` selector by interpolating `base_sha:path` directly into the query body. If a filename contains characters that need escaping inside a GraphQL string (`"`, `\`, newlines), the query becomes malformed. GitHub returns a parse error and the entire batch falls back to `FileContentPair(None, None)`, zeroing the token score for those files.

GraphQL variables are serialized by the client library and never touch the query parser, so this class of bug goes away entirely.

Closes #532

### Test plan

- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Syntax check passes