### PR TITLE
fix: add PR number context to file-content fetch failure warning

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1143,6 +1143,7 @@ def _fetch_file_contents_with_base_batch(
     head_sha: str,
     batch_changes: List['FileChangeType'],
     token: str,
+    pr_number: Optional[int] = None,
 ) -> Dict[str, FileContentPair]:
     """Fetch base and head file contents for a single batch of file changes.
 
@@ -1192,11 +1193,13 @@ def _fetch_file_contents_with_base_batch(
 
     data = execute_graphql_query(query, variables, token)
     if data is None:
-        bt.logging.warning(f'Failed to fetch file contents for {repo_owner}/{repo_name}')
+        ctx = f' (PR #{pr_number})' if pr_number else ''
+        bt.logging.warning(f'Failed to fetch file contents for {repo_owner}/{repo_name}{ctx}')
         return {fc.filename: FileContentPair(None, None) for fc in batch_changes}
 
     if 'errors' in data:
-        bt.logging.warning(f'GraphQL errors fetching files: {data["errors"]}')
+        ctx = f' (PR #{pr_number})' if pr_number else ''
+        bt.logging.warning(f'GraphQL errors fetching files for {repo_owner}/{repo_name}{ctx}: {data["errors"]}')
 
     repo_data = data.get('data', {}).get('repository', {})
     results: Dict[str, FileContentPair] = {}
@@ -1229,6 +1232,7 @@ def fetch_file_contents_with_base(
     head_sha: str,
     file_changes: List['FileChangeType'],
     token: str,
+    pr_number: Optional[int] = None,
 ) -> Dict[str, FileContentPair]:
     """Fetch old and new versions of files in batches so large PRs don't hit complexity limits.
 
@@ -1250,7 +1254,9 @@ def fetch_file_contents_with_base(
 
     for batch_start in range(0, len(file_changes), MAX_FILES_PER_GRAPHQL_BATCH):
         batch = file_changes[batch_start : batch_start + MAX_FILES_PER_GRAPHQL_BATCH]
-        batch_results = _fetch_file_contents_with_base_batch(repo_owner, repo_name, base_sha, head_sha, batch, token)
+        batch_results = _fetch_file_contents_with_base_batch(
+            repo_owner, repo_name, base_sha, head_sha, batch, token, pr_number=pr_number
+        )
         results.update(batch_results)
 
     return results

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1198,8 +1198,7 @@ def _fetch_file_contents_with_base_batch(
         return {fc.filename: FileContentPair(None, None) for fc in batch_changes}
 
     if 'errors' in data:
-        ctx = f' (PR #{pr_number})' if pr_number else ''
-        bt.logging.warning(f'GraphQL errors fetching files for {repo_owner}/{repo_name}{ctx}: {data["errors"]}')
+        bt.logging.warning(f'GraphQL errors fetching files: {data["errors"]}')
 
     repo_data = data.get('data', {}).get('repository', {})
     results: Dict[str, FileContentPair] = {}

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -138,7 +138,9 @@ def fetch_file_contents_for_pr(pr: PullRequest, github_pat: str) -> Dict[str, Fi
             f'PR #{pr.number}: using merge-base {merge_base[:8]} instead of base_ref {pr.base_ref_oid[:8]}'
         )
 
-    return fetch_file_contents_with_base(owner, repo_name, base_sha, pr.head_ref_oid, pr.file_changes, github_pat)
+    return fetch_file_contents_with_base(
+        owner, repo_name, base_sha, pr.head_ref_oid, pr.file_changes, github_pat, pr_number=pr.number
+    )
 
 
 def calculate_base_score(


### PR DESCRIPTION
## Summary

- Adds optional `pr_number` context to the existing warning in `_fetch_file_contents_with_base_batch` when file-content GraphQL fetch returns `None`.
- Threads `pr.number` from scoring into `fetch_file_contents_with_base(...)` so logs identify the exact failed PR.
- Keeps behavior intentionally unchanged:
  - no tuple-return API changes
  - no skip-vs-zero branching changes
  - no `None` vs `[]` return-contract changes
  - no new test file
- Net diff is minimal (13 lines total: +10 / -3 across 2 files).

## Related Issues

 Closes #710
 Supersedes #645

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

- Ran:
  - `uv run pytest tests/utils/test_github_api_tools.py tests/validator/test_base_score.py`
- Result:
  - `82 passed`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
