### PR TITLE
fix: use emit_json for bounty pool json output

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -204,15 +204,12 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         total_bounty_pool = sum(issue.get('bounty_amount', 0) for issue in issues)
 
         if as_json:
-            console.print(
-                json_mod.dumps(
-                    {
-                        'total_bounty_pool_raw': total_bounty_pool,
-                        'total_bounty_pool_alpha': format_alpha(total_bounty_pool, 4),
-                        'issue_count': len(issues),
-                    },
-                    indent=2,
-                )
+            emit_json(
+                {
+                    'total_bounty_pool_raw': total_bounty_pool,
+                    'total_bounty_pool_alpha': format_alpha(total_bounty_pool, 4),
+                    'issue_count': len(issues),
+                }
             )
             return
 

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -27,6 +27,7 @@ from .helpers import (
     colorize_status,
     console,
     emit_error_json,
+    emit_json,
     format_alpha,
     print_error,
     print_network_header,

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -23,6 +23,7 @@ from .helpers import (
     _make_contract_client,
     _resolve_contract_and_network,
     console,
+    emit_json,
     print_error,
     print_network_header,
     print_success,
@@ -235,15 +236,12 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
         required = (n // 2) + 1
 
         if as_json:
-            console.print(
-                json_mod.dumps(
-                    {
-                        'validators': validators,
-                        'count': n,
-                        'consensus_threshold': required,
-                    },
-                    indent=2,
-                )
+            emit_json(
+                {
+                    'validators': validators,
+                    'count': n,
+                    'consensus_threshold': required,
+                }
             )
             return
 


### PR DESCRIPTION
## Summary
- replace Rich JSON printing in `issues_bounty_pool` with `emit_json`
- keep `gitt issues bounty-pool --json` machine-readable like the other CLI JSON helpers

## Problem
`issues_bounty_pool` still prints JSON via `console.print(json.dumps(...))`, which routes through Rich instead of the existing `emit_json` helper.

## Validation
- ran `python3 -m py_compile gittensor/cli/issue_commands/view.py`
