### PR TITLE
fix(storage): rollback partial evaluation writes

### DIFF
--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -37,6 +37,10 @@ class BaseRepository:
         self.db = db_connection
         self.logger = logging.getLogger(self.__class__.__name__)
 
+    def _manages_own_transaction(self) -> bool:
+        """Return True when repository methods should commit/rollback directly."""
+        return bool(getattr(self.db, 'autocommit', True))
+
     @contextmanager
     def get_cursor(self):
         """
@@ -63,10 +67,12 @@ class BaseRepository:
         try:
             with self.get_cursor() as cursor:
                 cursor.execute(query, params)
-                self.db.commit()
+                if self._manages_own_transaction():
+                    self.db.commit()
                 return True
         except Exception as e:
-            self.db.rollback()
+            if self._manages_own_transaction():
+                self.db.rollback()
             self.logger.error(f'Error executing command: {e}')
             return False
 
@@ -206,10 +212,12 @@ class Repository(BaseRepository):
                     template=None,
                     page_size=100,
                 )
-                self.db.commit()
+                if self._manages_own_transaction():
+                    self.db.commit()
                 return len(values)
         except Exception as e:
-            self.db.rollback()
+            if self._manages_own_transaction():
+                self.db.rollback()
             self.logger.error(f'Error in bulk pull request storage: {e}')
             return 0
 
@@ -261,10 +269,12 @@ class Repository(BaseRepository):
                 execute_values(
                     cursor, BULK_UPSERT_ISSUES.replace('VALUES %s', 'VALUES %s'), values, template=None, page_size=100
                 )
-                self.db.commit()
+                if self._manages_own_transaction():
+                    self.db.commit()
                 return len(values)
         except Exception as e:
-            self.db.rollback()
+            if self._manages_own_transaction():
+                self.db.rollback()
             self.logger.error(f'Error in bulk issue storage: {e}')
             return 0
 
@@ -310,10 +320,12 @@ class Repository(BaseRepository):
                     template=None,
                     page_size=100,
                 )
-                self.db.commit()
+                if self._manages_own_transaction():
+                    self.db.commit()
                 return len(values)
         except Exception as e:
-            self.db.rollback()
+            if self._manages_own_transaction():
+                self.db.rollback()
             prs = {(fc.pr_number, fc.repository_full_name) for fc in file_changes}
             self.logger.error(f'Error in bulk file change storage: {e} | PRs: {prs}')
             return 0
@@ -366,9 +378,11 @@ class Repository(BaseRepository):
                 from psycopg2.extras import execute_values
 
                 execute_values(cursor, BULK_UPSERT_MINER_EVALUATION, eval_values)
-                self.db.commit()
+                if self._manages_own_transaction():
+                    self.db.commit()
                 return True
         except Exception as e:
-            self.db.rollback()
+            if self._manages_own_transaction():
+                self.db.rollback()
             self.logger.error(f'Error in miner evaluation storage: {e}')
             return False

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -29,6 +29,15 @@ class DatabaseStorage:
     def is_enabled(self) -> bool:
         return self.db_connection is not None
 
+    @staticmethod
+    def _validate_stored_count(name: str, stored_count: int | bool, expected_count: int) -> str | None:
+        """Return an error string when a storage helper failed for non-empty input."""
+        if expected_count == 0:
+            return None
+        if isinstance(stored_count, bool):
+            return None if stored_count else f'Failed to store {name}'
+        return None if stored_count == expected_count else f'Failed to store all {name}: stored {stored_count}/{expected_count}'
+
     def store_evaluation(self, miner_eval: MinerEvaluation) -> StorageResult:
         """
         Store all evaluation data in an optimized manner with proper error handling.
@@ -70,6 +79,27 @@ class DatabaseStorage:
             self.repo.cleanup_stale_miner_data(miner_eval)
 
             result.stored_counts['evaluations'] = 1 if self.repo.set_miner_evaluation(miner_eval) else 0
