### PR TITLE
fix: guard handle_pat_check against unregistered hotkey

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -101,6 +101,12 @@ async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSy
 async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> PatCheckSynapse:
     """Check if the validator has the miner's PAT stored and re-validate it."""
     hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        synapse.has_pat = False
+        synapse.pat_valid = False
+        synapse.rejection_reason = 'Hotkey not registered on subnet'
+        bt.logging.warning(f'PAT check rejected — hotkey {hotkey[:16]}... not in metagraph')
+        return synapse
     uid = validator.metagraph.hotkeys.index(hotkey)
     entry = pat_storage.get_pat_by_uid(uid)
 


### PR DESCRIPTION
Fixes #574

`handle_pat_check` called `.index(hotkey)` without first checking membership, raising `ValueError` if the metagraph resyncs between the blacklist check and handler execution. `handle_pat_broadcast` already guards this correctly; apply the same pattern.

Changes:
- `gittensor/validator/pat_handler.py` — add membership check before `.index(hotkey)` in `handle_pat_check`