### PR TITLE
fix: reject invalid --network strings unless they look like RPC URLs

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -21,6 +21,7 @@ from rich.console import Console
 
 from gittensor.cli.issue_commands.tables import build_pr_table
 from gittensor.constants import NETWORK_MAP
+from gittensor.utils.network import looks_like_chain_endpoint
 from gittensor.validator.issue_competitions.storage_utils import (
     compute_ink5_lazy_key,
     decode_issue_from_storage,
@@ -350,8 +351,9 @@ def validate_bounty_amount(bounty: str) -> int:
 def validate_repository(repo: str, verify_exists: bool = True) -> Tuple[str, str]:
     """Validate owner/repo format and optionally verify it exists on GitHub.
 
-    Returns (owner, repo_name) on success.
-    Raises click.BadParameter on failure.
+    Returns (owner, repo_name) parsed from the stripped input. Callers that need
+    the full ``owner/repo`` string (e.g. URLs, chain payloads) should use
+    ``f"{owner}/{repo_name}"`` so it matches what was validated.
     """
     repo = repo.strip()
 
@@ -560,8 +562,9 @@ def resolve_network(network: Optional[str] = None, rpc_url: Optional[str] = None
         4. Default: finney (mainnet)
 
     Args:
-        network: Network name from --network option (test/finney/local)
-        rpc_url: Explicit RPC URL from --rpc-url option
+        network: Built-in name (``finney`` / ``test`` / ``local``) or a full
+            WebSocket/HTTP endpoint URL. Other strings raise ``ClickException``.
+        rpc_url: Explicit RPC URL from --rpc-url option (always accepted as-is).
 
     Returns:
         Tuple of (ws_endpoint, network_name)
@@ -571,13 +574,18 @@ def resolve_network(network: Optional[str] = None, rpc_url: Optional[str] = None
         name = _URL_TO_NETWORK.get(rpc_url, 'custom')
         return rpc_url, name
 
-    # --network maps to a known endpoint
+    # --network maps to a known endpoint, or must be an explicit endpoint URL
     if network:
         key = network.lower()
         if key in NETWORK_MAP:
             return NETWORK_MAP[key], key
-        # Treat unknown network value as a custom URL
-        return network, 'custom'
+        stripped = network.strip()
+        if looks_like_chain_endpoint(stripped):
+            return stripped, 'custom'
+        valid = ', '.join(sorted(NETWORK_MAP))
+        raise click.ClickException(
+            f'Unknown network {network!r}. Use one of: {valid}, or pass a full endpoint URL (e.g. wss://...).'
+        )
 
     # Fall back to config file
     config = load_config()

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -13,6 +13,7 @@ import click
 from rich.console import Console
 
 from gittensor.constants import NETWORK_MAP
+from gittensor.utils.network import looks_like_chain_endpoint
 
 console = Console()
 
@@ -47,7 +48,16 @@ def _resolve_endpoint(network: str | None, rpc_url: str | None) -> str:
     if rpc_url:
         return rpc_url
     if network:
-        return NETWORK_MAP.get(network.lower(), network)
+        key = network.lower()
+        if key in NETWORK_MAP:
+            return NETWORK_MAP[key]
+        stripped = network.strip()
+        if looks_like_chain_endpoint(stripped):
+            return stripped
+        valid = ', '.join(sorted(NETWORK_MAP))
+        raise click.ClickException(
+            f'Unknown network {network!r}. Use one of: {valid}, or pass a full endpoint URL (e.g. wss://...).'
+        )
     config_network = _load_config_value('network')
     config_endpoint = _load_config_value('ws_endpoint')
     if config_endpoint:

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -27,6 +27,7 @@ from gittensor.cli.issue_commands.helpers import (
     colorize_status,
     emit_json,
     format_alpha,
+    resolve_network,
     validate_bounty_amount,
     validate_github_issue,
     validate_issue_id,
@@ -34,6 +35,44 @@ from gittensor.cli.issue_commands.helpers import (
     validate_ss58_address,
 )
 from gittensor.cli.issue_commands.vote import parse_pr_number
+from gittensor.cli.miner_commands.helpers import _resolve_endpoint
+
+# =============================================================================
+# resolve_network / miner _resolve_endpoint
+# =============================================================================
+
+
+class TestResolveNetwork:
+    def test_known_network(self):
+        url, name = resolve_network('test', None)
+        assert name == 'test'
+        assert 'test.finney' in url or url.startswith('wss://')
+
+    def test_unknown_network_typo_raises(self):
+        with pytest.raises(click.ClickException, match='Unknown network'):
+            resolve_network('finny', None)
+
+    def test_custom_wss_accepted(self):
+        ep = 'wss://example.com/custom/ws'
+        url, name = resolve_network(ep, None)
+        assert url == ep
+        assert name == 'custom'
+
+    def test_rpc_url_unvalidated_even_if_network_typo(self):
+        url, name = resolve_network('finny', 'wss://override.example/ws')
+        assert url == 'wss://override.example/ws'
+        assert name == 'custom'
+
+
+class TestMinerResolveEndpoint:
+    def test_unknown_network_typo_raises(self):
+        with pytest.raises(click.ClickException, match='Unknown network'):
+            _resolve_endpoint('finny', None)
+
+    def test_custom_https_accepted(self):
+        ep = 'https://rpc.example.com'
+        assert _resolve_endpoint(ep, None) == ep
+
 
 # =============================================================================
 # format_alpha

--- a/tests/utils/network.py
+++ b/tests/utils/network.py
@@ -1,0 +1,13 @@
+# Entrius 2025
+
+"""Network / endpoint helpers (non-constant logic shared by CLI and tooling)."""
+
+
+def looks_like_chain_endpoint(value: str) -> bool:
+    """Return True if ``value`` looks like a WebSocket or HTTP RPC endpoint.
+
+    Used so unknown ``--network`` strings are not mistaken for endpoints (e.g.
+    a typo ``finny`` instead of ``finney``).
+    """
+    v = value.strip().lower()
+    return v.startswith(('ws://', 'wss://', 'http://', 'https://'))


### PR DESCRIPTION

## Summary

Unknown values for `--network` were previously treated as custom WebSocket endpoints (`resolve_network` returned them as `(network, 'custom')`; miner `_resolve_endpoint` used `NETWORK_MAP.get(..., network)`). A typo such as `finny` instead of `finney` was passed straight to the client as the “URL”, producing confusing connection errors instead of a clear validation message.

Issue subcommands that use `Click.Choice` for `--network` already rejected invalid tokens at parse time; this fix mainly helps **programmatic** callers of `resolve_network`, and **miner** commands (`gitt miner post` / `gitt miner check`), where `--network` is a plain string.

## Changes

- Add `gittensor/utils/network.py` with `looks_like_chain_endpoint()`
- **`resolve_network`** in `gittensor/cli/issue_commands/helpers.py`: if `network` is set and is not a key in `NETWORK_MAP`, require a value that looks like `ws://`, `wss://`, `http://`, or `https://`; otherwise raise `click.ClickException` listing built-in names (`finney`, `local`, `test`) and pointing users at full URLs when needed.
- **`_resolve_endpoint`** in `gittensor/cli/miner_commands/helpers.py`: same rules for miner `--network`.
- **`--rpc-url`** is unchanged: when provided, it still wins and is not subject to this network-string check.

## Related Issue

Closes https://github.com/entrius/gittensor/issues/694


## Tests

- `tests/cli/test_cli_helpers.py`: `TestResolveNetwork` and `TestMinerResolveEndpoint` (typo raises, custom `wss://` / `https://` accepted, `rpc_url` overrides bad `network`).

## How to test

```bash
pytest tests/cli/test_cli_helpers.py::TestResolveNetwork tests/cli/test_cli_helpers.py::TestMinerResolveEndpoint -q
```