### PR TITLE
fix: add success field to vote list json output

### DIFF
--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -10,7 +10,6 @@ Commands:
     gitt vote list
 """
 
-import json as json_mod
 import re
 
 import click
@@ -23,6 +22,7 @@ from .helpers import (
     _make_contract_client,
     _resolve_contract_and_network,
     console,
+    emit_json,
     print_error,
     print_network_header,
     print_success,
@@ -235,15 +235,13 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
         required = (n // 2) + 1
 
         if as_json:
-            console.print(
-                json_mod.dumps(
-                    {
-                        'validators': validators,
-                        'count': n,
-                        'consensus_threshold': required,
-                    },
-                    indent=2,
-                )
+            emit_json(
+                {
+                    'success': True,
+                    'validators': validators,
+                    'count': n,
+                    'consensus_threshold': required,
+                }
             )
             return
 


### PR DESCRIPTION
## Summary
- use the shared `emit_json` helper for `gitt vote list --json`
- add top-level `success: true` to the success-path payload

## Problem
`gitt vote list --json` returns machine-readable output without the top-level `success` field used by the other issue CLI JSON commands.

## Validation
- ran `python3 -m py_compile gittensor/cli/issue_commands/vote.py`