### PR TITLE
fix(cli): resolve miner --hotkey from SS58 and load wallet before Den…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ gitt miner post --wallet <name> --hotkey <hotkey>
 gitt miner check --wallet <name> --hotkey <hotkey>
 ```
 
+Use the hotkey **file name** under `~/.bittensor/wallets/<wallet>/hotkeys/` (for example `default`), or the hotkey **SS58 address** if it matches a key on disk.
+
 See full guide **[here](https://docs.gittensor.io/miner.html)**
 
 ## Validators

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -27,7 +27,12 @@ console = Console()
 
 @click.command()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
-@click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
+@click.option(
+    '--hotkey',
+    'wallet_hotkey',
+    default=None,
+    help='Bittensor hotkey file name under ~/.bittensor/wallets/<wallet>/hotkeys/ (or matching SS58).',
+)
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -57,11 +57,54 @@ def _resolve_endpoint(network: str | None, rpc_url: str | None) -> str:
     return NETWORK_MAP['finney']
 
 
+def _resolve_wallet_hotkey_name(wallet_name: str, hotkey_spec: str) -> str:
+    """Resolve CLI --hotkey to a wallet hotkey *file name*.
+
+    Bittensor stores keys as ``~/.bittensor/wallets/<wallet>/hotkeys/<name>``.
+    Users often paste the SS58 address instead of the key name; map that when possible.
+    """
+    hdir = Path.home() / '.bittensor' / 'wallets' / wallet_name / 'hotkeys'
+    if not hdir.is_dir():
+        return hotkey_spec
+    direct = hdir / hotkey_spec
+    if direct.is_file():
+        return hotkey_spec
+
+    import bittensor as bt
+
+    matches: list[str] = []
+    for p in sorted(hdir.iterdir()):
+        if not p.is_file() or p.name.endswith('pub.txt'):
+            continue
+        try:
+            w = bt.Wallet(name=wallet_name, hotkey=p.name)
+            if w.hotkey.ss58_address == hotkey_spec:
+                matches.append(p.name)
+        except Exception:
+            continue
+
+    if len(matches) > 1:
+        raise ValueError(f'Multiple hotkey files match SS58 {hotkey_spec}: {matches}')
+    if len(matches) == 1:
+        return matches[0]
+
+    available = sorted(
+        p.name for p in hdir.iterdir() if p.is_file() and not p.name.endswith('pub.txt')
+    )
+    raise ValueError(
+        f"No hotkey file {hotkey_spec!r} under wallet {wallet_name!r} "
+        f'({hdir}). Use the key name (filename), not the SS58, unless that address '
+        f'matches a local hotkey file. Available names: {", ".join(available) or "(none)"}'
+    )
+
+
 def _connect_bittensor(wallet_name: str, wallet_hotkey: str, ws_endpoint: str, netuid: int):
     """Set up and return bittensor wallet, subtensor, metagraph and dendrite."""
     import bittensor as bt
 
-    w = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+    resolved_hotkey = _resolve_wallet_hotkey_name(wallet_name, wallet_hotkey)
+    w = bt.Wallet(name=wallet_name, hotkey=resolved_hotkey)
+    _ = w.hotkey.ss58_address  # load before Dendrite so failures do not construct a half-initialized dendrite
     st = bt.Subtensor(network=ws_endpoint)
     mg = st.metagraph(netuid=netuid)
     dd = bt.Dendrite(wallet=w)

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -33,7 +33,12 @@ console = Console()
 
 @click.command()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
-@click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
+@click.option(
+    '--hotkey',
+    'wallet_hotkey',
+    default=None,
+    help='Bittensor hotkey file name under ~/.bittensor/wallets/<wallet>/hotkeys/ (or matching SS58).',
+)
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')

--- a/tests/cli/test_miner_helpers.py
+++ b/tests/cli/test_miner_helpers.py
@@ -1,0 +1,54 @@
+# Entrius 2025
+
+"""Tests for miner CLI helpers (hotkey resolution)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_resolve_hotkey_returns_name_when_file_exists(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, 'home', classmethod(lambda cls: tmp_path))
+    hk = tmp_path / '.bittensor' / 'wallets' / 'alice' / 'hotkeys' / 'myhotkey'
+    hk.parent.mkdir(parents=True)
+    hk.write_text('x')
+
+    from gittensor.cli.miner_commands.helpers import _resolve_wallet_hotkey_name
+
+    assert _resolve_wallet_hotkey_name('alice', 'myhotkey') == 'myhotkey'
+
+
+def test_resolve_hotkey_maps_ss58_to_file_name(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, 'home', classmethod(lambda cls: tmp_path))
+    hdir = tmp_path / '.bittensor' / 'wallets' / 'alice' / 'hotkeys'
+    hdir.mkdir(parents=True)
+    (hdir / 'minerhk').write_text('placeholder')
+
+    def fake_wallet(name: str, hotkey: str):
+        w = MagicMock()
+        if hotkey == 'minerhk':
+            w.hotkey.ss58_address = '5FtEXFJHQkV6wgjT1By59zUSZHVE4Ah3FbDynEYnmUBmRZxK'
+        else:
+            w.hotkey.ss58_address = '5Other'
+        return w
+
+    from gittensor.cli.miner_commands.helpers import _resolve_wallet_hotkey_name
+
+    with patch('bittensor.Wallet', side_effect=fake_wallet):
+        out = _resolve_wallet_hotkey_name('alice', '5FtEXFJHQkV6wgjT1By59zUSZHVE4Ah3FbDynEYnmUBmRZxK')
+        assert out == 'minerhk'
+
+
+def test_resolve_hotkey_unknown_lists_available(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, 'home', classmethod(lambda cls: tmp_path))
+    hdir = tmp_path / '.bittensor' / 'wallets' / 'alice' / 'hotkeys'
+    hdir.mkdir(parents=True)
+    (hdir / 'hk1').write_text('a')
+
+    from gittensor.cli.miner_commands.helpers import _resolve_wallet_hotkey_name
+
+    with pytest.raises(ValueError) as exc:
+        _resolve_wallet_hotkey_name('alice', 'not-a-key')
+    assert 'hk1' in str(exc.value)
+    assert 'Available names' in str(exc.value)


### PR DESCRIPTION
…drite

- Map hotkey SS58 to the local key filename when users paste the address
- Fail fast on hotkey load before constructing Dendrite (avoids __del__ noise)
- Clearer errors listing available hotkey names; update --help and README
- Add unit tests for hotkey resolution
