### PR TITLE
fix(issue-bounties): align solver selection with issue discovery

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1043,7 +1043,7 @@ def find_solver_from_cross_references(
     - merged, and
     - explicitly closing ``issue_number``.
 
-    If multiple candidates exist, the most recent ``merged_at`` is selected.
+    If multiple candidates exist, the earliest ``merged_at`` is selected.
 
     Returns:
         ``None`` when lookup fails and should be retried later. Otherwise a
@@ -1060,14 +1060,14 @@ def find_solver_from_cross_references(
         return None, None
 
     if len(merged) > 1:
-        bt.logging.warning(f'Multiple closing PRs found for {repo}#{issue_number}, selecting most recent.')
+        bt.logging.warning(f'Multiple closing PRs found for {repo}#{issue_number}, selecting earliest.')
         for candidate in merged:
             bt.logging.debug(
                 f'  PR#{candidate.get("number")}, solver_id={candidate.get("author_id")}, '
                 f'merged_at={candidate.get("merged_at")}'
             )
 
-    merged.sort(key=lambda p: p.get('merged_at') or '', reverse=True)
+    merged.sort(key=lambda p: (p.get('merged_at') or '', p.get('number') or 0))
     best = merged[0]
     bt.logging.debug(
         f'Solver via GraphQL cross-reference: PR#{best.get("number")}, '

--- a/tests/test_solver_selection.py
+++ b/tests/test_solver_selection.py
@@ -1,0 +1,46 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for solver selection from cross references."""
+
+import importlib
+import sys
+from enum import Enum
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+
+def _install_github_api_stubs(monkeypatch):
+    fake_bt = SimpleNamespace(logging=SimpleNamespace(debug=lambda *_args, **_kwargs: None, warning=lambda *_args, **_kwargs: None))
+    monkeypatch.setitem(sys.modules, 'bittensor', fake_bt)
+
+    fake_classes = ModuleType('gittensor.classes')
+    fake_classes.FileChange = object
+    fake_classes.MinerEvaluation = object
+
+    class FakePRState(Enum):
+        MERGED = 'MERGED'
+        OPEN = 'OPEN'
+        CLOSED = 'CLOSED'
+
+    fake_classes.PRState = FakePRState
+    monkeypatch.setitem(sys.modules, 'gittensor.classes', fake_classes)
+
+    monkeypatch.delitem(sys.modules, 'gittensor.utils.github_api_tools', raising=False)
+
+
+def test_find_solver_prefers_earliest_merged_pr(monkeypatch):
+    _install_github_api_stubs(monkeypatch)
+    github_api_tools = importlib.import_module('gittensor.utils.github_api_tools')
+
+    prs = [
+        {'number': 20, 'author_id': 200, 'state': 'MERGED', 'merged_at': '2025-06-15T00:00:00Z', 'closing_numbers': [12]},
+        {'number': 10, 'author_id': 100, 'state': 'MERGED', 'merged_at': '2025-01-01T00:00:00Z', 'closing_numbers': [12]},
+        {'number': 15, 'author_id': 150, 'state': 'MERGED', 'merged_at': '2025-03-01T00:00:00Z', 'closing_numbers': [12]},
+    ]
+
+    with patch.object(github_api_tools, '_search_issue_referencing_prs_graphql', return_value=prs):
+        solver_id, pr_number = github_api_tools.find_solver_from_cross_references('owner/repo', 12, 'token')
+
+    assert solver_id == 100
+    assert pr_number == 10


### PR DESCRIPTION
## Summary

- make issue bounty solver lookup prefer the earliest merged closing PR
- align cross-reference solver selection with issue discovery's canonical attribution rule
- add a regression test for multi-PR closing cases

## Related Issues

- None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)