### PR TITLE
refactor: extract shared _blacklist_pat and _priority_pat helpers in pat_handler

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -78,19 +78,12 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
 
 async def blacklist_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSynapse) -> Tuple[bool, str]:
     """Reject PAT broadcasts from unregistered hotkeys."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return True, f'Hotkey {hotkey[:16]}... not registered'
-    return False, 'Hotkey recognized'
+    return await _blacklist_pat(validator, synapse)
 
 
 async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSynapse) -> float:
     """Prioritize PAT broadcasts by stake."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return 0.0
-    uid = validator.metagraph.hotkeys.index(hotkey)
-    return float(validator.metagraph.S[uid])
+    return await _priority_pat(validator, synapse)
 
 
 # ---------------------------------------------------------------------------
@@ -138,24 +131,34 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
 
 async def blacklist_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> Tuple[bool, str]:
     """Reject PAT checks from unregistered hotkeys."""
+    return await _blacklist_pat(validator, synapse)
+
+
+async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> float:
+    """Prioritize PAT checks by stake."""
+    return await _priority_pat(validator, synapse)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _blacklist_pat(validator: 'Validator', synapse: bt.Synapse) -> Tuple[bool, str]:
+    """Shared blacklist logic: reject synapses from hotkeys not on the subnet."""
     hotkey = _get_hotkey(synapse)
     if hotkey not in validator.metagraph.hotkeys:
         return True, f'Hotkey {hotkey[:16]}... not registered'
     return False, 'Hotkey recognized'
 
 
-async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> float:
-    """Prioritize PAT checks by stake."""
+async def _priority_pat(validator: 'Validator', synapse: bt.Synapse) -> float:
+    """Shared priority logic: rank by stake, defaulting to 0 for unregistered hotkeys."""
     hotkey = _get_hotkey(synapse)
     if hotkey not in validator.metagraph.hotkeys:
         return 0.0
     uid = validator.metagraph.hotkeys.index(hotkey)
     return float(validator.metagraph.S[uid])
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
 
 
 def _test_pat_against_repo(pat: str) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Extracts duplicated blacklist and priority logic into shared `_blacklist_pat` and `_priority_pat` helpers
- The four public handler functions (`blacklist_pat_broadcast`, `priority_pat_broadcast`, `blacklist_pat_check`, `priority_pat_check`) now delegate to the shared helpers
- No behavior change — pure deduplication

Closes #568

## Test plan
- [ ] Existing `tests/validator/test_pat_handler.py` passes unchanged
- [ ] Blacklist behavior still rejects unregistered hotkeys
- [ ] Priority still returns stake for registered hotkeys
