### PR TITLE
fix: handle deleted label events when parsing PR timeline

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -292,7 +292,8 @@ class PullRequest:
 
         # Extract last label from timeline events
         timeline_nodes = pr_data.get('timelineItems', {}).get('nodes', [])
-        label = timeline_nodes[0]['label']['name'].lower() if timeline_nodes else None
+        label_node = timeline_nodes[0].get('label') if timeline_nodes and timeline_nodes[0] else None
+        label = label_node['name'].lower() if label_node else None
 
         return cls(
             number=pr_data['number'],

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,0 +1,27 @@
+from gittensor.classes import PullRequest
+
+
+def test_pull_request_handles_deleted_label_event():
+    pr_data = {
+        'number': 42,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'state': 'OPEN',
+        'closingIssuesReferences': {'nodes': []},
+        'bodyText': 'Fix bug',
+        'lastEditedAt': None,
+        'mergedAt': None,
+        'timelineItems': {'nodes': [{'label': None}]},
+        'title': 'fix: guard deleted label events',
+        'author': {'login': 'alice'},
+        'createdAt': '2026-04-18T00:00:00Z',
+        'additions': 3,
+        'deletions': 1,
+        'commits': {'totalCount': 1},
+        'headRefOid': 'abc123',
+        'baseRefOid': 'def456',
+    }
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.label is None
+    assert pr.author_login == 'alice'


### PR DESCRIPTION
## Summary
- guard against `LABELED_EVENT` timeline nodes whose nested `label` is null
- preserve PR parsing instead of raising on deleted labels
- add a direct regression test for `PullRequest.from_graphql_response`

Fixes #536.

## Validation
- exercised `PullRequest.from_graphql_response` with a deleted-label timeline node
- ran `python3 -m py_compile gittensor/classes.py tests/test_classes.py`
