### PR TITLE
refactor: use emit_json for JSON output in view commands

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -204,12 +204,12 @@ def emit_error_json(message: str, error_type: str = 'cli_error') -> None:
     click.echo(json.dumps(payload), err=False)
 
 
-def emit_json(payload: Any, pretty: bool = True) -> None:
+def emit_json(payload: Any, pretty: bool = True, default: Optional[Callable] = str) -> None:
     """Emit a machine-readable JSON payload to stdout."""
     if pretty:
-        output = json.dumps(payload, indent=2, ensure_ascii=False)
+        output = json.dumps(payload, indent=2, ensure_ascii=False, default=default)
     else:
-        output = json.dumps(payload, separators=(',', ':'), ensure_ascii=False)
+        output = json.dumps(payload, separators=(',', ':'), ensure_ascii=False, default=default)
     click.echo(output, err=False)
 
 

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -11,7 +11,6 @@ Commands:
     gitt admin info
 """
 
-import json as json_mod
 from decimal import Decimal
 
 import click
@@ -27,6 +26,7 @@ from .helpers import (
     colorize_status,
     console,
     emit_error_json,
+    emit_json,
     format_alpha,
     print_error,
     print_network_header,
@@ -83,9 +83,9 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
             if issue is None:
                 emit_error_json(f'Issue {issue_id} not found on-chain.', error_type='not_found')
                 raise SystemExit(1)
-            console.print(json_mod.dumps(issue, indent=2, default=str))
+            emit_json(issue)
         else:
-            console.print(json_mod.dumps(issues, indent=2, default=str))
+            emit_json(issues)
         return
 
     # Single issue detail view
@@ -204,15 +204,12 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         total_bounty_pool = sum(issue.get('bounty_amount', 0) for issue in issues)
 
         if as_json:
-            console.print(
-                json_mod.dumps(
-                    {
-                        'total_bounty_pool_raw': total_bounty_pool,
-                        'total_bounty_pool_alpha': format_alpha(total_bounty_pool, 4),
-                        'issue_count': len(issues),
-                    },
-                    indent=2,
-                )
+            emit_json(
+                {
+                    'total_bounty_pool_raw': total_bounty_pool,
+                    'total_bounty_pool_alpha': format_alpha(total_bounty_pool, 4),
+                    'issue_count': len(issues),
+                }
             )
             return
 
@@ -264,18 +261,15 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         pending_harvest = max(0, treasury_stake - total_bounty_pool)
 
         if as_json:
-            console.print(
-                json_mod.dumps(
-                    {
-                        'treasury_stake_raw': treasury_stake,
-                        'treasury_stake_alpha': format_alpha(treasury_stake, 4),
-                        'allocated_bounties_raw': total_bounty_pool,
-                        'allocated_bounties_alpha': format_alpha(total_bounty_pool, 4),
-                        'pending_harvest_raw': pending_harvest,
-                        'pending_harvest_alpha': format_alpha(pending_harvest, 4),
-                    },
-                    indent=2,
-                )
+            emit_json(
+                {
+                    'treasury_stake_raw': treasury_stake,
+                    'treasury_stake_alpha': format_alpha(treasury_stake, 4),
+                    'allocated_bounties_raw': total_bounty_pool,
+                    'allocated_bounties_alpha': format_alpha(total_bounty_pool, 4),
+                    'pending_harvest_raw': pending_harvest,
+                    'pending_harvest_alpha': format_alpha(pending_harvest, 4),
+                }
             )
             return
 
@@ -311,7 +305,7 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
 
         if packed:
             if as_json:
-                console.print(json_mod.dumps(packed, indent=2, default=str))
+                emit_json(packed)
                 return
 
             console.print(

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -25,6 +25,7 @@ from gittensor.cli.issue_commands.helpers import (
     MAX_ISSUE_NUMBER,
     STATUS_COLORS,
     colorize_status,
+    emit_json,
     format_alpha,
     validate_bounty_amount,
     validate_github_issue,
@@ -721,3 +722,20 @@ class TestCliRuntimeExceptions:
             )
         assert result.exit_code != 0
         assert 'boom-harvest' in result.output
+
+
+class TestEmitJson:
+    @pytest.mark.parametrize(
+        'value',
+        [
+            Decimal('10.5'),
+            __import__('datetime').datetime(2026, 1, 1, 12, 0, 0),
+            __import__('datetime').date(2026, 1, 1),
+        ],
+        ids=['Decimal', 'datetime', 'date'],
+    )
+    def test_non_native_types_serialized_via_default(self, value, capsys):
+        emit_json({'field': value})
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed['field'] == str(value)


### PR DESCRIPTION
## Summary

- Replace `console.print(json_mod.dumps(...))` with `emit_json(...)` in view.py
- Covers `issues_list`, `issues_pending_harvest`, and `admin_info` JSON paths
- Ensures JSON output goes through `click.echo` (no Rich styling) for clean pipe consumption

## Problem

`view.py` uses `console.print(json_mod.dumps(...))` for JSON output while the codebase already
has an `emit_json` helper that uses `click.echo` for clean, machine-readable output. Rich's
`console.print` can inject ANSI escape codes in some terminal configurations, breaking downstream
JSON parsers.

## Test plan

- [ ] `gitt issues list --json` outputs valid JSON without ANSI codes
- [ ] `gitt issues list --json | jq .` parses correctly
- [ ] All existing tests pass

Fixes #562