### PR TITLE
fix(issue-discovery): scan pre-inactive issues by close date

### DIFF
--- a/gittensor/validator/issue_discovery/repo_scan.py
+++ b/gittensor/validator/issue_discovery/repo_scan.py
@@ -78,13 +78,10 @@ async def scan_closed_issues(
     # Sort repos by weight descending (high-value repos first)
     sorted_repos = sorted(master_repositories.items(), key=lambda x: x[1].weight, reverse=True)
 
-    # Filter out inactive repos
-    active_repos = [(name, config) for name, config in sorted_repos if config.inactive_at is None]
-
     result: Dict[str, List[Issue]] = {}
     global_lookup_count = 0
 
-    for i, (repo_name, repo_config) in enumerate(active_repos, 1):
+    for i, (repo_name, repo_config) in enumerate(sorted_repos, 1):
         if global_lookup_count >= REPO_SCAN_GLOBAL_CAP:
             bt.logging.info(f'Issue discovery scan: global cap ({REPO_SCAN_GLOBAL_CAP}) reached, stopping')
             break
@@ -92,6 +89,7 @@ async def scan_closed_issues(
         remaining_global = REPO_SCAN_GLOBAL_CAP - global_lookup_count
         lookups_done = await _scan_repo(
             repo_name,
+            repo_config,
             lookback_date,
             validator_pat,
             miner_github_ids,
@@ -103,7 +101,7 @@ async def scan_closed_issues(
 
         if i % 25 == 0:
             bt.logging.info(
-                f'Issue discovery scan: {i}/{len(active_repos)} repos scanned, {global_lookup_count} lookups'
+                f'Issue discovery scan: {i}/{len(sorted_repos)} repos scanned, {global_lookup_count} lookups'
             )
 
     total_issues = sum(len(issues) for issues in result.values())
@@ -116,6 +114,7 @@ async def scan_closed_issues(
 
 async def _scan_repo(
     repo_name: str,
+    repo_config: RepositoryConfig,
     lookback_date: str,
     validator_pat: str,
     miner_github_ids: Set[str],
@@ -132,10 +131,12 @@ async def _scan_repo(
     # GitHub REST ``since`` filters by updated_at, not closed_at.
     # Pre-parse the cutoff once so we can drop stale issues inside the loop.
     lookback_dt = datetime.fromisoformat(lookback_date.replace('Z', '+00:00'))
+    inactive_dt = parse_github_iso_to_utc(repo_config.inactive_at) if repo_config.inactive_at else None
 
     # Filter to miner-authored issues not already known
     unmatched: List[dict] = []
     stale_count = 0
+    inactive_count = 0
     for issue_raw in closed_issues:
         user = issue_raw.get('user') or {}
         author_id = str(user.get('id', ''))
@@ -153,11 +154,16 @@ async def _scan_repo(
         if closed_at is None or closed_at < lookback_dt:
             stale_count += 1
             continue
+        if inactive_dt is not None and closed_at >= inactive_dt:
+            inactive_count += 1
+            continue
 
         unmatched.append(issue_raw)
 
     if stale_count:
         bt.logging.debug(f'{repo_name}: dropped {stale_count} issues closed before lookback window')
+    if inactive_count:
+        bt.logging.debug(f'{repo_name}: dropped {inactive_count} issues closed after repo inactivity')
 
     if not unmatched:
         return 0

--- a/tests/test_repo_scan_inactive_repos.py
+++ b/tests/test_repo_scan_inactive_repos.py
@@ -1,0 +1,72 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for repo scan handling of inactive repositories."""
+
+import asyncio
+import importlib
+import sys
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+
+
+@dataclass
+class FakeIssue:
+    number: int
+    pr_number: int
+    repository_full_name: str
+    title: str
+    created_at: object = None
+    closed_at: object = None
+    author_login: str | None = None
+    author_github_id: str | None = None
+    state: str | None = None
+    state_reason: str | None = None
+
+
+def _install_repo_scan_stubs(monkeypatch):
+    fake_bt = SimpleNamespace(
+        logging=SimpleNamespace(info=lambda *_args, **_kwargs: None, debug=lambda *_args, **_kwargs: None, warning=lambda *_args, **_kwargs: None)
+    )
+    monkeypatch.setitem(sys.modules, 'bittensor', fake_bt)
+
+    fake_classes = ModuleType('gittensor.classes')
+    fake_classes.Issue = FakeIssue
+    fake_classes.MinerEvaluation = object
+    monkeypatch.setitem(sys.modules, 'gittensor.classes', fake_classes)
+
+    fake_github_tools = ModuleType('gittensor.utils.github_api_tools')
+    fake_github_tools.find_solver_from_cross_references = lambda *_args, **_kwargs: (None, None)
+    monkeypatch.setitem(sys.modules, 'gittensor.utils.github_api_tools', fake_github_tools)
+
+    monkeypatch.delitem(sys.modules, 'gittensor.validator.issue_discovery.repo_scan', raising=False)
+
+
+def test_scan_closed_issues_keeps_pre_inactive_closures(monkeypatch):
+    _install_repo_scan_stubs(monkeypatch)
+    repo_scan = importlib.import_module('gittensor.validator.issue_discovery.repo_scan')
+
+    closed_issue = {
+        'number': 7,
+        'title': 'pre-inactive issue',
+        'user': {'id': 101, 'login': 'miner'},
+        'state': 'closed',
+        'state_reason': 'completed',
+        'created_at': '2026-04-01T00:00:00Z',
+        'closed_at': '2026-04-10T00:00:00Z',
+    }
+
+    monkeypatch.setattr(repo_scan, '_fetch_closed_issues', lambda *_args, **_kwargs: [closed_issue])
+    monkeypatch.setattr(repo_scan, 'find_solver_from_cross_references', lambda *_args, **_kwargs: (None, None))
+
+    miner_eval = SimpleNamespace(github_id='101', merged_pull_requests=[], open_pull_requests=[], closed_pull_requests=[])
+    result = asyncio.run(
+            repo_scan.scan_closed_issues(
+                miner_evaluations={1: miner_eval},
+                master_repositories={'owner/repo': SimpleNamespace(weight=1.0, inactive_at='2026-04-15T00:00:00Z')},
+                validator_pat='token',
+            )
+        )
+
+    assert '101' in result
+    assert [issue.number for issue in result['101']] == [7]


### PR DESCRIPTION
## Summary

- stop excluding inactive repos before scan time
- keep issue discovery scan results for issues closed before repo inactivity
- drop only issues whose  is on or after the repo's inactivity timestamp

## Related Issues

- None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)