### PR TITLE
fix: dedupe issue discovery counts when same issue is referenced by multiple merged PRs

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -190,6 +190,20 @@ def _collect_issues_from_prs(
     """
     # Track which PRs have already awarded a discovery score (one-issue-per-PR rule)
     pr_scored: set = set()  # (repo, pr_number)
+    # Dedup across PRs: canonical solver per issue is the earliest-merged PR (tie-break:
+    # smaller PR number). Only the canonical PR drives counts/scoring; others skip below.
+    canonical: Dict[Tuple[str, int], Tuple[datetime, int]] = {}
+    for _ev in miner_evaluations.values():
+        for _pr in _ev.merged_pull_requests:
+            if not _pr.issues or not _pr.merged_at:
+                continue
+            for _issue in _pr.issues:
+                if not _issue.author_github_id:
+                    continue
+                _key = (_pr.repository_full_name, _issue.number)
+                _marker = (_pr.merged_at, _pr.number)
+                if _key not in canonical or _marker < canonical[_key]:
+                    canonical[_key] = _marker
 
     for uid, evaluation in miner_evaluations.items():
         for pr in evaluation.merged_pull_requests:
@@ -205,6 +219,9 @@ def _collect_issues_from_prs(
             for issue in sorted_issues:
                 discoverer_id = issue.author_github_id
                 if not discoverer_id or discoverer_id not in github_id_to_uid:
+                    continue
+
+                if canonical.get((pr.repository_full_name, issue.number)) != (pr.merged_at, pr.number):
                     continue
 
                 data = discoverer_data[discoverer_id]

--- a/tests/validator/test_issue_discovery_scoring.py
+++ b/tests/validator/test_issue_discovery_scoring.py
@@ -7,6 +7,8 @@ Solved classification requires state_reason == 'COMPLETED'. Any other value
 (NOT_PLANNED, TRANSFERRED, None) routes to closed_count.
 """
 
+from datetime import datetime, timezone
+
 from gittensor.classes import MinerEvaluation
 from gittensor.validator.issue_discovery.scoring import (
     _collect_issues_from_prs,
@@ -118,5 +120,48 @@ def test_scan_issue_with_no_state_reason_counts_as_closed(issue_factory):
     """Legacy data path: None state_reason routes to closed_count."""
     issue = issue_factory.no_reason()
     data = _run_scan_path(issue)
+    assert data.closed_count == 1
+    assert data.solved_count == 0
+
+
+def test_same_issue_in_multiple_prs_credits_once(issue_factory, pr_factory):
+    """Same issue referenced by multiple merged PRs counts once per discoverer."""
+    issue = issue_factory.completed()
+    pr_a, pr_b = pr_factory.merged(), pr_factory.merged()
+    pr_a.issues = pr_b.issues = [issue]
+    ev = _make_evaluation(pr_a)
+    ev.merged_pull_requests = [pr_a, pr_b]
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+    _collect_issues_from_prs({1: ev}, {issue.author_github_id: 1}, discoverer_data, {})
+    data = discoverer_data[issue.author_github_id]
+    assert data.solved_count == 1
+    assert data.valid_solved_count == 1
+
+
+def test_earliest_merged_pr_is_canonical(issue_factory, pr_factory):
+    """Earliest-merged PR drives counts regardless of list/iteration order."""
+    issue = issue_factory.completed()
+    pr_early = pr_factory.merged(merged_at=datetime(2026, 1, 1, tzinfo=timezone.utc), token_score=2.0)
+    pr_late = pr_factory.merged(merged_at=datetime(2026, 1, 2, tzinfo=timezone.utc), token_score=10.0)
+    pr_early.issues = pr_late.issues = [issue]
+    ev = _make_evaluation(pr_early)
+    ev.merged_pull_requests = [pr_late, pr_early]  # late listed first; canonical must still be pr_early
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+    _collect_issues_from_prs({1: ev}, {issue.author_github_id: 1}, discoverer_data, {})
+    data = discoverer_data[issue.author_github_id]
+    assert data.solved_count == 1
+    assert data.valid_solved_count == 0  # canonical pr_early is below token threshold
+
+
+def test_transferred_issue_in_multiple_prs_counts_closed_once(issue_factory, pr_factory):
+    """Transferred issue referenced by multiple PRs hits closed_count exactly once."""
+    issue = issue_factory.transferred()
+    pr_a, pr_b = pr_factory.merged(), pr_factory.merged()
+    pr_a.issues = pr_b.issues = [issue]
+    ev = _make_evaluation(pr_a)
+    ev.merged_pull_requests = [pr_a, pr_b]
+    discoverer_data = {issue.author_github_id: _DiscovererData()}
+    _collect_issues_from_prs({1: ev}, {issue.author_github_id: 1}, discoverer_data, {})
+    data = discoverer_data[issue.author_github_id]
     assert data.closed_count == 1
     assert data.solved_count == 0


### PR DESCRIPTION
Closes: #628
Closes: #540 

## The fix

Pick a canonical solving PR per issue - the earliest-merged one (tie-broken by smaller PR number) - in a small pre-pass at the top of `_collect_issues_from_prs`. Inside the main loop, iterations where the current PR isn't the canonical one for its issue skip out before any counter is touched.

That's it - no changes to `state_reason` routing, post-merge-edit detection, same-account check, `pr_scored`, or scoring. Those keep running exactly as they do today for whichever PR is canonical.

Picking canonical by `merged_at` (not by dict iteration order) makes the dedup deterministic across runs: same inputs always produce the same outputs, no matter how `miner_evaluations` is iterated.

## Files changed

- `gittensor/validator/issue_discovery/scoring.py` - +17 lines (pre-pass that builds the canonical map, plus a one-line guard in the main loop)
- `tests/validator/test_issue_discovery_scoring.py` - 3 new tests:
  - same issue across multiple PRs counts once
  - earliest-merged PR is canonical (even when listed after a later-merged PR)
  - transferred issue across multiple PRs hits `closed_count` exactly once

## Test plan

- [x] `uv run pytest tests/validator/` - 183 passed
- [x] `uv run ruff check` - clean
- [x] `uv run ruff format --check` - clean
- [x] `uv run pyright` - 0 errors
- [x] Existing 8 `state_reason` tests still pass (no regression)
