### PR TITLE
fix: dedupe issue discovery counts across multiple solving PRs

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -190,6 +190,7 @@ def _collect_issues_from_prs(
     """
     # Track which PRs have already awarded a discovery score (one-issue-per-PR rule)
     pr_scored: set = set()  # (repo, pr_number)
+    seen_issues: set = set()  # (repo, issue_number)
 
     for uid, evaluation in miner_evaluations.items():
         for pr in evaluation.merged_pull_requests:
@@ -206,6 +207,11 @@ def _collect_issues_from_prs(
                 discoverer_id = issue.author_github_id
                 if not discoverer_id or discoverer_id not in github_id_to_uid:
                     continue
+
+                issue_key = (issue.repository_full_name, issue.number)
+                if issue_key in seen_issues:
+                    continue
+                seen_issues.add(issue_key)
 
                 data = discoverer_data[discoverer_id]
 

--- a/tests/validator/test_issue_discovery_scoring.py
+++ b/tests/validator/test_issue_discovery_scoring.py
@@ -88,6 +88,29 @@ def test_issue_with_no_state_reason_in_pr_path_counts_as_closed(
     assert data.solved_count == 0
 
 
+def test_duplicate_issue_referenced_by_multiple_prs_counts_once(issue_factory, pr_factory):
+    issue_a = issue_factory.completed(number=42, repository_full_name='test/repo', author_github_id='1001')
+    issue_b = issue_factory.completed(number=42, repository_full_name='test/repo', author_github_id='1001')
+
+    pr_one = pr_factory.merged(number=10, uid=2, repo='test/repo')
+    pr_one.issues = [issue_a]
+    pr_two = pr_factory.merged(number=20, uid=3, repo='test/repo')
+    pr_two.issues = [issue_b]
+
+    miner_evaluations = {
+        2: MinerEvaluation(uid=2, hotkey='hotkey_2', github_id='2', merged_pull_requests=[pr_one]),
+        3: MinerEvaluation(uid=3, hotkey='hotkey_3', github_id='3', merged_pull_requests=[pr_two]),
+    }
+    discoverer_data = {'1001': _DiscovererData()}
+
+    _collect_issues_from_prs(miner_evaluations, {'1001': 1}, discoverer_data, {})
+
+    data = discoverer_data['1001']
+    assert data.solved_count == 1
+    assert data.valid_solved_count == 1
+    assert len(data.scored_issues) == 1
+
+
 # ---------------------------------------------------------------------------
 # Scan path (_merge_scan_issues)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- dedupe issue discovery credibility counting by `(repo, issue_number)` before incrementing solved and valid counters
- prevent the same issue from inflating eligibility when multiple miners reference it
- add a regression test for duplicate `closingIssuesReferences`

Fixes #540.

## Validation
- exercised `_collect_issues_from_prs` with two merged PRs referencing the same issue
- ran `python3 -m py_compile gittensor/validator/issue_discovery/scoring.py tests/validator/test_issue_discovery_scoring.py`
