### PR TITLE
fix: increment valid_solved_count for scan-path Case 2 issues

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -297,6 +297,7 @@ def _merge_scan_issues(
             if issue.state == 'CLOSED' and issue.closed_at:
                 # Case 2: solved by non-miner PR → positive credibility
                 data.solved_count += 1
+                data.valid_solved_count += 1
             else:
                 # Case 3: closed without PR → negative credibility
                 data.closed_count += 1


### PR DESCRIPTION
Fixes #604

`_merge_scan_issues` only incremented `solved_count` for Case 2 issues (solved by non-miner PR), leaving `valid_solved_count` untouched. `check_issue_eligibility` receives `valid_solved_count`, so scan-solved issues had no effect on credibility or the eligibility gate despite the module docstring claiming positive credibility for Case 2.

Fix: also increment `valid_solved_count` in the Case 2 branch of `_merge_scan_issues`.

Changes:
- `gittensor/validator/issue_discovery/scoring.py` — add `data.valid_solved_count += 1` in `_merge_scan_issues` Case 2