### PR TITLE
fix(validator): fail fast when contract verification fails

### DIFF
--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -116,7 +116,7 @@ class IssueCompetitionContractClient:
         except ValueError:
             raise
         except Exception as e:
-            bt.logging.warning(f'Could not verify contract at {self.contract_address}: {e}')
+            raise ValueError(f'Could not verify contract at {self.contract_address}: {e}') from e
 
         bt.logging.debug(f'Contract client initialized: {self.contract_address}')
 

--- a/tests/validator/test_contract_client_transactions.py
+++ b/tests/validator/test_contract_client_transactions.py
@@ -71,6 +71,38 @@ def wallet():
     return w
 
 
+def test_init_verifies_contract_exists():
+    subtensor = MagicMock()
+    subtensor.substrate.query.return_value = SimpleNamespace(value={'trie_id': '0x01'})
+
+    client = IssueCompetitionContractClient(contract_address='5FakeContract', subtensor=subtensor)
+
+    assert client.contract_address == '5FakeContract'
+    assert client.subtensor is subtensor
+    subtensor.substrate.query.assert_called_once_with('Contracts', 'ContractInfoOf', ['5FakeContract'])
+
+
+def test_init_raises_when_contract_missing():
+    subtensor = MagicMock()
+    subtensor.substrate.query.return_value = SimpleNamespace(value=None)
+
+    with pytest.raises(ValueError) as exc_info:
+        IssueCompetitionContractClient(contract_address='5FakeContract', subtensor=subtensor)
+
+    assert 'No contract found at 5FakeContract' in str(exc_info.value)
+
+
+def test_init_raises_when_contract_cannot_be_verified():
+    subtensor = MagicMock()
+    subtensor.substrate.query.side_effect = RuntimeError('rpc down')
+
+    with pytest.raises(ValueError) as exc_info:
+        IssueCompetitionContractClient(contract_address='5FakeContract', subtensor=subtensor)
+
+    assert 'Could not verify contract at 5FakeContract' in str(exc_info.value)
+    assert 'rpc down' in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     'method, kwargs_fn, contract_method, expected_args, uses_hotkey, has_gas', METHOD_TABLE, ids=_IDS
 )


### PR DESCRIPTION
## Summary

- raise a clear initialization error when contract verification RPC/query calls fail
- keep the existing missing-contract check but stop constructing a client after an unverified startup
- add constructor-level coverage for present, missing, and unverified contract states

## Related Issues

- None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested
- `pytest -q tests/validator/test_contract_client_transactions.py` could not run here because this environment is missing the validator dependency stack (`bittensor`, `substrateinterface`, and `uv`)
- validated the constructor behavior with a focused `python3` stub script covering successful verification, missing contract info, and RPC verification failure

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
