### PR TITLE
fix: include label_multiplier in open PR collateral score

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -506,7 +506,7 @@ def calculate_open_pr_collateral_score(pr: PullRequest) -> float:
 
     Collateral = base_score * applicable_multipliers * OPEN_PR_COLLATERAL_PERCENT
 
-    Applicable multipliers: repo_weight, issue
+    Applicable multipliers: repo_weight, issue, label
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
                     open_pr_spam (not for collateral)
     """
@@ -515,6 +515,7 @@ def calculate_open_pr_collateral_score(pr: PullRequest) -> float:
     multipliers = {
         'repo_weight': pr.repo_weight_multiplier,
         'issue': pr.issue_multiplier,
+        'label': pr.label_multiplier,
     }
 
     potential_score = pr.base_score * prod(multipliers.values())


### PR DESCRIPTION
Fixes #612

`calculate_open_pr_collateral_score` applied `repo_weight` and `issue` multipliers but omitted `label_multiplier`. Labels are already set on PRs before merge, so a `feature`-labeled PR should carry higher collateral than an unlabeled one with the same base score, mirroring what happens after merge.

Changes:
- `gittensor/validator/oss_contributions/scoring.py` — add `label` to the multipliers dict in `calculate_open_pr_collateral_score`