### PR TITLE
fix: escape file paths in GraphQL object expressions to prevent query breakage

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1198,6 +1198,25 @@ class FileContentPair:
     new_content: Optional[str]  # None for deleted files
 
 
+def _escape_graphql_string(value: str) -> str:
+    """Escape special characters for safe interpolation inside a GraphQL double-quoted string.
+
+    File paths may legitimately contain backslashes, double quotes, or newlines,
+    all of which break the ``object(expression: "...")`` syntax if unescaped.
+    """
+    return value.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n').replace('\r', '\\r')
+
+
+def _build_blob_field(alias: str, sha: str, path: str) -> str:
+    """Build a GraphQL ``object(expression: ...)`` field for fetching blob content.
+
+    Escapes the ``sha:path`` expression so that special characters in file paths
+    cannot break out of the GraphQL string literal or corrupt the query.
+    """
+    escaped_expr = _escape_graphql_string(f'{sha}:{path}')
+    return f'{alias}: object(expression: "{escaped_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+
+
 def _fetch_file_contents_with_base_batch(
     repo_owner: str,
     repo_name: str,
@@ -1227,17 +1246,11 @@ def _fetch_file_contents_with_base_batch(
 
         # New files have no base version to fetch
         if fc.status != 'added':
-            base_expr = f'{base_sha}:{base_path}'
-            file_fields.append(
-                f'base{i}: object(expression: "{base_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
-            )
+            file_fields.append(_build_blob_field(f'base{i}', base_sha, base_path))
 
         # Deleted files have no head version to fetch
         if fc.status != 'removed':
-            head_expr = f'{head_sha}:{head_path}'
-            file_fields.append(
-                f'head{i}: object(expression: "{head_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
-            )
+            file_fields.append(_build_blob_field(f'head{i}', head_sha, head_path))
 
     if not file_fields:
         return {}

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1199,20 +1199,10 @@ class FileContentPair:
 
 
 def _escape_graphql_string(value: str) -> str:
-    """Escape special characters for safe interpolation inside a GraphQL double-quoted string.
-
-    File paths may legitimately contain backslashes, double quotes, or newlines,
-    all of which break the ``object(expression: "...")`` syntax if unescaped.
-    """
     return value.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n').replace('\r', '\\r')
 
 
 def _build_blob_field(alias: str, sha: str, path: str) -> str:
-    """Build a GraphQL ``object(expression: ...)`` field for fetching blob content.
-
-    Escapes the ``sha:path`` expression so that special characters in file paths
-    cannot break out of the GraphQL string literal or corrupt the query.
-    """
     escaped_expr = _escape_graphql_string(f'{sha}:{path}')
     return f'{alias}: object(expression: "{escaped_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
 

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1559,5 +1559,59 @@ class TestFetchFileContentsForPrMergeBase:
         assert call_args[0][2] == 'base_branch_tip_sha', 'Should fall back to base_ref_oid'
 
 
+# ============================================================================
+# GraphQL Expression Escaping Tests
+# ============================================================================
+
+_escape_graphql_string = github_api_tools._escape_graphql_string
+_build_blob_field = github_api_tools._build_blob_field
+
+
+class TestEscapeGraphQLString:
+    """Test suite for _escape_graphql_string to prevent query-breakage from file paths."""
+
+    def test_plain_path_unchanged(self):
+        assert _escape_graphql_string('src/main.py') == 'src/main.py'
+
+    def test_escapes_double_quotes(self):
+        assert _escape_graphql_string('file"name.py') == 'file\\"name.py'
+
+    def test_escapes_backslashes(self):
+        assert _escape_graphql_string('path\\to\\file.py') == 'path\\\\to\\\\file.py'
+
+    def test_escapes_newlines(self):
+        assert _escape_graphql_string('line1\nline2') == 'line1\\nline2'
+
+    def test_escapes_carriage_returns(self):
+        assert _escape_graphql_string('line1\rline2') == 'line1\\rline2'
+
+    def test_escapes_combined_special_chars(self):
+        result = _escape_graphql_string('dir\\file"name\n.py')
+        assert result == 'dir\\\\file\\"name\\n.py'
+
+    def test_empty_string(self):
+        assert _escape_graphql_string('') == ''
+
+
+class TestBuildBlobField:
+    """Test suite for _build_blob_field GraphQL expression builder."""
+
+    def test_builds_correct_field_for_normal_path(self):
+        result = _build_blob_field('base0', 'abc123', 'src/main.py')
+        assert result == 'base0: object(expression: "abc123:src/main.py") { ... on Blob { text byteSize isBinary } }'
+
+    def test_escapes_quotes_in_path(self):
+        result = _build_blob_field('head0', 'abc123', 'file"with"quotes.py')
+        assert '"abc123:file\\"with\\"quotes.py"' in result
+
+    def test_escapes_backslash_in_path(self):
+        result = _build_blob_field('base1', 'abc123', 'windows\\path\\file.py')
+        assert '"abc123:windows\\\\path\\\\file.py"' in result
+
+    def test_alias_preserved(self):
+        result = _build_blob_field('head42', 'sha', 'f.py')
+        assert result.startswith('head42: object')
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Fixes #532 

## Summary

- Extract `_escape_graphql_string()` to sanitize special characters in file paths
- Extract `_build_blob_field()` to build safe GraphQL `object(expression: ...)` fields
- Replace raw f-string interpolation with escaped helper calls
- Add 11 tests covering escaping edge cases and field construction

## Problem

`_fetch_file_contents_with_base_batch` interpolates `sha:path` directly into a GraphQL
string literal via f-string. File paths containing `"`, `\`, or newlines break the query,
causing the file to silently get zero score. The `_build_blob_field` helper escapes the
expression before interpolation.

## Test plan

- [ ] `TestEscapeGraphQLString` — 7 tests: plain path, quotes, backslashes, newlines, carriage returns, combined, empty
- [ ] `TestBuildBlobField` — 4 tests: normal path, quotes in path, backslash in path, alias preserved
- [ ] Existing `TestFetchFileContentsWithBase` renamed-file test still passes (verifies backward compatibility)
- [ ] Full test suite passes (337 tests)
