### PR TITLE
fix: guard null closing issue refs in graphql parser

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -477,7 +477,7 @@ def _search_issue_referencing_prs_graphql(
 
         author = pr.get('author') or {}
         reviews = pr.get('reviews') or {}
-        closing = pr.get('closingIssuesReferences', {}).get('nodes', [])
+        closing = (pr.get('closingIssuesReferences') or {}).get('nodes', [])
         closing_numbers = [n.get('number') for n in closing if n.get('number') is not None]
 
         pr_info: PRInfo = {


### PR DESCRIPTION
## Summary
- guard `closingIssuesReferences` when GitHub returns `null`
- keep GraphQL PR parsing resilient instead of raising on `.get()`

## Problem
`_search_issue_referencing_prs_graphql` assumes `closingIssuesReferences` is always an object, but GitHub can return `null`.

## Validation
- ran `python3 -m py_compile gittensor/utils/github_api_tools.py`

Closes #647