### PR TITLE
fix: fully paginate closing issue references for PR ingestion

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -88,7 +88,11 @@ QUERY = """
               mergedBy {
                 login
               }
-              closingIssuesReferences(first: 3) {
+              closingIssuesReferences(first: 20) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
                 nodes {
                   number
                   title
@@ -141,6 +145,98 @@ QUERY = """
       }
     }
     """
+
+_PR_CLOSING_ISSUES_PAGE_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 50, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          number
+          title
+          state
+          stateReason
+          createdAt
+          closedAt
+          updatedAt
+          author {
+            login
+            ... on User { databaseId }
+          }
+          authorAssociation
+          userContentEdits(first: 1) {
+            nodes { editedAt }
+          }
+          timelineItems(itemTypes: [RENAMED_TITLE_EVENT], last: 1) {
+            nodes {
+              ... on RenamedTitleEvent { createdAt }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _hydrate_all_closing_issues_for_pr(pr_raw: Dict[str, Any], token: str) -> Dict[str, Any]:
+    """Fetch all closing issue references for a PR when the first page is truncated."""
+    closing_refs = pr_raw.get('closingIssuesReferences') or {}
+    page_info = closing_refs.get('pageInfo') or {}
+    if not page_info.get('hasNextPage'):
+        return pr_raw
+
+    owner = ((pr_raw.get('repository') or {}).get('owner') or {}).get('login')
+    name = (pr_raw.get('repository') or {}).get('name')
+    pr_number = pr_raw.get('number')
+    if not owner or not name or not pr_number:
+        return pr_raw
+
+    all_nodes = list(closing_refs.get('nodes') or [])
+    cursor = page_info.get('endCursor')
+    seen_cursors = set()
+
+    while True:
+        if not cursor:
+            break
+        if cursor in seen_cursors:
+            bt.logging.warning(
+                f'Repeated cursor while paginating closing issues for PR #{pr_number} in {owner}/{name}; stopping to avoid infinite loop'
+            )
+            break
+        seen_cursors.add(cursor)
+
+        result = execute_graphql_query(
+            query=_PR_CLOSING_ISSUES_PAGE_QUERY,
+            variables={'owner': owner, 'name': name, 'number': int(pr_number), 'cursor': cursor},
+            token=token,
+            max_attempts=3,
+        )
+        if not result or result.get('errors'):
+            bt.logging.warning(f'Failed to paginate closing issues for PR #{pr_number} in {owner}/{name}')
+            break
+
+        closing_page = (
+            (result.get('data') or {})
+            .get('repository', {})
+            .get('pullRequest', {})
+            .get('closingIssuesReferences', {})
+        )
+        new_nodes = closing_page.get('nodes') or []
+        all_nodes.extend(new_nodes)
+
+        next_page_info = closing_page.get('pageInfo') or {}
+        if not next_page_info.get('hasNextPage'):
+            break
+        cursor = next_page_info.get('endCursor')
+
+    pr_raw['closingIssuesReferences'] = {'nodes': all_nodes, 'pageInfo': {'hasNextPage': False, 'endCursor': None}}
+    return pr_raw
 
 
 def branch_matches_pattern(branch_name: str, patterns: List[str]) -> bool:
@@ -1012,7 +1108,8 @@ def load_miners_prs(
                         bt.logging.debug(skip_reason or '')
                         continue
 
-                    miner_eval.add_merged_pull_request(pr_raw)
+                    hydrated_pr_raw = _hydrate_all_closing_issues_for_pr(pr_raw, miner_eval.github_pat)
+                    miner_eval.add_merged_pull_request(hydrated_pr_raw)
 
                 except Exception as e:
                     pr_number = pr_raw.get('number', '?')

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -25,3 +25,48 @@ def test_pull_request_handles_deleted_label_event():
 
     assert pr.label is None
     assert pr.author_login == 'alice'
+
+
+def test_pull_request_parses_all_closing_issues_from_graphql_node_list():
+    pr_data = {
+        'number': 77,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'state': 'MERGED',
+        'closingIssuesReferences': {
+            'nodes': [
+                {
+                    'number': issue_number,
+                    'title': f'Issue {issue_number}',
+                    'state': 'CLOSED',
+                    'stateReason': 'COMPLETED',
+                    'createdAt': '2026-04-10T00:00:00Z',
+                    'closedAt': '2026-04-11T00:00:00Z',
+                    'updatedAt': '2026-04-11T00:00:00Z',
+                    'author': {'login': 'reporter', 'databaseId': 123},
+                    'authorAssociation': 'CONTRIBUTOR',
+                    'userContentEdits': {'nodes': []},
+                    'timelineItems': {'nodes': []},
+                }
+                for issue_number in [101, 102, 103, 104, 105]
+            ]
+        },
+        'bodyText': 'Fix multiple issues',
+        'lastEditedAt': None,
+        'mergedAt': '2026-04-12T00:00:00Z',
+        'timelineItems': {'nodes': []},
+        'labels': {'nodes': []},
+        'title': 'fix: close multiple issues',
+        'author': {'login': 'alice'},
+        'createdAt': '2026-04-09T00:00:00Z',
+        'additions': 10,
+        'deletions': 2,
+        'commits': {'totalCount': 1},
+        'headRefOid': 'abc123',
+        'baseRefOid': 'def456',
+        'changesRequestedReviews': {'nodes': []},
+    }
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.issues is not None
+    assert [issue.number for issue in pr.issues] == [101, 102, 103, 104, 105]

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -33,6 +33,8 @@ get_merge_base_sha = github_api_tools.get_merge_base_sha
 find_prs_for_issue = github_api_tools.find_prs_for_issue
 execute_graphql_query = github_api_tools.execute_graphql_query
 check_github_issue_closed = github_api_tools.check_github_issue_closed
+QUERY = github_api_tools.QUERY
+hydrate_all_closing_issues_for_pr = github_api_tools._hydrate_all_closing_issues_for_pr
 
 
 # ============================================================================
@@ -1125,6 +1127,125 @@ def _make_pr_node(
         'closingIssuesReferences': closing_issues_refs,
         'reviews': {'nodes': [{'author': {'login': 'reviewer'}}]},
     }
+
+
+def test_main_pr_query_fetches_more_than_three_closing_issue_references():
+    """Regression test: prevent truncating PR closing issues to only 3 entries."""
+    assert 'closingIssuesReferences(first: 20)' in QUERY
+    assert 'pageInfo {' in QUERY
+
+
+@patch('gittensor.utils.github_api_tools.execute_graphql_query')
+def test_hydrate_all_closing_issues_for_pr_fetches_remaining_pages(mock_execute):
+    pr_raw = {
+        'number': 77,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'closingIssuesReferences': {
+            'nodes': [{'number': 1}, {'number': 2}],
+            'pageInfo': {'hasNextPage': True, 'endCursor': 'cursor-1'},
+        },
+    }
+    mock_execute.return_value = {
+        'data': {
+            'repository': {
+                'pullRequest': {
+                    'closingIssuesReferences': {
+                        'nodes': [{'number': 3}, {'number': 4}],
+                        'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                    }
+                }
+            }
+        }
+    }
+
+    hydrated = hydrate_all_closing_issues_for_pr(pr_raw, token='fake')
+
+    assert [issue['number'] for issue in hydrated['closingIssuesReferences']['nodes']] == [1, 2, 3, 4]
+    assert mock_execute.call_count == 1
+
+
+@patch('gittensor.utils.github_api_tools.execute_graphql_query')
+def test_hydrate_all_closing_issues_for_pr_fetches_all_pages_without_fixed_cap(mock_execute):
+    pr_raw = {
+        'number': 77,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'closingIssuesReferences': {
+            'nodes': [{'number': 1}],
+            'pageInfo': {'hasNextPage': True, 'endCursor': 'cursor-1'},
+        },
+    }
+
+    side_effect_pages = []
+    for i in range(2, 15):
+        has_next = i < 14
+        end_cursor = f'cursor-{i}' if has_next else None
+        side_effect_pages.append(
+            {
+                'data': {
+                    'repository': {
+                        'pullRequest': {
+                            'closingIssuesReferences': {
+                                'nodes': [{'number': i}],
+                                'pageInfo': {'hasNextPage': has_next, 'endCursor': end_cursor},
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+    mock_execute.side_effect = side_effect_pages
+
+    hydrated = hydrate_all_closing_issues_for_pr(pr_raw, token='fake')
+
+    assert [issue['number'] for issue in hydrated['closingIssuesReferences']['nodes']] == list(range(1, 15))
+    assert mock_execute.call_count == 13
+
+
+@patch('gittensor.utils.github_api_tools.execute_graphql_query')
+def test_hydrate_all_closing_issues_for_pr_stops_on_repeated_cursor(mock_execute):
+    pr_raw = {
+        'number': 77,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'closingIssuesReferences': {
+            'nodes': [{'number': 1}],
+            'pageInfo': {'hasNextPage': True, 'endCursor': 'cursor-1'},
+        },
+    }
+    mock_execute.return_value = {
+        'data': {
+            'repository': {
+                'pullRequest': {
+                    'closingIssuesReferences': {
+                        'nodes': [{'number': 2}],
+                        'pageInfo': {'hasNextPage': True, 'endCursor': 'cursor-1'},
+                    }
+                }
+            }
+        }
+    }
+
+    hydrated = hydrate_all_closing_issues_for_pr(pr_raw, token='fake')
+
+    assert [issue['number'] for issue in hydrated['closingIssuesReferences']['nodes']] == [1, 2]
+    assert mock_execute.call_count == 1
+
+
+@patch('gittensor.utils.github_api_tools.execute_graphql_query')
+def test_hydrate_all_closing_issues_for_pr_skips_when_single_page(mock_execute):
+    pr_raw = {
+        'number': 77,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'closingIssuesReferences': {
+            'nodes': [{'number': 1}, {'number': 2}],
+            'pageInfo': {'hasNextPage': False, 'endCursor': None},
+        },
+    }
+
+    hydrated = hydrate_all_closing_issues_for_pr(pr_raw, token='fake')
+
+    assert [issue['number'] for issue in hydrated['closingIssuesReferences']['nodes']] == [1, 2]
+    mock_execute.assert_not_called()
 
 
 def _make_graphql_response(pr_nodes):


### PR DESCRIPTION
## Summary

This PR fully resolves issue #653 by removing truncation in PR-linked closing issue ingestion.

Previously, validator PR ingestion fetched only a partial `closingIssuesReferences` set, which could cause downstream scoring logic to operate on incomplete `pr.issues`. This patch now hydrates the full closing-issue connection via cursor pagination.

## What Changed

- Updated main PR GraphQL query to include:
  - `closingIssuesReferences(first: 20)`
  - `closingIssuesReferences.pageInfo { hasNextPage, endCursor }`
- Added per-PR hydration logic in `load_miners_prs()`:
  - Detects when closing issue refs are paginated
  - Fetches additional pages using a dedicated GraphQL query
  - Continues until `hasNextPage == false`
- Added safety guard for repeated cursors to prevent infinite loops on malformed pagination responses.
- Added/updated regression tests covering:
  - query shape includes closing-issues `pageInfo`
  - multi-page hydration appends all pages
  - behavior is not bounded by a fixed loop cap
  - repeated-cursor stop condition
  - single-page no-op behavior

## Why This Fix

Scoring paths (issue multiplier + issue discovery) depend on `pr.issues`.  
If ingestion truncates linked issues, scoring can diverge from GitHub’s actual closure graph.  
This change ensures `pr.issues` reflects the complete set of linked closing issues for each PR.

## Test Plan

- [x] `.venv/bin/pytest tests/utils/test_github_api_tools.py tests/test_classes.py`

Result: **78 passed**

## Notes

- Branch history is intentionally squashed to a single commit for clean review.

## Issues

Closes #653