### PR TITLE
feat: enforce minimum issue age before PR qualifies for issue bonuses

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -92,6 +92,7 @@ PIONEER_DIVIDEND_MAX_RATIO = 1.0  # Cap dividend at 1× pioneer's own earned_sco
 
 # Issue boosts
 MAX_ISSUE_CLOSE_WINDOW_DAYS = 1
+MIN_ISSUE_AGE_HOURS = 24  # minimum hours between issue creation and PR creation to qualify for issue bonus
 
 # Time decay (sigmoid curve)
 TIME_DECAY_GRACE_PERIOD_HOURS = 12  # hours before time decay begins

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -13,6 +13,7 @@ from gittensor.constants import (
     ISSUE_REVIEW_CLEAN_BONUS,
     ISSUE_REVIEW_PENALTY_RATE,
     MAX_OPEN_ISSUE_THRESHOLD,
+    MIN_ISSUE_AGE_HOURS,
     MIN_ISSUE_CREDIBILITY,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     MIN_VALID_SOLVED_ISSUES,
@@ -246,6 +247,17 @@ def _collect_issues_from_prs(
                 # Same-account: discoverer == solver → 0 score but credibility counts
                 if discoverer_id == pr.github_id:
                     continue
+
+                # Minimum issue age: skip discovery score if issue was too new when PR was created.
+                # Prevents creating an issue and immediately solving it to farm discovery bonuses.
+                if issue.created_at and pr.created_at:
+                    gap_hours = (pr.created_at - issue.created_at).total_seconds() / 3600
+                    if gap_hours < MIN_ISSUE_AGE_HOURS:
+                        bt.logging.info(
+                            f'Issue #{issue.number} skipped for discovery — too new when PR was created '
+                            f'(gap: {gap_hours:.1f}h < {MIN_ISSUE_AGE_HOURS}h)'
+                        )
+                        continue
 
                 # One-issue-per-PR: only the first (earliest-created) issue gets scored
                 pr_key = (pr.repository_full_name, pr.number)

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -24,6 +24,7 @@ from gittensor.constants import (
     MAX_ISSUE_CLOSE_WINDOW_DAYS,
     MAX_OPEN_PR_THRESHOLD,
     MERGED_PR_BASE_SCORE,
+    MIN_ISSUE_AGE_HOURS,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     OPEN_PR_COLLATERAL_PERCENT,
     OPEN_PR_THRESHOLD_TOKEN_SCORE,
@@ -474,6 +475,15 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
     if issue.created_at and pr.created_at and issue.created_at > pr.created_at:
         bt.logging.warning(f'Skipping issue #{issue.number} - Issue was created after PR was created')
         return False
+
+    if issue.created_at and pr.created_at:
+        gap_hours = (pr.created_at - issue.created_at).total_seconds() / 3600
+        if gap_hours < MIN_ISSUE_AGE_HOURS:
+            bt.logging.warning(
+                f'Skipping issue #{issue.number} - Issue too new when PR was created '
+                f'(gap: {gap_hours:.1f}h < {MIN_ISSUE_AGE_HOURS}h)'
+            )
+            return False
 
     if is_merged and pr.merged_at:
         if pr.last_edited_at and pr.last_edited_at > pr.merged_at:


### PR DESCRIPTION
Closes #462

## Problem

Miners can create an issue and immediately open a PR solving it to gain the issue multiplier (×1.33 or ×1.66) and/or issue discovery score. This defeats the purpose of issues as a discussion/approval mechanism.

## Fix

Add `MIN_ISSUE_AGE_HOURS = 24` constant and enforce it in two places:

**OSS scoring (`is_valid_issue`):** Skip the issue multiplier if the PR was created within 24 hours of issue creation. Other validity checks (same-author, post-merge edits, close window) are unaffected.

**Issue discovery (`_collect_issues_from_prs`):** Skip the discovery score for the same time-gap condition. Credibility counting (solved/closed counts) is unaffected so the gate applies only to the score, not the eligibility signal.

Changes:
- `constants.py`: add `MIN_ISSUE_AGE_HOURS = 24`
- `validator/oss_contributions/scoring.py`: enforce age gap in `is_valid_issue`
- `validator/issue_discovery/scoring.py`: enforce age gap in `_collect_issues_from_prs`