### PR TITLE
fix: reject non-COMPLETED issues in is_valid_issue

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -477,6 +477,12 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
             bt.logging.warning(f'Skipping issue #{issue.number} - Issue state not CLOSED (state: {issue.state})')
             return False
 
+        if issue.state_reason != 'COMPLETED':
+            bt.logging.warning(
+                f'Skipping issue #{issue.number} - state_reason={issue.state_reason}, only COMPLETED grants multiplier'
+            )
+            return False
+
         if issue.closed_at and pr.merged_at:
             days_diff = abs((issue.closed_at - pr.merged_at).total_seconds()) / SECONDS_PER_DAY
             if days_diff > MAX_ISSUE_CLOSE_WINDOW_DAYS:

--- a/tests/validator/test_is_valid_issue.py
+++ b/tests/validator/test_is_valid_issue.py
@@ -1,0 +1,48 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""
+Tests for is_valid_issue (issue #605).
+
+Verifies that is_valid_issue mirrors the anti-gaming state_reason gate already
+applied in issue_discovery/scoring.py: only state_reason == 'COMPLETED' grants
+the 1.33x / 1.66x issue multiplier. Anything else (NOT_PLANNED, TRANSFERRED,
+DUPLICATE, None) is rejected.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gittensor.validator.oss_contributions.scoring import is_valid_issue
+
+
+class TestIsValidIssueStateReasonGate:
+    """Lock down the state_reason gate symmetry with issue_discovery/scoring.py."""
+
+    @pytest.mark.parametrize(
+        'state_reason,expected',
+        [
+            ('COMPLETED', True),
+            ('NOT_PLANNED', False),
+            ('TRANSFERRED', False),
+            ('DUPLICATE', False),
+            (None, False),
+        ],
+    )
+    def test_only_completed_state_reason_is_valid(self, pr_factory, issue_factory, state_reason, expected):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'miner_user'
+        pr.created_at = now - timedelta(days=1)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_login='other_user',
+            created_at=now - timedelta(days=5),
+            closed_at=now - timedelta(hours=1),
+            state='CLOSED',
+            state_reason=state_reason,
+        )
+
+        assert is_valid_issue(issue, pr) is expected


### PR DESCRIPTION
## Summary

- Adds `state_reason != 'COMPLETED'` gate to `is_valid_issue` in `gittensor/validator/oss_contributions/scoring.py`
- Closes the symmetry gap with `issue_discovery/scoring.py:216` and `:293`, which already apply the same anti-gaming gate
- Adds parametrized test `tests/validator/test_is_valid_issue.py` locking down the five cases: `COMPLETED` → allow, `NOT_PLANNED` / `TRANSFERRED` / `DUPLICATE` / `None` → reject

## Problem

`is_valid_issue` filtered on author, creation order, PR edit time, and issue state / close-window, but not on `state_reason`. That meant a PR linked to an issue closed as `NOT_PLANNED`, `TRANSFERRED`, `DUPLICATE`, or with `state_reason=None` passed validation and received the 1.33x (standard) or 1.66x (maintainer) issue multiplier.

Meanwhile, the parallel path in `issue_discovery/scoring.py` correctly routes those same `state_reason` values to `closed_count` (negative credibility). Same issue, two inconsistent scoring treatments: negative on the discovery side, bonus on the PR-multiplier side.

## Fix

One-line gate mirroring the existing discovery pattern exactly:

```python
if issue.state_reason != 'COMPLETED':
    bt.logging.warning(
        f'Skipping issue #{issue.number} - state_reason={issue.state_reason}, only COMPLETED grants multiplier'
    )
    return False
```

Strict equality, no `None` guard, no truthy check. Default-deny: anything that isn't explicitly `COMPLETED` is rejected, including any future state_reason values GitHub may add. Matches `issue_discovery/scoring.py:216` character-for-character.

## Related

- Fixes #605
- Closes #606 and #608 (both proposed variants of this fix added a `None` guard that weakened the anti-gaming pattern and left a consistency gap between the two scoring paths; rewriting for the strict form)

## Test plan

- [x] `uv run pytest tests/validator/test_is_valid_issue.py -v` — 5 passed
- [x] `uv run pytest tests/` — 371 passed
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — 2 files already formatted