### PR TITLE
refactor: inline find_solver_from_timeline into single caller

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1076,22 +1076,6 @@ def find_solver_from_cross_references(
     return best.get('author_id'), best.get('number')
 
 
-def find_solver_from_timeline(
-    repo: str, issue_number: int, token: str
-) -> Optional[tuple[Optional[int], Optional[int]]]:
-    """Find the PR author who closed an issue.
-
-    Uses GraphQL cross-reference analysis to find merged PRs that close the
-    issue, with baseRepository validation and closingIssuesReferences check.
-
-    Returns:
-        ``None`` when lookup fails and should be retried later. Otherwise
-        ``(solver_github_id, pr_number)`` where either may be None if not found.
-    """
-    bt.logging.debug(f'Finding solver for {repo}#{issue_number}')
-    return find_solver_from_cross_references(repo, issue_number, token)
-
-
 def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optional[Dict[str, Any]]:
     """Check if a GitHub issue is closed and get the solving PR info.
 
@@ -1121,7 +1105,8 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
         if data.get('state') != 'closed':
             return {'is_closed': False}
 
-        solver_lookup = find_solver_from_timeline(repo, issue_number, token)
+        bt.logging.debug(f'Finding solver for {repo}#{issue_number}')
+        solver_lookup = find_solver_from_cross_references(repo, issue_number, token)
         if solver_lookup is None:
             bt.logging.warning(f'Solver lookup failed for {repo}#{issue_number}')
             solver_lookup_failed = True

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -817,7 +817,6 @@ def test_find_prs_without_token_only_uses_unauth_rest(mock_graphql, mock_rest):
 # Solver Detection Tests
 # ============================================================================
 
-find_solver_from_timeline = github_api_tools.find_solver_from_timeline
 find_solver_from_cross_references = github_api_tools.find_solver_from_cross_references
 
 
@@ -1011,22 +1010,6 @@ class TestFindSolverFromCrossReferences:
             mock_graphql.return_value = graphql_response
             result = find_solver_from_cross_references('owner/repo', 12, 'fake_token')
             assert result is None
-
-
-class TestFindSolverFromTimeline:
-    """Test that find_solver_from_timeline delegates to cross-references."""
-
-    @patch('gittensor.utils.github_api_tools.find_solver_from_cross_references')
-    @patch('gittensor.utils.github_api_tools.bt.logging')
-    def test_delegates_to_cross_references(self, mock_logging, mock_cross_ref):
-        """find_solver_from_timeline delegates directly to find_solver_from_cross_references."""
-        mock_cross_ref.return_value = (42, 14)
-
-        solver_id, pr_number = find_solver_from_timeline('owner/repo', 12, 'fake_token')
-
-        assert solver_id == 42
-        assert pr_number == 14
-        mock_cross_ref.assert_called_once_with('owner/repo', 12, 'fake_token')
 
 
 class TestCheckGithubIssueClosed:


### PR DESCRIPTION
## Summary

- Inlined solver lookup into `check_github_issue_closed` by calling `find_solver_from_cross_references(...)` directly.
- Moved `Finding solver for {repo}#{issue_number}` debug log to `check_github_issue_closed`.
- Removed dead wrapper `find_solver_from_timeline`.
- Removed delegation-only test class `TestFindSolverFromTimeline`.
- Kept existing `TestFindSolverFromCrossReferences` behavior coverage intact.

## Related Issues

Closes #640

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `uv run pytest tests/utils/test_github_api_tools.py -v`
- `uv run pytest tests/utils/test_github_api_tools.py::TestFindSolverFromCrossReferences -v`
- `uv run pytest tests/utils/test_github_api_tools.py::TestCheckGithubIssueClosed -v`
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push`
- `uv run pyright`
- `uv run pytest tests/ -v`

## Checklist

- [x] Branch created from `test` and intended target is `test`
- [x] Changes are scoped to issue and avoid unrelated edits
- [x] Tests updated to match refactor (delegation-only test removed)
- [x] Lint, format, type checks, and tests pass locally
