### PR TITLE
refactor: remove dead CUDA detection and unused `self.device` attribute

### DIFF
--- a/gittensor/utils/config.py
+++ b/gittensor/utils/config.py
@@ -18,28 +18,11 @@
 
 import argparse
 import os
-import subprocess
 from typing import Any
 
 import bittensor as bt
 
 from gittensor.utils.logging import setup_events_logger
-
-
-def is_cuda_available():
-    try:
-        output = subprocess.check_output(['nvidia-smi', '-L'], stderr=subprocess.STDOUT)
-        if 'NVIDIA' in output.decode('utf-8'):
-            return 'cuda'
-    except Exception:
-        pass
-    try:
-        output = subprocess.check_output(['nvcc', '--version']).decode('utf-8')
-        if 'release' in output:
-            return 'cuda'
-    except Exception:
-        pass
-    return 'cpu'
 
 
 def check_config(cls, config: Any):
@@ -77,7 +60,7 @@ def add_args(cls, parser):
         '--neuron.device',
         type=str,
         help='Device to run on.',
-        default=is_cuda_available(),
+        default='cpu',
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary

Removes the [is_cuda_available()](cci:1://file:///root/mkdev11/gold/gittensor/gittensor/utils/config.py:18:0-31:16) function which shells out to `nvidia-smi`/`nvcc` at import time to set the `--neuron.device` default. GitTensor has no GPU workloads; the function was inert template code. The `--neuron.device` flag now defaults to `'cpu'` directly.

## Related Issues

Closes #674

## Type of Change

- [ ] Bug fix
- [x] Refactor
- [ ] New feature
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

Full test suite passes (406 tests). `ruff check`, `ruff format`, and `pyright` all clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)