### PR TITLE
Reduce UI repo weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -200,13 +200,13 @@
     "weight": 1.0
   },
   "entrius/allways-ui": {
-    "weight": 0.88
+    "weight": 0.5
   },
   "entrius/gittensor": {
     "weight": 1.0
   },
   "entrius/gittensor-ui": {
-    "weight": 0.74
+    "weight": 0.5
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444


### PR DESCRIPTION
Reducing weights for entrius/allways-ui and entrius/gittensor-ui to 0.5.