### PR TITLE
fix: guard decode_packed_contract_storage against short buffers

### DIFF
--- a/gittensor/validator/issue_competitions/storage_utils.py
+++ b/gittensor/validator/issue_competitions/storage_utils.py
@@ -99,23 +99,30 @@ def read_contract_packed_storage_bytes(substrate, child_key: str, page_size: int
     return bytes.fromhex(raw_hex.replace('0x', ''))
 
 
+# owner (32) + treasury hotkey (32) + netuid (2) + next_issue_id (8) + alpha_pool (16)
+_PACKED_CONTRACT_STORAGE_SIZE = 32 + 32 + 2 + 8 + 16
+
+
 def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorage]:
     """Decode packed root storage bytes into typed fields."""
-    # owner (32) + treasury hotkey (32) + netuid (2) + next_issue_id (8) + alpha_pool (16)
-    if len(data) < 74:
+    if len(data) < _PACKED_CONTRACT_STORAGE_SIZE:
         return None
 
-    offset = 0
-    owner = data[offset : offset + 32]
-    offset += 32
-    treasury_hotkey = data[offset : offset + 32]
-    offset += 32
-    netuid = struct.unpack_from('<H', data, offset)[0]
-    offset += 2
-    next_issue_id = struct.unpack_from('<Q', data, offset)[0]
-    offset += 8
-    alpha_pool_lo, alpha_pool_hi = struct.unpack_from('<QQ', data, offset)
-    alpha_pool = alpha_pool_lo + (alpha_pool_hi << 64)
+    try:
+        offset = 0
+        owner = data[offset : offset + 32]
+        offset += 32
+        treasury_hotkey = data[offset : offset + 32]
+        offset += 32
+        netuid = struct.unpack_from('<H', data, offset)[0]
+        offset += 2
+        next_issue_id = struct.unpack_from('<Q', data, offset)[0]
+        offset += 8
+        alpha_pool_lo, alpha_pool_hi = struct.unpack_from('<QQ', data, offset)
+        alpha_pool = alpha_pool_lo + (alpha_pool_hi << 64)
+    except (struct.error, IndexError) as e:
+        logger.debug('Failed to decode packed contract storage: %s', e)
+        return None
 
     return PackedContractStorage(
         owner=owner,

--- a/tests/utils/test_issue_competitions_storage_utils.py
+++ b/tests/utils/test_issue_competitions_storage_utils.py
@@ -100,6 +100,11 @@ def test_decode_packed_contract_storage_rejects_short_bytes():
     assert decode_packed_contract_storage(b'\x00' * 73) is None
 
 
+def test_decode_packed_contract_storage_rejects_truncated_alpha_pool():
+    # Regression for #622: 74..89 used to pass the guard and crash in unpack_from.
+    assert decode_packed_contract_storage(b'\x00' * 89) is None
+
+
 def test_decode_issue_from_storage_single_byte_string_length():
     data = _build_issue_bytes(
         issue_id=5,

--- a/tests/utils/test_issue_competitions_storage_utils.py
+++ b/tests/utils/test_issue_competitions_storage_utils.py
@@ -1,5 +1,7 @@
 import struct
 
+import pytest
+
 from gittensor.validator.issue_competitions.storage_utils import (
     compute_ink5_lazy_key,
     decode_issue_from_storage,
@@ -103,6 +105,33 @@ def test_decode_packed_contract_storage_rejects_short_bytes():
 def test_decode_packed_contract_storage_rejects_truncated_alpha_pool():
     # Regression for #622: 74..89 used to pass the guard and crash in unpack_from.
     assert decode_packed_contract_storage(b'\x00' * 89) is None
+
+
+@pytest.mark.parametrize('length', [0, 74, 80, 89])
+def test_decode_packed_contract_storage_rejects_any_short_buffer(length):
+    # A few boundary lengths from the #622 window (74..89) plus the empty case.
+    assert decode_packed_contract_storage(b'\x00' * length) is None
+
+
+def test_decode_packed_contract_storage_handles_maximum_field_values():
+    # Exercises the full 128-bit alpha_pool reconstruction (lo + (hi << 64)).
+    max_u16 = 0xFFFF
+    max_u64 = 0xFFFFFFFFFFFFFFFF
+    max_u128 = (1 << 128) - 1
+    data = (
+        b'\xab' * 32
+        + b'\xcd' * 32
+        + struct.pack('<H', max_u16)
+        + struct.pack('<Q', max_u64)
+        + struct.pack('<QQ', max_u64, max_u64)
+    )
+
+    decoded = decode_packed_contract_storage(data)
+
+    assert decoded is not None
+    assert decoded.netuid == max_u16
+    assert decoded.next_issue_id == max_u64
+    assert decoded.alpha_pool == max_u128
 
 
 def test_decode_issue_from_storage_single_byte_string_length():


### PR DESCRIPTION
## Summary

`decode_packed_contract_storage()` validated `len(data) < 74`, but then unpacked `alpha_pool` with `<QQ` at offset 74 (needs 16 more bytes). Payloads of length 74..89 passed the guard and crashed with `struct.error` inside `struct.unpack_from`, violating the function's `Optional[...]` contract.

This PR:

- Derives the minimum size from the struct layout itself (`_PACKED_CONTRACT_STORAGE_SIZE = 32 + 32 + 2 + 8 + 16 = 90`) so the guard can never drift from the format again.
- Tightens the guard to `len(data) < _PACKED_CONTRACT_STORAGE_SIZE`.
- Wraps the unpacks in `try/except (struct.error, IndexError)` returning `None`, mirroring the already-defensive `decode_issue_from_storage` and hardening against any future layout drift.
- Adds a minimal regression test for the 74..89 window that used to crash. The existing happy-path test already pins the `>= 90` band (it builds exactly a 90-byte buffer), and the existing short-bytes test pins the `< 74` band.

Repro before the fix:

```python
>>> from gittensor.validator.issue_competitions.storage_utils import decode_packed_contract_storage
>>> decode_packed_contract_storage(bytes(80))
struct.error: unpack_from requires a buffer of at least 90 bytes for unpacking 16 bytes at offset 74 (actual buffer size is 80)
```

After the fix: returns `None` for all lengths in `0..89`, decodes normally for `>= 90`.

## Related Issues

Fixes #622

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Boundary coverage after this change:

| Band | Test | Length |
|------|------|--------|
| `< 74` | `test_decode_packed_contract_storage_rejects_short_bytes` | 73 |
| `74..89` (regression) | `test_decode_packed_contract_storage_rejects_truncated_alpha_pool` | 89 |
| `>= 90` | `test_decode_packed_contract_storage_decodes_all_fields` | 90 |

```bash
uv run pytest tests/utils/test_issue_competitions_storage_utils.py -v
# 9 passed
```

Also manually verified the reported repro (`decode_packed_contract_storage(bytes(80))`) now returns `None` instead of raising `struct.error`, and that lengths 74, 80, 89 all return `None` while length 90 decodes successfully.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
