### PR TITLE
fix: guard handle_pat_check against unregistered hotkeys and use descriptive errors

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -28,7 +28,7 @@ console = Console()
 
 
 @click.group(cls=StyledAliasGroup)
-@click.version_option(version='3.2.0', prog_name='gittensor')
+@click.version_option(version='5.0.0', prog_name='gittensor')
 def cli():
     """Gittensor CLI - Manage issue bounties and validator operations"""
     pass

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 
 def _get_hotkey(synapse: bt.Synapse) -> str:
     """Extract the caller's hotkey from a synapse, raising if missing."""
-    assert synapse.dendrite is not None and synapse.dendrite.hotkey is not None
+    if synapse.dendrite is None or synapse.dendrite.hotkey is None:
+        raise ValueError('Synapse dendrite or hotkey is missing')
     return synapse.dendrite.hotkey
 
 
@@ -101,6 +102,13 @@ async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSy
 async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> PatCheckSynapse:
     """Check if the validator has the miner's PAT stored and re-validate it."""
     hotkey = _get_hotkey(synapse)
+
+    if hotkey not in validator.metagraph.hotkeys:
+        synapse.has_pat = False
+        synapse.pat_valid = False
+        synapse.rejection_reason = 'Hotkey not registered on subnet'
+        return synapse
+
     uid = validator.metagraph.hotkeys.index(hotkey)
     entry = pat_storage.get_pat_by_uid(uid)
 

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -223,3 +223,11 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is False
         assert 'PAT expired' in (result.rejection_reason or '')
+
+    def test_unregistered_hotkey_rejected(self, mock_validator):
+        """handle_pat_check returns has_pat=False when hotkey is not in metagraph."""
+        synapse = _make_check_synapse('unknown_hotkey')
+        result = _run(handle_pat_check(mock_validator, synapse))
+        assert result.has_pat is False
+        assert result.pat_valid is False
+        assert 'not registered' in (result.rejection_reason or '')


### PR DESCRIPTION
## Summary

- `handle_pat_check` now checks metagraph membership before calling `.index()`, preventing a `ValueError` crash when a hotkey disappears between the blacklist check and handler invocation (race condition on deregistration)
- `_get_hotkey` replaces a bare `assert` with a `ValueError` carrying a meaningful message — `AssertionError` is opaque and is silently stripped when Python runs with `-O`
- Fix `gitt --version` displaying `3.2.0` instead of the actual package version `5.0.0`

## Related Issues

N/A

## Type of Change

- [x] Bug fix

## Testing

- Added `TestHandlePatCheck::test_unregistered_hotkey_rejected` covering the new guard
- All 16 PAT handler tests pass

## Checklist

- [x] Code follows existing style conventions
- [x] Self-reviewed the diff
- [x] No documentation changes required
