### PR TITLE
fix(cli): require ws(s) scheme for miner --rpc-url

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -30,7 +30,11 @@ console = Console()
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
-@click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
+@click.option(
+    '--rpc-url',
+    default=None,
+    help='Subtensor WebSocket endpoint (wss:// or ws://), overrides --network.',
+)
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode):
     """Check how many validators have your PAT stored.

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -45,7 +45,14 @@ def _load_config_value(key: str):
 def _resolve_endpoint(network: str | None, rpc_url: str | None) -> str:
     """Resolve the subtensor endpoint from CLI args or config."""
     if rpc_url:
-        return rpc_url
+        u = rpc_url.strip()
+        if u and not (u.startswith('ws://') or u.startswith('wss://')):
+            raise ValueError(
+                '`--rpc-url` must be a WebSocket URL (ws:// or wss://). '
+                f'Example: wss://entrypoint-finney.opentensor.ai:443 (got {u!r}).'
+            )
+        if u:
+            return u
     if network:
         return NETWORK_MAP.get(network.lower(), network)
     config_network = _load_config_value('network')

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -36,7 +36,11 @@ console = Console()
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
-@click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
+@click.option(
+    '--rpc-url',
+    default=None,
+    help='Subtensor WebSocket endpoint (wss:// or ws://), overrides --network.',
+)
 @click.option(
     '--pat',
     default=None,

--- a/tests/cli/test_miner_resolve_endpoint.py
+++ b/tests/cli/test_miner_resolve_endpoint.py
@@ -1,0 +1,22 @@
+# Entrius 2025
+
+"""Tests for miner CLI endpoint resolution."""
+
+import pytest
+
+from gittensor.cli.miner_commands.helpers import _resolve_endpoint
+from gittensor.constants import NETWORK_MAP
+
+
+def test_resolve_endpoint_rpc_url_requires_ws_scheme() -> None:
+    with pytest.raises(ValueError, match='rpc-url'):
+        _resolve_endpoint(None, 'entrypoint-finney.opentensor.ai:443')
+
+
+def test_resolve_endpoint_rpc_url_strips_and_accepts_wss() -> None:
+    out = _resolve_endpoint(None, '  wss://entrypoint-finney.opentensor.ai:443  ')
+    assert out == 'wss://entrypoint-finney.opentensor.ai:443'
+
+
+def test_resolve_endpoint_rpc_url_whitespace_only_falls_through_to_network() -> None:
+    assert _resolve_endpoint('finney', '  \t') == NETWORK_MAP['finney']


### PR DESCRIPTION
## Summary

Miner CLI (`gitt miner post`, `gitt miner check`) now validates `--rpc-url` before connecting: non-empty values must use a WebSocket scheme (`ws://` or `wss://`). Host-only values (e.g. `entrypoint-finney.opentensor.ai:443`) fail early with an explicit error and example URL. Whitespace-only `--rpc-url` is ignored so `--network` still applies. `--help` text for `--rpc-url` was updated to say “WebSocket endpoint”.

## Related Issues

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated (`tests/cli/test_miner_resolve_endpoint.py`)
- [x] Manually checked: invalid `--rpc-url` surfaces a clear error; `wss://…` and `ws://…` still work; `finney` + blank `--rpc-url` resolves to the mapped endpoint

`uv run --extra dev pytest` — all tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)