### PR TITLE
fix: read label_multiplier from currently-applied labels, not last LABELED_EVENT

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -8,7 +8,12 @@ from typing import DefaultDict, Dict, List, Optional, Set
 
 import bittensor as bt
 
-from gittensor.constants import MAINTAINER_ASSOCIATIONS, MAX_CODE_DENSITY_MULTIPLIER, MIN_TOKEN_SCORE_FOR_BASE_SCORE
+from gittensor.constants import (
+    LABEL_MULTIPLIERS,
+    MAINTAINER_ASSOCIATIONS,
+    MAX_CODE_DENSITY_MULTIPLIER,
+    MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+)
 from gittensor.utils.utils import parse_repo_name
 
 GITHUB_DOMAIN = 'https://github.com/'
@@ -297,10 +302,15 @@ class PullRequest:
                 1 for r in cr_reviews if r.get('authorAssociation') in MAINTAINER_ASSOCIATIONS
             )
 
-        # Extract last label from timeline events
-        timeline_nodes = pr_data.get('timelineItems', {}).get('nodes', [])
-        label_node = timeline_nodes[0].get('label') if timeline_nodes and timeline_nodes[0] else None
-        label = label_node['name'].lower() if label_node else None
+        # Pick the last LABELED_EVENT whose label is still applied and in
+        # LABEL_MULTIPLIERS, so workflow labels (lgtm, size:*, topic:*) added
+        # after the scoring label don't mask it.
+        current = {(n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n}
+        label: Optional[str] = None
+        for event in (pr_data.get('timelineItems') or {}).get('nodes') or []:
+            name = ((event or {}).get('label') or {}).get('name', '').lower()
+            if name in current and name in LABEL_MULTIPLIERS:
+                label = name
 
         return cls(
             number=pr_data['number'],

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -302,15 +302,14 @@ class PullRequest:
                 1 for r in cr_reviews if r.get('authorAssociation') in MAINTAINER_ASSOCIATIONS
             )
 
-        # Pick the last LABELED_EVENT whose label is still applied and in
-        # LABEL_MULTIPLIERS, so workflow labels (lgtm, size:*, topic:*) added
-        # after the scoring label don't mask it.
         current = {(n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n}
         label: Optional[str] = None
-        for event in (pr_data.get('timelineItems') or {}).get('nodes') or []:
-            name = ((event or {}).get('label') or {}).get('name', '').lower()
-            if name in current and name in LABEL_MULTIPLIERS:
-                label = name
+        if not current.isdisjoint(LABEL_MULTIPLIERS):
+            for event in reversed((pr_data.get('timelineItems') or {}).get('nodes') or []):
+                name = ((event or {}).get('label') or {}).get('name', '').lower()
+                if name in current and name in LABEL_MULTIPLIERS:
+                    label = name
+                    break
 
         return cls(
             number=pr_data['number'],

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -124,7 +124,10 @@ QUERY = """
                   authorAssociation
                 }
               }
-              timelineItems(itemTypes: [LABELED_EVENT], last: 1) {
+              labels(first: 20) {
+                nodes { name }
+              }
+              timelineItems(itemTypes: [LABELED_EVENT], last: 20) {
                 nodes {
                   ... on LabeledEvent {
                     label { name }

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -124,10 +124,10 @@ QUERY = """
                   authorAssociation
                 }
               }
-              labels(first: 20) {
+              labels(first: 5) {
                 nodes { name }
               }
-              timelineItems(itemTypes: [LABELED_EVENT], last: 20) {
+              timelineItems(itemTypes: [LABELED_EVENT], last: 5) {
                 nodes {
                   ... on LabeledEvent {
                     label { name }

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -1,5 +1,6 @@
 import pytest
 
+from gittensor.classes import PullRequest
 from gittensor.constants import LABEL_MULTIPLIERS
 
 
@@ -11,3 +12,72 @@ def test_known_labels(label, expected):
 @pytest.mark.parametrize('label', ['docs', 'question', 'wontfix', 'kind/feature'])
 def test_unknown_labels_return_default(label):
     assert LABEL_MULTIPLIERS.get(label, 1.0) == 1.0
+
+
+def _pr_payload(current, timeline):
+    """Minimal GraphQL payload; current=list[str], timeline=list[str or None]."""
+    return {
+        'number': 1,
+        'repository': {'owner': {'login': 'x'}, 'name': 'y'},
+        'state': 'MERGED',
+        'title': 't',
+        'bodyText': '',
+        'author': {'login': 'a'},
+        'createdAt': '2026-04-20T00:00:00Z',
+        'mergedAt': '2026-04-20T01:00:00Z',
+        'lastEditedAt': None,
+        'additions': 1,
+        'deletions': 0,
+        'commits': {'totalCount': 1},
+        'mergedBy': {'login': 'a'},
+        'headRefOid': 'h',
+        'baseRefOid': 'b',
+        'closingIssuesReferences': {'nodes': []},
+        'changesRequestedReviews': {'nodes': []},
+        'labels': {'nodes': [{'name': n} for n in current]},
+        'timelineItems': {'nodes': [{'label': {'name': n} if n else None} for n in timeline]},
+    }
+
+
+def _parse(current, timeline):
+    return PullRequest.from_graphql_response(_pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh').label
+
+
+@pytest.mark.parametrize(
+    'current,timeline,expected',
+    [
+        # Single scoring label — unchanged behavior
+        (['feature'], ['feature'], 'feature'),
+        # dify case: refactor masked by lgtm added after — fix picks refactor
+        (['size:M', 'refactor', 'lgtm'], ['size:M', 'refactor', 'lgtm'], 'refactor'),
+        # godot case: bug masked by topic:* added after — fix picks bug
+        (['bug', 'topic:editor', 'topic:shaders'], ['bug', 'topic:editor', 'topic:shaders'], 'bug'),
+        # Reclassification: feature then bug — last scoring label wins
+        (['feature', 'bug'], ['feature', 'bug'], 'bug'),
+        # Label added then removed — not in current, skipped
+        ([], ['feature'], None),
+        # No labels
+        ([], [], None),
+        # Only non-scoring labels
+        (['size:M', 'lgtm', 'ci'], ['size:M', 'lgtm', 'ci'], None),
+        # Case insensitive
+        (['Bug'], ['Bug'], 'bug'),
+        # Null label node (PR #553 — deleted repo label)
+        (['feature'], [None, 'feature'], 'feature'),
+        (['feature'], [None], None),
+        # Remove-and-replace: feature removed, bug added
+        (['bug'], ['feature', 'bug'], 'bug'),
+        # Only scoring label was removed
+        (['lgtm'], ['feature'], None),
+    ],
+)
+def test_label_extraction(current, timeline, expected):
+    assert _parse(current, timeline) == expected
+
+
+def test_missing_labels_key_does_not_crash():
+    """Backward-compat: payloads without the new 'labels' key yield None."""
+    payload = _pr_payload([], ['feature'])
+    del payload['labels']
+    pr = PullRequest.from_graphql_response(payload, uid=0, hotkey='hk', github_id='gh')
+    assert pr.label is None


### PR DESCRIPTION
## Summary

- Fetch the PR's current `labels` connection alongside the `LABELED_EVENT` timeline in the GraphQL query.
- Pick the last `LABELED_EVENT` whose label is still currently applied AND is in `LABEL_MULTIPLIERS`, instead of blindly reading the last-added label.
- Preserves the "last label set" semantic from the original design while correctly handling multi-label PRs and removed labels.

## Related Issues

Fixes #633

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added 13 regression tests in `tests/validator/test_label_multiplier.py` covering single-label, multi-label workflow-after-scoring, reclassification, removed labels, null label nodes, and backward compatibility with missing `labels` key.

Verified end-to-end against live GitHub data for [entrius/gittensor-ui#313](https://github.com/entrius/gittensor-ui/pull/313) and `entrius/gittensor#518` (no-regression control). All produce correct labels.

`uv run pytest tests/` → 376 passed. `uv run ruff check` / `ruff format --check` / `pyright` all clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
`
