### PR TITLE
refactor: deduplicate JSON weight loading and remove dead table theme code

### DIFF
--- a/gittensor/cli/issue_commands/tables.py
+++ b/gittensor/cli/issue_commands/tables.py
@@ -3,56 +3,10 @@
 
 """Reusable Rich table presets."""
 
-from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from rich import box
 from rich.table import Table
-
-
-@dataclass(frozen=True)
-class TableTheme:
-    box_style: box.Box
-    header_style: str
-    border_style: str
-    show_lines: bool
-    pad_edge: bool
-
-
-TABLE_THEMES = {
-    # Full wrapped grid
-    'square': TableTheme(
-        box_style=box.SQUARE,
-        header_style='bold white',  #'bold magenta',
-        border_style='grey35',
-        show_lines=True,
-        pad_edge=True,
-    ),
-    # Minimal separators with a heavier header rule
-    'minimal': TableTheme(
-        box_style=box.MINIMAL_HEAVY_HEAD,
-        header_style='bold white',
-        border_style='grey50',
-        show_lines=False,
-        pad_edge=False,
-    ),
-}
-
-DEFAULT_TABLE_THEME = 'minimal'
-
-
-def build_table(theme: str = DEFAULT_TABLE_THEME, **kwargs) -> Table:
-    """Create a Rich table using a named visual theme."""
-    preset = TABLE_THEMES.get(theme, TABLE_THEMES[DEFAULT_TABLE_THEME])
-    params = {
-        'box': preset.box_style,
-        'header_style': preset.header_style,
-        'border_style': preset.border_style,
-        'show_lines': preset.show_lines,
-        'pad_edge': preset.pad_edge,
-    }
-    params.update(kwargs)
-    return Table(**params)
 
 
 def build_pr_table(prs: List[Dict[str, Any]]) -> Table:
@@ -61,7 +15,14 @@ def build_pr_table(prs: List[Dict[str, Any]]) -> Table:
     Note: ``review_count`` counts APPROVED reviews only. "Approved" means at
     least one approval review exists; it does not mean the PR is merge-ready.
     """
-    table = build_table(theme='square', show_header=True)
+    table = Table(
+        box=box.SQUARE,
+        header_style='bold white',
+        border_style='grey35',
+        show_lines=True,
+        pad_edge=True,
+        show_header=True,
+    )
     table.add_column('PR #', style='white', justify='right')
     table.add_column('Title', style='white', max_width=50)
     table.add_column('Author', style='white')

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -3,7 +3,7 @@
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Dict, List, Optional
 
 import bittensor as bt
 
@@ -83,104 +83,99 @@ def _get_weights_dir() -> Path:
     return Path(__file__).parent.parent / 'weights'
 
 
-_T = TypeVar('_T')
-
-
-def _load_json_file(filename: str, label: str) -> Any:
-    """Open a JSON file from the weights directory and return its parsed content.
-
-    Logs an error and re-raises on ``FileNotFoundError`` or ``json.JSONDecodeError``.
-    """
-    weights_file = _get_weights_dir() / filename
-    try:
-        with open(weights_file, 'r') as f:
-            return json.load(f)
-    except FileNotFoundError:
-        bt.logging.error(f'{label.title()} weights file not found: {weights_file}')
-        raise
-    except json.JSONDecodeError as e:
-        bt.logging.error(f'Invalid JSON in {label} weights file {weights_file}: {e}')
-        raise
-
-
-def _load_json_weights(
-    filename: str,
-    parse_entry: Callable[[str, Any], Tuple[str, _T]],
-    label: str,
-) -> Dict[str, _T]:
-    """Load a JSON weights dict and parse each entry via *parse_entry*.
-
-    ``parse_entry(key, value)`` returns ``(normalised_key, parsed_object)``.
-    If it raises ``ValueError`` or ``TypeError`` the entry is logged and skipped.
-
-    Returns empty dict on any file-level or structural error.
-    """
-    try:
-        data = _load_json_file(filename, label)
-    except (FileNotFoundError, json.JSONDecodeError):
-        return {}
-    except Exception as e:
-        bt.logging.error(f'Unexpected error loading {label} weights: {e}')
-        return {}
-
-    if not isinstance(data, dict):
-        bt.logging.error(f'Expected dict from {_get_weights_dir() / filename}, got {type(data)}')
-        return {}
-
-    result: Dict[str, _T] = {}
-    for key, value in data.items():
-        try:
-            norm_key, parsed = parse_entry(key, value)
-            result[norm_key] = parsed
-        except (ValueError, TypeError) as e:
-            bt.logging.warning(f'Could not parse {label} config for {key}: {e}')
-
-    bt.logging.debug(f'Successfully loaded {len(result)} {label} entries from {_get_weights_dir() / filename}')
-    return result
-
-
 def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
-    """Load repository weights from the local JSON file.
-
+    """
+    Load repository weights from the local JSON file.
     Normalizes repository names to lowercase for case-insensitive matching.
 
     Returns:
-        Dictionary mapping normalized (lowercase) fullName to RepositoryConfig.
+        Dictionary mapping normalized (lowercase) fullName (str) to RepositoryConfig object.
         Returns empty dict on error.
     """
+    weights_file = _get_weights_dir() / 'master_repositories.json'
 
-    def _parse_repo(name: str, metadata: Any) -> Tuple[str, RepositoryConfig]:
-        try:
-            config = RepositoryConfig(
-                weight=float(metadata.get('weight', 0.01)),
-                inactive_at=metadata.get('inactive_at'),
-                additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
-            )
-        except (ValueError, TypeError) as e:
-            bt.logging.warning(f'Could not parse config for {name}: {e}, using defaults')
-            config = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
-        return name.lower(), config
+    try:
+        with open(weights_file, 'r') as f:
+            data = json.load(f)
 
-    return _load_json_weights('master_repositories.json', _parse_repo, 'repository')
+        if not isinstance(data, dict):
+            bt.logging.error(f'Expected dict from {weights_file}, got {type(data)}')
+            return {}
+
+        # Parse JSON data into RepositoryConfig objects
+        normalized_data: Dict[str, RepositoryConfig] = {}
+        for repo_name, metadata in data.items():
+            try:
+                config = RepositoryConfig(
+                    weight=float(metadata.get('weight', 0.01)),
+                    inactive_at=metadata.get('inactive_at'),
+                    additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
+                )
+                normalized_data[repo_name.lower()] = config
+            except (ValueError, TypeError) as e:
+                bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
+                # Create config with defaults if parsing fails
+                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+
+        bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
+        return normalized_data
+
+    except FileNotFoundError:
+        bt.logging.error(f'Weights file not found: {weights_file}')
+        return {}
+    except json.JSONDecodeError as e:
+        bt.logging.error(f'Failed to parse JSON from {weights_file}: {e}')
+        return {}
+    except Exception as e:
+        bt.logging.error(f'Unexpected error loading repository weights: {e}')
+        return {}
 
 
 def load_programming_language_weights() -> Dict[str, LanguageConfig]:
-    """Load programming language weights from the local JSON file.
+    """
+    Load programming language weights from the local JSON file.
 
     Returns:
-        Dictionary mapping extension to LanguageConfig.
+        Dictionary mapping extension (str) to LanguageConfig object.
         Returns empty dict on error.
     """
+    weights_file = _get_weights_dir() / 'programming_languages.json'
 
-    def _parse_lang(extension: str, config: Any) -> Tuple[str, LanguageConfig]:
-        if isinstance(config, dict):
-            return extension, LanguageConfig(
-                weight=float(config.get('weight', 1.0)),
-                language=config.get('language'),
-            )
-        return extension, LanguageConfig(weight=float(config))
+    try:
+        with open(weights_file, 'r') as f:
+            data = json.load(f)
 
-    return _load_json_weights('programming_languages.json', _parse_lang, 'language')
+        if not isinstance(data, dict):
+            bt.logging.error(f'Expected dict from {weights_file}, got {type(data)}')
+            return {}
+
+        result: Dict[str, LanguageConfig] = {}
+        for extension, config in data.items():
+            try:
+                if isinstance(config, dict):
+                    result[extension] = LanguageConfig(
+                        weight=float(config.get('weight', 1.0)),
+                        language=config.get('language'),
+                    )
+                else:
+                    # Backwards compatibility: handle plain float values
+                    result[extension] = LanguageConfig(weight=float(config))
+            except (ValueError, TypeError) as e:
+                bt.logging.warning(f'Could not parse config for {extension}: {config} - {e}')
+                continue
+
+        bt.logging.debug(f'Successfully loaded {len(result)} language entries from {weights_file}')
+        return result
+
+    except FileNotFoundError:
+        bt.logging.error(f'Weights file not found: {weights_file}')
+        return {}
+    except json.JSONDecodeError as e:
+        bt.logging.error(f'Failed to parse JSON from {weights_file}: {e}')
+        return {}
+    except Exception as e:
+        bt.logging.error(f'Unexpected error loading language weights: {e}')
+        return {}
 
 
 def load_token_config() -> TokenConfig:
@@ -191,16 +186,26 @@ def load_token_config() -> TokenConfig:
 
     Returns:
         TokenConfig with all scoring configuration loaded.
-
-    Raises:
-        FileNotFoundError: If token_weights.json is missing.
-        json.JSONDecodeError: If token_weights.json contains invalid JSON.
     """
