### PR TITLE
fix: keep miner post json success for zero accepts

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -139,7 +139,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         click.echo(
             json.dumps(
                 {
-                    'success': accepted_count > 0,
+                    'success': True,
                     'total_validators': len(results),
                     'accepted': accepted_count,
                     'rejected': len(results) - accepted_count,


### PR DESCRIPTION
## Summary
- keep `success: true` for completed `gitt miner post --json-output` runs even when zero validators accept the PAT

## Problem
The command currently uses `success` to mean "at least one validator accepted the PAT" instead of "the command completed successfully". That makes a completed zero-accept result look like a CLI failure to JSON consumers.

## Validation
- ran `python3 -m py_compile gittensor/cli/miner_commands/post.py`