### PR TITLE
fix: reject non-COMPLETED issues in is_valid_issue

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -484,6 +484,12 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
             bt.logging.warning(f'Skipping issue #{issue.number} - Issue state not CLOSED (state: {issue.state})')
             return False
 
+        if issue.state_reason is not None and issue.state_reason != 'COMPLETED':
+            bt.logging.warning(
+                f'Skipping issue #{issue.number} - Issue not COMPLETED (state_reason: {issue.state_reason})'
+            )
+            return False
+
         if issue.closed_at and pr.merged_at:
             days_diff = abs((issue.closed_at - pr.merged_at).total_seconds()) / SECONDS_PER_DAY
             if days_diff > MAX_ISSUE_CLOSE_WINDOW_DAYS:


### PR DESCRIPTION
Fixes #605

Mirror the `state_reason != COMPLETED` gate already applied in issue discovery (`_collect_issues_from_prs` L216, `_merge_scan_issues` L293) so that `NOT_PLANNED`, `TRANSFERRED`, `DUPLICATE`, and `null` state_reason issues no longer grant the 1.33×/1.66× PR multiplier.

Changes:
- `gittensor/validator/oss_contributions/scoring.py` — added `state_reason` check in `is_valid_issue`