### PR TITLE
fix: add success field to submissions JSON output and use shared header builders in PAT validation 

### DIFF
--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -102,6 +102,7 @@ def issues_submissions(
             for pr in pull_requests
         ]
         payload = {
+            'success': True,
             'issue_id': issue_id,
             'repository': repo_name,
             'issue_number': issue_number,

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -172,7 +172,9 @@ def _validate_pat_locally(pat: str) -> bool:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
     try:
         # Check basic auth
-        user_resp = requests.get(f'{BASE_GITHUB_API_URL}/user', headers=make_headers(pat), timeout=GITHUB_HTTP_TIMEOUT_SECONDS)
+        user_resp = requests.get(
+            f'{BASE_GITHUB_API_URL}/user', headers=make_headers(pat), timeout=GITHUB_HTTP_TIMEOUT_SECONDS
+        )
         if user_resp.status_code != 200:
             return False
 

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -26,6 +26,7 @@ from gittensor.cli.miner_commands.helpers import (
     _status,
 )
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
+from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
 
 console = Console()
 
@@ -169,19 +170,17 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
 
 def _validate_pat_locally(pat: str) -> bool:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
-    headers = {'Authorization': f'token {pat}', 'Accept': 'application/vnd.github.v3+json'}
     try:
         # Check basic auth
-        user_resp = requests.get(f'{BASE_GITHUB_API_URL}/user', headers=headers, timeout=GITHUB_HTTP_TIMEOUT_SECONDS)
+        user_resp = requests.get(f'{BASE_GITHUB_API_URL}/user', headers=make_headers(pat), timeout=GITHUB_HTTP_TIMEOUT_SECONDS)
         if user_resp.status_code != 200:
             return False
 
         # Check GraphQL access (same test the validator runs during PAT broadcast)
-        gql_headers = {'Authorization': f'Bearer {pat}', 'Accept': 'application/json'}
         gql_resp = requests.post(
             f'{BASE_GITHUB_API_URL}/graphql',
             json={'query': GRAPHQL_VIEWER_QUERY},
-            headers=gql_headers,
+            headers=make_graphql_headers(pat),
             timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
         if gql_resp.status_code != 200:

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -24,7 +24,8 @@ def test_submissions_json_schema_is_stable(cli_root, runner, sample_issue, sampl
     assert '\x1b[' not in result.output
 
     payload = json.loads(result.output)
-    assert set(payload.keys()) == {'issue_id', 'repository', 'issue_number', 'submission_count', 'submissions'}
+    assert set(payload.keys()) == {'success', 'issue_id', 'repository', 'issue_number', 'submission_count', 'submissions'}
+    assert payload['success'] is True
     assert payload['issue_id'] == 42
     assert payload['repository'] == 'entrius/gittensor'
     assert payload['issue_number'] == 223

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -24,7 +24,14 @@ def test_submissions_json_schema_is_stable(cli_root, runner, sample_issue, sampl
     assert '\x1b[' not in result.output
 
     payload = json.loads(result.output)
-    assert set(payload.keys()) == {'success', 'issue_id', 'repository', 'issue_number', 'submission_count', 'submissions'}
+    assert set(payload.keys()) == {
+        'success',
+        'issue_id',
+        'repository',
+        'issue_number',
+        'submission_count',
+        'submissions',
+    }
     assert payload['success'] is True
     assert payload['issue_id'] == 42
     assert payload['repository'] == 'entrius/gittensor'


### PR DESCRIPTION
## Summary

- `gitt i submissions --json` was missing a `success` field in its JSON output,  inconsistent with `gitt miner check` and `gitt miner post` which both include it.  Adds `'success': True` to the payload so callers can reliably check the result.

- `_validate_pat_locally` in `miner_commands/post.py` was constructing GitHub API  headers inline (`{'Authorization': f'token {pat}', ...}`) instead of using the  shared `make_headers()` and `make_graphql_headers()` utilities already available  in `github_api_tools.py`. Replaces both inline dicts with the shared builders.
