### PR TITLE
fix(validator): validate PAT access against tracked repos

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -25,8 +25,9 @@ from gittensor.cli.miner_commands.helpers import (
     _resolve_endpoint,
     _status,
 )
-from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
-from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
+from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS
+from gittensor.utils.github_api_tools import make_headers
+from gittensor.validator.utils.github_validation import validate_github_repo_access
 
 console = Console()
 
@@ -169,7 +170,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
 
 
 def _validate_pat_locally(pat: str) -> bool:
-    """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
+    """Validate PAT mirrors the validator-side checks: user identity + tracked repo access."""
     try:
         # Check basic auth
         user_resp = requests.get(
@@ -178,16 +179,11 @@ def _validate_pat_locally(pat: str) -> bool:
         if user_resp.status_code != 200:
             return False
 
-        # Check GraphQL access (same test the validator runs during PAT broadcast)
-        gql_resp = requests.post(
-            f'{BASE_GITHUB_API_URL}/graphql',
-            json={'query': GRAPHQL_VIEWER_QUERY},
-            headers=make_graphql_headers(pat),
-            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
-        )
-        if gql_resp.status_code != 200:
+        test_error = validate_github_repo_access(pat)
+        if test_error:
             console.print(
-                '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
+                f'[red]PAT lacks tracked repository GraphQL access: {test_error}. '
+                'Fine-grained PATs need access to at least one tracked public repo.[/red]'
             )
             return False
 

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -9,12 +9,10 @@ Miners check if a validator has their PAT via PatCheckSynapse.
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import bittensor as bt
-import requests
 
-from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.validator import pat_storage
-from gittensor.validator.utils.github_validation import validate_github_credentials
+from gittensor.validator.utils.github_validation import validate_github_credentials, validate_github_repo_access
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -164,19 +162,4 @@ def _test_pat_against_repo(pat: str) -> Optional[str]:
     Scoring uses the GraphQL API to fetch miner PRs, so this mirrors the real path.
     Returns an error string on failure, None on success.
     """
-    headers = {'Authorization': f'Bearer {pat}', 'Accept': 'application/json'}
-    try:
-        response = requests.post(
-            f'{BASE_GITHUB_API_URL}/graphql',
-            json={'query': GRAPHQL_VIEWER_QUERY},
-            headers=headers,
-            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
-        )
-        if response.status_code != 200:
-            return f'GitHub GraphQL API returned {response.status_code}'
-        data = response.json()
-        if 'errors' in data:
-            return f'GraphQL error: {data["errors"][0].get("message", "unknown")}'
-        return None
-    except requests.RequestException as e:
-        return str(e)
+    return validate_github_repo_access(pat)

--- a/gittensor/validator/utils/github_validation.py
+++ b/gittensor/validator/utils/github_validation.py
@@ -5,7 +5,11 @@
 
 from typing import Optional, Tuple
 
+import requests
+
+from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS
 from gittensor.utils.github_api_tools import get_github_id
+from gittensor.validator.utils.load_weights import load_master_repo_weights
 
 
 def validate_github_credentials(uid: int, pat: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
@@ -18,3 +22,46 @@ def validate_github_credentials(uid: int, pat: Optional[str]) -> Tuple[Optional[
         return None, f"No Github id found for miner {uid}'s PAT"
 
     return github_id, None
+
+
+def validate_github_repo_access(pat: Optional[str]) -> Optional[str]:
+    """Validate that a PAT can query at least one tracked repository via GraphQL."""
+    if not pat:
+        return 'No Github PAT provided'
+
+    master_repositories = load_master_repo_weights()
+    if not master_repositories:
+        return None
+
+    repo_name = next(iter(sorted(master_repositories)))
+    try:
+        owner, name = repo_name.split('/', 1)
+    except ValueError:
+        return f'Invalid tracked repository name: {repo_name}'
+
+    query = """
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) {
+            id
+          }
+        }
+    """
+    headers = {'Authorization': f'Bearer {pat}', 'Accept': 'application/json'}
+
+    try:
+        response = requests.post(
+            f'{BASE_GITHUB_API_URL}/graphql',
+            json={'query': query, 'variables': {'owner': owner, 'name': name}},
+            headers=headers,
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
+        )
+        if response.status_code != 200:
+            return f'GitHub GraphQL API returned {response.status_code}'
+        data = response.json()
+        if 'errors' in data:
+            return f'GraphQL error: {data["errors"][0].get("message", "unknown")}'
+        if not data.get('data', {}).get('repository'):
+            return f'PAT could not access tracked repo {repo_name}'
+        return None
+    except requests.RequestException as e:
+        return str(e)

--- a/tests/test_github_repo_access_validation.py
+++ b/tests/test_github_repo_access_validation.py
@@ -1,0 +1,59 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for tracked-repo PAT validation."""
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+def _install_validation_stubs(monkeypatch):
+    fake_constants = ModuleType('gittensor.constants')
+    fake_constants.BASE_GITHUB_API_URL = 'https://api.github.com'
+    fake_constants.GITHUB_HTTP_TIMEOUT_SECONDS = 15
+    monkeypatch.setitem(sys.modules, 'gittensor.constants', fake_constants)
+
+    fake_github_api_tools = ModuleType('gittensor.utils.github_api_tools')
+    fake_github_api_tools.get_github_id = lambda _pat: '123'
+    monkeypatch.setitem(sys.modules, 'gittensor.utils.github_api_tools', fake_github_api_tools)
+
+    fake_load_weights = ModuleType('gittensor.validator.utils.load_weights')
+    fake_load_weights.load_master_repo_weights = lambda: {'owner/repo': SimpleNamespace(weight=1.0)}
+    monkeypatch.setitem(sys.modules, 'gittensor.validator.utils.load_weights', fake_load_weights)
+
+    monkeypatch.delitem(sys.modules, 'gittensor.validator.utils.github_validation', raising=False)
+
+
+def test_validate_github_repo_access_queries_tracked_repo(monkeypatch):
+    _install_validation_stubs(monkeypatch)
+    github_validation = importlib.import_module('gittensor.validator.utils.github_validation')
+
+    captured = {}
+
+    def fake_post(url, json, headers, timeout):
+        captured['url'] = url
+        captured['json'] = json
+        captured['headers'] = headers
+        captured['timeout'] = timeout
+        return SimpleNamespace(status_code=200, json=lambda: {'data': {'repository': {'id': 'repo123'}}})
+
+    monkeypatch.setattr(github_validation.requests, 'post', fake_post)
+
+    assert github_validation.validate_github_repo_access('ghp_token') is None
+    assert captured['json']['variables'] == {'owner': 'owner', 'name': 'repo'}
+    assert 'repository(owner: $owner, name: $name)' in captured['json']['query']
+
+
+def test_validate_github_repo_access_rejects_missing_repository(monkeypatch):
+    _install_validation_stubs(monkeypatch)
+    github_validation = importlib.import_module('gittensor.validator.utils.github_validation')
+
+    monkeypatch.setattr(
+        github_validation.requests,
+        'post',
+        lambda *args, **kwargs: SimpleNamespace(status_code=200, json=lambda: {'data': {'repository': None}}),
+    )
+
+    error = github_validation.validate_github_repo_access('ghp_token')
+    assert 'could not access tracked repo owner/repo' in error


### PR DESCRIPTION
## Summary

- validate PAT GraphQL access against a tracked repository instead of only checking `viewer`
- share the tracked-repo access check between validator broadcast handling and miner-side local validation
- add regression coverage for successful tracked-repo access and missing-repo failures

## Related Issues

- None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
