### PR TITLE
fix: replace deprecated asyncio.get_event_loop() in validator init and test helpers

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -70,7 +70,8 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.warning('axon off, not serving ip to chain.')
 
         # Create asyncio event loop to manage async tasks.
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
 
         # Instantiate runners
         self.should_exit: bool = False

--- a/tests/validator/test_issue_discovery_repo_scan.py
+++ b/tests/validator/test_issue_discovery_repo_scan.py
@@ -38,7 +38,7 @@ def _run_scan(monkeypatch, raw_issues):
     )
 
     result: dict = {}
-    asyncio.get_event_loop().run_until_complete(
+    asyncio.run(
         repo_scan._scan_repo(
             repo_name='test/repo',
             lookback_date='2026-01-01T00:00:00Z',

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -20,7 +20,7 @@ from gittensor.validator.pat_handler import (
 
 def _run(coro):
     """Run an async function synchronously."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/validator/test_repo_scan.py
+++ b/tests/validator/test_repo_scan.py
@@ -37,7 +37,7 @@ def _make_issue(number: int, author_id: str, closed_at: Optional[str], updated_a
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _run_scan(issues: List[dict], lookback_date: str) -> Dict[str, List[Issue]]:


### PR DESCRIPTION
## Summary

Follow-up to #395, which migrated `miner_check` and `miner_post` off the deprecated `asyncio.get_event_loop()` API. Four call sites were left behind — one in the production validator init and three in validator test helpers — still emitting
`DeprecationWarning` on every test run.

- `neurons/base/validator.py:73` — `self.loop` is cached on the instance and reused every step via `self.loop.run_until_complete(self.concurrent_forward())`, so `asyncio.run(...)` is **not** a drop-in. Replaced with
  `asyncio.new_event_loop() + asyncio.set_event_loop()` to preserve the long-lived loop semantics the existing code relies on.
- Three test helpers (`tests/validator/test_pat_handler.py`, `tests/validator/test_repo_scan.py`, `tests/validator/test_issue_discovery_repo_scan.py`) are single-shot callers; replaced with `asyncio.run(coro)` drop-in.

After this PR, `grep -rn "asyncio\.get_event_loop" neurons/ gittensor/ tests/` returns zero matches.

## Related Issues

Closes #634

## Type of Change

- [x] Bug fix
- [x] Refactor

## Testing

- [x] `uv run pytest tests/ -q` → 394 passed
- [x] `uv run pytest tests/validator/ tests/utils/ -W error::DeprecationWarning -q` → 305 passed (DeprecationWarning eliminated in strict mode)
- [x] `uv run pre-commit run --all-files --hook-stage pre-push` → ruff, pyright, pytest all pass

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed