### PR TITLE
fix: use emit_json for validator list json output

### DIFF
--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -23,6 +23,7 @@ from .helpers import (
     _make_contract_client,
     _resolve_contract_and_network,
     console,
+    emit_json,
     print_error,
     print_network_header,
     print_success,
@@ -235,15 +236,12 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
         required = (n // 2) + 1
 
         if as_json:
-            console.print(
-                json_mod.dumps(
-                    {
-                        'validators': validators,
-                        'count': n,
-                        'consensus_threshold': required,
-                    },
-                    indent=2,
-                )
+            emit_json(
+                {
+                    'validators': validators,
+                    'count': n,
+                    'consensus_threshold': required,
+                }
             )
             return
 


### PR DESCRIPTION
## Summary
- replace Rich JSON printing in the validator list command with `emit_json`
- keep `gitt vote list --json` machine-readable like the rest of the issue CLI

## Problem
The validator list JSON path still uses `console.print(json.dumps(...))`, which routes through Rich instead of the shared `emit_json` helper.

## Validation
- ran `python3 -m py_compile gittensor/cli/issue_commands/vote.py`
