### PR TITLE
fix: route --json error output through handle_exception

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -19,7 +19,6 @@ from rich.table import Table
 
 from .help import StyledCommand
 from .helpers import (
-    _handle_command_error,
     _read_contract_packed_storage,
     _read_issues_from_child_storage,
     _resolve_contract_and_network,
@@ -28,7 +27,7 @@ from .helpers import (
     emit_error_json,
     emit_json,
     format_alpha,
-    print_error,
+    handle_exception,
     print_network_header,
     read_issues_from_contract,
     with_cli_behavior_options,
@@ -219,8 +218,7 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         )
         console.print(f'[dim]Sum of bounty amounts from {len(issues)} issue(s)[/dim]')
     except Exception as e:
-        print_error(str(e))
-        raise SystemExit(1)
+        handle_exception(as_json=as_json, message=str(e))
 
 
 @click.command('pending-harvest', cls=StyledCommand)
@@ -279,7 +277,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         console.print(f'[green]Allocated to Bounties:[/green] {format_alpha(total_bounty_pool, 4)} ALPHA')
         console.print(f'[green]Pending Harvest:[/green] {format_alpha(pending_harvest, 4)} ALPHA')
     except Exception as e:
-        _handle_command_error(e)
+        handle_exception(as_json=as_json, message=str(e))
 
 
 @click.command('info', cls=StyledCommand)
@@ -321,8 +319,11 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
                 )
             )
         else:
-            console.print('[yellow]Could not read contract configuration.[/yellow]')
+            msg = 'Could not read contract configuration.'
+            if as_json:
+                emit_error_json(msg, error_type='read_failed')
+                raise SystemExit(1)
+            console.print(f'[yellow]{msg}[/yellow]')
             console.print('[dim]Try running with --verbose to see debug details.[/dim]')
     except Exception as e:
-        print_error(str(e))
-        raise SystemExit(1)
+        handle_exception(as_json=as_json, message=str(e))

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -23,6 +23,7 @@ from .helpers import (
     _resolve_contract_and_network,
     console,
     emit_json,
+    handle_exception,
     print_error,
     print_network_header,
     print_success,
@@ -261,4 +262,4 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
             console.print('[dim]Add validators with: gitt admin add-vali <HOTKEY>[/dim]')
 
     except Exception as e:
-        _handle_command_error(e)
+        handle_exception(as_json=as_json, message=str(e))

--- a/tests/cli/test_cli_json_error_output.py
+++ b/tests/cli/test_cli_json_error_output.py
@@ -1,0 +1,68 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Regression tests: --json mode must emit JSON even on the exception path.
+
+Covers `issues bounty-pool`, `issues pending-harvest`, `admin info`, and `vote list`.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+FORCED_MESSAGE = 'forced test failure for json-error assertion'
+
+
+@pytest.mark.parametrize(
+    'argv',
+    [
+        ['issues', 'bounty-pool', '--json'],
+        ['issues', 'pending-harvest', '--json'],
+        ['admin', 'info', '--json'],
+        ['vote', 'list', '--json'],
+    ],
+)
+def test_cli_commands_emit_json_on_exception(cli_root, runner, argv):
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch(
+            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch(
+            'substrateinterface.SubstrateInterface',
+            side_effect=RuntimeError(FORCED_MESSAGE),
+        ),
+        patch(
+            'bittensor.Subtensor',
+            side_effect=RuntimeError(FORCED_MESSAGE),
+        ),
+    ):
+        result = runner.invoke(cli_root, argv, catch_exceptions=False)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert FORCED_MESSAGE in payload['error']['message']
+
+
+def test_admin_info_emits_json_on_soft_read_failure(cli_root, runner):
+    """`admin info --json` must emit structured JSON when packed storage read returns None."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('substrateinterface.SubstrateInterface', return_value=object()),
+        patch('gittensor.cli.issue_commands.view._read_contract_packed_storage', return_value=None),
+    ):
+        result = runner.invoke(cli_root, ['admin', 'info', '--json'], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'


### PR DESCRIPTION
## Summary

Route the `except Exception` blocks in `issues bounty-pool`, `issues pending-harvest`, `admin info`, and `vote list` through the existing `handle_exception(as_json=…, message=…)` helper from `helpers.py:216`. Fixes JSON-contract violation where `--json` mode emitted Rich-formatted text on stdout when these commands failed.

Companion to #660 which completed the success path for the same commands.

## Before

    $ gitt issues bounty-pool --json --rpc-url ws://unreachable
    ✗ Could not connect to ws://unreachable
    $ echo $?
    1

`json.loads(stdout)` raises `JSONDecodeError`.

## After

    $ gitt issues bounty-pool --json --rpc-url ws://unreachable
    {"success": false, "error": {"type": "cli_error", "message": "Could not connect to ws://unreachable"}}
    $ echo $?
    1

## Changes

- `view.py`: 3 exception handlers → `handle_exception(as_json=as_json, message=str(e))`
- `vote.py`: 1 exception handler (`vote_list_validators`) → same
- Import swaps: drop `print_error` from view.py, drop `_handle_command_error` from view.py, add `handle_exception` to both
- `_handle_command_error` kept in place for the 2 non-JSON vote commands that still use it

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- New `tests/cli/test_cli_json_error_output.py` parametrizes all 4 commands, forces an exception, and asserts stdout is valid JSON with `success: false`.
- `uv run pytest tests/cli/` → 92 passed (88 pre-existing + 4 new).
- `pre-commit run --all-files` → all hooks pass.

Closes #692
