### PR TITLE
fix: validator traceback logging and __exit__ deduplication

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -20,7 +20,7 @@ import argparse
 import asyncio
 import copy
 import threading
-from traceback import print_exception
+from traceback import format_exception
 from typing import List, Union
 
 import bittensor as bt
@@ -165,7 +165,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # In case of unforeseen errors, the validator will log the error and continue operations.
         except Exception as err:
             bt.logging.error(f'Error during validation: {str(err)}')
-            bt.logging.debug(str(print_exception(type(err), err, err.__traceback__)))
+            bt.logging.debug(''.join(format_exception(type(err), err, err.__traceback__)))
 
     def run_in_background_thread(self):
         """
@@ -208,12 +208,7 @@ class BaseValidatorNeuron(BaseNeuron):
             traceback: A traceback object encoding the stack trace.
                        None if the context was exited without an exception.
         """
-        if self.is_running:
-            bt.logging.debug('Stopping validator in background thread.')
-            self.should_exit = True
-            self.thread.join(5)
-            self.is_running = False
-            bt.logging.debug('Stopped')
+        self.stop_run_thread()
 
     def set_weights(self):
         """


### PR DESCRIPTION
## Summary
- Fixes `bt.logging.debug(str(print_exception(...)))` which always logged `None` (print_exception returns None, not a string)
- Switches to `format_exception` which returns the traceback as a string
- Deduplicates `__exit__` by delegating to `stop_run_thread()` instead of repeating 6 identical lines

Closes #564

## Test plan
- [ ] Exception during validator run now logs full traceback instead of `None`
- [ ] `__exit__` correctly stops background thread
