### PR TITLE
fix: guard null base repository in graphql parser

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -463,7 +463,7 @@ def _search_issue_referencing_prs_graphql(
         if not pr:
             continue
 
-        base_repo = pr.get('baseRepository', {}).get('nameWithOwner', '')
+        base_repo = (pr.get('baseRepository') or {}).get('nameWithOwner', '')
         if base_repo.lower() != repo.lower():
             continue
 


### PR DESCRIPTION
## Summary
- guard `baseRepository` when GitHub returns `null`
- keep GraphQL PR parsing resilient instead of raising on `.get()`

## Problem
`_search_issue_referencing_prs_graphql` assumes `baseRepository` is always an object, but GitHub can return `null`.

## Validation
- ran `python3 -m py_compile gittensor/utils/github_api_tools.py`

Closes #658