### PR TITLE
fix: json mode and human mode disagree on exit codes and aggregates

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -25,9 +25,9 @@ from .helpers import (
     _resolve_contract_and_network,
     colorize_status,
     console,
-    emit_error_json,
     emit_json,
     format_alpha,
+    handle_exception,
     print_error,
     print_network_header,
     read_issues_from_contract,
@@ -81,8 +81,7 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
         if issue_id is not None:
             issue = next((i for i in issues if i['id'] == issue_id), None)
             if issue is None:
-                emit_error_json(f'Issue {issue_id} not found on-chain.', error_type='not_found')
-                raise SystemExit(1)
+                handle_exception(as_json, f'Issue {issue_id} not found on-chain.', 'not_found')
             emit_json({'success': True, 'issue': issue})
         else:
             emit_json({'success': True, 'issue_count': len(issues), 'issues': issues})
@@ -110,7 +109,7 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
                 )
             )
         else:
-            console.print(f'[yellow]Issue {issue_id} not found.[/yellow]')
+            handle_exception(as_json, f'Issue {issue_id} not found on-chain.', 'not_found')
         return
 
     # Table view of all issues

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -319,8 +319,7 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
         else:
             msg = 'Could not read contract configuration.'
             if as_json:
-                emit_error_json(msg, error_type='read_failed')
-                raise SystemExit(1)
+                handle_exception(as_json=as_json, message=msg, error_type='read_failed')
             console.print(f'[yellow]{msg}[/yellow]')
             console.print('[dim]Try running with --verbose to see debug details.[/dim]')
     except Exception as e:

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -15,6 +15,8 @@ from .helpers import (
     _connect_bittensor,
     _error,
     _load_config_value,
+    _pat_check_aggregate_counts,
+    _pat_check_row_category,
     _print,
     _require_registered,
     _require_validator_axons,
@@ -23,6 +25,13 @@ from .helpers import (
 )
 
 console = Console()
+
+_PAT_CHECK_STATUS_MARKUP = {
+    'valid': '[green]✓ valid[/green]',
+    'no_pat': '[red]✗ no PAT[/red]',
+    'invalid_pat': '[red]✗ invalid[/red]',
+    'no_response': '[yellow]— no response[/yellow]',
+}
 
 
 @click.command()
@@ -95,8 +104,8 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
             }
         )
 
-    valid_count = sum(1 for r in results if r['pat_valid'] is True)
-    no_response_count = sum(1 for r in results if r['has_pat'] is None)
+    counts = _pat_check_aggregate_counts(results)
+    valid_count = counts['valid']
 
     # 6. Display results
     if json_mode:
@@ -105,9 +114,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
                 {
                     'success': valid_count > 0,
                     'total_validators': len(results),
-                    'valid': valid_count,
-                    'invalid': len(results) - valid_count - no_response_count,
-                    'no_response': no_response_count,
+                    **counts,
                     'results': results,
                 },
                 indent=2,
@@ -121,14 +128,8 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         table.add_column('Reason', style='dim')
 
         for r in results:
-            if r['pat_valid'] is True:
-                status = '[green]✓ valid[/green]'
-            elif r['has_pat'] is False:
-                status = '[red]✗ no PAT[/red]'
-            elif r['pat_valid'] is False:
-                status = '[red]✗ invalid[/red]'
-            else:
-                status = '[yellow]— no response[/yellow]'
+            category = _pat_check_row_category(r)
+            status = _PAT_CHECK_STATUS_MARKUP[category]
             table.add_row(str(r['uid']), r['hotkey'], status, r.get('rejection_reason') or '')
 
         console.print(table)

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 import json
 import sys
+from collections import Counter
 from contextlib import nullcontext
 from pathlib import Path
+from typing import Any
 
 import click
 from rich.console import Console
@@ -101,3 +103,25 @@ def _require_validator_axons(metagraph, json_mode: bool) -> tuple[list, list]:
         _error('No reachable validator axons found on the network.', json_mode)
         sys.exit(1)
     return validator_axons, validator_uids
