### PR TITLE
fix(cli): validate coldkey path and load hotkey before dendrite for miners

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The result: a sustainable incentive layer that channels resources toward buildin
 
 ## Miners
 
-No miner neuron required — just register your GitHub PAT with validators using the CLI.
+No miner neuron required — just register your GitHub PAT with validators using the CLI. Use an existing coldkey name for `--wallet` (`~/.bittensor/wallets/<name>/`) and the **hotkey file name** (not the SS58 string) for `--hotkey`.
 
 ```bash
 # Install

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -27,7 +27,12 @@ console = Console()
 
 @click.command()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
-@click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
+@click.option(
+    '--hotkey',
+    'wallet_hotkey',
+    default=None,
+    help='Hotkey file name under ~/.bittensor/wallets/<wallet>/hotkeys/ (not the SS58 address).',
+)
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -57,11 +57,30 @@ def _resolve_endpoint(network: str | None, rpc_url: str | None) -> str:
     return NETWORK_MAP['finney']
 
 
+def _require_wallet_directory(wallet_name: str) -> None:
+    """Raise if the coldkey wallet directory is missing (clearer than downstream bittensor errors)."""
+    wallets_root = Path.home() / '.bittensor' / 'wallets'
+    coldkey_dir = wallets_root / wallet_name
+    if coldkey_dir.is_dir():
+        return
+    hint = ''
+    if wallets_root.is_dir():
+        names = sorted(p.name for p in wallets_root.iterdir() if p.is_dir())[:20]
+        if names:
+            hint = f" Known coldkey names: {', '.join(names)}."
+    raise ValueError(
+        f'Wallet {wallet_name!r} not found at {coldkey_dir}. '
+        f'Create a coldkey (for example with btcli) or pass the correct --wallet.{hint}'
+    )
+
+
 def _connect_bittensor(wallet_name: str, wallet_hotkey: str, ws_endpoint: str, netuid: int):
     """Set up and return bittensor wallet, subtensor, metagraph and dendrite."""
     import bittensor as bt
 
+    _require_wallet_directory(wallet_name)
     w = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+    _ = w.hotkey.ss58_address  # load before Dendrite so failures do not construct a half-initialized dendrite
     st = bt.Subtensor(network=ws_endpoint)
     mg = st.metagraph(netuid=netuid)
     dd = bt.Dendrite(wallet=w)

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -33,7 +33,12 @@ console = Console()
 
 @click.command()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
-@click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
+@click.option(
+    '--hotkey',
+    'wallet_hotkey',
+    default=None,
+    help='Hotkey file name under ~/.bittensor/wallets/<wallet>/hotkeys/ (not the SS58 address).',
+)
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')

--- a/tests/cli/test_miner_wallet_directory.py
+++ b/tests/cli/test_miner_wallet_directory.py
@@ -1,0 +1,27 @@
+# Entrius 2025
+
+"""Tests for miner CLI wallet directory guard."""
+
+from pathlib import Path
+
+import pytest
+
+from gittensor.cli.miner_commands.helpers import _require_wallet_directory
+
+
+def test_require_wallet_directory_ok(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, 'home', classmethod(lambda cls: tmp_path))
+    cold = tmp_path / '.bittensor' / 'wallets' / 'alice'
+    cold.mkdir(parents=True)
+    _require_wallet_directory('alice')
+
+
+def test_require_wallet_directory_missing_lists_known(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, 'home', classmethod(lambda cls: tmp_path))
+    root = tmp_path / '.bittensor' / 'wallets'
+    root.mkdir(parents=True)
+    (root / 'bob').mkdir()
+    with pytest.raises(ValueError) as exc:
+        _require_wallet_directory('missing')
+    assert 'missing' in str(exc.value)
+    assert 'bob' in str(exc.value)


### PR DESCRIPTION
## Summary

Miner CLI (`gitt miner post`, `gitt miner check`) now checks that the coldkey folder `~/.bittensor/wallets/<wallet>` exists before opening Subtensor or building a `Dendrite`. If it is missing, the error lists up to 20 known coldkey directory names when available. The hotkey keypair is loaded immediately after `Wallet` construction and before `Dendrite`, so a bad or missing hotkey fails without constructing a half-initialized dendrite (cleaner errors on bittensor 10.x).

`--hotkey` help text and the README miners section clarify that `--hotkey` must be the **hotkey file name** under `hotkeys/`, not the SS58 address. `--wallet` must name an existing coldkey directory.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Testing

- [x] Added `tests/cli/test_miner_wallet_directory.py` for the coldkey directory guard.
- [x] `uv run --extra dev pytest` — all tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)