### PR TITLE
fix: skip PR scoring on file-content GraphQL fetch failure

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -377,7 +377,7 @@ def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -
     bt.logging.error(
         f'File changes request for PR #{pr_number} in {repository} failed after {max_attempts} attempts: {last_error}'
     )
-    return []
+    return None
 
 
 # GraphQL fragment used by both issue submissions and solver detection.
@@ -1136,6 +1136,10 @@ class FileContentPair:
     new_content: Optional[str]  # None for deleted files
 
 
+def _empty_file_content_pairs(batch_changes: List['FileChangeType']) -> Dict[str, FileContentPair]:
+    return {fc.filename: FileContentPair(None, None) for fc in batch_changes}
+
+
 def _fetch_file_contents_with_base_batch(
     repo_owner: str,
     repo_name: str,
@@ -1143,7 +1147,7 @@ def _fetch_file_contents_with_base_batch(
     head_sha: str,
     batch_changes: List['FileChangeType'],
     token: str,
-) -> Dict[str, FileContentPair]:
+) -> tuple[Dict[str, FileContentPair], bool]:
     """Fetch base and head file contents for a single batch of file changes.
 
     Args:
@@ -1155,7 +1159,7 @@ def _fetch_file_contents_with_base_batch(
         token: GitHub PAT for authentication
 
     Returns:
-        Dict mapping file paths to FileContentPair (old_content, new_content)
+        Tuple of (file-content dict, fetch_failed flag).
     """
     file_fields = []
     for i, fc in enumerate(batch_changes):
@@ -1178,7 +1182,7 @@ def _fetch_file_contents_with_base_batch(
             )
 
     if not file_fields:
-        return {}
+        return {}, False
 
     query = f"""
         query($owner: String!, $name: String!) {{
@@ -1193,12 +1197,17 @@ def _fetch_file_contents_with_base_batch(
     data = execute_graphql_query(query, variables, token)
     if data is None:
         bt.logging.warning(f'Failed to fetch file contents for {repo_owner}/{repo_name}')
-        return {fc.filename: FileContentPair(None, None) for fc in batch_changes}
+        return _empty_file_content_pairs(batch_changes), True
 
     if 'errors' in data:
         bt.logging.warning(f'GraphQL errors fetching files: {data["errors"]}')
 
-    repo_data = data.get('data', {}).get('repository', {})
+    data_payload = data.get('data')
+    repo_data = data_payload.get('repository') if isinstance(data_payload, dict) else None
+    if repo_data is None:
+        bt.logging.warning(f'GraphQL response missing repository data for {repo_owner}/{repo_name}')
+        return _empty_file_content_pairs(batch_changes), True
+
     results: Dict[str, FileContentPair] = {}
 
     for i, fc in enumerate(batch_changes):
@@ -1219,7 +1228,7 @@ def _fetch_file_contents_with_base_batch(
 
         results[fc.filename] = FileContentPair(old_content=old_content, new_content=new_content)
 
-    return results
+    return results, False
 
 
 def fetch_file_contents_with_base(
@@ -1229,7 +1238,7 @@ def fetch_file_contents_with_base(
     head_sha: str,
     file_changes: List['FileChangeType'],
     token: str,
-) -> Dict[str, FileContentPair]:
+) -> tuple[Dict[str, FileContentPair], bool]:
     """Fetch old and new versions of files in batches so large PRs don't hit complexity limits.
 
     Args:
