### PR TITLE
fix: preserve github_id and metadata when zeroing duplicate miner scores

### DIFF
--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -37,7 +37,13 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         bt.logging.info(f'Detected UIDs {uids} sharing GitHub account')
         for uid in uids:
             bt.logging.info(f'PENALTY: Zeroing score for duplicate uid {uid}')
-            miner_evaluations[uid] = MinerEvaluation(uid=uid, hotkey=miner_evaluations[uid].hotkey)
+            evaluation = miner_evaluations[uid]
+            evaluation.total_score = 0.0
+            evaluation.base_total_score = 0.0
+            evaluation.total_collateral_score = 0.0
+            evaluation.is_eligible = False
+            evaluation.issue_discovery_score = 0.0
+            evaluation.failed_reason = 'Duplicate GitHub account detected'
             duplicate_count += 1
 
     bt.logging.info(f'Total duplicate miners penalized: {duplicate_count}')


### PR DESCRIPTION
### Summary

Zero the scores on the existing `MinerEvaluation` instead of replacing it with a blank one. The old code at `inspections.py:40` did `miner_evaluations[uid] = MinerEvaluation(uid, hotkey)`, which reset `github_id` to `'0'` and wiped `total_open_issues`, PR lists, and other metadata. That caused the DB/in-memory divergence described in the issue.

### Why

When a uid is in `cached_uids` (API failure fallback), `bulk_store_evaluation` skips the overwrite. The old code created a fresh zero-score object in memory but left the stale non-zero row in the DB. On-chain weight was 0 but the dashboard/W&B showed the cached score.

Zeroing fields in-place keeps `github_id` intact for downstream issue discovery and open-issue spam gating.

Closes #533

### Test plan

- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Syntax check passes