### PR TITLE
fix(cli): add --ignore-vtrust flag to gitt miner post/check

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -32,7 +32,13 @@ console = Console()
 @click.option('--network', default=None, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
-def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode):
+@click.option(
+    '--ignore-vtrust',
+    is_flag=True,
+    default=False,
+    help='Probe all serving validators regardless of validator_trust. Useful on testnets where consensus has not yet assigned vtrust scores.',
+)
+def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode, ignore_vtrust):
     """Check how many validators have your PAT stored.
 
     Sends a lightweight probe to each validator — no PAT is transmitted.
@@ -62,8 +68,9 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
     # Verify miner is registered
     _require_registered(wallet, metagraph, netuid, json_mode)
 
-    # 3. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode)
+    # 3. Find active validator axons (vtrust > 0.1 by default, see --ignore-vtrust)
+    min_vtrust = -1.0 if ignore_vtrust else 0.1
+    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode, min_vtrust=min_vtrust)
 
     # 4. Send check probes
     synapse = PatCheckSynapse()

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -19,12 +19,18 @@ console = Console()
 NETUID_DEFAULT = 74
 
 
-def _get_validator_axons(metagraph) -> tuple[list, list]:
-    """Return (axons, uids) for all active validators (vtrust > 0.1, serving)."""
+def _get_validator_axons(metagraph, min_vtrust: float = 0.1) -> tuple[list, list]:
+    """Return (axons, uids) for serving validators with vtrust > min_vtrust.
+
+    The default threshold (0.1) matches mainnet behavior where active
+    validators have established consensus. Pass a negative value (e.g.
+    -1.0) to disable the filter entirely — useful on testnets where
+    consensus has not yet assigned vtrust scores to any UID.
+    """
     axons = []
     uids = []
     for uid in range(metagraph.n):
-        if metagraph.validator_trust[uid] > 0.1 and metagraph.axons[uid].is_serving:
+        if metagraph.validator_trust[uid] > min_vtrust and metagraph.axons[uid].is_serving:
             axons.append(metagraph.axons[uid])
             uids.append(uid)
     return axons, uids
@@ -94,9 +100,9 @@ def _require_registered(wallet, metagraph, netuid: int, json_mode: bool) -> None
         sys.exit(1)
 
 
-def _require_validator_axons(metagraph, json_mode: bool) -> tuple[list, list]:
+def _require_validator_axons(metagraph, json_mode: bool, min_vtrust: float = 0.1) -> tuple[list, list]:
     """Return validator (axons, uids), or exit with error if none found."""
-    validator_axons, validator_uids = _get_validator_axons(metagraph)
+    validator_axons, validator_uids = _get_validator_axons(metagraph, min_vtrust=min_vtrust)
     if not validator_axons:
         _error('No reachable validator axons found on the network.', json_mode)
         sys.exit(1)

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -43,7 +43,13 @@ console = Console()
     help='GitHub Personal Access Token. If not provided, falls back to GITTENSOR_MINER_PAT env var or interactive prompt.',
 )
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
-def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_mode):
+@click.option(
+    '--ignore-vtrust',
+    is_flag=True,
+    default=False,
+    help='Broadcast to all serving validators regardless of validator_trust. Useful on testnets where consensus has not yet assigned vtrust scores.',
+)
+def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_mode, ignore_vtrust):
     """Broadcast your GitHub PAT to all validators on the network.
 
     Validators will validate your PAT (test GitHub API access, check account age),
@@ -99,8 +105,9 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
     # Verify miner is registered
     _require_registered(wallet, metagraph, netuid, json_mode)
 
