### PR TITLE
fix(cli): surface contract read failures to issue commands

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -843,14 +843,11 @@ def read_issues_from_contract(ws_endpoint: str, contract_addr: str, verbose: boo
         return _read_issues_from_child_storage(substrate, contract_addr, verbose)
 
     except ImportError as e:
-        console.print(f'[yellow]Cannot read from contract: {e}[/yellow]')
-        console.print('[dim]Install with: uv sync[/dim]')
-        return []
+        raise click.ClickException(f'Cannot read from contract: {e}. Install with: uv sync')
     except Exception as e:
         if verbose:
             console.print(f'[dim]Debug: Connection/read error: {e}[/dim]')
-        console.print(f'[yellow]Error reading from contract: {e}[/yellow]')
-        return []
+        raise click.ClickException(f'Error reading from contract: {e}')
 
 
 def fetch_issue_from_contract(

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -70,8 +70,14 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
     if not as_json:
         print_network_header(network_name, contract_addr)
 
-    with console.status('[bold cyan]Reading issues from contract...', spinner='dots'):
-        issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
+    try:
+        with console.status('[bold cyan]Reading issues from contract...', spinner='dots'):
+            issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
+    except click.ClickException as e:
+        if as_json:
+            emit_error_json(str(e), error_type='contract_read_error')
+            raise SystemExit(1)
+        _handle_command_error(e)
 
     if as_json:
         # Enrich with human-readable ALPHA amounts for JSON consumers

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -6,6 +6,8 @@
 import json
 from unittest.mock import patch
 
+import click
+
 
 def test_submissions_json_schema_is_stable(cli_root, runner, sample_issue, sample_prs):
     with (
@@ -91,6 +93,28 @@ def test_submissions_json_missing_contract_returns_config_error(cli_root, runner
     assert payload['success'] is False
     assert payload['error']['type'] == 'config_error'
     assert 'Contract address not configured' in payload['error']['message']
+
+
+def test_submissions_json_contract_read_failure_returns_structured_error(cli_root, runner):
+    with (
+        patch('gittensor.cli.issue_commands.submissions.get_contract_address', return_value='0xabc'),
+        patch('gittensor.cli.issue_commands.submissions.resolve_network', return_value=('ws://x', 'test')),
+        patch(
+            'gittensor.cli.issue_commands.submissions.fetch_issue_from_contract',
+            side_effect=click.ClickException('Error reading from contract: node down'),
+        ),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'submissions', '--id', '42', '--json'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'cli_error'
+    assert 'node down' in payload['error']['message']
 
 
 def test_submissions_json_invalid_issue_id_returns_bad_parameter(cli_root, runner):

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -6,6 +6,8 @@
 import json
 from unittest.mock import patch
 
+import click
+
 FAKE_ISSUES = [
     {
         'id': 1,
@@ -35,3 +37,24 @@ def test_issues_list_json_missing_issue_returns_structured_error(cli_root, runne
     assert payload['success'] is False
     assert payload['error']['type'] == 'not_found'
     assert '999' in payload['error']['message']
+
+
+def test_issues_list_json_contract_read_failure_returns_structured_error(cli_root, runner):
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch(
+            'gittensor.cli.issue_commands.view.read_issues_from_contract',
+            side_effect=click.ClickException('Error reading from contract: node down'),
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'contract_read_error'
+    assert 'node down' in payload['error']['message']


### PR DESCRIPTION
## Summary

- raise explicit contract-read errors instead of returning empty issue lists on read failures
- make `gitt issues list --json` report contract read failures with a structured error payload
- add CLI regression coverage for JSON list and submissions flows when contract reads fail

## Related Issues

- None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested
- `pytest -q tests/cli/test_issues_list_json.py tests/cli/test_issue_submission.py`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
