### PR TITLE
Unify _read_contract_u128/u32 in contract_client.py

### DIFF
--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -9,7 +9,7 @@ import struct
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import bittensor as bt
 from substrateinterface import Keypair
@@ -218,28 +218,17 @@ class IssueCompetitionContractClient:
     def get_alpha_pool(self) -> int:
         """Get the current alpha pool balance."""
         try:
-            value = self._read_contract_u128('get_alpha_pool')
-            return value
+            return self._read_contract_numeric('get_alpha_pool', self._extract_u128_from_response)
         except Exception as e:
             bt.logging.error(f'Error fetching alpha pool: {e}')
             return 0
 
-    def _read_contract_u128(self, method_name: str) -> int:
-        """Read a u128 value from a no-arg contract method."""
+    def _read_contract_numeric(self, method_name: str, extractor: Callable[[bytes], Optional[int]]) -> int:
+        """Read a numeric value from a no-arg contract method via ``extractor``."""
         response = self._raw_contract_read(method_name)
         if response is None:
             return 0
-
-        value = self._extract_u128_from_response(response)
-        return value if value is not None else 0
-
-    def _read_contract_u32(self, method_name: str) -> int:
-        """Read a u32 value from a no-arg contract method."""
-        response = self._raw_contract_read(method_name)
-        if response is None:
-            return 0
-
-        value = self._extract_u32_from_response(response)
+        value = extractor(response)
         return value if value is not None else 0
 
     def _raw_contract_read(self, method_name: str, args: dict = None) -> Optional[bytes]:  # type: ignore[assignment]
@@ -612,8 +601,7 @@ class IssueCompetitionContractClient:
     def get_last_harvest_block(self) -> int:
         """Query the block number of the last harvest."""
         try:
-            value = self._read_contract_u32('get_last_harvest_block')
-            return value
+            return self._read_contract_numeric('get_last_harvest_block', self._extract_u32_from_response)
         except Exception as e:
             bt.logging.error(f'Error fetching last harvest block: {e}')
             return 0

--- a/tests/validator/test_contract_client_reads.py
+++ b/tests/validator/test_contract_client_reads.py
@@ -1,0 +1,58 @@
+# Entrius 2025
+
+"""Tests for IssueCompetitionContractClient numeric read methods."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gittensor.validator.issue_competitions.contract_client import (
+    IssueCompetitionContractClient,
+)
+
+
+@pytest.fixture()
+def client():
+    with patch.object(IssueCompetitionContractClient, '__init__', lambda self, *a, **kw: None):
+        c = IssueCompetitionContractClient.__new__(IssueCompetitionContractClient)
+        c.contract_address = '5FakeContract'
+        c.subtensor = MagicMock()
+        return c
+
+
+def test_read_contract_numeric_returns_zero_when_response_is_none(client):
+    extractor = MagicMock()
+    with patch.object(client, '_raw_contract_read', return_value=None):
+        assert client._read_contract_numeric('any', extractor) == 0
+    extractor.assert_not_called()
+
+
+def test_read_contract_numeric_returns_zero_when_extractor_returns_none(client):
+    with patch.object(client, '_raw_contract_read', return_value=b'\x00'):
+        assert client._read_contract_numeric('any', lambda _b: None) == 0
+
+
+def test_read_contract_numeric_returns_extracted_value(client):
+    with patch.object(client, '_raw_contract_read', return_value=b'\xff' * 4):
+        assert client._read_contract_numeric('any', lambda _b: 1234) == 1234
+
+
+@pytest.mark.parametrize(
+    'method, contract_method, extractor_attr',
+    [
+        ('get_alpha_pool', 'get_alpha_pool', '_extract_u128_from_response'),
+        ('get_last_harvest_block', 'get_last_harvest_block', '_extract_u32_from_response'),
+    ],
+)
+def test_public_read_wires_method_name_and_extractor(client, method, contract_method, extractor_attr):
+    with patch.object(client, '_read_contract_numeric', return_value=42) as mock:
+        assert getattr(client, method)() == 42
+    name_arg, extractor_arg = mock.call_args.args
+    assert name_arg == contract_method
+    assert extractor_arg == getattr(client, extractor_attr)
+
+
+@pytest.mark.parametrize('method', ['get_alpha_pool', 'get_last_harvest_block'])
+def test_public_read_returns_zero_on_exception(client, method):
+    with patch.object(client, '_read_contract_numeric', side_effect=RuntimeError('node down')):
+        assert getattr(client, method)() == 0


### PR DESCRIPTION
## Summary

`_read_contract_u128` and `_read_contract_u32` in `contract_client.py` were 8-line methods that differed only in which extractor they called. Replaced both with a single `_read_contract_numeric(method_name, extractor)` helper and updated the two call sites (`get_alpha_pool`, `get_last_harvest_block`) to pass their extractor explicitly. 
## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated
- [x] Manually tested

New tests in `tests/validator/test_contract_client_reads.py` cover the three helper paths (None response, extractor returns None, success) and assert that each public caller is wired to the correct method name **and** extractor — so a swap regression fails fast. All 417 tests pass; ruff/pyright clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

## Behavior equivalence

| Path | Before | After |
|---|---|---|
| `_raw_contract_read` returns `None` | `return 0` | `return 0` |
| Extractor returns `None` | `return 0` | `return 0` |
| Extractor returns `int` | `return int` | `return int` |

Public signatures (`get_alpha_pool`, `get_last_harvest_block`), RPC selector lookup, SCALE decoding, and `try/except` surface are all unchanged.