-    # 4. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode)
+    # 4. Find active validator axons (vtrust > 0.1 by default, see --ignore-vtrust)
+    min_vtrust = -1.0 if ignore_vtrust else 0.1
+    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode, min_vtrust=min_vtrust)
 
     # 5. Broadcast
     synapse = PatBroadcastSynapse(github_access_token=pat)

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -3,13 +3,14 @@
 """Tests for gitt miner post and gitt miner check CLI commands."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from gittensor import __version__
 from gittensor.cli.main import cli
+from gittensor.cli.miner_commands.helpers import _get_validator_axons
 
 
 @pytest.fixture
@@ -75,3 +76,62 @@ class TestCliVersion:
         result = runner.invoke(cli, ['--version'])
         assert result.exit_code == 0
         assert result.output == f'gittensor, version {__version__}\n'
+
+
+def _make_metagraph(vtrusts, servings):
+    """Build a MagicMock metagraph with the given per-UID vtrust and serving flags."""
+    mg = MagicMock()
+    mg.n = len(vtrusts)
+    mg.validator_trust = vtrusts
+    axons = []
+    for s in servings:
+        ax = MagicMock()
+        ax.is_serving = s
+        axons.append(ax)
+    mg.axons = axons
+    return mg
+
+
+class TestGetValidatorAxons:
+    def test_default_threshold_filters_low_trust(self):
+        """Default threshold (0.1) excludes validators with vtrust <= 0.1."""
+        mg = _make_metagraph(vtrusts=[0.0, 0.05, 0.2], servings=[True, True, True])
+        _, uids = _get_validator_axons(mg)
+        assert uids == [2]
+
+    def test_default_threshold_excludes_non_serving(self):
+        """Non-serving axons are excluded even when vtrust passes."""
+        mg = _make_metagraph(vtrusts=[0.5, 0.5], servings=[True, False])
+        _, uids = _get_validator_axons(mg)
+        assert uids == [0]
+
+    def test_negative_threshold_bypasses_filter(self):
+        """Passing min_vtrust=-1.0 admits any serving validator.
+
+        This is the testnet escape hatch: on networks where consensus has
+        not yet assigned vtrust, the default 0.1 threshold would exclude
+        every validator.
+        """
+        mg = _make_metagraph(vtrusts=[0.0, 0.0, 0.0], servings=[True, True, False])
+        _, uids = _get_validator_axons(mg, min_vtrust=-1.0)
+        assert uids == [0, 1]
+
+    def test_custom_threshold(self):
+        """Caller can request an arbitrary threshold."""
+        mg = _make_metagraph(vtrusts=[0.05, 0.15, 0.25, 0.35], servings=[True] * 4)
+        _, uids = _get_validator_axons(mg, min_vtrust=0.2)
+        assert uids == [2, 3]
+
+
+class TestMinerPostIgnoreVtrust:
+    def test_help_mentions_flag(self, runner):
+        result = runner.invoke(cli, ['miner', 'post', '--help'])
+        assert result.exit_code == 0
+        assert '--ignore-vtrust' in result.output
+
+
+class TestMinerCheckIgnoreVtrust:
+    def test_help_mentions_flag(self, runner):
+        result = runner.invoke(cli, ['miner', 'check', '--help'])
+        assert result.exit_code == 0
+        assert '--ignore-vtrust' in result.output


### PR DESCRIPTION
## Summary

Adds an opt-in `--ignore-vtrust` flag to `gitt miner post` and `gitt miner check` to unblock end-to-end testing on testnet netuid 422.

**Default mainnet behavior is unchanged.** The `vtrust > 0.1` filter is preserved when the flag is not passed.

## Problem

On testnet `422` (`entrius-test`), no UID currently has `validator_trust > 0.1` (consensus has not established vtrust scores for any axon). The filter in `_get_validator_axons` therefore excludes every validator, and the CLI aborts with:

```
Error: No reachable validator axons found on the network.
```

Repro (testnet, 2026-04-22):

```
$ gitt miner post --wallet <miner> --hotkey default --netuid 422 --network test
PAT is valid.
Wallet: <miner>/default | Network: wss://test.finney.opentensor.ai:443 | Netuid: 422
Error: No reachable validator axons found on the network.
```

Metagraph snapshot at the time of the repro: 30 UIDs, 19 serving axons, **0 with vtrust > 0.1**. Same failure on `gitt miner check`.

This blocks new miners from validating their PAT broadcast flow on testnet before committing mainnet registration TAO.

## Fix

1. Parameterize `_get_validator_axons` and `_require_validator_axons` in `gittensor/cli/miner_commands/helpers.py` with an optional `min_vtrust: float = 0.1`. Mainnet callers keep the default; nothing else changes.
2. Add an opt-in `--ignore-vtrust` flag to `gitt miner post` and `gitt miner check`. When set, the command passes `min_vtrust=-1.0`, admitting every serving validator regardless of trust.

The flag is **opt-in**, so mainnet users who do nothing keep the prior behavior.

## Related Issues

No existing issue tracked — filing this PR directly. Happy to open a bug report first if preferred.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated
  - `TestGetValidatorAxons` (4 unit tests) in `tests/cli/test_miner_commands.py` covering default threshold, non-serving exclusion, negative-threshold bypass, and custom thresholds.
  - `TestMinerPostIgnoreVtrust` / `TestMinerCheckIgnoreVtrust` verify the flag appears in `--help` output.
- [x] Manually tested end-to-end on testnet netuid 422 (UID 29):
  - Without flag → `No reachable validator axons found` (pre-fix behavior preserved).
  - With `--ignore-vtrust` → broadcast reaches all 19 serving validators; `gitt miner check` returns response table.

## Checklist

- [x] Code follows project style guidelines (ruff format clean, 4-space indent, single-quote strings)
- [x] Self-review completed
- [x] Changes are documented (docstring on `_get_validator_axons` explains the threshold and the testnet use case; CLI `--help` text for the new flag explains when to use it)
- [x] No changes to `smart-contracts/` or other out-of-scope areas
- [x] No unrelated file modifications
- [x] Pre-commit + pre-push hooks pass locally (`ruff`, `pyright`, `pytest`)
