### PR TITLE
fix: escape filenames in GraphQL expression using json.dumps

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1,6 +1,7 @@
 # Entrius 2025
 import base64
 import fnmatch
+import json
 import os
 import time
 from dataclasses import dataclass
@@ -1227,16 +1228,16 @@ def _fetch_file_contents_with_base_batch(
 
         # New files have no base version to fetch
         if fc.status != 'added':
-            base_expr = f'{base_sha}:{base_path}'
+            base_expr = json.dumps(f'{base_sha}:{base_path}')
             file_fields.append(
-                f'base{i}: object(expression: "{base_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+                f'base{i}: object(expression: {base_expr}) {{ ... on Blob {{ text byteSize isBinary }} }}'
             )
 
         # Deleted files have no head version to fetch
         if fc.status != 'removed':
-            head_expr = f'{head_sha}:{head_path}'
+            head_expr = json.dumps(f'{head_sha}:{head_path}')
             file_fields.append(
-                f'head{i}: object(expression: "{head_expr}") {{ ... on Blob {{ text byteSize isBinary }} }}'
+                f'head{i}: object(expression: {head_expr}) {{ ... on Blob {{ text byteSize isBinary }} }}'
             )
 
     if not file_fields:


### PR DESCRIPTION
## Summary
- `_fetch_file_contents_with_base_batch` interpolated `base_path` and `head_path` directly into the GraphQL query string via f-string
- Filenames containing `"`, `\`, or newlines (all legal on case-sensitive filesystems) broke the GraphQL string literal, producing a malformed query
- The broad `except Exception` in the caller silently dropped the entire PR's token score
- Fixed by replacing raw string interpolation with `json.dumps()`, which produces a properly JSON-escaped quoted string safe for use inside a GraphQL string literal

Closes #532

## Test plan
- [ ] PRs containing files with `"` or `\` in their names score correctly
- [ ] Normal filenames (no special chars) produce identical GraphQL queries
- [ ] `json` module added to imports
