### PR TITLE
fix: remove penalized UIDs from cached_uids so zeroed score is written to DB

### DIFF
--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -126,7 +126,8 @@ async def get_rewards(
 
     # Remove penalized UIDs from cached_uids so their zeroed score is written to DB
     penalized_uids = {
-        uid for uid, evaluation in miner_evaluations.items()
+        uid
+        for uid, evaluation in miner_evaluations.items()
         if evaluation.total_score == 0.0 and evaluation.failed_reason is None and uid in cached_uids
     }
     cached_uids -= penalized_uids

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -124,6 +124,13 @@ async def get_rewards(
     # Adjust scores for duplicate accounts
     detect_and_penalize_miners_sharing_github(miner_evaluations)
 
+    # Remove penalized UIDs from cached_uids so their zeroed score is written to DB
+    penalized_uids = {
+        uid for uid, evaluation in miner_evaluations.items()
+        if evaluation.total_score == 0.0 and evaluation.failed_reason is None and uid in cached_uids
+    }
+    cached_uids -= penalized_uids
+
     # Finalize scores: apply eligibility gate, credibility, pioneer dividends, collateral
     finalize_miner_scores(miner_evaluations)
 


### PR DESCRIPTION
Fixes #596

## Problem
`get_rewards` in `reward.py` runs cache restoration before duplicate
detection:

1. `store_or_use_cached_evaluation` restores cached eval for a miner
   whose GitHub API failed, and adds their UID to `cached_uids`
2. `detect_and_penalize_miners_sharing_github` then zeroes their score
   in-memory
3. `bulk_store_evaluation` sees the UID in `cached_uids` and skips the
   DB write

The zeroed penalty score is never persisted. Next cycle, cache returns
the old positive score and the duplicate miner keeps earning.

## Fix
After `detect_and_penalize_miners_sharing_github` runs, remove any
penalized UIDs from `cached_uids` so `bulk_store_evaluation` writes
their zeroed score to DB.

A UID is considered penalized when `total_score == 0.0` and
`failed_reason is None` (genuine penalty, not a validation failure).

## Changes
- `gittensor/validator/oss_contributions/reward.py` — remove penalized
  UIDs from `cached_uids` after duplicate detection