### PR TITLE
fix: handle null closingIssuesReferences in GraphQL PR timeline parsing

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -477,7 +477,8 @@ def _search_issue_referencing_prs_graphql(
 
         author = pr.get('author') or {}
         reviews = pr.get('reviews') or {}
-        closing = pr.get('closingIssuesReferences', {}).get('nodes', [])
+        closing_refs = pr.get('closingIssuesReferences') or {}
+        closing = closing_refs.get('nodes', [])
         closing_numbers = [n.get('number') for n in closing if n.get('number') is not None]
 
         pr_info: PRInfo = {

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -919,6 +919,19 @@ class TestFindSolverFromCrossReferences:
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
     @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_closing_issues_references_is_handled(self, mock_logging, mock_graphql):
+        """Null closingIssuesReferences should be treated as empty and not crash parsing."""
+        null_closing_node = _pr_node(number=14, user_id=42, closing_issues=[12])
+        null_closing_node['source']['closingIssuesReferences'] = None
+        mock_graphql.return_value = _graphql_response([null_closing_node])
+
+        solver_id, pr_number = find_solver_from_cross_references('owner/repo', 12, 'fake_token')
+
+        assert solver_id is None
+        assert pr_number is None
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
     def test_multiple_candidates_picks_most_recent(self, mock_logging, mock_graphql):
         """When multiple merged PRs close the issue, the most recently merged one is selected."""
         mock_graphql.return_value = _graphql_response(


### PR DESCRIPTION
## Summary
- Fix a crash in GraphQL PR timeline parsing when `closingIssuesReferences` is `null`.
- Treat `null` `closingIssuesReferences` as an empty list instead of calling `.get('nodes')` on `None`.
- Add a regression test to ensure null values are handled safely.

## Why
GitHub can return `closingIssuesReferences: null` for some PR timeline nodes.  
Previously this caused:
`AttributeError: 'NoneType' object has no attribute 'get'`
which aborted PR parsing.

## Changes
- Updated `_search_issue_referencing_prs_graphql` in `gittensor/utils/github_api_tools.py`:
  - from direct chained `.get('closingIssuesReferences', {}).get('nodes', [])`
  - to null-safe handling using an intermediate fallback object.
- Added test `test_null_closing_issues_references_is_handled` in `tests/utils/test_github_api_tools.py`.

## Test Plan
- [x] `uv run pytest -q tests/utils/test_github_api_tools.py -k null_closing_issues_references_is_handled`
- [x] `uv run pytest -q tests/utils/test_github_api_tools.py -k cross_references`

## Issue
Closes #647