### PR TITLE
fix: apply is_valid_issue state_reason gate to open PR collateral

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -452,6 +452,17 @@ def calculate_issue_multiplier(pr: PullRequest) -> float:
     return multiplier
 
 
+def _is_completed_when_closed(issue: Issue) -> bool:
+    if issue.state != 'CLOSED':
+        return True
+    if issue.state_reason != 'COMPLETED':
+        bt.logging.warning(
+            f'Skipping issue #{issue.number} - state_reason={issue.state_reason}, only COMPLETED grants multiplier'
+        )
+        return False
+    return True
+
+
 def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
     """Check if issue is valid for bonus calculation (works for both merged and open PRs)."""
     is_merged = pr.pr_state == PRState.MERGED
@@ -468,6 +479,9 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
         bt.logging.warning(f'Skipping issue #{issue.number} - Issue was created after PR was created')
         return False
 
+    if not _is_completed_when_closed(issue):
+        return False
+
     if is_merged and pr.merged_at:
         if pr.last_edited_at and pr.last_edited_at > pr.merged_at:
             bt.logging.warning(f'Skipping issue #{issue.number} - PR was edited after merge')
@@ -475,12 +489,6 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
 
         if issue.state and issue.state != 'CLOSED':
             bt.logging.warning(f'Skipping issue #{issue.number} - Issue state not CLOSED (state: {issue.state})')
-            return False
-
-        if issue.state_reason != 'COMPLETED':
-            bt.logging.warning(
-                f'Skipping issue #{issue.number} - state_reason={issue.state_reason}, only COMPLETED grants multiplier'
-            )
             return False
 
         if issue.closed_at and pr.merged_at:

--- a/tests/validator/test_is_valid_issue.py
+++ b/tests/validator/test_is_valid_issue.py
@@ -75,3 +75,47 @@ class TestIsValidIssueCloseWindow:
         )
 
         assert is_valid_issue(issue, pr) is expected
+
+
+class TestIsValidIssueOpenPRCollateral:
+    @pytest.mark.parametrize(
+        'state_reason,expected',
+        [
+            ('COMPLETED', True),
+            ('NOT_PLANNED', False),
+            ('TRANSFERRED', False),
+            ('DUPLICATE', False),
+            (None, False),
+        ],
+    )
+    def test_open_pr_rejects_closed_issue_when_not_completed(self, pr_factory, issue_factory, state_reason, expected):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.open()
+        pr.author_login = 'miner_user'
+        pr.created_at = now
+
+        issue = issue_factory.create(
+            author_login='other_user',
+            created_at=now - timedelta(days=5),
+            closed_at=now - timedelta(hours=1),
+            state='CLOSED',
+            state_reason=state_reason,
+        )
+
+        assert is_valid_issue(issue, pr) is expected
+
+    def test_open_pr_accepts_open_issue(self, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.open()
+        pr.author_login = 'miner_user'
+        pr.created_at = now
+
+        issue = issue_factory.create(
+            author_login='other_user',
+            created_at=now - timedelta(days=5),
+            closed_at=None,
+            state='OPEN',
+            state_reason=None,
+        )
+
+        assert is_valid_issue(issue, pr) is True


### PR DESCRIPTION
# Description

## Summary

`is_valid_issue()` enforces the `state_reason == 'COMPLETED'` check only inside the merged-PR branch. An open PR linked to a closed issue with `state_reason` of `NOT_PLANNED` / `TRANSFERRED` / `DUPLICATE` / `None` still receives `issue_multiplier`, inflating open-PR collateral.

This PR extracts the gate into a small helper applied to both merged-PR earnings and open-PR collateral. Open issues bypass the gate so work-in-progress on active issues still drives collateral.

## Related Issues

Closes #690

## Type of Change

- [x] Bug fix

## Testing

- [x] Tests added/updated
- [x] Manually tested

5 new parametrized cases covering open PR + closed issue (one per state_reason), plus 1 case confirming open PR + open issue still passes. All 243 validator tests pass; ruff + pyright clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
