### PR TITLE
refactor: deduplicate `__exit__` shutdown logic via `stop_run_thread`

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -209,12 +209,7 @@ class BaseValidatorNeuron(BaseNeuron):
             traceback: A traceback object encoding the stack trace.
                        None if the context was exited without an exception.
         """
-        if self.is_running:
-            bt.logging.debug('Stopping validator in background thread.')
-            self.should_exit = True
-            self.thread.join(5)
-            self.is_running = False
-            bt.logging.debug('Stopped')
+        self.stop_run_thread()
 
     def set_weights(self):
         """


### PR DESCRIPTION
## Summary

`__exit__` inlined the same shutdown logic already implemented in `stop_run_thread()`, which had zero callers. Replace the duplicated body with a single call to `stop_run_thread()`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

Existing test suite passes (70/70). Behavioral no-op — `stop_run_thread` contains the identical logic that was inlined in `__exit__`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)