### PR TITLE
fix(pat): guard against unregistered hotkey in handle_pat_check

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -101,6 +101,15 @@ async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSy
 async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> PatCheckSynapse:
     """Check if the validator has the miner's PAT stored and re-validate it."""
     hotkey = _get_hotkey(synapse)
+
+    # Guard against metagraph resync between blacklist and handler (hotkey deregistered mid-request)
+    if hotkey not in validator.metagraph.hotkeys:
+        synapse.has_pat = False
+        synapse.pat_valid = False
+        synapse.rejection_reason = 'Hotkey not registered on subnet'
+        bt.logging.warning(f'PAT check rejected — hotkey: {hotkey[:16]}... reason: Hotkey not registered on subnet')
+        return synapse
+
     uid = validator.metagraph.hotkeys.index(hotkey)
     entry = pat_storage.get_pat_by_uid(uid)
 

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -223,3 +223,18 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is False
         assert 'PAT expired' in (result.rejection_reason or '')
+
+    def test_unregistered_hotkey_does_not_raise(self, mock_validator):
+        """Regression: hotkey deregistered between blacklist and handler must not crash.
+
+        Simulates the race where blacklist_pat_check passes but the metagraph resyncs
+        before handle_pat_check runs. Previously raised ValueError on .index().
+        """
+        mock_validator.metagraph.hotkeys = []
+
+        synapse = _make_check_synapse('hotkey_1')
+        result = _run(handle_pat_check(mock_validator, synapse))
+
+        assert result.has_pat is False
+        assert result.pat_valid is False
+        assert 'not registered' in (result.rejection_reason or '').lower()


### PR DESCRIPTION
## Summary

`handle_pat_check` in `gittensor/validator/pat_handler.py` called `metagraph.hotkeys.index(hotkey)` without first verifying membership. If the metagraph resynced between `blacklist_pat_check` (which only accepts registered hotkeys) and the handler execution — e.g. a miner deregistered mid-request — `.index()` raised `ValueError` and crashed the handler.

This mirrors the guard that `handle_pat_broadcast` already has (see the early `_reject('Hotkey not registered on subnet')` path), returning a proper rejection synapse instead of raising.

## Changes

- `gittensor/validator/pat_handler.py`: add membership check before `metagraph.hotkeys.index(hotkey)` in `handle_pat_check`. Returns a synapse with `has_pat=False`, `pat_valid=False`, and `rejection_reason="Hotkey not registered on subnet"` — same pattern and log format as the existing `_reject` closure in `handle_pat_broadcast`.
- `tests/validator/test_pat_handler.py`: add regression test `test_unregistered_hotkey_does_not_raise` in `TestHandlePatCheck`. Mocks `metagraph.hotkeys = []` and verifies the handler returns a rejection synapse instead of raising.

## Verification

- `ruff check` — passes
- `pytest tests/validator/ -k pat` — 47 passed (46 existing + 1 new)
- Reproduced the original bug before patching: `[].index('absent_hotkey')` raises `ValueError: 'absent_hotkey' is not in list`

## Scope

Minimal defensive fix. No refactor, no change to `handle_pat_broadcast`, `blacklist_*`, `priority_*`, or any other handler. +24 / -0 lines total.

Closes #574
