### PR TITLE
fix: guard null mergedBy in PullRequest.from_graphql_response

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -329,7 +329,7 @@ class PullRequest:
             additions=pr_data['additions'],
             deletions=pr_data['deletions'],
             commits=pr_data.get('commits', {}).get('totalCount', 0),
-            merged_by_login=pr_data.get('mergedBy', {}).get('login') if is_merged else None,
+            merged_by_login=(pr_data.get('mergedBy') or {}).get('login') if is_merged else None,
             issues=issues if issues else None,
             description=description,
             last_edited_at=last_edited_at,

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,8 +1,8 @@
 from gittensor.classes import PullRequest
 
 
-def test_pull_request_handles_deleted_label_event():
-    pr_data = {
+def _base_pr_data():
+    return {
         'number': 42,
         'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
         'state': 'OPEN',
@@ -21,7 +21,26 @@ def test_pull_request_handles_deleted_label_event():
         'baseRefOid': 'def456',
     }
 
-    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+def test_pull_request_handles_deleted_label_event():
+    pr = PullRequest.from_graphql_response(_base_pr_data(), uid=1, hotkey='5Hotkey', github_id='123')
 
     assert pr.label is None
+    assert pr.author_login == 'alice'
+
+
+def test_pull_request_handles_null_merged_by():
+    # GitHub returns mergedBy=null for bot merges or deleted merger accounts.
+    # The previous parser used pr_data.get('mergedBy', {}).get('login') which
+    # returns None (not {}) when the key is present with value None, then crashes
+    # with AttributeError on the second .get().
+    pr_data = _base_pr_data()
+    pr_data['state'] = 'MERGED'
+    pr_data['mergedAt'] = '2026-04-18T12:00:00Z'
+    pr_data['mergedBy'] = None
+    pr_data['changesRequestedReviews'] = {'nodes': []}
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.merged_by_login is None
     assert pr.author_login == 'alice'


### PR DESCRIPTION
```
## Summary

Fixes a crash in `PullRequest.from_graphql_response()` when GitHub's GraphQL API returns `"mergedBy": null` (deleted merger accounts or certain bot merges).

The parser read the field as:

    merged_by_login=pr_data.get('mergedBy', {}).get('login') if is_merged else None

`.get('mergedBy', {})` returns `None` (not `{}`) when the key is present with value None — so the second `.get('login')` crashes with `AttributeError`. Same class of bug as #688 (null `author`); this path was missed.

## Fix

    merged_by_login=(pr_data.get('mergedBy') or {}).get('login') if is_merged else None

Matches the `(x or {})` idiom PR #688 established for guarding null GraphQL fields.

## Verification

    # Reproduce the crash
    python3 -c "d={'mergedBy': None}; d.get('mergedBy', {}).get('login')"
    # AttributeError: 'NoneType' object has no attribute 'get'

    # Fixed form
    python3 -c "d={'mergedBy': None}; print((d.get('mergedBy') or {}).get('login'))"
    # None

## Tests

Adds `test_pull_request_handles_null_merged_by` in tests/test_classes.py that feeds a merged PR with `mergedBy=null` through the parser and asserts `merged_by_login` is None (no crash).

Also refactored the existing single-fixture test to share `_base_pr_data()` with the new test.

## Type of Change

- [x] Bug fix
```