### PR TITLE
fix: guard remaining null-author PR paths

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -315,6 +315,8 @@ class PullRequest:
                 # Timeline truncated — fall back to highest-multiplier currently-applied label
                 label = max(scoring_labels, key=lambda n: (LABEL_MULTIPLIERS[n], n))
 
+        author = pr_data.get('author') or {}
+
         return cls(
             number=pr_data['number'],
             repository_full_name=repository_full_name,
@@ -322,7 +324,7 @@ class PullRequest:
             hotkey=hotkey,
             github_id=github_id,
             title=pr_data['title'],
-            author_login=pr_data['author']['login'],
+            author_login=author.get('login') or 'ghost',
             merged_at=merged_at,
             created_at=parse_github_timestamp_to_cst(pr_data['createdAt']),
             pr_state=pr_state,

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -860,12 +860,12 @@ def should_skip_merged_pr(
         )
 
     # Skip if PR was merged by the same person who created it (self-merge) AND there's no approvals from a differing party
-    if pr_raw['mergedBy'] and pr_raw['author']['login'] == pr_raw['mergedBy']['login']:
+    author_login = (pr_raw.get('author') or {}).get('login')
+    merged_by_login = (pr_raw.get('mergedBy') or {}).get('login')
+    if author_login and merged_by_login and author_login == merged_by_login:
         # Check if there are any approvals from users other than the author
         reviews = pr_raw.get('reviews', {}).get('nodes', [])
-        has_external_approval = any(
-            review.get('author') and review['author']['login'] != pr_raw['author']['login'] for review in reviews
-        )
+        has_external_approval = any(review.get('author') and review['author'].get('login') != author_login for review in reviews)
 
         if not has_external_approval:
             return (True, f'Skipping PR #{pr_raw["number"]} in {repository_full_name} - self-merged, no approval')

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,8 +1,8 @@
 from gittensor.classes import PullRequest
 
 
-def test_pull_request_handles_deleted_label_event():
-    pr_data = {
+def _base_pr_data():
+    return {
         'number': 42,
         'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
         'state': 'OPEN',
@@ -21,7 +21,18 @@ def test_pull_request_handles_deleted_label_event():
         'baseRefOid': 'def456',
     }
 
-    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+def test_pull_request_handles_deleted_label_event():
+    pr = PullRequest.from_graphql_response(_base_pr_data(), uid=1, hotkey='5Hotkey', github_id='123')
 
     assert pr.label is None
     assert pr.author_login == 'alice'
+
+
+def test_pull_request_handles_null_author():
+    pr_data = _base_pr_data()
+    pr_data['author'] = None
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.author_login == 'ghost'

--- a/tests/utils/test_null_author_guards.py
+++ b/tests/utils/test_null_author_guards.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+github_api_tools = pytest.importorskip(
+    'gittensor.utils.github_api_tools', reason='Requires gittensor package with all dependencies'
+)
+
+should_skip_merged_pr = github_api_tools.should_skip_merged_pr
+
+
+def test_should_skip_merged_pr_allows_null_author_without_crashing():
+    pr_raw = {
+        'number': 42,
+        'author': None,
+        'authorAssociation': 'NONE',
+        'mergedBy': {'login': 'maintainer'},
+        'reviews': {'nodes': []},
+        'repository': {'defaultBranchRef': {'name': 'main'}},
+        'baseRefName': 'main',
+        'headRefName': 'feature/null-author',
+        'headRepository': {'owner': {'login': 'forker'}, 'name': 'gittensor'},
+        'mergedAt': datetime.now(timezone.utc).isoformat(),
+    }
+
+    should_skip, reason = should_skip_merged_pr(
+        pr_raw,
+        repository_full_name='entrius/gittensor',
+        repo_config=RepositoryConfig(weight=1.0),
+        lookback_date_filter=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert should_skip is False
+    assert reason is None


### PR DESCRIPTION
## Summary
- guard the remaining direct `author["login"]` reads when GraphQL returns a null PR author
- default `PullRequest.from_graphql_response()` to `ghost` for missing authors instead of crashing
- add regressions for both the class parser and self-merge guard path

## Validation
- `uv run --python 3.12 --with pytest pytest tests/test_classes.py tests/utils/test_null_author_guards.py -q`
- `python3 -m py_compile gittensor/classes.py gittensor/utils/github_api_tools.py tests/test_classes.py tests/utils/test_null_author_guards.py`