### PR TITLE
fix: sync CLI version output with package version

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -20,6 +20,7 @@ from click.shell_completion import get_completion_class
 from rich.console import Console
 from rich.table import Table
 
+from gittensor import __version__
 from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR
@@ -28,7 +29,7 @@ console = Console()
 
 
 @click.group(cls=StyledAliasGroup)
-@click.version_option(version='3.2.0', prog_name='gittensor')
+@click.version_option(version=__version__, prog_name='gittensor')
 def cli():
     """Gittensor CLI - Manage issue bounties and validator operations"""
     pass

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from gittensor import __version__
 from gittensor.cli.main import cli
 
 
@@ -67,3 +68,10 @@ class TestMinerCheck:
         result = runner.invoke(cli, ['m', 'check', '--help'])
         assert result.exit_code == 0
         assert 'Check how many validators' in result.output
+
+
+class TestCliVersion:
+    def test_version_matches_package_version(self, runner):
+        result = runner.invoke(cli, ['--version'])
+        assert result.exit_code == 0
+        assert result.output == f'gittensor, version {__version__}\n'


### PR DESCRIPTION
## Summary

Sync CLI version output with the package source of truth by replacing the hardcoded Click version (`3.2.0`) with `gittensor.__version__`. Add a regression test to ensure `gitt --version` always matches package version.

## Related Issues

Closes #618

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)