### PR TITLE
fix: skip scoring CLOSED PRs in score_miner_prs to save GitHub API budget

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -65,7 +65,6 @@ def score_miner_prs(
     pr_groups = [
         ('MERGED', miner_eval.merged_pull_requests),
         ('OPEN', miner_eval.open_pull_requests),
-        ('CLOSED', miner_eval.closed_pull_requests),
     ]
 
     for label, prs in pr_groups:


### PR DESCRIPTION
Closes #681

Remove CLOSED from pr_groups in score_miner_prs. Closed-PR base_score is never used in reward calculation — only len(closed_prs) matters for credibility. This saves 2-3 GitHub API calls per closed PR per round.
