### PR TITLE
fix: keep miner post JSON output parseable on PAT failure

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -72,7 +72,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
 
     # 1b. Validate PAT locally
     with _status('[bold]Validating PAT...', json_mode):
-        pat_valid = _validate_pat_locally(pat)
+        pat_valid = _validate_pat_locally(pat, json_mode=json_mode)
 
     if not pat_valid:
         _error('GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.', json_mode)
@@ -167,7 +167,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         console.print(f'\n[bold]{accepted_count}/{len(results)} validators accepted your PAT.[/bold]')
 
 
-def _validate_pat_locally(pat: str) -> bool:
+def _validate_pat_locally(pat: str, json_mode: bool = False) -> bool:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
     headers = {'Authorization': f'token {pat}', 'Accept': 'application/vnd.github.v3+json'}
     try:
@@ -185,9 +185,10 @@ def _validate_pat_locally(pat: str) -> bool:
             timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
         if gql_resp.status_code != 200:
-            console.print(
-                '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
-            )
+            if not json_mode:
+                console.print(
+                    '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
+                )
             return False
 
         return True

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -35,7 +35,7 @@ class TestMinerPost:
         result = runner.invoke(cli, ['miner', 'post', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'])
         assert result.exit_code != 0
         assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
-        mock_validate.assert_called_once_with('ghp_test123')
+        mock_validate.assert_called_once_with('ghp_test123', json_mode=False)
 
     @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
     def test_invalid_pat_exits(self, mock_validate, runner, monkeypatch):
@@ -54,6 +54,19 @@ class TestMinerPost:
         result = runner.invoke(cli, ['m', 'post', '--help'])
         assert result.exit_code == 0
         assert 'Broadcast your GitHub PAT' in result.output
+
+    def test_json_mode_keeps_stdout_clean_when_graphql_check_fails(self, runner, monkeypatch):
+        user_resp = type('Resp', (), {'status_code': 200})()
+        gql_resp = type('Resp', (), {'status_code': 403})()
+        monkeypatch.setattr('gittensor.cli.miner_commands.post.requests.get', lambda *args, **kwargs: user_resp)
+        monkeypatch.setattr('gittensor.cli.miner_commands.post.requests.post', lambda *args, **kwargs: gql_resp)
+
+        result = runner.invoke(cli, ['miner', 'post', '--json-output', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'])
+
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output['success'] is False
+        assert 'invalid or expired' in output['error'].lower()
 
 
 class TestMinerCheck:


### PR DESCRIPTION
## Summary
- suppress the GraphQL permission warning in `--json-output` mode
- keep the human-readable warning in non-JSON mode
- add a CLI test that verifies stdout stays valid JSON

Fixes #539.

## Validation
- exercised `gitt miner post --json-output` with a mocked GraphQL permission failure
- ran `python3 -m py_compile gittensor/cli/miner_commands/post.py tests/cli/test_miner_commands.py`
