### PR TITLE
fix: use __version__ instead of hardcoded version in gitt CLI

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -20,6 +20,7 @@ from click.shell_completion import get_completion_class
 from rich.console import Console
 from rich.table import Table
 
+from gittensor import __version__
 from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR
@@ -28,7 +29,7 @@ console = Console()
 
 
 @click.group(cls=StyledAliasGroup)
-@click.version_option(version='3.2.0', prog_name='gittensor')
+@click.version_option(version=__version__, prog_name='gittensor')
 def cli():
     """Gittensor CLI - Manage issue bounties and validator operations"""
     pass


### PR DESCRIPTION
Fixes #618

## Problem
`gitt --version` reports `3.2.0` because the version string is
hardcoded in `gittensor/cli/main.py`:
`@click.version_option(version='3.2.0', prog_name='gittensor')`

The package version in both `pyproject.toml` and
`gittensor/__init__.py` is `5.0.0`, so the CLI reports a stale version.

## Fix
Import `__version__` from the `gittensor` package and pass it to
`click.version_option` so the CLI always reports the current package
version automatically.

## Changes
- `gittensor/cli/main.py` — import `__version__` and use it in
  `version_option` instead of the hardcoded string