### PR TITLE
fix: stub heavy imports during shell completion

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -14,6 +14,22 @@ Usage:
 
 import json
 import os
+import sys
+
+# Stub heavy imports during shell completion so tab-completion stays fast.
+if os.environ.get('_GITT_COMPLETE'):
+    import types as _types
+
+    class _Stub(_types.ModuleType):
+        def __getattr__(self, _name):
+            return self
+
+        def __call__(self, *_a, **_kw):
+            return self
+
+    _stub = _Stub('_gitt_completion_stub')
+    for _pkg in ('bittensor', 'requests'):
+        sys.modules[_pkg] = _stub
 
 import click
 from click.shell_completion import get_completion_class


### PR DESCRIPTION
Closes #703 

## Summary

Completions were introduced in https://github.com/entrius/gittensor/pull/431 and seemd work quite fast, but currently they're noticeable slow. You can check it either right during completion attempt or by running:

```sh
$ time _GITT_COMPLETE=zsh_complete COMP_WORDS="gitt " COMP_CWORD=1 gitt >/dev/null
0.711 total
```

The reason is heavy `bittensor` import which was introduced to the `main.py` by https://github.com/entrius/gittensor/pull/637: 

```py
# added in #637:
from gittensor.utils.github_api_tools import make_graphql_headers, make_headers

# gittensor/utils/github_api_tools.py:
import bittensor as bt
```

Such heavy-imports issue is already solved in allways (https://github.com/entrius/allways/pull/45), so looks like it's time to replicate the same fix here.

## After

```sh
$ time _GITT_COMPLETE=zsh_complete COMP_WORDS="gitt " COMP_CWORD=1 gitt >/dev/null
0.081 total
```