+
+
+def _pat_check_row_category(row: dict[str, Any]) -> str:
+    """Classify a PAT probe row; must match `miner check` table rendering order."""
+    if row.get('pat_valid') is True:
+        return 'valid'
+    if row.get('has_pat') is False:
+        return 'no_pat'
+    if row.get('has_pat') is True and row.get('pat_valid') is False:
+        return 'invalid_pat'
+    return 'no_response'
+
+
+def _pat_check_aggregate_counts(results: list[dict[str, Any]]) -> dict[str, int]:
+    """Count PAT check rows by status for JSON summaries."""
+    counts = Counter(_pat_check_row_category(r) for r in results)
+    return {
+        'valid': counts['valid'],
+        'no_pat': counts['no_pat'],
+        'invalid_pat': counts['invalid_pat'],
+        'no_response': counts['no_response'],
+    }

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -35,3 +35,19 @@ def test_issues_list_json_missing_issue_returns_structured_error(cli_root, runne
     assert payload['success'] is False
     assert payload['error']['type'] == 'not_found'
     assert '999' in payload['error']['message']
+
+
+def test_issues_list_human_missing_issue_exits_non_zero(cli_root, runner):
+    """Human mode must exit non-zero for missing --id, matching JSON semantics."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--id', '999'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert '999' in result.output
+    assert 'not found' in result.output.lower()

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from gittensor import __version__
 from gittensor.cli.main import cli
+from gittensor.cli.miner_commands.helpers import _pat_check_aggregate_counts
 
 
 @pytest.fixture
@@ -75,3 +76,19 @@ class TestCliVersion:
         result = runner.invoke(cli, ['--version'])
         assert result.exit_code == 0
         assert result.output == f'gittensor, version {__version__}\n'
+
+
+class TestPatCheckAggregateCounts:
+    def test_splits_valid_no_pat_invalid_and_no_response(self):
+        results = [
+            {'pat_valid': True, 'has_pat': True},
+            {'pat_valid': False, 'has_pat': False},
+            {'pat_valid': False, 'has_pat': True},
+            {'pat_valid': None, 'has_pat': None},
+        ]
+        assert _pat_check_aggregate_counts(results) == {
+            'valid': 1,
+            'no_pat': 1,
+            'invalid_pat': 1,
+            'no_response': 1,
+        }


### PR DESCRIPTION
## Summary

1. **`gitt issues list --id`** — Missing on-chain issue: JSON already exited non-zero with a structured error; human mode exited **0** after a soft warning. Both paths now use the same helper as other issue commands (`handle_exception`) so exit code and error shape stay consistent.

2. **`gitt miner check --json-output`** — The top-level **`invalid`** count mixed “no PAT” (`has_pat is False`) with “invalid PAT” rows. JSON now exposes **`no_pat`**, **`invalid_pat`**, and **`no_response`** (plus **`valid`**), matching the human table semantics. **`invalid` is removed** from the JSON payload (breaking change for scripts that read that field).

## Related Issues
Closes https://github.com/entrius/gittensor/issues/723

## Type of Changes

- [x]  Bug Fix

## Tests

- `tests/cli/test_issues_list_json.py` — **`test_issues_list_human_missing_issue_exits_non_zero`**
- `tests/cli/test_miner_commands.py` — **`TestPatCheckAggregateCounts`** (imports `_pat_check_aggregate_counts` from miner `helpers`)

## Migration notes (miner check JSON)

- Replace reads of **`invalid`** with **`no_pat`** + **`invalid_pat`**, or derive from **`results`**.
- **`no_response`** still means rows classified as no response (including cases that do not match the other three categories).

## Test plan

```bash
pytest tests/cli/test_issues_list_json.py -q
pytest tests/cli/test_miner_commands.py::TestPatCheckAggregateCounts -q
```
