### PR TITLE
fix(cli): validate WebSocket URLs for miner endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ gitt miner post --wallet <name> --hotkey <hotkey>
 gitt miner check --wallet <name> --hotkey <hotkey>
 ```
 
+`--rpc-url` and the optional `ws_endpoint` field in `~/.gittensor/config.json` must be WebSocket URLs (`wss://` or `ws://`).
+
 See full guide **[here](https://docs.gittensor.io/miner.html)**
 
 ## Validators

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -30,7 +30,11 @@ console = Console()
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
-@click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
+@click.option(
+    '--rpc-url',
+    default=None,
+    help='Subtensor WebSocket endpoint (wss:// or ws://), overrides --network.',
+)
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode):
     """Check how many validators have your PAT stored.

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -45,13 +45,27 @@ def _load_config_value(key: str):
 def _resolve_endpoint(network: str | None, rpc_url: str | None) -> str:
     """Resolve the subtensor endpoint from CLI args or config."""
     if rpc_url:
-        return rpc_url
+        u = rpc_url.strip()
+        if u and not (u.startswith('ws://') or u.startswith('wss://')):
+            raise ValueError(
+                '`--rpc-url` must be a WebSocket URL (ws:// or wss://). '
+                f'Example: wss://entrypoint-finney.opentensor.ai:443 (got {u!r}).'
+            )
+        if u:
+            return u
     if network:
         return NETWORK_MAP.get(network.lower(), network)
     config_network = _load_config_value('network')
     config_endpoint = _load_config_value('ws_endpoint')
     if config_endpoint:
-        return config_endpoint
+        u = config_endpoint.strip()
+        if u and not (u.startswith('ws://') or u.startswith('wss://')):
+            raise ValueError(
+                '`ws_endpoint` in ~/.gittensor/config.json must use ws:// or wss://. '
+                f'Example: wss://entrypoint-finney.opentensor.ai:443 (got {u!r}).'
+            )
+        if u:
+            return u
     if config_network:
         return NETWORK_MAP.get(config_network.lower()) or config_network
     return NETWORK_MAP['finney']

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -36,7 +36,11 @@ console = Console()
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
-@click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
+@click.option(
+    '--rpc-url',
+    default=None,
+    help='Subtensor WebSocket endpoint (wss:// or ws://), overrides --network.',
+)
 @click.option(
     '--pat',
     default=None,

--- a/tests/cli/test_miner_resolve_endpoint.py
+++ b/tests/cli/test_miner_resolve_endpoint.py
@@ -1,0 +1,49 @@
+# Entrius 2025
+
+"""Tests for miner CLI subtensor endpoint resolution."""
+
+from unittest.mock import patch
+
+import pytest
+
+from gittensor.cli.miner_commands.helpers import _resolve_endpoint
+from gittensor.constants import NETWORK_MAP
+
+
+def test_resolve_endpoint_rpc_url_requires_ws_scheme() -> None:
+    with pytest.raises(ValueError, match='rpc-url'):
+        _resolve_endpoint(None, 'entrypoint-finney.opentensor.ai:443')
+
+
+def test_resolve_endpoint_rpc_url_strips_and_accepts_wss() -> None:
+    out = _resolve_endpoint(None, '  wss://entrypoint-finney.opentensor.ai:443  ')
+    assert out == 'wss://entrypoint-finney.opentensor.ai:443'
+
+
+def test_resolve_endpoint_rpc_url_whitespace_only_falls_through_to_network() -> None:
+    assert _resolve_endpoint('finney', '  \t') == NETWORK_MAP['finney']
+
+
+def test_resolve_endpoint_config_ws_endpoint_requires_scheme() -> None:
+    def _load(key: str):
+        if key == 'ws_endpoint':
+            return 'bad.example.com:443'
+        if key == 'network':
+            return None
+        return None
+
+    with patch('gittensor.cli.miner_commands.helpers._load_config_value', side_effect=_load):
+        with pytest.raises(ValueError, match='ws_endpoint'):
+            _resolve_endpoint(None, None)
+
+
+def test_resolve_endpoint_config_ws_endpoint_ok() -> None:
+    def _load(key: str):
+        if key == 'ws_endpoint':
+            return '  wss://custom.example/  '
+        if key == 'network':
+            return None
+        return None
+
+    with patch('gittensor.cli.miner_commands.helpers._load_config_value', side_effect=_load):
+        assert _resolve_endpoint(None, None) == 'wss://custom.example/'


### PR DESCRIPTION
## Summary

Miner CLI endpoint resolution now requires WebSocket URLs (`ws://` or `wss://`) for:

- `--rpc-url` on `gitt miner post` and `gitt miner check` (host-only values fail early with an example URL).
- `ws_endpoint` in `~/.gittensor/config.json` (same rules, so bad config fails before connecting).

Whitespace-only `--rpc-url` is ignored so `--network` / config fallbacks still work. `--help` for `--rpc-url` and the README miners section describe WebSocket URLs.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Testing

- [x] Tests added: `tests/cli/test_miner_resolve_endpoint.py` (CLI flag, config `ws_endpoint`, fallbacks).
- [x] `uv run --extra dev pytest` — all tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)