### PR TITLE
refactor: consolidate duplicated CLI endpoint/config resolution into shared module

### DIFF
--- a/gittensor/cli/shared/__init__.py
+++ b/gittensor/cli/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared CLI utilities."""

--- a/gittensor/cli/shared/config_helpers.py
+++ b/gittensor/cli/shared/config_helpers.py
@@ -49,7 +49,7 @@ def resolve_network(
     config = load_config()
     if config.get('ws_endpoint'):
         endpoint = config['ws_endpoint']
-        name = _URL_TO_NETWORK.get(endpoint, config.get('network', 'custom'))
+        name = _URL_TO_NETWORK.get(endpoint, config.get('network') or 'custom')
         return endpoint, name
 
     config_network = config.get('network', '').lower()

--- a/gittensor/cli/shared/config_helpers.py
+++ b/gittensor/cli/shared/config_helpers.py
@@ -1,0 +1,59 @@
+"""Shared config loading and endpoint resolution for CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from gittensor.constants import NETWORK_MAP
+
+CONFIG_FILE = Path.home() / '.gittensor' / 'config.json'
+
+_URL_TO_NETWORK = {url: name for name, url in NETWORK_MAP.items()}
+
+
+def load_config() -> Dict[str, Any]:
+    """Load ~/.gittensor/config.json, returning empty dict if missing."""
+    if CONFIG_FILE.exists():
+        try:
+            with open(CONFIG_FILE, 'r') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def resolve_network(
+    network: Optional[str] = None,
+    rpc_url: Optional[str] = None,
+) -> Tuple[str, str]:
+    """Resolve --network and --rpc-url into (ws_endpoint, network_name).
+
+    Precedence:
+        1. --rpc-url (explicit URL always wins)
+        2. --network (mapped to known endpoint)
+        3. Config file ws_endpoint / network
+        4. Default: finney (mainnet)
+    """
+    if rpc_url:
+        name = _URL_TO_NETWORK.get(rpc_url, 'custom')
+        return rpc_url, name
+
+    if network:
+        key = network.lower()
+        if key in NETWORK_MAP:
+            return NETWORK_MAP[key], key
+        return network, 'custom'
+
+    config = load_config()
+    if config.get('ws_endpoint'):
+        endpoint = config['ws_endpoint']
+        name = _URL_TO_NETWORK.get(endpoint, config.get('network', 'custom'))
+        return endpoint, name
+
+    config_network = config.get('network', '').lower()
+    if config_network and config_network in NETWORK_MAP:
+        return NETWORK_MAP[config_network], config_network
+
+    return NETWORK_MAP['finney'], 'finney'


### PR DESCRIPTION
Closes #623

## Problem

Two CLI helper modules independently implemented identical config loading and endpoint resolution logic, with subtle structural differences that made them a maintenance hazard:

### `gittensor/cli/issue_commands/helpers.py`
- `load_config()` — read full config dict from `~/.gittensor/config.json`
- `resolve_network(network, rpc_url) -> tuple` — returned `(ws_endpoint, network_name)`
- `_URL_TO_NETWORK` — reverse lookup dict built from `NETWORK_MAP`

### `gittensor/cli/miner_commands/helpers.py`
- `_load_config_value(key)` — read one key at a time from `~/.gittensor/config.json`, opening and parsing the file on every call
- `_resolve_endpoint(network, rpc_url) -> str` — returned only the endpoint string, discarding network name

Both modules loaded the same config file, applied the same 4-step precedence rule, and mapped the same network names — but in slightly different ways. Any future change to precedence logic, config path, default network, or `NETWORK_MAP` handling would require synchronized updates in both places. Miss one and behavior drifts silently between `gitt issues` and `gitt miner` commands.

Additionally, `miner_commands/helpers.py` called `_load_config_value` twice per `_resolve_endpoint` invocation — once for `network`, once for `ws_endpoint` — parsing and reading the config file twice unnecessarily.

## Solution

Created `gittensor/cli/shared/config_helpers.py` as the single source of truth for both utilities:

### `load_config() -> Dict[str, Any]`
Loads `~/.gittensor/config.json` once, returns the full dict. Gracefully returns `{}` on missing file or malformed JSON. Used by both helpers and by `resolve_network` internally — config file is now read exactly once per resolution call.

### `resolve_network(network, rpc_url) -> Tuple[str, str]`
Returns `(ws_endpoint, network_name)`. Canonicalizes the full 4-step precedence rule in one place:

1. `--rpc-url` — explicit URL always wins; reverse-looked up against `NETWORK_MAP` for name
2. `--network` — mapped to known endpoint via `NETWORK_MAP`; unknown values treated as custom URLs
3. Config file — `ws_endpoint` takes priority over `network` key
4. Default — `finney` mainnet

### Backward compatibility
- `miner_commands/helpers.py` retains `_load_config_value` and `_resolve_endpoint` as thin wrappers so `check.py` and `post.py` require zero changes
- `issue_commands/helpers.py` retains `get_contract_address` and `_resolve_contract_and_network` untouched — only the two duplicated functions and their supporting constants are removed

## Files Changed

| File | Change |
|------|--------|
| `gittensor/cli/shared/__init__.py` | New — package marker |
| `gittensor/cli/shared/config_helpers.py` | New — canonical `load_config` and `resolve_network` |
| `gittensor/cli/miner_commands/helpers.py` | Removed `_load_config_value`, `_resolve_endpoint`, unused `json`/`Path`/`NETWORK_MAP` imports. Added thin wrappers delegating to shared module |
| `gittensor/cli/issue_commands/helpers.py` | Removed `load_config`, `resolve_network`, `_URL_TO_NETWORK`, `GITTENSOR_DIR`, `CONFIG_FILE`, `NETWORK_MAP` import. Now imports from shared module |

## Verification

All modified files pass `py_compile` and `ruff check/format` with no errors.