### PR TITLE
fix: exception handling against deregistered miners

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -101,6 +101,12 @@ async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSy
 async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> PatCheckSynapse:
     """Check if the validator has the miner's PAT stored and re-validate it."""
     hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        synapse.has_pat = False
+        synapse.pat_valid = False
+        synapse.rejection_reason = 'Hotkey not registered on subnet'
+        bt.logging.warning(f'PAT check rejected — hotkey {hotkey[:16]}... not in metagraph')
+        return synapse
     uid = validator.metagraph.hotkeys.index(hotkey)
     entry = pat_storage.get_pat_by_uid(uid)
 


### PR DESCRIPTION
## Summary

- Add hotkey membership check before `.index()` in `handle_pat_check`
- Add warning log when a deregistered hotkey is rejected
- Matches the existing guard pattern in `handle_pat_broadcast` (line 46-49)

Fixes #574

## Problem

`handle_pat_check` calls `validator.metagraph.hotkeys.index(hotkey)` without first
checking membership. If the metagraph resyncs between the blacklist check and handler
execution, a deregistered hotkey causes `.index()` to raise `ValueError`.

`handle_pat_broadcast` already guards against this at line 46-49 — this PR applies the
same pattern to `handle_pat_check` for consistency.

## Difference from #570

PR #570 bundles this fix with two unrelated changes (assert→ValueError in `_get_hotkey`
and CLI version bump). This PR is a focused single-concern fix for #574 only, with a
warning log for observability.

## Test plan

- [ ] Existing PAT handler tests pass
- [ ] Full test suite passes
