### PR TITLE
fix: persist zeroed duplicate-account penalty to DB for cached miners

### DIFF
--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -2,7 +2,7 @@
 # Copyright © 2025 Entrius
 
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 import bittensor as bt
 
@@ -11,7 +11,7 @@ from gittensor.constants import RECYCLE_UID
 from gittensor.validator.utils.github_validation import validate_github_credentials
 
 
-def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, MinerEvaluation]):
+def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, MinerEvaluation]) -> Set[int]:
     """
     Detects miners that used the same github, duplicated across multiple uids.
     Will then penalize detected 'duplicate miners' with a score of 0.0.
@@ -19,6 +19,9 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
 
     Args:
         miner_evaluations (Dict[int, MinerEvaluation]): Mapping of miner UID to their MinerEvaluation.
+
+    Returns:
+        Set of UIDs that were penalized (score zeroed).
     """
 
     bt.logging.info('Now checking for duplicate users across miners...')
@@ -29,7 +32,7 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         if evaluation.github_id and evaluation.github_id != '0':
             github_id_to_uids[evaluation.github_id].append(uid)
 
-    duplicate_count = 0
+    penalized_uids: Set[int] = set()
     for _, uids in github_id_to_uids.items():
         if len(uids) <= 1:
             continue
@@ -38,9 +41,10 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         for uid in uids:
             bt.logging.info(f'PENALTY: Zeroing score for duplicate uid {uid}')
             miner_evaluations[uid] = MinerEvaluation(uid=uid, hotkey=miner_evaluations[uid].hotkey)
-            duplicate_count += 1
+            penalized_uids.add(uid)
 
-    bt.logging.info(f'Total duplicate miners penalized: {duplicate_count}')
+    bt.logging.info(f'Total duplicate miners penalized: {len(penalized_uids)}')
+    return penalized_uids
 
 
 def validate_response_and_initialize_miner_evaluation(

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -121,8 +121,10 @@ async def get_rewards(
     # If evaluation of miner was successful, store to cache, if api failure, fallback to previous successful evaluation if any
     cached_uids = self.store_or_use_cached_evaluation(miner_evaluations)
 
-    # Adjust scores for duplicate accounts
-    detect_and_penalize_miners_sharing_github(miner_evaluations)
+    # Adjust scores for duplicate accounts; returns penalized UIDs so they are
+    # removed from cached_uids and their zeroed scores are written to DB.
+    penalized_uids = detect_and_penalize_miners_sharing_github(miner_evaluations)
+    cached_uids -= penalized_uids
 
     # Finalize scores: apply eligibility gate, credibility, pioneer dividends, collateral
     finalize_miner_scores(miner_evaluations)


### PR DESCRIPTION
Fixes #596

## Problem

`store_or_use_cached_evaluation` runs before `detect_and_penalize_miners_sharing_github`, adding UIDs to `cached_uids`. When a miner in `cached_uids` also shares a GitHub account with another miner, their score is zeroed by the penalty function — but `bulk_store_evaluation` skips writing any UID in `cached_uids` to DB, so the old (non-zero) cached score remains in the database.

## Fix

`detect_and_penalize_miners_sharing_github` now returns the set of penalized UIDs. In `get_rewards`, those UIDs are subtracted from `cached_uids` immediately after the penalty is applied, so `bulk_store_evaluation` writes the zeroed score to DB for that round.

Changes:
- `inspections.py`: return `Set[int]` of penalized UIDs from `detect_and_penalize_miners_sharing_github`
- `reward.py`: capture return value and apply `cached_uids -= penalized_uids`