### PR TITLE
fix: use emit_json in view commands

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -27,6 +27,7 @@ from .helpers import (
     colorize_status,
     console,
     emit_error_json,
+    emit_json,
     format_alpha,
     print_error,
     print_network_header,
@@ -83,9 +84,9 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
             if issue is None:
                 emit_error_json(f'Issue {issue_id} not found on-chain.', error_type='not_found')
                 raise SystemExit(1)
-            console.print(json_mod.dumps(issue, indent=2, default=str))
+            emit_json(issue)
         else:
-            console.print(json_mod.dumps(issues, indent=2, default=str))
+            emit_json(issues)
         return
 
     # Single issue detail view
@@ -264,18 +265,15 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         pending_harvest = max(0, treasury_stake - total_bounty_pool)
 
         if as_json:
-            console.print(
-                json_mod.dumps(
-                    {
-                        'treasury_stake_raw': treasury_stake,
-                        'treasury_stake_alpha': format_alpha(treasury_stake, 4),
-                        'allocated_bounties_raw': total_bounty_pool,
-                        'allocated_bounties_alpha': format_alpha(total_bounty_pool, 4),
-                        'pending_harvest_raw': pending_harvest,
-                        'pending_harvest_alpha': format_alpha(pending_harvest, 4),
-                    },
-                    indent=2,
-                )
+            emit_json(
+                {
+                    'treasury_stake_raw': treasury_stake,
+                    'treasury_stake_alpha': format_alpha(treasury_stake, 4),
+                    'allocated_bounties_raw': total_bounty_pool,
+                    'allocated_bounties_alpha': format_alpha(total_bounty_pool, 4),
+                    'pending_harvest_raw': pending_harvest,
+                    'pending_harvest_alpha': format_alpha(pending_harvest, 4),
+                }
             )
             return
 
@@ -311,7 +309,7 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
 
         if packed:
             if as_json:
-                console.print(json_mod.dumps(packed, indent=2, default=str))
+                emit_json(packed)
                 return
 
             console.print(


### PR DESCRIPTION
Fixes #562

## Summary
- replace Rich JSON printing in `issues_list`, `issues_pending_harvest`, and `admin_info` with `emit_json`
- keep the existing payloads the same while making stdout machine-readable

## Validation
- ran `python3 -m py_compile gittensor/cli/issue_commands/view.py`