### PR TITLE
Update validator weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -456,6 +456,9 @@
     ],
     "weight": 0.0751
   },
+  "nousresearch/hermes-agent": {
+    "weight": 0.59
+  },
   "numinouslabs/numinous": {
     "weight": 0.0413
   },

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -200,13 +200,13 @@
     "weight": 1.0
   },
   "entrius/allways-ui": {
-    "weight": 0.5
+    "weight": 0.88
   },
   "entrius/gittensor": {
     "weight": 1.0
   },
   "entrius/gittensor-ui": {
-    "weight": 0.5
+    "weight": 0.74
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444
@@ -475,7 +475,7 @@
     "weight": 0.0407
   },
   "openclaw/openclaw": {
-    "weight": 0.2316
+    "weight": 0.6
   },
   "OpenGradient/BitQuant-Subnet": {
     "weight": 0.0462

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -481,7 +481,7 @@
     "weight": 0.0407
   },
   "openclaw/openclaw": {
-    "weight": 0.6
+    "weight": 0.8
   },
   "OpenGradient/BitQuant-Subnet": {
     "weight": 0.0462

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -121,6 +121,9 @@
   "brave/brave-browser": {
     "weight": 0.0946
   },
+  "browser-use/browser-harness": {
+    "weight": 0.1
+  },
   "browser-use/browser-use": {
     "weight": 0.0526
   },

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -200,13 +200,13 @@
     "weight": 1.0
   },
   "entrius/allways-ui": {
-    "weight": 0.88
+    "weight": 0.5
   },
   "entrius/gittensor": {
     "weight": 1.0
   },
   "entrius/gittensor-ui": {
-    "weight": 0.74
+    "weight": 0.5
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444


### PR DESCRIPTION
Updates to master_repositories.json:
- Increased weight for `openclaw/openclaw` to `0.8`
- Added `nousresearch/hermes-agent` at weight `0.59`
- Added `browser-use/browser-harness` at weight `0.1`