### PR TITLE
`refactor: remove unused wandb CLI args and replace stray print in utils/config.py`

### DIFF
--- a/gittensor/utils/config.py
+++ b/gittensor/utils/config.py
@@ -55,7 +55,7 @@ def check_config(cls, config: Any):
             config.neuron.name,
         )
     )
-    print('full path:', full_path)
+    bt.logging.debug(f'full path: {full_path}')
     config.neuron.full_path = os.path.expanduser(full_path)
     if not os.path.exists(config.neuron.full_path):
         os.makedirs(config.neuron.full_path, exist_ok=True)
@@ -176,20 +176,6 @@ def add_validator_args(cls, parser):
         type=int,
         help='The maximum number of TAO allowed to query a validator with a vpermit.',
         default=4096,
-    )
-
-    parser.add_argument(
-        '--wandb.project_name',
-        type=str,
-        help='The name of the project where you are sending the new run.',
-        default='template-validators',
-    )
-
-    parser.add_argument(
-        '--wandb.entity',
-        type=str,
-        help='The name of the project where you are sending the new run.',
-        default='opentensor-dev',
     )
 
 


### PR DESCRIPTION
```
## Summary

Removes two dead argparse arguments and replaces a stray print() in gittensor/utils/config.py:

1. --wandb.project_name and --wandb.entity are template leftovers (defaults template-validators and opentensor-dev) that aren't read anywhere in the codebase. The actual wandb init in neurons/validator.py:88-94 uses the WANDB_PROJECT env var and a hardcoded 'entrius-gittensor' entity.

2. print('full path:', full_path) in check_config() was inconsistent with bt.logging used everywhere else in the module. Replaced with bt.logging.debug(...).

Verified unused via grep -rn "wandb.project_name\|wandb.entity" — only hits are the definitions being removed.

## Type of Change
- [x] Refactor

## Testing
- [x] Manually tested — ast.parse succeeds, all 5 function definitions preserved
```