### PR TITLE
refactor: deduplicate blacklist and priority handlers in pat_handler

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -78,19 +78,12 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
 
 async def blacklist_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSynapse) -> Tuple[bool, str]:
     """Reject PAT broadcasts from unregistered hotkeys."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return True, f'Hotkey {hotkey[:16]}... not registered'
-    return False, 'Hotkey recognized'
+    return await _blacklist_handler(validator, synapse)
 
 
 async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSynapse) -> float:
     """Prioritize PAT broadcasts by stake."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return 0.0
-    uid = validator.metagraph.hotkeys.index(hotkey)
-    return float(validator.metagraph.S[uid])
+    return await _priority_handler(validator, synapse)
 
 
 # ---------------------------------------------------------------------------
@@ -138,25 +131,33 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
 
 async def blacklist_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> Tuple[bool, str]:
     """Reject PAT checks from unregistered hotkeys."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return True, f'Hotkey {hotkey[:16]}... not registered'
-    return False, 'Hotkey recognized'
+    return await _blacklist_handler(validator, synapse)
 
 
 async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> float:
     """Prioritize PAT checks by stake."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return 0.0
-    uid = validator.metagraph.hotkeys.index(hotkey)
-    return float(validator.metagraph.S[uid])
+    return await _priority_handler(validator, synapse)
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+async def _blacklist_handler(validator: 'Validator', synapse: bt.Synapse) -> Tuple[bool, str]:
+    """Shared blacklist logic: reject unregistered hotkeys."""
+    hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        return True, f'Hotkey {hotkey[:16]}... not registered'
+    return False, 'Hotkey recognized'
+
+
+async def _priority_handler(validator: 'Validator', synapse: bt.Synapse) -> float:
+    """Shared priority logic: prioritize by stake."""
+    hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        return 0.0
+    uid = validator.metagraph.hotkeys.index(hotkey)
+    return float(validator.metagraph.S[uid])
 
 def _test_pat_against_repo(pat: str) -> Optional[str]:
     """Run a test GraphQL call to verify the PAT has the access scoring requires.

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -143,6 +143,7 @@ async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+
 async def _blacklist_handler(validator: 'Validator', synapse: bt.Synapse) -> Tuple[bool, str]:
     """Shared blacklist logic: reject unregistered hotkeys."""
     hotkey = _get_hotkey(synapse)
@@ -158,6 +159,7 @@ async def _priority_handler(validator: 'Validator', synapse: bt.Synapse) -> floa
         return 0.0
     uid = validator.metagraph.hotkeys.index(hotkey)
     return float(validator.metagraph.S[uid])
+
 
 def _test_pat_against_repo(pat: str) -> Optional[str]:
     """Run a test GraphQL call to verify the PAT has the access scoring requires.


### PR DESCRIPTION
Fixes #568

## Problem
`pat_handler.py` had two pairs of completely identical functions:
- `blacklist_pat_broadcast` and `blacklist_pat_check` — exact same body
- `priority_pat_broadcast` and `priority_pat_check` — exact same body

Both pairs only call `_get_hotkey(synapse)` which accepts any `bt.Synapse`,
so the synapse type was irrelevant to the logic.

## Solution
Extracted two shared async helpers:
- `_blacklist_handler(validator, synapse)` — shared blacklist logic
- `_priority_handler(validator, synapse)` — shared priority logic

The four typed wrappers now delegate to these helpers, eliminating
the duplicated logic while preserving the public API.

## Changes
- `gittensor/validator/pat_handler.py` — extracted 2 helpers, simplified 4 functions