### PR TITLE
fix(cli): fail closed when issue registration cannot verify github

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -347,7 +347,11 @@ def validate_bounty_amount(bounty: str) -> int:
     return raw
 
 
-def validate_repository(repo: str, verify_exists: bool = True) -> Tuple[str, str]:
+def validate_repository(
+    repo: str,
+    verify_exists: bool = True,
+    require_verified_exists: bool = False,
+) -> Tuple[str, str]:
     """Validate owner/repo format and optionally verify it exists on GitHub.
 
     Returns (owner, repo_name) on success.
@@ -377,16 +381,33 @@ def validate_repository(repo: str, verify_exists: bool = True) -> Tuple[str, str
                     param_hint='--repo',
                 )
             if not resp.ok:
+                if require_verified_exists:
+                    raise click.BadParameter(
+                        f"Could not verify repository '{owner}/{repo_name}' on GitHub "
+                        f'(status {resp.status_code}). Try again when GitHub is reachable.',
+                        param_hint='--repo',
+                    )
                 console.print(
                     f'[yellow]Warning: GitHub API returned {resp.status_code} — skipping existence check[/yellow]'
                 )
         except requests.RequestException:
+            if require_verified_exists:
+                raise click.BadParameter(
+                    f"Could not verify repository '{owner}/{repo_name}' on GitHub. "
+                    'Try again when GitHub is reachable.',
+                    param_hint='--repo',
+                )
             console.print('[yellow]Warning: Could not reach GitHub API — skipping existence check[/yellow]')
 
     return owner, repo_name
 
 
-def validate_github_issue(owner: str, repo: str, issue_number: int) -> Optional[Dict[str, Any]]:
+def validate_github_issue(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    require_verified_exists: bool = False,
+) -> Optional[Dict[str, Any]]:
     """Verify a GitHub issue exists, is open, and is not a pull request.
 
     Returns the issue JSON data on success, or None if verification was skipped
@@ -399,6 +420,12 @@ def validate_github_issue(owner: str, repo: str, issue_number: int) -> Optional[
             timeout=GITHUB_API_TIMEOUT,
         )
     except requests.RequestException:
+        if require_verified_exists:
+            raise click.BadParameter(
+                f'Could not verify issue #{issue_number} in {owner}/{repo} on GitHub. '
+                'Try again when GitHub is reachable.',
+                param_hint='--issue',
+            )
         console.print('[yellow]Warning: Could not reach GitHub API — skipping issue check[/yellow]')
         return None
 
@@ -408,6 +435,12 @@ def validate_github_issue(owner: str, repo: str, issue_number: int) -> Optional[
             param_hint='--issue',
         )
     if not resp.ok:
+        if require_verified_exists:
+            raise click.BadParameter(
+                f'Could not verify issue #{issue_number} in {owner}/{repo} on GitHub '
+                f'(status {resp.status_code}). Try again when GitHub is reachable.',
+                param_hint='--issue',
+            )
         console.print(f'[yellow]Warning: GitHub API returned {resp.status_code} — skipping issue check[/yellow]')
         return None
 

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -129,14 +129,14 @@ def issue_register(
 
     # Validate inputs before showing summary
     try:
-        owner, repo_name = validate_repository(repo)
+        owner, repo_name = validate_repository(repo, require_verified_exists=True)
         bounty_amount = validate_bounty_amount(bounty)
         if issue_number < 1 or issue_number > MAX_ISSUE_NUMBER:
             raise click.BadParameter(
                 f'Issue number must be between 1 and {MAX_ISSUE_NUMBER} (got {issue_number})',
                 param_hint='--issue',
             )
-        validate_github_issue(owner, repo_name, issue_number)
+        validate_github_issue(owner, repo_name, issue_number, require_verified_exists=True)
     except click.BadParameter as e:
         raise click.ClickException(str(e))
 

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -213,6 +213,23 @@ class TestValidateRepository:
             validate_repository('no-slash', verify_exists=False)
         assert exc_info.value.param_hint == '--repo'
 
+    def test_require_verified_exists_rejects_skipped_api_check(self):
+        mock_resp = type(
+            'Resp',
+            (),
+            {
+                'status_code': 500,
+                'ok': False,
+            },
+        )()
+        with (
+            patch('gittensor.cli.issue_commands.helpers.requests.get', return_value=mock_resp),
+            pytest.raises(click.BadParameter) as exc_info,
+        ):
+            validate_repository('owner/repo', require_verified_exists=True)
+        assert exc_info.value.param_hint == '--repo'
+        assert 'Could not verify repository' in str(exc_info.value)
+
 
 # =============================================================================
 # validate_issue_id
@@ -269,6 +286,23 @@ class TestValidateGitHubIssue:
         mock_print.assert_called_once()
         call_args = mock_print.call_args[0][0]
         assert 'Issue #42 is already closed' in call_args
+
+    def test_require_verified_exists_rejects_skipped_issue_check(self):
+        mock_resp = type(
+            'Resp',
+            (),
+            {
+                'status_code': 503,
+                'ok': False,
+            },
+        )()
+        with (
+            patch('gittensor.cli.issue_commands.helpers.requests.get', return_value=mock_resp),
+            pytest.raises(click.BadParameter) as exc_info,
+        ):
+            validate_github_issue('owner', 'repo', 42, require_verified_exists=True)
+        assert exc_info.value.param_hint == '--issue'
+        assert 'Could not verify issue #42' in str(exc_info.value)
 
 
 # =============================================================================
@@ -455,6 +489,53 @@ class TestCliRegisterValidation:
             )
         assert result.exit_code != 0
         assert 'between' in result.output or over_max in result.output or 'issue' in result.output.lower()
+
+    def test_register_fails_closed_when_repo_verification_is_skipped(self, cli_root, runner):
+        with (
+            patch(
+                'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.mutations.validate_repository',
+                side_effect=click.BadParameter('Could not verify repository', param_hint='--repo'),
+            ),
+        ):
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'register', '--repo', 'owner/repo', '--issue', '1', '--bounty', '10', '-y'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'Could not verify repository' in result.output
+
+    def test_register_fails_closed_when_issue_verification_is_skipped(self, cli_root, runner):
+        with (
+            patch(
+                'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch('gittensor.cli.issue_commands.mutations.validate_repository', return_value=('owner', 'repo')),
+            patch(
+                'gittensor.cli.issue_commands.mutations.validate_github_issue',
+                side_effect=click.BadParameter('Could not verify issue', param_hint='--issue'),
+            ),
+        ):
+            result = runner.invoke(
+                cli_root,
+                ['issues', 'register', '--repo', 'owner/repo', '--issue', '1', '--bounty', '10', '-y'],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert 'Could not verify issue' in result.output
 
 
 class TestCliVoteValidation:


### PR DESCRIPTION
## Summary

- require successful GitHub verification before `gitt issues register` proceeds on-chain
- keep the existing warning-only helper behavior for non-registration callers
- add CLI regression coverage for skipped repository and issue verification

## Related Issues

- None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested
- `pytest -q tests/cli/test_cli_helpers.py -k 'require_verified_exists or fails_closed'`
- Full `pytest -q tests/cli/test_cli_helpers.py` still has one pre-existing environment failure here because `substrateinterface` is not installed locally for `test_harvest_runtime_exception_exits_non_zero`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
