### PR TITLE
fix: handle partial miner responses and require explicit register success

### DIFF
--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -140,11 +140,14 @@ def issue_register(
     except click.BadParameter as e:
         raise click.ClickException(str(e))
 
-    github_url = f'https://github.com/{repo}/issues/{issue_number}'
+    # validate_repository strips internally but does not return the full string; rebuild
+    # so URLs and on-chain repository_full_name match what was validated.
+    repository_full_name = f'{owner}/{repo_name}'
+    github_url = f'https://github.com/{repository_full_name}/issues/{issue_number}'
 
     console.print(
         Panel(
-            f'[cyan]Repository:[/cyan] {repo}\n'
+            f'[cyan]Repository:[/cyan] {repository_full_name}\n'
             f'[cyan]Issue Number:[/cyan] #{issue_number}\n'
             f'[cyan]GitHub URL:[/cyan] {github_url}\n'
             f'[cyan]Target Bounty:[/cyan] {format_alpha(bounty_amount, 2)} ALPHA\n'
@@ -212,19 +215,24 @@ def issue_register(
             'register_issue',
             args={
                 'github_url': github_url,
-                'repository_full_name': repo,
+                'repository_full_name': repository_full_name,
                 'issue_number': issue_number,
                 'target_bounty': bounty_amount,
             },
             gas_limit={'ref_time': 10_000_000_000, 'proof_size': 1_000_000},
         )
 
-        # Check if transaction was successful
-        if hasattr(result, 'is_success') and not result.is_success:
+        # Be conservative: only explicit success is treated as success.
+        tx_success = getattr(result, 'is_success', None)
+        if tx_success is not True:
             error_info = getattr(result, 'error_message', None)
             is_revert = error_info and isinstance(error_info, dict) and error_info.get('name') == 'ContractReverted'
 
-            if is_revert:
+            if tx_success is None:
+                print_error('Could not verify transaction success from contract response.')
+                if error_info:
+                    console.print(f'[yellow]Details:[/yellow] {error_info}')
+            elif is_revert:
                 print_error('Contract rejected the request')
                 console.print('[yellow]Possible reasons:[/yellow]')
                 console.print('  \u2022 Issue already registered (same repo + issue number)')
@@ -232,9 +240,13 @@ def issue_register(
                 console.print('  \u2022 Caller is not the contract owner')
             elif error_info:
                 print_error(str(error_info))
+            else:
+                print_error('Transaction failed.')
 
-            console.print(f'[cyan]Transaction Hash:[/cyan] {result.extrinsic_hash}')
-            return
+            tx_hash = getattr(result, 'extrinsic_hash', None)
+            if tx_hash:
+                console.print(f'[cyan]Transaction Hash:[/cyan] {tx_hash}')
+            raise SystemExit(1)
 
         print_success('Issue registered successfully!')
         console.print(f'[cyan]Transaction Hash:[/cyan] {result.extrinsic_hash}')

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -25,6 +25,33 @@ from .helpers import (
 console = Console()
 
 
+def _build_check_results(validator_uids, validator_axons, responses):
+    """Build result rows without truncation when responses are partial."""
+    expected = len(validator_uids)
+    actual = len(responses)
+    missing_count = max(0, expected - actual)
+
+    results = []
+    for idx, (uid, axon) in enumerate(zip(validator_uids, validator_axons)):
+        resp = responses[idx] if idx < actual else None
+        has_pat = getattr(resp, 'has_pat', None)
+        pat_valid = getattr(resp, 'pat_valid', None)
+        reason = getattr(resp, 'rejection_reason', None)
+        if resp is None and not reason:
+            reason = 'No response received from validator.'
+        results.append(
+            {
+                'uid': uid,
+                'hotkey': axon.hotkey[:16] + '...',
+                'has_pat': has_pat,
+                'pat_valid': pat_valid,
+                'rejection_reason': reason,
+            }
+        )
+
+    return results, missing_count
+
+
 @click.command()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
@@ -80,20 +107,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         responses = asyncio.run(_check())
 
     # 5. Collect results
-    results = []
-    for uid, axon, resp in zip(validator_uids, validator_axons, responses):
-        has_pat = getattr(resp, 'has_pat', None)
-        pat_valid = getattr(resp, 'pat_valid', None)
-        reason = getattr(resp, 'rejection_reason', None)
-        results.append(
-            {
-                'uid': uid,
-                'hotkey': axon.hotkey[:16] + '...',
-                'has_pat': has_pat,
-                'pat_valid': pat_valid,
-                'rejection_reason': reason,
-            }
-        )
+    results, missing_count = _build_check_results(validator_uids, validator_axons, responses)
 
     valid_count = sum(1 for r in results if r['pat_valid'] is True)
     no_response_count = sum(1 for r in results if r['has_pat'] is None)
@@ -103,17 +117,22 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         click.echo(
             json.dumps(
                 {
-                    'success': valid_count > 0,
+                    'success': valid_count > 0 and missing_count == 0,
                     'total_validators': len(results),
                     'valid': valid_count,
                     'invalid': len(results) - valid_count - no_response_count,
                     'no_response': no_response_count,
+                    'missing_responses': missing_count,
                     'results': results,
                 },
                 indent=2,
             )
         )
     else:
+        if missing_count > 0:
+            console.print(
+                f'[yellow]Warning: no response from {missing_count}/{len(results)} validators.[/yellow]'
+            )
         table = Table(title='PAT Check Results')
         table.add_column('UID', style='cyan', justify='right')
         table.add_column('Validator', style='dim')

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -31,6 +31,34 @@ from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
 console = Console()
 
 
+def _build_broadcast_results(validator_uids, validator_axons, responses):
+    """Build result rows without silently truncating on partial response lists."""
+    expected = len(validator_uids)
+    actual = len(responses)
+    missing_count = max(0, expected - actual)
+
+    results = []
+    for idx, (uid, axon) in enumerate(zip(validator_uids, validator_axons)):
+        resp = responses[idx] if idx < actual else None
+        accepted = getattr(resp, 'accepted', None)
+        reason = getattr(resp, 'rejection_reason', None)
+        status_code = getattr(resp.dendrite, 'status_code', None) if hasattr(resp, 'dendrite') else None
+        if resp is None and not reason:
+            reason = 'No response received from validator.'
+
+        results.append(
+            {
+                'uid': uid,
+                'hotkey': axon.hotkey[:16] + '...',
+                'accepted': accepted,
+                'rejection_reason': reason,
+                'status_code': status_code,
+            }
+        )
+
+    return results, missing_count
+
+
 @click.command()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
@@ -117,20 +145,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         responses = asyncio.run(_broadcast())
 
     # 6. Collect results
-    results = []
-    for uid, axon, resp in zip(validator_uids, validator_axons, responses):
-        accepted = getattr(resp, 'accepted', None)
-        reason = getattr(resp, 'rejection_reason', None)
-        status_code = getattr(resp.dendrite, 'status_code', None) if hasattr(resp, 'dendrite') else None
-        results.append(
-            {
-                'uid': uid,
-                'hotkey': axon.hotkey[:16] + '...',
-                'accepted': accepted,
-                'rejection_reason': reason,
-                'status_code': status_code,
-            }
-        )
+    results, missing_count = _build_broadcast_results(validator_uids, validator_axons, responses)
 
     accepted_count = sum(1 for r in results if r['accepted'] is True)
 
@@ -139,16 +154,21 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         click.echo(
             json.dumps(
                 {
-                    'success': accepted_count > 0,
+                    'success': accepted_count > 0 and missing_count == 0,
                     'total_validators': len(results),
                     'accepted': accepted_count,
                     'rejected': len(results) - accepted_count,
+                    'no_response': missing_count,
                     'results': results,
                 },
                 indent=2,
             )
         )
     else:
+        if missing_count > 0:
+            console.print(
+                f'[yellow]Warning: no response from {missing_count}/{len(results)} validators.[/yellow]'
+            )
         table = Table(title='PAT Broadcast Results')
         table.add_column('UID', style='cyan', justify='right')
         table.add_column('Validator', style='dim')

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -3,13 +3,16 @@
 """Tests for gitt miner post and gitt miner check CLI commands."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
 from gittensor import __version__
+from gittensor.cli.miner_commands.check import _build_check_results
 from gittensor.cli.main import cli
+from gittensor.cli.miner_commands.post import _build_broadcast_results
 
 
 @pytest.fixture
@@ -75,3 +78,38 @@ class TestCliVersion:
         result = runner.invoke(cli, ['--version'])
         assert result.exit_code == 0
         assert result.output == f'gittensor, version {__version__}\n'
+
+
+class TestMinerResponseAlignment:
+    def test_build_broadcast_results_keeps_all_validators(self):
+        validator_uids = [1, 2, 3]
+        validator_axons = [
+            SimpleNamespace(hotkey='hk1' * 16),
+            SimpleNamespace(hotkey='hk2' * 16),
+            SimpleNamespace(hotkey='hk3' * 16),
+        ]
+        responses = [SimpleNamespace(accepted=True, rejection_reason=None, dendrite=SimpleNamespace(status_code=200))]
+
+        results, missing = _build_broadcast_results(validator_uids, validator_axons, responses)
+
+        assert len(results) == 3
+        assert missing == 2
+        assert results[0]['accepted'] is True
+        assert results[1]['accepted'] is None
+        assert results[1]['rejection_reason'] == 'No response received from validator.'
+
+    def test_build_check_results_keeps_all_validators(self):
+        validator_uids = [10, 11]
+        validator_axons = [
+            SimpleNamespace(hotkey='hk10' * 12),
+            SimpleNamespace(hotkey='hk11' * 12),
+        ]
+        responses = [SimpleNamespace(has_pat=True, pat_valid=True, rejection_reason=None)]
+
+        results, missing = _build_check_results(validator_uids, validator_axons, responses)
+
+        assert len(results) == 2
+        assert missing == 1
+        assert results[0]['pat_valid'] is True
+        assert results[1]['has_pat'] is None
+        assert results[1]['rejection_reason'] == 'No response received from validator.'


### PR DESCRIPTION
## Summary

- `issues register` previously treated missing `is_success` on contract execution results as success.
- `miner post` / `miner check` previously used `zip(...)` over validators and responses, which silently dropped validators when response lists were shorter.

The update makes both flows conservative and explicit:

- register succeeds only on explicit `is_success is True`
- miner result output now includes all targeted validators, including explicit no-response rows

## What changed

### 1) `gittensor/cli/issue_commands/mutations.py`

- Replaced `hasattr(result, 'is_success') and not result.is_success` handling with explicit success check:
  - `tx_success = getattr(result, 'is_success', None)`
  - only `tx_success is True` is considered success
- Unknown or failed result shapes now print an error and exit non-zero (`SystemExit(1)`).
- Transaction hash is still printed when available to aid debugging.

### 2) `gittensor/cli/miner_commands/post.py`

- Added `_build_broadcast_results(...)` to prevent truncation on partial response arrays.
- Builds one result row per targeted validator, filling missing responses with:
  - `accepted: None`
  - `rejection_reason: "No response received from validator."`
- JSON output now includes `no_response`.
- Human output prints a warning when there are missing responses.

### 3) `gittensor/cli/miner_commands/check.py`

- Added `_build_check_results(...)` with the same full-length alignment logic.
- Missing responses now appear as explicit rows rather than being dropped.
- JSON output includes `missing_responses` (and existing `no_response` remains based on row values).
- Human output prints a warning when there are missing responses.

### 4) Tests

- Added response-alignment tests in `tests/cli/test_miner_commands.py`:
  - `test_build_broadcast_results_keeps_all_validators`
  - `test_build_check_results_keeps_all_validators`

## Why this fixes the bug

- The register command no longer assumes success when receipt shape is incomplete.
- Miner commands no longer hide partial network failures by truncating result rows.
- Operators get explicit warnings and machine-readable counts for missing responses.

## Related Issue
Closes https://github.com/entrius/gittensor/issues/699

## Test plan

```bash
pytest tests/cli/test_miner_commands.py::TestMinerResponseAlignment -q
```

If full test tooling is available:

```bash
pytest tests/cli/test_miner_commands.py -q
```

