### PR TITLE
fix: handle merged PRs with null GitHub authors

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -294,6 +294,8 @@ class PullRequest:
         timeline_nodes = pr_data.get('timelineItems', {}).get('nodes', [])
         label = timeline_nodes[0]['label']['name'].lower() if timeline_nodes else None
 
+        author_login = pr_data.get('author', {}).get('login') if pr_data.get('author') else None
+
         return cls(
             number=pr_data['number'],
             repository_full_name=repository_full_name,
@@ -301,7 +303,7 @@ class PullRequest:
             hotkey=hotkey,
             github_id=github_id,
             title=pr_data['title'],
-            author_login=pr_data['author']['login'],
+            author_login=author_login,
             merged_at=merged_at,
             created_at=parse_github_timestamp_to_cst(pr_data['createdAt']),
             pr_state=pr_state,

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -920,12 +920,12 @@ def should_skip_merged_pr(
         )
 
     # Skip if PR was merged by the same person who created it (self-merge) AND there's no approvals from a differing party
-    if pr_raw['mergedBy'] and pr_raw['author']['login'] == pr_raw['mergedBy']['login']:
+    author_login = pr_raw.get('author', {}).get('login') if pr_raw.get('author') else None
+    merged_by_login = pr_raw.get('mergedBy', {}).get('login') if pr_raw.get('mergedBy') else None
+    if author_login and merged_by_login and author_login == merged_by_login:
         # Check if there are any approvals from users other than the author
         reviews = pr_raw.get('reviews', {}).get('nodes', [])
-        has_external_approval = any(
-            review.get('author') and review['author']['login'] != pr_raw['author']['login'] for review in reviews
-        )
+        has_external_approval = any(review.get('author') and review['author']['login'] != author_login for review in reviews)
 
         if not has_external_approval:
             return (True, f'Skipping PR #{pr_raw["number"]} in {repository_full_name} - self-merged, no approval')

--- a/tests/test_pr_guard_regressions.py
+++ b/tests/test_pr_guard_regressions.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone
+
+from gittensor.classes import PullRequest
+from gittensor.utils.github_api_tools import should_skip_merged_pr
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+def test_pull_request_handles_null_author():
+    pr_data = {
+        'number': 43,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'state': 'MERGED',
+        'closingIssuesReferences': {'nodes': []},
+        'bodyText': 'Fix bug',
+        'lastEditedAt': None,
+        'mergedAt': '2026-04-18T00:00:00Z',
+        'timelineItems': {'nodes': []},
+        'title': 'fix: guard null authors',
+        'author': None,
+        'createdAt': '2026-04-17T23:00:00Z',
+        'additions': 3,
+        'deletions': 1,
+        'commits': {'totalCount': 1},
+        'mergedBy': {'login': 'maintainer'},
+        'headRefOid': 'abc123',
+        'baseRefOid': 'def456',
+    }
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.author_login is None
+    assert pr.merged_by_login == 'maintainer'
+
+
+def test_should_skip_merged_pr_handles_null_author():
+    pr_raw = {
+        'number': 44,
+        'mergedAt': '2026-04-18T00:00:00Z',
+        'authorAssociation': 'CONTRIBUTOR',
+        'author': None,
+        'mergedBy': {'login': 'maintainer'},
+        'reviews': {'nodes': []},
+        'repository': {'defaultBranchRef': {'name': 'main'}},
+        'baseRefName': 'main',
+        'headRefName': 'feature-branch',
+        'headRepository': {'owner': {'login': 'forkuser'}, 'name': 'gittensor'},
+    }
+
+    should_skip, reason = should_skip_merged_pr(
+        pr_raw,
+        'entrius/gittensor',
+        RepositoryConfig(weight=1.0),
+        datetime.now(timezone.utc) - timedelta(days=30),
+    )
+
+    assert should_skip is False
+    assert reason is None


### PR DESCRIPTION
## Summary
- guard the self-merge check when GraphQL returns a null PR author
- allow `PullRequest.from_graphql_response` to handle null authors without crashing
- add regression tests for both guard paths

Fixes #537.

## Validation
- exercised `should_skip_merged_pr` and `PullRequest.from_graphql_response` with null-author PR payloads
- ran `python3 -m py_compile gittensor/classes.py gittensor/utils/github_api_tools.py tests/test_pr_guard_regressions.py`