-    data = _load_json_file('token_weights.json', 'token')
+    weights_file = _get_weights_dir() / 'token_weights.json'
+
+    try:
+        with open(weights_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        bt.logging.error(f'Token weights file not found: {weights_file}')
+        raise
+    except json.JSONDecodeError as e:
+        bt.logging.error(f'Invalid JSON in token weights file: {e}')
+        raise
 
     structural_bonus = dict(data.get('structural_bonus', {}))
     leaf_tokens = dict(data.get('leaf_tokens', {}))
+
+    # Load language configurations (includes tree-sitter language mapping)
     language_configs = load_programming_language_weights()
+
+    # Count languages with tree-sitter support
     tree_sitter_count = sum(1 for c in language_configs.values() if c.language is not None)
 
     config = TokenConfig(
@@ -213,4 +218,5 @@ def load_token_config() -> TokenConfig:
         f'Loaded token config: {len(structural_bonus)} structural, '
         f'{len(leaf_tokens)} leaf, {tree_sitter_count} tree-sitter languages'
     )
+
     return config

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -3,7 +3,7 @@
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 import bittensor as bt
 
@@ -83,99 +83,104 @@ def _get_weights_dir() -> Path:
     return Path(__file__).parent.parent / 'weights'
 
 
-def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
+_T = TypeVar('_T')
+
+
+def _load_json_file(filename: str, label: str) -> Any:
+    """Open a JSON file from the weights directory and return its parsed content.
+
+    Logs an error and re-raises on ``FileNotFoundError`` or ``json.JSONDecodeError``.
     """
-    Load repository weights from the local JSON file.
+    weights_file = _get_weights_dir() / filename
+    try:
+        with open(weights_file, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        bt.logging.error(f'{label.title()} weights file not found: {weights_file}')
+        raise
+    except json.JSONDecodeError as e:
+        bt.logging.error(f'Invalid JSON in {label} weights file {weights_file}: {e}')
+        raise
+
+
+def _load_json_weights(
+    filename: str,
+    parse_entry: Callable[[str, Any], Tuple[str, _T]],
+    label: str,
+) -> Dict[str, _T]:
+    """Load a JSON weights dict and parse each entry via *parse_entry*.
+
+    ``parse_entry(key, value)`` returns ``(normalised_key, parsed_object)``.
+    If it raises ``ValueError`` or ``TypeError`` the entry is logged and skipped.
+
+    Returns empty dict on any file-level or structural error.
+    """
+    try:
+        data = _load_json_file(filename, label)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    except Exception as e:
+        bt.logging.error(f'Unexpected error loading {label} weights: {e}')
+        return {}
+
+    if not isinstance(data, dict):
+        bt.logging.error(f'Expected dict from {_get_weights_dir() / filename}, got {type(data)}')
+        return {}
+
+    result: Dict[str, _T] = {}
+    for key, value in data.items():
+        try:
+            norm_key, parsed = parse_entry(key, value)
+            result[norm_key] = parsed
+        except (ValueError, TypeError) as e:
+            bt.logging.warning(f'Could not parse {label} config for {key}: {e}')
+
+    bt.logging.debug(f'Successfully loaded {len(result)} {label} entries from {_get_weights_dir() / filename}')
+    return result
+
+
+def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
+    """Load repository weights from the local JSON file.
+
     Normalizes repository names to lowercase for case-insensitive matching.
 
     Returns:
-        Dictionary mapping normalized (lowercase) fullName (str) to RepositoryConfig object.
+        Dictionary mapping normalized (lowercase) fullName to RepositoryConfig.
         Returns empty dict on error.
     """
-    weights_file = _get_weights_dir() / 'master_repositories.json'
 
-    try:
-        with open(weights_file, 'r') as f:
-            data = json.load(f)
+    def _parse_repo(name: str, metadata: Any) -> Tuple[str, RepositoryConfig]:
+        try:
+            config = RepositoryConfig(
+                weight=float(metadata.get('weight', 0.01)),
+                inactive_at=metadata.get('inactive_at'),
+                additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
+            )
+        except (ValueError, TypeError) as e:
+            bt.logging.warning(f'Could not parse config for {name}: {e}, using defaults')
+            config = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+        return name.lower(), config
 
-        if not isinstance(data, dict):
-            bt.logging.error(f'Expected dict from {weights_file}, got {type(data)}')
-            return {}
-
-        # Parse JSON data into RepositoryConfig objects
-        normalized_data: Dict[str, RepositoryConfig] = {}
-        for repo_name, metadata in data.items():
-            try:
-                config = RepositoryConfig(
-                    weight=float(metadata.get('weight', 0.01)),
-                    inactive_at=metadata.get('inactive_at'),
-                    additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
-                )
-                normalized_data[repo_name.lower()] = config
-            except (ValueError, TypeError) as e:
-                bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
-                # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
-
-        bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
-        return normalized_data
-
-    except FileNotFoundError:
-        bt.logging.error(f'Weights file not found: {weights_file}')
-        return {}
-    except json.JSONDecodeError as e:
-        bt.logging.error(f'Failed to parse JSON from {weights_file}: {e}')
-        return {}
-    except Exception as e:
-        bt.logging.error(f'Unexpected error loading repository weights: {e}')
-        return {}
+    return _load_json_weights('master_repositories.json', _parse_repo, 'repository')
 
 
 def load_programming_language_weights() -> Dict[str, LanguageConfig]:
-    """
-    Load programming language weights from the local JSON file.
+    """Load programming language weights from the local JSON file.
 
     Returns:
-        Dictionary mapping extension (str) to LanguageConfig object.
+        Dictionary mapping extension to LanguageConfig.
         Returns empty dict on error.
     """
-    weights_file = _get_weights_dir() / 'programming_languages.json'
 
-    try:
-        with open(weights_file, 'r') as f:
-            data = json.load(f)
+    def _parse_lang(extension: str, config: Any) -> Tuple[str, LanguageConfig]:
+        if isinstance(config, dict):
+            return extension, LanguageConfig(
+                weight=float(config.get('weight', 1.0)),
+                language=config.get('language'),
+            )
+        return extension, LanguageConfig(weight=float(config))
 
-        if not isinstance(data, dict):
-            bt.logging.error(f'Expected dict from {weights_file}, got {type(data)}')
-            return {}
-
-        result: Dict[str, LanguageConfig] = {}
-        for extension, config in data.items():
-            try:
-                if isinstance(config, dict):
-                    result[extension] = LanguageConfig(
-                        weight=float(config.get('weight', 1.0)),
-                        language=config.get('language'),
-                    )
-                else:
-                    # Backwards compatibility: handle plain float values
-                    result[extension] = LanguageConfig(weight=float(config))
-            except (ValueError, TypeError) as e:
-                bt.logging.warning(f'Could not parse config for {extension}: {config} - {e}')
-                continue
-
-        bt.logging.debug(f'Successfully loaded {len(result)} language entries from {weights_file}')
-        return result
-
-    except FileNotFoundError:
-        bt.logging.error(f'Weights file not found: {weights_file}')
-        return {}
-    except json.JSONDecodeError as e:
-        bt.logging.error(f'Failed to parse JSON from {weights_file}: {e}')
-        return {}
-    except Exception as e:
-        bt.logging.error(f'Unexpected error loading language weights: {e}')
-        return {}
+    return _load_json_weights('programming_languages.json', _parse_lang, 'language')
 
 
 def load_token_config() -> TokenConfig:
@@ -186,26 +191,16 @@ def load_token_config() -> TokenConfig:
 
     Returns:
         TokenConfig with all scoring configuration loaded.
-    """
-    weights_file = _get_weights_dir() / 'token_weights.json'
 
-    try:
-        with open(weights_file, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-    except FileNotFoundError:
-        bt.logging.error(f'Token weights file not found: {weights_file}')
-        raise
-    except json.JSONDecodeError as e:
-        bt.logging.error(f'Invalid JSON in token weights file: {e}')
-        raise
+    Raises:
+        FileNotFoundError: If token_weights.json is missing.
+        json.JSONDecodeError: If token_weights.json contains invalid JSON.
+    """
+    data = _load_json_file('token_weights.json', 'token')
 
     structural_bonus = dict(data.get('structural_bonus', {}))
     leaf_tokens = dict(data.get('leaf_tokens', {}))
-
-    # Load language configurations (includes tree-sitter language mapping)
     language_configs = load_programming_language_weights()
-
-    # Count languages with tree-sitter support
     tree_sitter_count = sum(1 for c in language_configs.values() if c.language is not None)
 
     config = TokenConfig(
@@ -218,5 +213,4 @@ def load_token_config() -> TokenConfig:
         f'Loaded token config: {len(structural_bonus)} structural, '
         f'{len(leaf_tokens)} leaf, {tree_sitter_count} tree-sitter languages'
     )
-
     return config


### PR DESCRIPTION
## Summary

- **`load_weights.py`**: Extract shared `_load_json_file` and `_load_json_weights` helpers to consolidate three independent file-loading and error-handling paths into one reusable flow. No behavioral change for valid inputs.
- **`tables.py`**: Remove unused `TableTheme` dataclass, `TABLE_THEMES` dict, `DEFAULT_TABLE_THEME` constant, and `build_table()` function. The only caller (`build_pr_table`) always used `theme='square'`, so the square configuration is inlined directly. No behavioral change.

Net reduction: **−45 lines** across 2 files.

## Related Issues

N/A — standalone housekeeping refactor.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

`ruff check` and `ruff format` pass cleanly on both files. No existing tests broke — the refactored functions produce identical results for all valid inputs.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)