+
+            validation_errors = [
+                self._validate_stored_count('miner', result.stored_counts['miners'], 1),
+                self._validate_stored_count(
+                    'merged pull requests', result.stored_counts['merged_pull_requests'], len(miner_eval.merged_pull_requests)
+                ),
+                self._validate_stored_count(
+                    'open pull requests', result.stored_counts['open_pull_requests'], len(miner_eval.open_pull_requests)
+                ),
+                self._validate_stored_count(
+                    'closed pull requests', result.stored_counts['closed_pull_requests'], len(miner_eval.closed_pull_requests)
+                ),
+                self._validate_stored_count('issues', result.stored_counts['issues'], len(miner_eval.get_all_issues())),
+                self._validate_stored_count(
+                    'file changes', result.stored_counts['file_changes'], len(miner_eval.get_all_file_changes())
+                ),
+                self._validate_stored_count('evaluation', result.stored_counts['evaluations'], 1),
+            ]
+            validation_errors = [error for error in validation_errors if error]
+            if validation_errors:
+                raise RuntimeError('; '.join(validation_errors))
 
             # Commit transaction
             self.db_connection.commit()

--- a/tests/test_storage_atomicity.py
+++ b/tests/test_storage_atomicity.py
@@ -1,0 +1,179 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for validator storage transaction handling."""
+
+import importlib
+import sys
+from dataclasses import dataclass, field
+from types import ModuleType, SimpleNamespace
+
+
+class FakeCursor:
+    def __init__(self):
+        self.executed = []
+
+    def execute(self, query, params):
+        self.executed.append((query, params))
+
+    def close(self):
+        return None
+
+
+class FakeConnection:
+    def __init__(self, autocommit=True):
+        self.autocommit = autocommit
+        self.commit_calls = 0
+        self.rollback_calls = 0
+        self.cursor_obj = FakeCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.commit_calls += 1
+
+    def rollback(self):
+        self.rollback_calls += 1
+
+
+@dataclass
+class FakeMiner:
+    uid: int
+    hotkey: str
+    github_id: str
+
+
+@dataclass
+class FakeMinerEvaluation:
+    uid: int
+    hotkey: str
+    github_id: str = '123'
+    merged_pull_requests: list = field(default_factory=lambda: [object()])
+    open_pull_requests: list = field(default_factory=list)
+    closed_pull_requests: list = field(default_factory=list)
+    failed_reason: str | None = None
+    base_total_score: float = 0.0
+    total_score: float = 0.0
+    total_collateral_score: float = 0.0
+    total_nodes_scored: int = 0
+    unique_repos_count: int = 0
+    is_eligible: bool = False
+    credibility: float = 0.0
+    total_token_score: float = 0.0
+    total_structural_count: int = 0
+    total_structural_score: float = 0.0
+    total_leaf_count: int = 0
+    total_leaf_score: float = 0.0
+    issue_discovery_score: float = 0.0
+    issue_token_score: float = 0.0
+    issue_credibility: float = 0.0
+    is_issue_eligible: bool = False
+    total_solved_issues: int = 0
+    total_valid_solved_issues: int = 0
+    total_closed_issues: int = 0
+    total_open_issues: int = 0
+    evaluation_timestamp: object = None
+
+    def get_all_issues(self):
+        return [object()]
+
+    def get_all_file_changes(self):
+        return []
+
+
+class FakeRepo:
+    def __init__(self, db_connection):
+        self.db = db_connection
+
+    def set_miner(self, _miner):
+        return True
+
+    def store_pull_requests_bulk(self, pull_requests):
+        return 0 if pull_requests else 0
+
+    def store_issues_bulk(self, issues):
+        return 0 if issues else 0
+
+    def store_file_changes_bulk(self, file_changes):
+        return len(file_changes)
+
+    def cleanup_stale_miner_data(self, _evaluation):
+        return None
+
+    def set_miner_evaluation(self, _evaluation):
+        return True
+
+
+def _install_common_stubs(monkeypatch):
+    fake_bt = SimpleNamespace(logging=SimpleNamespace(error=lambda *_args, **_kwargs: None))
+    monkeypatch.setitem(sys.modules, 'bittensor', fake_bt)
+
+
+def test_repository_skips_inner_commit_when_outer_transaction_active(monkeypatch):
+    _install_common_stubs(monkeypatch)
+
+    fake_numpy = ModuleType('numpy')
+    fake_numpy.integer = int
+    monkeypatch.setitem(sys.modules, 'numpy', fake_numpy)
+
+    fake_classes = ModuleType('gittensor.classes')
+    fake_classes.FileChange = object
+    fake_classes.Issue = object
+    fake_classes.Miner = FakeMiner
+    fake_classes.MinerEvaluation = FakeMinerEvaluation
+    fake_classes.PullRequest = object
+    monkeypatch.setitem(sys.modules, 'gittensor.classes', fake_classes)
+
+    fake_queries = ModuleType('gittensor.validator.storage.queries')
+    for name in [
+        'BULK_UPSERT_FILE_CHANGES',
+        'BULK_UPSERT_ISSUES',
+        'BULK_UPSERT_MINER_EVALUATION',
+        'BULK_UPSERT_PULL_REQUESTS',
+        'CLEANUP_STALE_MINER_EVALUATIONS',
+        'CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY',
+        'CLEANUP_STALE_MINERS',
+        'CLEANUP_STALE_MINERS_BY_HOTKEY',
+        'SET_MINER',
+    ]:
+        setattr(fake_queries, name, name)
+    monkeypatch.setitem(sys.modules, 'gittensor.validator.storage.queries', fake_queries)
+
+    monkeypatch.delitem(sys.modules, 'gittensor.validator.storage.repository', raising=False)
+    repository = importlib.import_module('gittensor.validator.storage.repository')
+
+    db = FakeConnection(autocommit=False)
+    repo = repository.Repository(db)
+
+    assert repo.set_miner(FakeMiner(uid=1, hotkey='hk', github_id='123')) is True
+    assert db.commit_calls == 0
+    assert db.rollback_calls == 0
+
+
+def test_store_evaluation_rolls_back_when_subwrite_returns_zero(monkeypatch):
+    _install_common_stubs(monkeypatch)
+
+    fake_classes = ModuleType('gittensor.classes')
+    fake_classes.Miner = FakeMiner
+    fake_classes.MinerEvaluation = FakeMinerEvaluation
+    monkeypatch.setitem(sys.modules, 'gittensor.classes', fake_classes)
+
+    fake_database = ModuleType('gittensor.validator.storage.database')
+    fake_database.create_database_connection = lambda: FakeConnection()
+    monkeypatch.setitem(sys.modules, 'gittensor.validator.storage.database', fake_database)
+
+    fake_repository = ModuleType('gittensor.validator.storage.repository')
+    fake_repository.Repository = FakeRepo
+    monkeypatch.setitem(sys.modules, 'gittensor.validator.storage.repository', fake_repository)
+
+    monkeypatch.delitem(sys.modules, 'gittensor.validator.utils.storage', raising=False)
+    storage = importlib.import_module('gittensor.validator.utils.storage')
+
+    db_storage = storage.DatabaseStorage()
+    result = db_storage.store_evaluation(FakeMinerEvaluation(uid=7, hotkey='hotkey'))
+
+    assert result.success is False
+    assert db_storage.db_connection.commit_calls == 0
+    assert db_storage.db_connection.rollback_calls == 1
+    assert result.errors


### PR DESCRIPTION
## Summary

- stop repository helpers from committing or rolling back inside an outer transaction
- fail `store_evaluation()` when any non-empty sub-write returns a falsey result
- add regression coverage for both transaction ownership and partial-write rollback

## Related Issues

- None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
