### PR TITLE
fix: sort repo_contributions iteration in calculate_pioneer_dividends

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -305,7 +305,7 @@ def calculate_pioneer_dividends(
                 else:
                     repo_contributions[repo][pr.uid] = (earliest_at, earliest_num, new_total)
 
-    for repo, uid_entries in repo_contributions.items():
+    for repo, uid_entries in sorted(repo_contributions.items()):
         sorted_uids = sorted(uid_entries.items(), key=lambda x: (x[1][0], x[1][1]))
 
         for rank_pos, (uid, _) in enumerate(sorted_uids):


### PR DESCRIPTION
## Summary
- `calculate_pioneer_dividends` iterated `repo_contributions.items()` in dict insertion order
- Insertion order depends on which miner's PRs are processed first, which can vary across validators if `miner_evaluations` is populated from async responses arriving in different orders
- This makes the dividend calculation non-deterministic: two validators seeing the same data but processing it in a different order could compute different pioneer dividends, causing consensus divergence
- Fixed by sorting `repo_contributions.items()` so repos are always processed in alphabetical order

Closes #538

## Test plan
- [ ] Pioneer dividends are identical across two runs with different dict insertion orders
- [ ] Existing pioneer dividend values are unchanged for repos with stable processing order
