### PR TITLE
fix: exit non-zero when issue metadata is missing

### DIFF
--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -197,7 +197,7 @@ def issue_register(
         )
         if not contract_metadata.exists():
             console.print(f'[red]Error: Contract metadata not found at {contract_metadata}[/red]')
-            return
+            raise SystemExit(1)
 
         contract_instance = ContractInstance.create_from_address(
             contract_address=contract_addr,


### PR DESCRIPTION
## Summary
- exit non-zero when `gitt issues register` cannot find the contract metadata file
- keep scripting behavior aligned with the printed error

## Problem
The command prints an error when the contract metadata file is missing, but then returns normally with exit code 0.

## Validation
- ran `python3 -m py_compile gittensor/cli/issue_commands/mutations.py`

Closes #657