### PR TITLE
fix: keep scan issues out of valid solved gate

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -312,9 +312,8 @@ def _merge_scan_issues(
                 data.closed_count += 1
                 continue
             if issue.state == 'CLOSED' and issue.closed_at:
-                # Case 2: solved by non-miner PR → positive credibility
+                # Case 2: solved by non-miner PR → positive credibility only
                 data.solved_count += 1
-                data.valid_solved_count += 1
             else:
                 # Case 3: closed without PR → negative credibility
                 data.closed_count += 1

--- a/tests/validator/test_issue_discovery_scoring.py
+++ b/tests/validator/test_issue_discovery_scoring.py
@@ -99,6 +99,7 @@ def test_completed_scan_issue_with_closed_at_counts_as_solved(issue_factory):
     issue = issue_factory.completed()
     data = _run_scan_path(issue)
     assert data.solved_count == 1
+    assert data.valid_solved_count == 0
     assert data.closed_count == 0
 
 


### PR DESCRIPTION
## Summary
- stop incrementing `valid_solved_count` for repository-scan issues solved outside the miner PR path
- keep scan-path solved issues contributing to `solved_count` only, matching the existing credibility-only comment
- add a regression test locking scan-path `valid_solved_count` at `0`

## Validation
- `uv run --python 3.12 --with pytest pytest tests/validator/test_issue_discovery_scoring.py -q`
- `python3 -m py_compile gittensor/validator/issue_discovery/scoring.py tests/validator/test_issue_discovery_scoring.py`