### PR TITLE
fix: return non-zero when PAT broadcast or check fails everywhere

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -132,3 +132,6 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
 
         console.print(table)
         console.print(f'\n[bold]{valid_count}/{len(results)} validators have a valid PAT stored.[/bold]')
+
+    if valid_count == 0:
+        sys.exit(1)

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -166,6 +166,9 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         console.print(table)
         console.print(f'\n[bold]{accepted_count}/{len(results)} validators accepted your PAT.[/bold]')
 
+    if accepted_count == 0:
+        sys.exit(1)
+
 
 def _validate_pat_locally(pat: str) -> bool:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -3,6 +3,8 @@
 """Tests for gitt miner post and gitt miner check CLI commands."""
 
 import json
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +16,48 @@ from gittensor.cli.main import cli
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+def _stub_miner_network(monkeypatch, *, response, synapse_name):
+    fake_hotkey = types.SimpleNamespace(ss58_address='5FakeHotkeyFromStub')
+    fake_wallet = types.SimpleNamespace(hotkey=fake_hotkey)
+    fake_axon = types.SimpleNamespace(hotkey='5ValidatorHotkey123456', is_serving=True)
+    fake_metagraph = types.SimpleNamespace(
+        hotkeys=[fake_hotkey.ss58_address],
+        n=1,
+        axons=[fake_axon],
+        validator_trust=[1.0],
+    )
+
+    class FakeSubtensor:
+        def __init__(self, network=None):
+            self.network = network
+
+        def metagraph(self, netuid=None):
+            return fake_metagraph
+
+    class FakeDendrite:
+        def __init__(self, wallet=None):
+            self.wallet = wallet
+
+    class FakeSynapse:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_bt = types.SimpleNamespace(
+        Wallet=lambda name=None, hotkey=None: fake_wallet,
+        Subtensor=FakeSubtensor,
+        Dendrite=FakeDendrite,
+    )
+    fake_synapses = types.SimpleNamespace(**{synapse_name: FakeSynapse})
+    monkeypatch.setitem(sys.modules, 'bittensor', fake_bt)
+    monkeypatch.setitem(sys.modules, 'gittensor.synapses', fake_synapses)
+
+    def fake_asyncio_run(coro):
+        coro.close()
+        return [response]
+
+    return fake_axon, fake_asyncio_run
 
 
 class TestMinerPost:
@@ -55,6 +99,33 @@ class TestMinerPost:
         assert result.exit_code == 0
         assert 'Broadcast your GitHub PAT' in result.output
 
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=True)
+    def test_json_mode_exits_nonzero_when_no_validators_accept_pat(self, mock_validate, runner, monkeypatch):
+        fake_response = types.SimpleNamespace(
+            accepted=False,
+            rejection_reason='PAT rejected',
+            dendrite=types.SimpleNamespace(status_code=200),
+        )
+        fake_axon, fake_asyncio_run = _stub_miner_network(
+            monkeypatch,
+            response=fake_response,
+            synapse_name='PatBroadcastSynapse',
+        )
+
+        monkeypatch.setattr('gittensor.cli.miner_commands.post._get_validator_axons', lambda metagraph: ([fake_axon], [50]))
+        monkeypatch.setattr('gittensor.cli.miner_commands.post.asyncio.run', fake_asyncio_run)
+
+        result = runner.invoke(
+            cli,
+            ['miner', 'post', '--json-output', '--wallet', 'test', '--hotkey', 'test'],
+            env={'GITTENSOR_MINER_PAT': 'ghp_test123'},
+        )
+
+        assert result.exit_code == 1
+        output = json.loads(result.output)
+        assert output['success'] is False
+        assert output['accepted'] == 0
+
 
 class TestMinerCheck:
     def test_help_text(self, runner):
@@ -67,3 +138,21 @@ class TestMinerCheck:
         result = runner.invoke(cli, ['m', 'check', '--help'])
         assert result.exit_code == 0
         assert 'Check how many validators' in result.output
+
+    def test_json_mode_exits_nonzero_when_no_validators_have_valid_pat(self, runner, monkeypatch):
+        fake_response = types.SimpleNamespace(has_pat=False, pat_valid=False, rejection_reason='No PAT stored')
+        fake_axon, fake_asyncio_run = _stub_miner_network(
+            monkeypatch,
+            response=fake_response,
+            synapse_name='PatCheckSynapse',
+        )
+
+        monkeypatch.setattr('gittensor.cli.miner_commands.check._get_validator_axons', lambda metagraph: ([fake_axon], [50]))
+        monkeypatch.setattr('gittensor.cli.miner_commands.check.asyncio.run', fake_asyncio_run)
+
+        result = runner.invoke(cli, ['miner', 'check', '--json-output', '--wallet', 'test', '--hotkey', 'test'])
+
+        assert result.exit_code == 1
+        output = json.loads(result.output)
+        assert output['valid'] == 0
+        assert output['invalid'] == 1


### PR DESCRIPTION
## Summary
- return exit code 1 from `gitt miner post` when zero validators accept the PAT
- return exit code 1 from `gitt miner check` when zero validators report a valid PAT
- add focused CLI tests for both failure paths

Fixes #542.

## Validation
- exercised both CLI paths through Click runner with mocked bittensor and synapse dependencies
- ran `python3 -m py_compile gittensor/cli/miner_commands/post.py gittensor/cli/miner_commands/check.py tests/cli/test_miner_commands.py`
