### PR TITLE
fix: route --json error output through handle_exception (#693)

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -279,7 +279,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         console.print(f'[green]Allocated to Bounties:[/green] {format_alpha(total_bounty_pool, 4)} ALPHA')
         console.print(f'[green]Pending Harvest:[/green] {format_alpha(pending_harvest, 4)} ALPHA')
     except Exception as e:
-        _handle_command_error(e)
+        handle_exception(as_json=as_json, message=str(e))
 
 
 @click.command('info', cls=StyledCommand)


### PR DESCRIPTION
## Summary

This PR fixes the `--json` mode error output for 3 commands that were emitting ANSI-styled text instead of JSON when errors occurred.

## Changes

Routes exception handlers through the existing `handle_exception(as_json=True)` helper:

- `issues bounty-pool --json`
- `issues pending-harvest --json`
- `admin info --json`

## Before

```bash
$ gitt issues bounty-pool --json --rpc-url ws://unreachable
✗ Could not connect to ws://unreachable
```

`json.loads(stdout)` raises `JSONDecodeError`.

## After

```bash
$ gitt issues bounty-pool --json --rpc-url ws://unreachable
{"success": false, "error": {"type": "cli_error", "message": "Could not connect to ws://unreachable"}}
```

## Related

Closes #693
Closes #692 (same issue, different report)