### PR TITLE
refactor: deduplicate __exit__ and fix traceback logging in BaseValidatorNeuron

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -20,7 +20,7 @@ import argparse
 import asyncio
 import copy
 import threading
-from traceback import print_exception
+from traceback import format_exception
 from typing import List, Union
 
 import bittensor as bt
@@ -165,7 +165,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # In case of unforeseen errors, the validator will log the error and continue operations.
         except Exception as err:
             bt.logging.error(f'Error during validation: {str(err)}')
-            bt.logging.debug(str(print_exception(type(err), err, err.__traceback__)))
+            bt.logging.debug(''.join(format_exception(type(err), err, err.__traceback__)))
 
     def run_in_background_thread(self):
         """
@@ -208,12 +208,7 @@ class BaseValidatorNeuron(BaseNeuron):
             traceback: A traceback object encoding the stack trace.
                        None if the context was exited without an exception.
         """
-        if self.is_running:
-            bt.logging.debug('Stopping validator in background thread.')
-            self.should_exit = True
-            self.thread.join(5)
-            self.is_running = False
-            bt.logging.debug('Stopped')
+        self.stop_run_thread()
 
     def set_weights(self):
         """


### PR DESCRIPTION
## Summary

- `__exit__` now delegates to `stop_run_thread()` instead of duplicating its body
- Replace `print_exception` with `format_exception` so the traceback is captured in
  bittensor logs instead of printed to stderr and lost
- Update import from `print_exception` to `format_exception`

## Problem

`__exit__` and `stop_run_thread` contain identical 5-line blocks. Also, `print_exception`
writes to stderr and returns `None`, so `str(print_exception(...))` logs `'None'` — the
actual traceback never reaches the bittensor log file.

## Test plan

- [ ] All existing tests pass
- [ ] `ruff check` and `ruff format` clean

Fixes #564