### PR TITLE
fix: prefer maintainer-authored issue in calculate_issue_multiplier

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -429,11 +429,11 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
 
 def calculate_issue_multiplier(pr: PullRequest) -> float:
     """
-    Calculate PR score multiplier based on the first valid linked issue.
+    Calculate PR score multiplier from the best valid linked issue.
 
-    Returns a flat multiplier: MAINTAINER_ISSUE_MULTIPLIER (1.66) if the issue author
-    is a maintainer (OWNER/MEMBER/COLLABORATOR), otherwise STANDARD_ISSUE_MULTIPLIER (1.33).
-    Returns 1.0 if no valid linked issues.
+    Returns a flat multiplier: MAINTAINER_ISSUE_MULTIPLIER (1.66) if any valid issue
+    author is a maintainer (OWNER/MEMBER/COLLABORATOR), otherwise
+    STANDARD_ISSUE_MULTIPLIER (1.33). Returns 1.0 if no valid linked issues.
     """
     if not pr.issues:
         bt.logging.info(f'PR #{pr.number} - Contains no linked issues')
@@ -444,7 +444,12 @@ def calculate_issue_multiplier(pr: PullRequest) -> float:
         bt.logging.info(f'PR #{pr.number} - Solved no valid issues')
         return 1.0
 
-    issue = valid_issues[0]
+    # Prefer a maintainer-authored valid issue if one exists, so the multiplier
+    # doesn't depend on GraphQL closingIssuesReferences ordering.
+    issue = next(
+        (i for i in valid_issues if i.author_association in MAINTAINER_ASSOCIATIONS),
+        valid_issues[0],
+    )
     is_maintainer = issue.author_association in MAINTAINER_ASSOCIATIONS if issue.author_association else False
     multiplier = MAINTAINER_ISSUE_MULTIPLIER if is_maintainer else STANDARD_ISSUE_MULTIPLIER
     label = 'maintainer' if is_maintainer else 'standard'

--- a/tests/validator/test_calculate_issue_multiplier.py
+++ b/tests/validator/test_calculate_issue_multiplier.py
@@ -1,0 +1,94 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""
+Tests for calculate_issue_multiplier maintainer-preference over GraphQL ordering.
+
+When a PR closes multiple valid issues (e.g., one regular-author, one maintainer),
+the multiplier must not depend on the order pr.issues was populated in.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from gittensor.constants import (
+    MAINTAINER_ISSUE_MULTIPLIER,
+    STANDARD_ISSUE_MULTIPLIER,
+)
+from gittensor.validator.oss_contributions.scoring import calculate_issue_multiplier
+
+
+def _make_valid_pair(pr_factory, issue_factory):
+    """Build a merged PR with two valid issues: one regular, one maintainer."""
+    now = datetime.now(timezone.utc)
+    pr = pr_factory.merged(merged_at=now)
+    pr.author_login = 'miner_user'
+    pr.created_at = now - timedelta(days=1)
+    pr.last_edited_at = None
+
+    standard_issue = issue_factory.create(
+        number=100,
+        author_login='regular_user',
+        created_at=now - timedelta(days=5),
+        closed_at=now - timedelta(hours=1),
+    )
+    standard_issue.author_association = 'CONTRIBUTOR'
+
+    maintainer_issue = issue_factory.create(
+        number=200,
+        author_login='maintainer_user',
+        created_at=now - timedelta(days=4),
+        closed_at=now - timedelta(hours=1),
+    )
+    maintainer_issue.author_association = 'OWNER'
+
+    return pr, standard_issue, maintainer_issue
+
+
+def test_maintainer_wins_when_listed_first(pr_factory, issue_factory):
+    pr, standard_issue, maintainer_issue = _make_valid_pair(pr_factory, issue_factory)
+    pr.issues = [maintainer_issue, standard_issue]
+    assert calculate_issue_multiplier(pr) == MAINTAINER_ISSUE_MULTIPLIER
+
+
+def test_maintainer_wins_when_listed_second(pr_factory, issue_factory):
+    """Regression for ordering-dependent multiplier: list[0] was a regular user."""
+    pr, standard_issue, maintainer_issue = _make_valid_pair(pr_factory, issue_factory)
+    pr.issues = [standard_issue, maintainer_issue]
+    assert calculate_issue_multiplier(pr) == MAINTAINER_ISSUE_MULTIPLIER
+
+
+def test_standard_multiplier_when_no_maintainer_issue(pr_factory, issue_factory):
+    now = datetime.now(timezone.utc)
+    pr = pr_factory.merged(merged_at=now)
+    pr.author_login = 'miner_user'
+    pr.created_at = now - timedelta(days=1)
+    pr.last_edited_at = None
+
+    issue = issue_factory.create(
+        author_login='regular_user',
+        created_at=now - timedelta(days=5),
+        closed_at=now - timedelta(hours=1),
+    )
+    issue.author_association = 'CONTRIBUTOR'
+    pr.issues = [issue]
+
+    assert calculate_issue_multiplier(pr) == STANDARD_ISSUE_MULTIPLIER
+
+
+def test_no_valid_issues_returns_one(pr_factory, issue_factory):
+    now = datetime.now(timezone.utc)
+    pr = pr_factory.merged(merged_at=now)
+    pr.author_login = 'miner_user'
+    pr.created_at = now - timedelta(days=1)
+    pr.last_edited_at = None
+
+    # Self-authored → is_valid_issue rejects.
+    self_issue = issue_factory.create(
+        author_login='miner_user',
+        created_at=now - timedelta(days=5),
+        closed_at=now - timedelta(hours=1),
+    )
+    self_issue.author_association = 'OWNER'
+    pr.issues = [self_issue]
+
+    assert calculate_issue_multiplier(pr) == 1.0

--- a/tests/validator/test_calculate_issue_multiplier.py
+++ b/tests/validator/test_calculate_issue_multiplier.py
@@ -29,7 +29,7 @@ def _make_valid_pair(pr_factory, issue_factory):
         number=100,
         author_login='regular_user',
         created_at=now - timedelta(days=5),
-        closed_at=now - timedelta(hours=1),
+        closed_at=now + timedelta(hours=1),
     )
     standard_issue.author_association = 'CONTRIBUTOR'
 
@@ -37,7 +37,7 @@ def _make_valid_pair(pr_factory, issue_factory):
         number=200,
         author_login='maintainer_user',
         created_at=now - timedelta(days=4),
-        closed_at=now - timedelta(hours=1),
+        closed_at=now + timedelta(hours=1),
     )
     maintainer_issue.author_association = 'OWNER'
 
@@ -67,7 +67,7 @@ def test_standard_multiplier_when_no_maintainer_issue(pr_factory, issue_factory)
     issue = issue_factory.create(
         author_login='regular_user',
         created_at=now - timedelta(days=5),
-        closed_at=now - timedelta(hours=1),
+        closed_at=now + timedelta(hours=1),
     )
     issue.author_association = 'CONTRIBUTOR'
     pr.issues = [issue]


### PR DESCRIPTION
Picking valid_issues[0] made the multiplier depend on GraphQL closingIssuesReferences response ordering, which isn't documented as stable. A PR closing both a maintainer and a regular-author issue could flip between 1.66x and 1.33x run-to-run, and closing more valid issues could lower the multiplier.

Fixes #671 