### PR TITLE
refactor: replace reimplemented packed storage reader with shared storage_utils call

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -25,8 +25,8 @@ from gittensor.constants import NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
     compute_ink5_lazy_key,
     decode_issue_from_storage,
-    decode_packed_contract_storage,
     get_contract_child_storage_key,
+    read_contract_packed_storage,
 )
 
 # Default CLI config paths
@@ -639,55 +639,13 @@ def _get_contract_child_storage_key(substrate, contract_addr: str, verbose: bool
 
 
 def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool = False) -> Optional[Dict[str, Any]]:
-    """
-    Read the packed root storage from a contract using childstate RPC
-
-    This bypasses the broken state_call/ContractsApi_call method and reads
-    storage directly. Works around substrate-interface Ink! 5 compatibility issues.
-
-    Args:
-        substrate: SubstrateInterface instance
-        contract_addr: Contract address
-        verbose: If True, print debug output
-
-    Returns:
-        Dict with owner, netuid, next_issue_id, etc. or None on error
-    """
+    """Read packed root storage from a contract and return a formatted dict."""
     try:
-        child_key = _get_contract_child_storage_key(substrate, contract_addr, verbose)
-        if not child_key:
-            if verbose:
-                console.print('[dim]Debug: Failed to get contract child storage key[/dim]')
-            return None
-
-        keys_result = substrate.rpc_request('childstate_getKeysPaged', [child_key, '0x', 100, None, None])
-        keys = keys_result.get('result', [])
-        if verbose:
-            console.print(f'[dim]Debug: Found {len(keys)} storage keys in contract[/dim]')
-
-        packed_key = next((key for key in keys if key.endswith('00000000')), None)
-        if not packed_key:
-            if verbose:
-                console.print('[dim]Debug: No packed storage key (ending in 00000000) found[/dim]')
-            return None
-
-        val_result = substrate.rpc_request('childstate_getStorage', [child_key, packed_key, None])
-        raw_hex = val_result.get('result')
-        if not raw_hex:
-            if verbose:
-                console.print('[dim]Debug: Failed to read packed storage value[/dim]')
-            return None
-
-        data = bytes.fromhex(raw_hex.replace('0x', ''))
-        if verbose:
-            console.print(f'[dim]Debug: Packed storage data length = {len(data)} bytes[/dim]')
-
-        packed = decode_packed_contract_storage(data)
+        packed = read_contract_packed_storage(substrate, contract_addr)
         if not packed:
             if verbose:
-                console.print(f'[dim]Debug: Packed storage too small ({len(data)} < 74 bytes)[/dim]')
+                console.print('[dim]Debug: Failed to read packed storage[/dim]')
             return None
-
         return {
             'owner': substrate.ss58_encode(packed.owner.hex()),
             'treasury_hotkey': substrate.ss58_encode(packed.treasury_hotkey.hex()),


### PR DESCRIPTION
## Summary
- `_read_contract_packed_storage` in `cli/issue_commands/helpers.py` reimplemented 60 lines of raw RPC orchestration that `read_contract_packed_storage()` in `storage_utils.py` already provides
- helpers.py already imported the component functions from storage_utils but did not call the top-level orchestrator
- Replaced with a thin 18-line wrapper that delegates to `read_contract_packed_storage()` and formats the result into a dict with ss58-encoded addresses
- Removed the now-unused `decode_packed_contract_storage` import

Closes #578

## Test plan
- [x] `gitt admin info` still returns correct contract configuration
- [x] `gitt admin info --json` still returns clean JSON
- [x] `gitt admin info --verbose` logs debug info on failure
