### PR TITLE
refactor: extract per-file scoring branches from calculate_token_score_from_file_changes

### DIFF
--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -229,6 +229,106 @@ def score_tree_diff(
 
     return breakdown
 
+def _score_non_code_file(
+    file: FileChange,
+    ext: str,
+    programming_languages: dict,
+    file_weight: float,
+    is_test_file: bool,
+) -> FileScoreResult:
+    lines_to_score = min(file.changes, MAX_LINES_SCORED_FOR_NON_CODE_EXT)
+    lang_config = programming_languages.get(ext)
+    lang_weight = lang_config.weight if lang_config else DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT
+    return FileScoreResult(
+        filename=file.short_name,
+        score=lang_weight * lines_to_score * file_weight,
+        nodes_scored=lines_to_score,
+        total_lines=file.changes,
+        is_test_file=is_test_file,
+        scoring_method='line-count',
+    )
+
+
+def _score_code_file(
+    file: FileChange,
+    ext: str,
+    content_pair,
+    weights,
+    programming_languages: dict,
+    file_weight: float,
+    is_test_file: bool,
+) -> FileScoreResult:
+    if content_pair is None or content_pair.new_content is None:
+        bt.logging.debug(f'  │   {file.short_name}: skipped (binary or fetch failed)')
+        return FileScoreResult(
+            filename=file.short_name,
+            score=0.0,
+            nodes_scored=0,
+            total_lines=file.changes,
+            is_test_file=is_test_file,
+            scoring_method='skipped-binary',
+        )
+    if len(content_pair.new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES:
+        bt.logging.debug(f'  │   {file.short_name}: skipped (file too large, >{MAX_FILE_SIZE_BYTES} bytes)')
+        return FileScoreResult(
+            filename=file.short_name,
+            score=0.0,
+            nodes_scored=0,
+            total_lines=file.changes,
+            is_test_file=is_test_file,
+            scoring_method='skipped-large',
+        )
+    if not weights.supports_tree_sitter(ext):
+        bt.logging.debug(f'  │   {file.short_name}: skipped (extension .{ext} not supported)')
+        return FileScoreResult(
+            filename=file.short_name,
+            score=0.0,
+            nodes_scored=0,
+            total_lines=file.changes,
+            is_test_file=is_test_file,
+            scoring_method='skipped-unsupported',
+        )
+    old_content = content_pair.old_content
+    new_content = content_pair.new_content
+    file_breakdown = score_tree_diff(old_content, new_content, ext, weights)
+    lang_config = programming_languages.get(ext)
+    lang_weight = lang_config.weight if lang_config else 1.0
+    if not is_test_file and ext in INLINE_TEST_EXTENSIONS:
+        if has_inline_tests(new_content, ext):
+            is_test_file = True
+            file_weight = TEST_FILE_CONTRIBUTION_WEIGHT
+    combined_weight = lang_weight * file_weight
+    file_breakdown = file_breakdown.with_weight(combined_weight)
+    nodes_scored = file_breakdown.added_count + file_breakdown.deleted_count
+    return FileScoreResult(
+        filename=file.short_name,
+        score=file_breakdown.total_score,
+        nodes_scored=nodes_scored,
+        total_lines=file.changes,
+        is_test_file=is_test_file,
+        scoring_method='tree-diff',
+        breakdown=file_breakdown,
+    )
+
+
+def _build_category_results(
+    cat_files: dict,
+    cat_score: dict,
+    cat_nodes: dict,
+    cat_lines: dict,
+    cat_breakdowns: dict,
+) -> dict:
+    by_category = {}
+    for cat in cat_files:
+        bd = cat_breakdowns.get(cat)
+        by_category[cat] = PrScoringResult(
+            total_score=cat_score[cat],
+            total_nodes_scored=cat_nodes[cat],
+            total_lines=cat_lines[cat],
+            file_results=cat_files[cat],
+            score_breakdown=sum(bd, start=ScoreBreakdown()) if bd else None,
+        )
+    return by_category
 
 def calculate_token_score_from_file_changes(
     file_changes: List['FileChange'],
@@ -285,79 +385,10 @@ def calculate_token_score_from_file_changes(
                 scoring_method='skipped',
             )
         elif ext in NON_CODE_EXTENSIONS:
-            lines_to_score = min(file.changes, MAX_LINES_SCORED_FOR_NON_CODE_EXT)
-            lang_config = programming_languages.get(ext)
-            lang_weight = lang_config.weight if lang_config else DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT
-            file_result = FileScoreResult(
-                filename=file.short_name,
-                score=lang_weight * lines_to_score * file_weight,
-                nodes_scored=lines_to_score,
-                total_lines=file.changes,
-                is_test_file=is_test_file,
-                scoring_method='line-count',
-            )
+            file_result = _score_non_code_file(file, ext, programming_languages, file_weight, is_test_file)
         else:
             content_pair = file_contents.get(file.filename)
-
-            if content_pair is None or content_pair.new_content is None:
-                bt.logging.debug(f'  │   {file.short_name}: skipped (binary or fetch failed)')
-                file_result = FileScoreResult(
-                    filename=file.short_name,
-                    score=0.0,
-                    nodes_scored=0,
-                    total_lines=file.changes,
-                    is_test_file=is_test_file,
-                    scoring_method='skipped-binary',
-                )
-            elif len(content_pair.new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES:
-                bt.logging.debug(f'  │   {file.short_name}: skipped (file too large, >{MAX_FILE_SIZE_BYTES} bytes)')
-                file_result = FileScoreResult(
-                    filename=file.short_name,
-                    score=0.0,
-                    nodes_scored=0,
-                    total_lines=file.changes,
-                    is_test_file=is_test_file,
-                    scoring_method='skipped-large',
-                )
-            elif not weights.supports_tree_sitter(ext):
-                bt.logging.debug(f'  │   {file.short_name}: skipped (extension .{ext} not supported)')
-                file_result = FileScoreResult(
-                    filename=file.short_name,
-                    score=0.0,
-                    nodes_scored=0,
-                    total_lines=file.changes,
-                    is_test_file=is_test_file,
-                    scoring_method='skipped-unsupported',
-                )
-            else:
-                # Tree diff scoring - compare old and new ASTs
-                old_content = content_pair.old_content
-                new_content = content_pair.new_content
-                file_breakdown = score_tree_diff(old_content, new_content, ext, weights)
-
-                lang_config = programming_languages.get(ext)
-                lang_weight = lang_config.weight if lang_config else 1.0
-
-                # For non-test files in inline-test languages, check if the current
-                # file contains inline tests and downweight the entire file if so
-                if not is_test_file and ext in INLINE_TEST_EXTENSIONS:
-                    if has_inline_tests(new_content, ext):
-                        is_test_file = True
-                        file_weight = TEST_FILE_CONTRIBUTION_WEIGHT
-
-                combined_weight = lang_weight * file_weight
-                file_breakdown = file_breakdown.with_weight(combined_weight)
-                nodes_scored = file_breakdown.added_count + file_breakdown.deleted_count
-
-                file_result = FileScoreResult(
-                    filename=file.short_name,
-                    score=file_breakdown.total_score,
-                    nodes_scored=nodes_scored,
-                    total_lines=file.changes,
-                    is_test_file=is_test_file,
-                    scoring_method='tree-diff',
-                    breakdown=file_breakdown,
-                )
+            file_result = _score_code_file(file, ext, content_pair, weights, programming_languages, file_weight, is_test_file)
 
         # Accumulate into results and per-category totals
         file_results.append(file_result)
@@ -374,16 +405,7 @@ def calculate_token_score_from_file_changes(
             all_breakdowns.append(file_result.breakdown)
 
     # Build per-category sub-results
-    by_category: Dict[ScoringCategory, PrScoringResult] = {}
-    for cat in cat_files:
-        bd = cat_breakdowns.get(cat)
-        by_category[cat] = PrScoringResult(
-            total_score=cat_score[cat],
-            total_nodes_scored=cat_nodes[cat],
-            total_lines=cat_lines[cat],
-            file_results=cat_files[cat],
-            score_breakdown=sum(bd, start=ScoreBreakdown()) if bd else None,
-        )
+    by_category = _build_category_results(cat_files, cat_score, cat_nodes, cat_lines, cat_breakdowns)
 
     result = PrScoringResult(
         total_score=total_score,


### PR DESCRIPTION
Fixes #547

## Problem
`calculate_token_score_from_file_changes` in `tree_sitter_scoring.py`
is 167 lines with four distinct scoring branches inlined into a single
for-loop, making it hard to read, test individually, and extend.

## Solution
Extracted three named helper functions:
- `_score_non_code_file` — handles line-count scoring for non-code files
- `_score_code_file` — handles tree-diff scoring for code files including
  binary, oversized, unsupported, and full tree-diff branches
- `_build_category_results` — assembles per-category PrScoringResult objects

The main function loop is now a clean dispatcher that delegates to these
helpers, making each scoring path understandable and testable in isolation.

## Changes
- `gittensor/validator/utils/tree_sitter_scoring.py` — extracted 3 helpers,
  simplified main loop and category-building block