### PR TITLE
refactor: deduplicate __exit__ and fix traceback logging in BaseValidatorNeuron

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -20,7 +20,7 @@ import argparse
 import asyncio
 import copy
 import threading
-from traceback import format_exception, print_exception
+from traceback import format_exception
 from typing import List, Union
 
 import bittensor as bt

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -20,7 +20,7 @@ import argparse
 import asyncio
 import copy
 import threading
-from traceback import print_exception
+from traceback import format_exception, print_exception
 from typing import List, Union
 
 import bittensor as bt
@@ -165,7 +165,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # In case of unforeseen errors, the validator will log the error and continue operations.
         except Exception as err:
             bt.logging.error(f'Error during validation: {str(err)}')
-            bt.logging.debug(str(print_exception(type(err), err, err.__traceback__)))
+            bt.logging.debug(''.join(format_exception(type(err), err, err.__traceback__)))
 
     def run_in_background_thread(self):
         """
@@ -195,7 +195,7 @@ class BaseValidatorNeuron(BaseNeuron):
         self.run_in_background_thread()
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, exc_tb):
         """
         Stops the validator's background operations upon exiting the context.
         This method facilitates the use of the validator in a 'with' statement.
@@ -205,15 +205,10 @@ class BaseValidatorNeuron(BaseNeuron):
                       None if the context was exited without an exception.
             exc_value: The instance of the exception that caused the context to be exited.
                        None if the context was exited without an exception.
-            traceback: A traceback object encoding the stack trace.
+            exc_tb: A traceback object encoding the stack trace.
                        None if the context was exited without an exception.
         """
-        if self.is_running:
-            bt.logging.debug('Stopping validator in background thread.')
-            self.should_exit = True
-            self.thread.join(5)
-            self.is_running = False
-            bt.logging.debug('Stopped')
+        self.stop_run_thread()
 
     def set_weights(self):
         """


### PR DESCRIPTION
Fixes #564

## Problem
Two issues in `neurons/base/validator.py`:

1. `__exit__` duplicated `stop_run_thread` — identical 5-line block
   repeated in both methods, meaning any future change needs to be
   made in two places.

2. `print_exception` returns `None` — the existing code logged
   `str(print_exception(...))` which always produces the string `'None'`
   while the actual traceback went to stderr uncaptured by bittensor logs.

## Fix
1. `__exit__` now delegates to `stop_run_thread()` — single source of truth.
2. Replaced `print_exception` with `format_exception` which returns a list
   of strings suitable for logging. Joined and passed to `bt.logging.debug`.

## Changes
- `neurons/base/validator.py` — deduplicated `__exit__`, fixed traceback logging