### PR TITLE
fix: keep miner check json success for zero valid PATs

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -103,7 +103,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         click.echo(
             json.dumps(
                 {
-                    'success': valid_count > 0,
+                    'success': True,
                     'total_validators': len(results),
                     'valid': valid_count,
                     'invalid': len(results) - valid_count - no_response_count,


### PR DESCRIPTION
## Summary
- keep `success: true` for completed `gitt miner check --json-output` runs even when zero validators report a valid PAT

## Problem
The command currently uses `success` to mean "at least one validator returned a valid PAT" instead of "the command completed successfully". That makes a completed zero-result check look like a transport or CLI failure to JSON consumers.

## Validation
- ran `python3 -m py_compile gittensor/cli/miner_commands/check.py`