### PR TITLE
fix: add success field to miner check JSON output

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -103,6 +103,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         click.echo(
             json.dumps(
                 {
+                    'success': valid_count > 0,
                     'total_validators': len(results),
                     'valid': valid_count,
                     'invalid': len(results) - valid_count - no_response_count,


### PR DESCRIPTION
Fixes #543

## Problem
`miner check --json-output` does not include a `success` field in its
JSON output, while `miner post --json-output` does. This inconsistency
means callers parsing both commands cannot use a consistent field to
determine success.

## Fix
Added `"success": valid_count > 0` to the `miner check` JSON output
in `check.py`, matching the pattern used by `miner post` in `post.py`.

## Changes
- `gittensor/cli/miner_commands/check.py` — added `success` field to JSON output