### PR TITLE
feat(cli): confirm destructive admin and vote commands

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -21,6 +21,7 @@ from .helpers import (
     _handle_command_error,
     _make_contract_client,
     _resolve_contract_and_network,
+    confirm_or_abort,
     console,
     format_alpha,
     print_error,
@@ -28,6 +29,7 @@ from .helpers import (
     print_success,
     require_valid_issue_id,
     require_valid_ss58,
+    with_cli_behavior_options,
     with_network_contract_options,
     with_wallet_options,
 )
@@ -46,7 +48,10 @@ def admin():
 @click.argument('issue_id', type=int)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
-def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_cancel(
+    issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool
+):
     """Cancel an issue (owner only).
 
     [dim]Immediately cancels an issue without validator consensus. Bounty funds are returned to the alpha pool.[/dim]
@@ -85,6 +90,9 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
             )
         )
 
+        if not confirm_or_abort(f'Cancel issue {issue_id}? This returns the bounty to the alpha pool.', yes):
+            return
+
         with console.status('[bold cyan]Submitting cancellation...', spinner='dots'):
             result = client.cancel_issue(issue_id, wallet)
 
@@ -100,7 +108,10 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
 @click.argument('issue_id', type=int)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
-def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_payout(
+    issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool
+):
     """Manual payout fallback (owner only).
 
     [dim]Pays out a completed issue bounty to the solver.
@@ -140,6 +151,9 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
             )
         )
 
+        if not confirm_or_abort(f'Pay out issue {issue_id}?', yes):
+            return
+
         with console.status('[bold cyan]Submitting payout...', spinner='dots'):
             result = client.payout_bounty(issue_id, wallet)
 
@@ -155,7 +169,10 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
 @click.argument('new_owner', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
-def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_set_owner(
+    new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool
+):
     """Transfer contract ownership (owner only).
 
     [dim]Arguments:
@@ -174,11 +191,15 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
 
     console.print(
         Panel(
-            f'[cyan]New Owner:[/cyan] {new_owner}',
+            f'[cyan]New Owner:[/cyan] {new_owner}\n'
+            '[bold red]This transfer is IRREVERSIBLE. A mistyped address makes the contract unrecoverable.[/bold red]',
             title='Transfer Ownership',
             border_style='red',
         )
     )
+
+    if not confirm_or_abort(f'Transfer ownership to {new_owner}?', yes):
+        return
 
     try:
         with console.status('[bold cyan]Transferring ownership...', spinner='dots'):
@@ -197,8 +218,9 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
 @click.argument('new_treasury', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
+@with_cli_behavior_options(include_yes=True)
 def admin_set_treasury(
-    new_treasury: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str
+    new_treasury: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool
 ):
     """Change treasury hotkey (owner only).
 
@@ -227,6 +249,11 @@ def admin_set_treasury(
         )
     )
 
