### PR TITLE
fix: sort repo_contributions iteration in calculate_pioneer_dividends

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -305,7 +305,7 @@ def calculate_pioneer_dividends(
                 else:
                     repo_contributions[repo][pr.uid] = (earliest_at, earliest_num, new_total)
 
-    for repo, uid_entries in repo_contributions.items():
+    for repo, uid_entries in sorted(repo_contributions.items()):
         sorted_uids = sorted(uid_entries.items(), key=lambda x: (x[1][0], x[1][1]))
 
         for rank_pos, (uid, _) in enumerate(sorted_uids):


### PR DESCRIPTION
Fixes #538

Dict iteration order depends on insertion order, which varies across validator runs (it follows the order miners's PRs are processed). When the same miner is a pioneer in repo A and a follower in repo B, processing A first inflates their `earned_score` before it feeds into B's follower tally. Sort by repo name to make the output deterministic.

Changes:
- `gittensor/validator/oss_contributions/scoring.py` — `sorted(repo_contributions.items())` in `calculate_pioneer_dividends`