### PR TITLE
fix: remove penalized UIDs from cached_uids so duplicate penalty persists to DB

### DIFF
--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -11,7 +11,7 @@ from gittensor.constants import RECYCLE_UID
 from gittensor.validator.utils.github_validation import validate_github_credentials
 
 
-def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, MinerEvaluation]):
+def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, MinerEvaluation]) -> set[int]:
     """
     Detects miners that used the same github, duplicated across multiple uids.
     Will then penalize detected 'duplicate miners' with a score of 0.0.
@@ -19,6 +19,9 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
 
     Args:
         miner_evaluations (Dict[int, MinerEvaluation]): Mapping of miner UID to their MinerEvaluation.
+
+    Returns:
+        Set of penalized UIDs.
     """
 
     bt.logging.info('Now checking for duplicate users across miners...')
@@ -29,7 +32,7 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         if evaluation.github_id and evaluation.github_id != '0':
             github_id_to_uids[evaluation.github_id].append(uid)
 
-    duplicate_count = 0
+    penalized_uids: set[int] = set()
     for _, uids in github_id_to_uids.items():
         if len(uids) <= 1:
             continue
@@ -38,9 +41,10 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         for uid in uids:
             bt.logging.info(f'PENALTY: Zeroing score for duplicate uid {uid}')
             miner_evaluations[uid] = MinerEvaluation(uid=uid, hotkey=miner_evaluations[uid].hotkey)
-            duplicate_count += 1
+            penalized_uids.add(uid)
 
-    bt.logging.info(f'Total duplicate miners penalized: {duplicate_count}')
+    bt.logging.info(f'Total duplicate miners penalized: {len(penalized_uids)}')
+    return penalized_uids
 
 
 def validate_response_and_initialize_miner_evaluation(

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -122,7 +122,8 @@ async def get_rewards(
     cached_uids = self.store_or_use_cached_evaluation(miner_evaluations)
 
     # Adjust scores for duplicate accounts
-    detect_and_penalize_miners_sharing_github(miner_evaluations)
+    penalized_uids = detect_and_penalize_miners_sharing_github(miner_evaluations)
+    cached_uids -= penalized_uids
 
     # Finalize scores: apply eligibility gate, credibility, pioneer dividends, collateral
     finalize_miner_scores(miner_evaluations)


### PR DESCRIPTION
## Summary

- After duplicate detection, remove penalized UIDs from `cached_uids` so the zeroed
  evaluation is written to DB by `bulk_store_evaluation`
- Prevents duplicate miners from retaining old positive scores across cycles when
  GitHub API is intermittently unavailable

Closes #596

## Problem

`store_or_use_cached_evaluation` adds UIDs to `cached_uids` (skip DB write) before
`detect_and_penalize_miners_sharing_github` zeroes their scores. The penalty is never
persisted - the old positive score stays in DB and cache indefinitely.

## Test plan

- [ ] Verify penalized UIDs are removed from cached_uids
- [ ] Verify zeroed evaluation is written to DB after duplicate detection
- [ ] All existing tests pass