+    if not confirm_or_abort(
+        f'Change treasury to {new_treasury}? This resets active/registered bounty amounts to 0.', yes
+    ):
+        return
+
     try:
         with console.status('[bold cyan]Updating treasury hotkey...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
@@ -247,7 +274,10 @@ def admin_set_treasury(
 @click.argument('hotkey', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
-def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_add_validator(
+    hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool
+):
     """Add a validator to the voting whitelist (owner only).
 
     [dim]Whitelisted validators can vote on solutions and issue cancellations.
@@ -275,6 +305,9 @@ def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, 
         )
     )
 
+    if not confirm_or_abort(f'Add {hotkey} to the validator whitelist?', yes):
+        return
+
     try:
         with console.status('[bold cyan]Adding validator...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
@@ -295,8 +328,9 @@ def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, 
 @click.argument('hotkey', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
+@with_cli_behavior_options(include_yes=True)
 def admin_remove_validator(
-    hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str
+    hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool
 ):
     """Remove a validator from the voting whitelist (owner only).
 
@@ -323,6 +357,9 @@ def admin_remove_validator(
             border_style='red',
         )
     )
+
+    if not confirm_or_abort(f'Remove {hotkey} from the validator whitelist?', yes):
+        return
 
     try:
         with console.status('[bold cyan]Removing validator...', spinner='dots'):

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -251,6 +251,21 @@ def _is_interactive() -> bool:
     return getattr(sys.stdin, 'isatty', lambda: False)()
 
 
+def confirm_or_abort(prompt: str, yes: bool, default: bool = False) -> bool:
+    """Prompt for confirmation before a destructive operation.
+
+    Returns True if the caller should proceed. Returns False (and prints a
+    cancellation message) if the user declines. `yes` and non-TTY input both
+    skip the prompt and proceed.
+    """
+    if yes or not _is_interactive():
+        return True
+    if click.confirm(f'\n{prompt}', default=default):
+        return True
+    console.print('[yellow]Cancelled.[/yellow]')
+    return False
+
+
 def get_github_pat() -> Optional[str]:
     """Return GITTENSOR_MINER_PAT from environment, or None."""
     return os.environ.get('GITTENSOR_MINER_PAT') or None

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -123,7 +123,7 @@ def with_cli_behavior_options(
     include_yes: bool = False,
     verbose_help: str = 'Show debug output',
     json_help: str = 'Output as JSON for scripting',
-    yes_help: str = 'Skip confirmation prompt (non-interactive/CI)',
+    yes_help: str = 'Skip confirmation prompt (non-interactive/CI). Alias: --no-prompt (btcli-compatible).',
 ) -> Callable[[CommandFunc], CommandFunc]:
     """Add common CLI behavior options such as verbose, JSON, and confirmation controls."""
     decorators: list[Callable[[CommandFunc], CommandFunc]] = []
@@ -150,7 +150,9 @@ def with_cli_behavior_options(
         decorators.append(
             click.option(
                 '--yes',
+                '--no-prompt',
                 '-y',
+                'yes',
                 is_flag=True,
                 help=yes_help,
             )

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -22,6 +22,7 @@ from .helpers import (
     _handle_command_error,
     _make_contract_client,
     _resolve_contract_and_network,
+    confirm_or_abort,
     console,
     print_error,
     print_network_header,
@@ -78,6 +79,7 @@ def vote():
 @click.argument('pr_number_or_url', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
+@with_cli_behavior_options(include_yes=True)
 def val_vote_solution(
     issue_id: int,
     solver_hotkey: str,
@@ -88,6 +90,7 @@ def val_vote_solution(
     network: str,
     rpc_url: str,
     contract: str,
+    yes: bool,
 ):
     """Vote for a solution on an active issue (triggers auto-payout on consensus).
 
@@ -133,6 +136,9 @@ def val_vote_solution(
         )
     )
 
+    if not confirm_or_abort(f'Vote that {solver_hotkey} solved issue {issue_id} via PR #{pr_number}?', yes):
+        return
+
     try:
         with console.status('[bold cyan]Submitting vote...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
@@ -151,6 +157,7 @@ def val_vote_solution(
 @click.argument('reason', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
+@with_cli_behavior_options(include_yes=True)
 def val_vote_cancel_issue(
     issue_id: int,
     reason: str,
@@ -159,6 +166,7 @@ def val_vote_cancel_issue(
     network: str,
     rpc_url: str,
     contract: str,
+    yes: bool,
 ):
     """Vote to cancel an issue (works on Registered or Active).
 
@@ -185,6 +193,9 @@ def val_vote_cancel_issue(
             border_style='yellow',
         )
     )
+
+    if not confirm_or_abort(f'Vote to cancel issue {issue_id}?', yes):
+        return
 
     try:
         with console.status('[bold cyan]Submitting cancel vote...', spinner='dots'):


### PR DESCRIPTION
## Summary
- Adds a y/n confirmation prompt before executing destructive owner/validator commands: `admin cancel`, `admin payout`, `admin set-owner`, `admin set-treasury`, `admin add-validator`, `admin remove-validator`, `vote solution`, `vote cancel-issue`.
- Flag mirrors btcli: `--no-prompt` skips the gate (with `--yes` and `-y` kept as aliases so existing gittensor scripts still work). Auto-skipped when stdin is not a TTY, so scripts and CI pipelines are unaffected.
- `admin set-owner` panel now calls out that the transfer is irreversible, since a mistyped address permanently bricks the contract.
- Confirmation lives in a shared `confirm_or_abort` helper in `issue_commands/helpers.py` reusing the existing `with_cli_behavior_options(include_yes=True)` decorator.
- Existing `issues register` already has this gate (introduced in #211); this PR extends the same pattern to the remaining on-chain writes. `register`'s inline check could later be migrated onto `confirm_or_abort` — left as a follow-up to keep this PR tight.

## Why — matches the `btcli` precedent
`btcli`, the reference Bittensor CLI, prompts for y/n confirmation before every state-changing / on-chain action and exposes `--no-prompt` / `-y` to skip it for scripting. Operators already expect this flag across the Bittensor ecosystem. Examples of what btcli gates:

- `btcli wallet transfer` — confirms recipient + amount before signing
- `btcli stake add` / `btcli stake remove` — confirms amount and hotkey
- `btcli subnet register` / `btcli root register` — confirms the burn cost
- `btcli root set-weights`, `btcli root boost`, `btcli root slash` — confirms weight changes
- `btcli subnet create` — confirms the lock cost
- `btcli wallet regen-*` / wallet deletion — confirms overwrite of existing keys

The gittensor admin and validator-vote commands are the same class of action — owner-only contract writes and validator votes that trigger payouts — so applying the same gate (print the details in a Panel, then `click.confirm`, with `--no-prompt` / `--yes` / `-y` to bypass and auto-skip on non-TTY) keeps UX consistent with what Bittensor operators already expect.

## Test plan
- [ ] `gitt admin cancel <id>` in a TTY prompts and aborts cleanly on `n`
- [ ] `gitt admin cancel <id> --no-prompt` skips the prompt (btcli-style)
- [ ] `gitt admin cancel <id> --yes` / `-y` also skip the prompt (back-compat)
- [ ] `echo | gitt admin cancel <id>` (non-TTY) does not hang on the prompt
- [ ] `gitt admin set-owner <addr>` shows the red irreversibility warning before prompting
- [ ] `gitt vote solution …` / `gitt vote cancel-issue …` prompt and honor `--no-prompt`
- [ ] `gitt admin cancel-issue --help` lists `--yes, --no-prompt / -y`


#714 