### PR TITLE
fix: reject non-COMPLETED issues in is_valid_issue to prevent multiplier abuse

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -484,6 +484,12 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
             bt.logging.warning(f'Skipping issue #{issue.number} - Issue state not CLOSED (state: {issue.state})')
             return False
 
+        if issue.state_reason and issue.state_reason != 'COMPLETED':
+            bt.logging.warning(
+                f'Skipping issue #{issue.number} - Issue state_reason={issue.state_reason}, only COMPLETED issues are valid'
+            )
+            return False
+
         if issue.closed_at and pr.merged_at:
             days_diff = abs((issue.closed_at - pr.merged_at).total_seconds()) / SECONDS_PER_DAY
             if days_diff > MAX_ISSUE_CLOSE_WINDOW_DAYS:


### PR DESCRIPTION
Fixes #605

## Problem
`is_valid_issue` in `oss_contributions/scoring.py` grants the 1.33x or
1.66x issue multiplier to PRs linked to issues closed as `NOT_PLANNED`,
`TRANSFERRED`, `DUPLICATE`, or with `state_reason=None`. This is
inconsistent with the anti-gaming logic already applied in
`issue_discovery/scoring.py` at both `_collect_issues_from_prs` (L216)
and `_merge_scan_issues` (L293), which route non-COMPLETED closures to
`closed_count`.

## Fix
Added a `state_reason` check inside the `is_merged` block of
`is_valid_issue`, mirroring the existing pattern from
`issue_discovery/scoring.py`:

```python
if issue.state_reason and issue.state_reason != 'COMPLETED':
    bt.logging.warning(...)
    return False
Only issues explicitly closed as COMPLETED now grant the multiplier,
closing the symmetry gap between the two scoring paths.
Changes
gittensor/validator/oss_contributions/scoring.py — added
state_reason check to is_valid_issue