### PR TITLE
fix: align exit codes and JSON aggregate fields for issues list and miner check

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -13,6 +13,7 @@ Commands:
 
 from decimal import Decimal
 
+import sys
 import click
 from rich.panel import Panel
 from rich.table import Table
@@ -110,7 +111,8 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
                 )
             )
         else:
-            console.print(f'[yellow]Issue {issue_id} not found.[/yellow]')
+            print_error(f'Issue {issue_id} not found on-chain.')
+            sys.exit(1)
         return
 
     # Table view of all issues

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -11,9 +11,9 @@ Commands:
     gitt admin info
 """
 
+import sys
 from decimal import Decimal
 
-import sys
 import click
 from rich.panel import Panel
 from rich.table import Table

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -96,6 +96,8 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
         )
 
     valid_count = sum(1 for r in results if r['pat_valid'] is True)
+    no_pat_count = sum(1 for r in results if r['has_pat'] is False)
+    invalid_pat_count = sum(1 for r in results if r['pat_valid'] is False and r['has_pat'] is True)
     no_response_count = sum(1 for r in results if r['has_pat'] is None)
 
     # 6. Display results
@@ -106,7 +108,8 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
                     'success': valid_count > 0,
                     'total_validators': len(results),
                     'valid': valid_count,
-                    'invalid': len(results) - valid_count - no_response_count,
+                    'no_pat': no_pat_count,
+                    'invalid_pat': invalid_pat_count,
                     'no_response': no_response_count,
                     'results': results,
                 },


### PR DESCRIPTION
Fixes #723

## Problem
Two inconsistencies in the CLI:

1. `gitt issues list --id <missing>` exited 0 in human mode but 1 in
   JSON mode for the same "not found" outcome.

2. `gitt miner check --json-output` reported a single `invalid` field
   computed as `len(results) - valid_count - no_response_count`, which
   lumped "no PAT stored" together with "PAT stored but invalid" —
   inconsistent with the human table which shows them separately.

## Fix

### issues list (`view.py`)
Human mode now calls `print_error(...)` and `sys.exit(1)` when `--id`
issue is not found on-chain, matching JSON mode's non-zero exit.

### miner check (`check.py`)
Replaced the ambiguous `invalid` aggregate with two explicit fields:
- `no_pat` — validators where `has_pat is False`
- `invalid_pat` — validators where `has_pat is True` but `pat_valid is False`

This matches the four categories shown in the human table: valid,
no PAT, invalid PAT, no response.

## Changes
- `gittensor/cli/miner_commands/check.py` — split `invalid` into `no_pat` and `invalid_pat`
- `gittensor/cli/issue_commands