### PR TITLE
fix: preserve repo weight precision by removing 2-decimal rounding

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -20,7 +20,7 @@ from gittensor.constants import (
     OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
 )
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
-from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.utils.load_weights import RepositoryConfig, resolve_repo_weight
 
 
 def calculate_issue_review_quality_multiplier(changes_requested_count: int) -> float:
@@ -277,7 +277,7 @@ def _collect_issues_from_prs(
                 # Populate discovery scoring fields
                 repo_config = master_repositories.get(pr.repository_full_name)
                 issue.discovery_base_score = pr.base_score
-                issue.discovery_repo_weight_multiplier = round(repo_config.weight if repo_config else 0.01, 2)
+                issue.discovery_repo_weight_multiplier = resolve_repo_weight(repo_config)
                 issue.discovery_time_decay_multiplier = round(calculate_time_decay(pr.merged_at), 2)
                 issue.discovery_review_quality_multiplier = round(
                     calculate_issue_review_quality_multiplier(pr.changes_requested_count), 2

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -43,7 +43,7 @@ from gittensor.utils.github_api_tools import (
 )
 from gittensor.validator.oss_contributions.credibility import check_eligibility
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
-from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig
+from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig, resolve_repo_weight
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
 
@@ -222,7 +222,7 @@ def calculate_pr_multipliers(
     is_merged = pr.pr_state == PRState.MERGED
     repo_config = master_repositories.get(pr.repository_full_name)
 
-    pr.repo_weight_multiplier = round(repo_config.weight if repo_config else 0.01, 2)
+    pr.repo_weight_multiplier = resolve_repo_weight(repo_config)
     pr.issue_multiplier = round(calculate_issue_multiplier(pr), 2)
     pr.label_multiplier = LABEL_MULTIPLIERS.get(pr.label, 1.0) if pr.label else 1.0
 

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -39,6 +39,12 @@ class RepositoryConfig:
     additional_acceptable_branches: Optional[List[str]] = None
 
 
+def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
+    if repo_config is None:
+        return 0.01
+    return repo_config.weight
+
+
 @dataclass
 class TokenConfig:
     """Configuration for token-based scoring weights.

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -17,6 +17,7 @@ from gittensor.validator.utils.load_weights import (
     load_master_repo_weights,
     load_programming_language_weights,
     load_token_config,
+    resolve_repo_weight,
 )
 
 
@@ -158,6 +159,37 @@ class TestBannedOrganizations:
                 active_banned.append(repo_name)
 
         assert len(active_banned) == 0, f'Found {len(active_banned)} active repos from banned orgs: {active_banned}'
+
+
+class TestResolveRepoWeight:
+    """Tests for resolve_repo_weight — full-precision repo weight lookup."""
+
+    def test_none_returns_default(self):
+        assert resolve_repo_weight(None) == 0.01
+
+    @pytest.mark.parametrize(
+        'weight',
+        [
+            0.0349,
+            0.0351,
+            0.0346,
+            0.0450,
+            0.4274,
+            1.0,
+        ],
+    )
+    def test_preserves_full_precision(self, weight):
+        """Previously `round(weight, 2)` truncated to 2 decimals — now full precision is preserved."""
+        config = RepositoryConfig(weight=weight)
+        assert resolve_repo_weight(config) == weight
+
+    def test_live_master_repo_precision(self):
+        """Live check: cronboard (0.0349) and fzf (0.0351) should no longer collapse to 0.03/0.04."""
+        repos = load_master_repo_weights()
+        if 'antoniorodr/cronboard' in repos:
+            assert resolve_repo_weight(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
+        if 'junegunn/fzf' in repos:
+            assert resolve_repo_weight(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Drop `round(repo_config.weight, 2)` at both multiplier assignment sites.
- Extract `resolve_repo_weight(repo_config)` helper in `load_weights.py` so the `None → DEFAULT_REPO_WEIGHT` fallback lives in one place.
- Preserves full 4-decimal precision from `master_repositories.json` through the multiplier chain into `earned_score`.

## Related Issues

Fixes #652

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `TestResolveRepoWeight` in `tests/validator/test_load_weights.py` covering `None` default, full-precision preservation for six real weights, and live-data verification against `master_repositories.json` (`antoniorodr/cronboard` 0.0349, `junegunn/fzf` 0.0351).

Verified end-to-end against live miner PRs on affected repos ([langgenius/dify#34813](https://gittensor.io/miners/pr?repo=langgenius%2Fdify&number=34813) and friends): `repoWeightMultiplier` stored as `0.03` now flows through as `0.0336`, lifting the PR's earned score by the expected +12%.

`uv run pytest tests/` → 402 passed. `uv run ruff check` / `ruff format --check` / `pyright` all clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
`