### PR TITLE
fix: fall back to currently-applied label when timelineItems truncates scoring LABELED_EVENT

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -304,12 +304,16 @@ class PullRequest:
 
         current = {(n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n}
         label: Optional[str] = None
-        if not current.isdisjoint(LABEL_MULTIPLIERS):
+        scoring_labels = current & LABEL_MULTIPLIERS.keys()
+        if scoring_labels:
             for event in reversed((pr_data.get('timelineItems') or {}).get('nodes') or []):
                 name = ((event or {}).get('label') or {}).get('name', '').lower()
-                if name in current and name in LABEL_MULTIPLIERS:
+                if name in scoring_labels:
                     label = name
                     break
+            if label is None:
+                # Timeline truncated — fall back to highest-multiplier currently-applied label
+                label = max(scoring_labels, key=lambda n: (LABEL_MULTIPLIERS[n], n))
 
         return cls(
             number=pr_data['number'],

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -64,11 +64,25 @@ def _parse(current, timeline):
         (['Bug'], ['Bug'], 'bug'),
         # Null label node (PR #553 — deleted repo label)
         (['feature'], [None, 'feature'], 'feature'),
-        (['feature'], [None], None),
+        (['feature'], [None], 'feature'),
         # Remove-and-replace: feature removed, bug added
         (['bug'], ['feature', 'bug'], 'bug'),
         # Only scoring label was removed
         (['lgtm'], ['feature'], None),
+        # Timeline truncated: scoring label in current but not in last-5 events (#646)
+        (
+            ['bug', 'size:s', 'area:test', 'priority:low', 'status:triaged'],
+            ['size:s', 'area:test', 'priority:low', 'status:triaged', 'lgtm'],
+            'bug',
+        ),
+        # Timeline truncated: penalty label still applied via fallback
+        (['refactor', 'size:M', 'lgtm'], ['size:M', 'lgtm'], 'refactor'),
+        # Timeline truncated: multiple scoring labels both truncated — highest multiplier wins
+        (['feature', 'bug'], [], 'feature'),
+        # Timeline partially truncated: one scoring label in timeline wins over truncated one
+        (['feature', 'bug'], ['bug'], 'bug'),
+        # Empty timeline with scoring label in current
+        (['enhancement'], [], 'enhancement'),
     ],
 )
 def test_label_extraction(current, timeline, expected):


### PR DESCRIPTION
## Summary

[PullRequest.from_graphql_response](cci:1://file:///root/74/gold/gittensor/gittensor/classes.py:233:4-339:9) determines the scoring label by intersecting currently-applied labels with `timelineItems(last: 5)` LABELED_EVENTs. When a PR has more than five label events and the scoring label's add-event falls outside that window, the lookup finds no match and `label` is left as `None` — causing [LABEL_MULTIPLIERS.get(None, 1.0)](cci:1://file:///root/74/gold/gittensor/gittensor/classes.py:626:4-650:42) to return the default 1.0× instead of the configured multiplier.

This fix pre-computes `scoring_labels = current & LABEL_MULTIPLIERS.keys()` and adds a fallback after the timeline scan: if no match is found in the timeline, the highest-multiplier currently-applied scoring label is selected. Timeline order is still preferred when available.

## Related Issues

Closes #646

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

New parametrized cases in [test_label_multiplier.py](cci:7://file:///root/74/gold/gittensor/tests/validator/test_label_multiplier.py:0:0-0:0):
- Exact issue reproducer (scoring label truncated out of last-5 window)
- Penalty label (`refactor`/0.5×) survives truncation
- Multiple scoring labels both truncated — highest multiplier wins
- One scoring label in timeline, one truncated — timeline match wins
- Empty timeline with scoring label in current

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)