@@ -1241,16 +1250,20 @@ def fetch_file_contents_with_base(
         token: GitHub PAT for authentication
 
     Returns:
-        Dict mapping file paths to FileContentPair (old_content, new_content)
+        Tuple of (file-content dict, fetch_failed flag).
     """
     if not file_changes:
-        return {}
+        return {}, False
 
     results: Dict[str, FileContentPair] = {}
+    fetch_failed = False
 
     for batch_start in range(0, len(file_changes), MAX_FILES_PER_GRAPHQL_BATCH):
         batch = file_changes[batch_start : batch_start + MAX_FILES_PER_GRAPHQL_BATCH]
-        batch_results = _fetch_file_contents_with_base_batch(repo_owner, repo_name, base_sha, head_sha, batch, token)
+        batch_results, batch_failed = _fetch_file_contents_with_base_batch(
+            repo_owner, repo_name, base_sha, head_sha, batch, token
+        )
         results.update(batch_results)
+        fetch_failed = fetch_failed or batch_failed
 
-    return results
+    return results, fetch_failed

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -92,13 +92,21 @@ def score_pull_request(
     # Only fetch file changes from GitHub if not already loaded (they are preloaded for testing only)
     if not pr.file_changes:
         file_changes = get_pull_request_file_changes(pr.repository_full_name, pr.number, miner_eval.github_pat)
+        if file_changes is None:
+            bt.logging.warning(f'PR #{pr.number}: file-changes fetch failed for {pr.repository_full_name}, skipping')
+            return
         if not file_changes:
             bt.logging.warning('No file changes found.')
             return
         pr.set_file_changes(file_changes)
 
     # Fetch full file contents for token-based scoring
-    file_contents = fetch_file_contents_for_pr(pr, miner_eval.github_pat)
+    file_contents, fetch_failed = fetch_file_contents_for_pr(pr, miner_eval.github_pat)
+    if fetch_failed:
+        bt.logging.warning(
+            f'PR #{pr.number}: GraphQL file-content fetch failed for {pr.repository_full_name}, skipping'
+        )
+        return
 
     pr.base_score = calculate_base_score(pr, programming_languages, token_config, file_contents)
 
@@ -108,24 +116,27 @@ def score_pull_request(
         miner_eval.unique_repos_contributed_to.add(pr.repository_full_name)
 
 
-def fetch_file_contents_for_pr(pr: PullRequest, github_pat: str) -> Dict[str, FileContentPair]:
+def fetch_file_contents_for_pr(
+    pr: PullRequest,
+    github_pat: str,
+) -> Tuple[Dict[str, FileContentPair], bool]:
     """Fetch both base and head file contents for all files in a PR using GraphQL batch fetch.
 
     Uses the merge-base commit (common ancestor) as the "before" state rather than
     the base branch tip, so the tree-diff only scores the PR's own changes.
 
     Returns:
-        Dict mapping filename to FileContentPair(old_content, new_content)
+        Tuple of (file-content dict, fetch_failed flag).
         - old_content: File content before the PR (None for new files)
         - new_content: File content after the PR (None for deleted files)
     """
     if not pr.file_changes or not pr.head_ref_oid or not pr.base_ref_oid:
-        return {}
+        return {}, False
 
     parts = pr.repository_full_name.split('/')
     if len(parts) != 2:
         bt.logging.warning(f'Invalid repository name format: {pr.repository_full_name}')
-        return {}
+        return {}, False
 
     owner, repo_name = parts
 
@@ -138,7 +149,10 @@ def fetch_file_contents_for_pr(pr: PullRequest, github_pat: str) -> Dict[str, Fi
             f'PR #{pr.number}: using merge-base {merge_base[:8]} instead of base_ref {pr.base_ref_oid[:8]}'
         )
 
-    return fetch_file_contents_with_base(owner, repo_name, base_sha, pr.head_ref_oid, pr.file_changes, github_pat)
+    file_contents, fetch_failed = fetch_file_contents_with_base(
+        owner, repo_name, base_sha, pr.head_ref_oid, pr.file_changes, github_pat
+    )
+    return file_contents, fetch_failed
 
 
 def calculate_base_score(

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -431,7 +431,7 @@ class TestFileChangesRetryLogic:
     @patch('gittensor.utils.github_api_tools.time.sleep')
     @patch('gittensor.utils.github_api_tools.bt.logging')
     def test_gives_up_after_three_attempts(self, mock_logging, mock_sleep, mock_get):
-        """Test that function gives up after 3 failed attempts and returns empty list."""
+        """Test that function gives up after 3 failed attempts and returns None."""
         mock_500 = Mock(status_code=500, text='Internal Server Error')
         mock_get.return_value = mock_500
 
@@ -439,7 +439,7 @@ class TestFileChangesRetryLogic:
 
         assert mock_get.call_count == 3
         assert mock_sleep.call_count == 2, 'Should sleep between attempts but not after the last one'
-        assert result == []
+        assert result is None
         mock_logging.error.assert_called()
 
     @patch('gittensor.utils.github_api_tools.requests.get')
@@ -472,7 +472,7 @@ class TestFileChangesRetryLogic:
         result = get_pull_request_file_changes('owner/repo', 1, 'fake_token')
 
         assert mock_get.call_count == 3
-        assert result == []
+        assert result is None
         mock_logging.error.assert_called()
 
     @patch('gittensor.utils.github_api_tools.requests.get')
@@ -702,13 +702,13 @@ class TestFileChangesPagination:
     @patch('gittensor.utils.github_api_tools.requests.get')
     @patch('gittensor.utils.github_api_tools.time.sleep')
     @patch('gittensor.utils.github_api_tools.bt.logging')
-    def test_all_pages_fail_returns_empty_list(self, mock_logging, mock_sleep, mock_get):
-        """If every attempt fails on the first page, return empty list."""
+    def test_all_pages_fail_returns_none(self, mock_logging, mock_sleep, mock_get):
+        """If every attempt fails on the first page, return None."""
         mock_get.return_value = Mock(status_code=500, text='Internal Server Error')
 
         result = get_pull_request_file_changes('owner/repo', 1, 'fake_token')
 
-        assert result == []
+        assert result is None
         assert mock_get.call_count == 3
         mock_logging.error.assert_called()
 
@@ -1254,8 +1254,9 @@ class TestFetchFileContentsWithBase:
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
     def test_empty_file_changes_returns_empty_dict(self, mock_execute):
         """No GraphQL call should be made when file_changes is empty."""
-        result = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', [], 'token')
+        result, fetch_failed = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', [], 'token')
         assert result == {}
+        assert fetch_failed is False
         mock_execute.assert_not_called()
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
@@ -1271,8 +1272,9 @@ class TestFetchFileContentsWithBase:
             }
         }
 
-        result = fetch_file_contents_with_base('owner', 'repo', 'base_sha', 'head_sha', changes, 'token')
+        result, fetch_failed = fetch_file_contents_with_base('owner', 'repo', 'base_sha', 'head_sha', changes, 'token')
 
+        assert fetch_failed is False
         assert len(result) == 1
         assert result['app.py'].old_content == 'old code'
         assert result['app.py'].new_content == 'new code'
@@ -1289,7 +1291,7 @@ class TestFetchFileContentsWithBase:
             }
         }
 
-        result = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
+        result, _ = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
 
         assert result['new_file.py'].old_content is None
         assert result['new_file.py'].new_content == 'brand new'
@@ -1306,7 +1308,7 @@ class TestFetchFileContentsWithBase:
             }
         }
 
-        result = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
+        result, _ = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
 
         assert result['old_file.py'].old_content == 'deleted code'
         assert result['old_file.py'].new_content is None
@@ -1330,10 +1332,11 @@ class TestFetchFileContentsWithBase:
 
         mock_execute.side_effect = mock_side_effect
 
-        result = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
+        result, fetch_failed = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
 
         # 5 files / batch size 2 = 3 batches (2 + 2 + 1)
         assert mock_execute.call_count == 3
+        assert fetch_failed is False
         assert len(result) == 5
 
     @patch('gittensor.utils.github_api_tools.MAX_FILES_PER_GRAPHQL_BATCH', 2)
@@ -1357,8 +1360,9 @@ class TestFetchFileContentsWithBase:
             None,  # second batch fails
         ]
 
-        result = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
+        result, fetch_failed = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
 
+        assert fetch_failed is True
         assert len(result) == 4
         # First batch succeeded
         assert result['f0.py'].old_content == 'old_0'
@@ -1366,6 +1370,45 @@ class TestFetchFileContentsWithBase:
         # Second batch failed — None pairs
         assert result['f2.py'].old_content is None
         assert result['f2.py'].new_content is None
+
+    @patch('gittensor.utils.github_api_tools.MAX_FILES_PER_GRAPHQL_BATCH', 2)
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_failed_batch_sets_fetch_failed_true(self, mock_logging, mock_execute):
+        changes = [_make_file_change(f'f{i}.py') for i in range(4)]
+
+        mock_execute.side_effect = [
+            {
+                'data': {
+                    'repository': {
+                        'base0': _make_blob_response('old_0'),
+                        'head0': _make_blob_response('new_0'),
+                        'base1': _make_blob_response('old_1'),
+                        'head1': _make_blob_response('new_1'),
+                    }
+                }
+            },
+            None,
+        ]
+
+        result, fetch_failed = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
+
+        assert fetch_failed is True
+        assert len(result) == 4
+        assert result['f2.py'].old_content is None
+        assert result['f2.py'].new_content is None
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_errors_with_missing_data_sets_fetch_failed_true(self, mock_logging, mock_execute):
+        changes = [_make_file_change('main.py', status='modified')]
+        mock_execute.return_value = {'data': None, 'errors': [{'type': 'RATE_LIMITED', 'message': 'too many'}]}
+
+        result, fetch_failed = fetch_file_contents_with_base('owner', 'repo', 'base', 'head', changes, 'token')
+
+        assert fetch_failed is True
+        assert result['main.py'].old_content is None
+        assert result['main.py'].new_content is None
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
     def test_renamed_file_fetches_from_previous_filename(self, mock_execute):
@@ -1380,7 +1423,7 @@ class TestFetchFileContentsWithBase:
             }
         }
 
-        result = fetch_file_contents_with_base('owner', 'repo', 'base_sha', 'head_sha', changes, 'token')
+        result, _ = fetch_file_contents_with_base('owner', 'repo', 'base_sha', 'head_sha', changes, 'token')
 
         assert result['new_name.py'].old_content == 'original'
         assert result['new_name.py'].new_content == 'updated'
@@ -1504,7 +1547,7 @@ class TestFetchFileContentsForPrMergeBase:
         from gittensor.validator.oss_contributions.scoring import fetch_file_contents_for_pr
 
         mock_merge_base.return_value = 'merge_base_sha_123'
-        mock_fetch.return_value = {}
+        mock_fetch.return_value = ({}, False)
 
         pr = PullRequest(
             number=1,
@@ -1548,7 +1591,7 @@ class TestFetchFileContentsForPrMergeBase:
         from gittensor.validator.oss_contributions.scoring import fetch_file_contents_for_pr
 
         mock_merge_base.return_value = None
-        mock_fetch.return_value = {}
+        mock_fetch.return_value = ({}, False)
 
         pr = PullRequest(
             number=1,
@@ -1581,6 +1624,46 @@ class TestFetchFileContentsForPrMergeBase:
         # Should fall back to base_ref_oid
         call_args = mock_fetch.call_args
         assert call_args[0][2] == 'base_branch_tip_sha', 'Should fall back to base_ref_oid'
+
+    @patch('gittensor.validator.oss_contributions.scoring.fetch_file_contents_with_base')
+    @patch('gittensor.validator.oss_contributions.scoring.get_merge_base_sha')
+    def test_returns_fetch_failed_flag(self, mock_merge_base, mock_fetch):
+        from gittensor.classes import FileChange, PRState, PullRequest
+        from gittensor.validator.oss_contributions.scoring import fetch_file_contents_for_pr
+
+        mock_merge_base.return_value = None
+        mock_fetch.return_value = ({'test.py': FileContentPair(None, None)}, True)
+
+        pr = PullRequest(
+            number=1,
+            repository_full_name='owner/repo',
+            uid=0,
+            hotkey='hk',
+            github_id='1',
+            title='test',
+            author_login='user',
+            merged_at=None,
+            created_at=__import__('datetime').datetime.now(__import__('datetime').timezone.utc),
+            pr_state=PRState.MERGED,
+            base_ref_oid='base_branch_tip_sha',
+            head_ref_oid='head_sha',
+            file_changes=[
+                FileChange(
+                    pr_number=1,
+                    repository_full_name='owner/repo',
+                    filename='test.py',
+                    status='modified',
+                    changes=5,
+                    additions=3,
+                    deletions=2,
+                ),
+            ],
+        )
+
+        result, fetch_failed = fetch_file_contents_for_pr(pr, 'fake_token')
+
+        assert fetch_failed is True
+        assert result['test.py'].new_content is None
 
 
 if __name__ == '__main__':

--- a/tests/validator/test_scoring_fetch_failure.py
+++ b/tests/validator/test_scoring_fetch_failure.py
@@ -1,0 +1,104 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+from gittensor.classes import MinerEvaluation, PRState, PullRequest
+from gittensor.validator.oss_contributions.scoring import score_miner_prs, score_pull_request
+
+
+def _make_pr(number: int) -> PullRequest:
+    now = datetime.now(timezone.utc)
+    return PullRequest(
+        number=number,
+        repository_full_name='owner/repo',
+        uid=1,
+        hotkey='hk',
+        github_id='1',
+        title=f'PR {number}',
+        author_login='miner',
+        merged_at=now,
+        created_at=now,
+        pr_state=PRState.MERGED,
+    )
+
+
+@patch('gittensor.validator.oss_contributions.scoring.get_pull_request_file_changes')
+def test_score_pull_request_skips_on_file_changes_none(mock_get_file_changes):
+    """When get_pull_request_file_changes returns None (REST failure), the PR is skipped."""
+    mock_get_file_changes.return_value = None
+
+    pr = _make_pr(10)
+    miner_eval = MinerEvaluation(uid=1, hotkey='hk', github_id='1', github_pat='fake_pat')
+
+    score_pull_request(
+        pr,
+        miner_eval,
+        master_repositories={'owner/repo': Mock(weight=1.0, inactive_at=None)},
+        programming_languages={},
+        token_config=Mock(),
+    )
+
+    assert miner_eval.github_pr_fetch_failed is False
+    assert pr.base_score == 0.0
+
+
+@patch('gittensor.validator.oss_contributions.scoring.get_pull_request_file_changes')
+def test_score_pull_request_skips_empty_file_changes_without_fetch_failed(mock_get_file_changes):
+    """An empty file-change list (not None) should skip scoring but NOT set fetch_failed."""
+    mock_get_file_changes.return_value = []
+
+    pr = _make_pr(11)
+    miner_eval = MinerEvaluation(uid=1, hotkey='hk', github_id='1', github_pat='fake_pat')
+
+    score_pull_request(
+        pr,
+        miner_eval,
+        master_repositories={'owner/repo': Mock(weight=1.0, inactive_at=None)},
+        programming_languages={},
+        token_config=Mock(),
+    )
+
+    assert miner_eval.github_pr_fetch_failed is False
+    assert pr.base_score == 0.0
+
+
+@patch('gittensor.validator.oss_contributions.scoring.fetch_file_contents_for_pr')
+@patch('gittensor.validator.oss_contributions.scoring.get_pull_request_file_changes')
+def test_score_pull_request_skips_on_graphql_content_fetch_failure(mock_get_file_changes, mock_fetch_contents):
+    """When GraphQL file-content fetch fails, the PR is skipped without setting miner-level flag."""
+    mock_get_file_changes.return_value = [Mock(filename='test.py', status='modified', changes=5)]
+    mock_fetch_contents.return_value = ({}, True)
+
+    pr = _make_pr(12)
+    miner_eval = MinerEvaluation(uid=1, hotkey='hk', github_id='1', github_pat='fake_pat')
+
+    score_pull_request(
+        pr,
+        miner_eval,
+        master_repositories={'owner/repo': Mock(weight=1.0, inactive_at=None)},
+        programming_languages={},
+        token_config=Mock(),
+    )
+
+    assert miner_eval.github_pr_fetch_failed is False
+    assert pr.base_score == 0.0
+
+
+@patch('gittensor.validator.oss_contributions.scoring.score_pull_request')
+def test_score_miner_prs_continues_after_per_pr_failure(mock_score_pull_request):
+    """A per-PR fetch failure should NOT prevent scoring subsequent PRs."""
+    miner_eval = MinerEvaluation(uid=1, hotkey='hk', github_id='1', github_pat='fake_pat')
+    miner_eval.merged_pull_requests = [_make_pr(1), _make_pr(2)]
+    miner_eval.open_pull_requests = [_make_pr(3)]
+
+    score_miner_prs(
+        miner_eval=miner_eval,
+        master_repositories={},
+        programming_languages={},
+        token_config=Mock(),
+    )
+
+    assert mock_score_pull_request.call_count == 3
+    assert miner_eval.github_pr_fetch_failed is False


### PR DESCRIPTION
## Summary

Surfaces file-content batch fetch failures so scoring can distinguish "transient API failure" from "no scorable content." Per-PR scoped only: the affected PR is skipped (contributes nothing) instead of recording a false `base_score=0`. Other PRs in the same cycle continue scoring normally.

This addresses the maintainer's feedback on the previous iteration — no miner-level abort, no `github_pr_fetch_failed` signaling, no cache fallback trigger.

## Changes

- [_fetch_file_contents_with_base_batch](cci:1://file:///root/mkdev11/gold/gittensor/gittensor/utils/github_api_tools.py:1142:0-1230:25) returns `(results, fetch_failed)` tuple; flags `True` on GraphQL failure or missing `data.repository`
- [fetch_file_contents_with_base](cci:1://file:///root/mkdev11/gold/gittensor/gittensor/utils/github_api_tools.py:1233:0-1268:32) propagates `fetch_failed` across batches
- [fetch_file_contents_for_pr](cci:1://file:///root/mkdev11/gold/gittensor/gittensor/validator/oss_contributions/scoring.py:118:0-154:38) returns `(dict, fetch_failed)` tuple (no `miner_eval` param)
- [score_pull_request](cci:1://file:///root/mkdev11/gold/gittensor/gittensor/validator/oss_contributions/scoring.py:76:0-113:75) early-returns when file-content fetch failed (mirrors existing `if not file_changes: return` pattern)
- [get_pull_request_file_changes](cci:1://file:///root/mkdev11/gold/gittensor/gittensor/utils/github_api_tools.py:296:0-379:15) returns `None` on final failure (was `[]`) so callers can distinguish "no files" from "fetch failed"

## What this does NOT do

- Does **not** set `github_pr_fetch_failed`
- Does **not** abort scoring for other PRs
- Does **not** trigger cache fallback
- Does **not** add "skip on failure" branches to other fetch paths (issue, review, label, credibility)

## Related Issues

Closes #644

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)