### PR TITLE
fix: increment valid_solved_count for scan-path Case 2 issues

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -297,6 +297,7 @@ def _merge_scan_issues(
             if issue.state == 'CLOSED' and issue.closed_at:
                 # Case 2: solved by non-miner PR → positive credibility
                 data.solved_count += 1
+                data.valid_solved_count += 1
             else:
                 # Case 3: closed without PR → negative credibility
                 data.closed_count += 1


### PR DESCRIPTION
Fixes #604

## Problem
`_merge_scan_issues` in `issue_discovery/scoring.py` increments
`data.solved_count` for Case 2 issues (solved by non-miner PR) but
never increments `data.valid_solved_count`. Since eligibility and
credibility are computed from `valid_solved_count` — not `solved_count`
— scan-solved issues have zero effect on credibility despite the module
docstring claiming they contribute positive credibility.

The discrepancy was introduced when `valid_solved_count` was added in
a follow-up refactor (#356). The two call sites in
`_collect_issues_from_prs` were updated but `_merge_scan_issues` was
not.

## Fix
Added `data.valid_solved_count += 1` alongside the existing
`data.solved_count += 1` in the Case 2 branch of `_merge_scan_issues`,
making the scan path consistent with `_collect_issues_from_prs`.

## Changes
- `gittensor/validator/issue_discovery/scoring.py` — increment
  `valid_solved_count` for scan-path Case 2 issues in `_merge_scan_issues`