### PR TITLE
fix: deduplicate issues per discoverer in _collect_issues_from_prs

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -190,6 +190,9 @@ def _collect_issues_from_prs(
     """
     # Track which PRs have already awarded a discovery score (one-issue-per-PR rule)
     pr_scored: set = set()  # (repo, pr_number)
+    # Track which issues have already been counted for each discoverer to prevent
+    # double-counting credibility when the same issue appears in multiple miners' PRs
+    issue_counted: set = set()  # (discoverer_id, repo, issue_number)
 
     for uid, evaluation in miner_evaluations.items():
         for pr in evaluation.merged_pull_requests:
@@ -206,6 +209,13 @@ def _collect_issues_from_prs(
                 discoverer_id = issue.author_github_id
                 if not discoverer_id or discoverer_id not in github_id_to_uid:
                     continue
+
+                # Skip if we've already counted this issue for this discoverer —
+                # the same issue can appear in multiple miners' closingIssuesReferences
+                issue_key = (discoverer_id, issue.repository_full_name, issue.number)
+                if issue_key in issue_counted:
+                    continue
+                issue_counted.add(issue_key)
 
                 data = discoverer_data[discoverer_id]
 


### PR DESCRIPTION
## Summary
- The same GitHub issue can appear in multiple miners' `closingIssuesReferences` when more than one merged PR closes it
- `_collect_issues_from_prs` incremented `solved_count` and `valid_solved_count` once **per solving PR** rather than once per unique issue, inflating the discoverer's credibility counters
- This made it easier to pass the `MIN_VALID_SOLVED_ISSUES` eligibility gate in `check_issue_eligibility`
- Added an `issue_counted` set keyed by `(discoverer_id, repo, issue_number)` so each (discoverer, issue) pair is counted at most once, regardless of how many miners' PRs reference it

Closes #540

## Test plan
- [ ] A discoverer whose issue is closed by two different miners' PRs has `solved_count` incremented only once
- [ ] `valid_solved_count` does not exceed the actual number of unique issues discovered
- [ ] Existing eligibility logic and scoring remain unchanged
