### PR TITLE
fix: guard against null label in timeline events for deleted labels

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -290,9 +290,11 @@ class PullRequest:
         last_edited_at = parse_github_timestamp_to_cst(raw_edited_at) if isinstance(raw_edited_at, str) else None
         merged_at = parse_github_timestamp_to_cst(pr_data['mergedAt']) if is_merged else None
 
-        # Extract last label from timeline events
+        # Extract last label from timeline events; guard against deleted labels
+        # (GitHub returns {"label": null} when the label was deleted from the repo)
         timeline_nodes = pr_data.get('timelineItems', {}).get('nodes', [])
-        label = timeline_nodes[0]['label']['name'].lower() if timeline_nodes else None
+        first_label = timeline_nodes[0].get('label') if timeline_nodes else None
+        label = first_label['name'].lower() if first_label else None
 
         return cls(
             number=pr_data['number'],


### PR DESCRIPTION
## Summary
- `PullRequest.from_graphql_response()` accessed `timeline_nodes[0]["label"]["name"]` without guarding against a `None` label
- When a label is deleted from a repo after a `LABELED_EVENT`, GitHub returns `{"label": null}` in the GraphQL response
- The previous code raised `TypeError: NoneType object is not subscriptable`, causing the broad `except Exception` in `github_api_tools.py` to silently drop the entire PR
- Fixed by checking `timeline_nodes[0].get("label")` before accessing `["name"]`

Closes #536

## Test plan
- [ ] PRs with deleted labels no longer crash during scoring
- [ ] PRs with valid labels still extract the label name correctly
- [ ] PRs with no LABELED_EVENT timeline nodes still return `label = None`
