### PR TITLE
feat: add confirmation prompts to destructive admin and vote commands

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -294,7 +294,7 @@ def admin_add_validator(
     """
     confirm_or_abort(f'Add validator {hotkey} to whitelist?', yes)
 
-    contract_addr, ws_endpoint
+    contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     require_valid_ss58(hotkey, 'hotkey')
 

--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -49,7 +49,9 @@ def admin():
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
 @with_cli_behavior_options(include_yes=True)
-def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
+def admin_cancel(
+    issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False
+):
     """Cancel an issue (owner only).
 
     [dim]Immediately cancels an issue without validator consensus. Bounty funds are returned to the alpha pool.[/dim]
@@ -105,7 +107,9 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
 @with_cli_behavior_options(include_yes=True)
-def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
+def admin_payout(
+    issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False
+):
     """Manual payout fallback (owner only).
 
     [dim]Pays out a completed issue bounty to the solver.
@@ -163,7 +167,9 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
 @with_wallet_options()
 @with_network_contract_options('Contract address')
 @with_cli_behavior_options(include_yes=True)
-def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
+def admin_set_owner(
+    new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False
+):
     """Transfer contract ownership (owner only).
 
     [dim]Arguments:
@@ -174,7 +180,9 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
         $ gitt admin set-owner 5Hxxx...
     [/dim]
     """
-    console.print('[red bold]WARNING: Ownership transfer is irreversible. A wrong address permanently bricks the contract.[/red bold]')
+    console.print(
+        '[red bold]WARNING: Ownership transfer is irreversible. A wrong address permanently bricks the contract.[/red bold]'
+    )
     confirm_or_abort(f'Transfer ownership to {new_owner}?', yes)
 
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
@@ -210,7 +218,13 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
 @with_network_contract_options('Contract address')
 @with_cli_behavior_options(include_yes=True)
 def admin_set_treasury(
-    new_treasury: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False
+    new_treasury: str,
+    network: str,
+    rpc_url: str,
+    contract: str,
+    wallet_name: str,
+    wallet_hotkey: str,
+    yes: bool = False,
 ):
     """Change treasury hotkey (owner only).
 
@@ -262,7 +276,9 @@ def admin_set_treasury(
 @with_wallet_options()
 @with_network_contract_options('Contract address')
 @with_cli_behavior_options(include_yes=True)
-def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
+def admin_add_validator(
+    hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False
+):
     """Add a validator to the voting whitelist (owner only).
 
     [dim]Whitelisted validators can vote on solutions and issue cancellations.

--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -21,6 +21,7 @@ from .helpers import (
     _handle_command_error,
     _make_contract_client,
     _resolve_contract_and_network,
+    confirm_or_abort,
     console,
     format_alpha,
     print_error,
@@ -28,6 +29,7 @@ from .helpers import (
     print_success,
     require_valid_issue_id,
     require_valid_ss58,
+    with_cli_behavior_options,
     with_network_contract_options,
     with_wallet_options,
 )
@@ -46,7 +48,8 @@ def admin():
 @click.argument('issue_id', type=int)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
-def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
     """Cancel an issue (owner only).
 
     [dim]Immediately cancels an issue without validator consensus. Bounty funds are returned to the alpha pool.[/dim]
@@ -60,6 +63,7 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
         $ gitt a cancel-issue 5 --network test
     [/dim]
     """
+    confirm_or_abort(f'Cancel issue #{issue_id}? This cannot be undone.', yes)
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     require_valid_issue_id(issue_id)
@@ -100,7 +104,8 @@ def admin_cancel(issue_id: int, network: str, rpc_url: str, contract: str, walle
 @click.argument('issue_id', type=int)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
-def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
     """Manual payout fallback (owner only).
 
     [dim]Pays out a completed issue bounty to the solver.
@@ -115,6 +120,8 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
         $ gitt a payout-issue 3 --network test
     [/dim]
     """
+    confirm_or_abort(f'Pay out bounty for issue #{issue_id}?', yes)
+
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     require_valid_issue_id(issue_id)
@@ -155,7 +162,8 @@ def admin_payout(issue_id: int, network: str, rpc_url: str, contract: str, walle
 @click.argument('new_owner', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
-def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
     """Transfer contract ownership (owner only).
 
     [dim]Arguments:
@@ -166,6 +174,9 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
         $ gitt admin set-owner 5Hxxx...
     [/dim]
     """
+    console.print('[red bold]WARNING: Ownership transfer is irreversible. A wrong address permanently bricks the contract.[/red bold]')
+    confirm_or_abort(f'Transfer ownership to {new_owner}?', yes)
+
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     require_valid_ss58(new_owner, 'new_owner')
@@ -197,8 +208,9 @@ def admin_set_owner(new_owner: str, network: str, rpc_url: str, contract: str, w
 @click.argument('new_treasury', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
+@with_cli_behavior_options(include_yes=True)
 def admin_set_treasury(
-    new_treasury: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str
+    new_treasury: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False
 ):
     """Change treasury hotkey (owner only).
 
@@ -213,6 +225,8 @@ def admin_set_treasury(
         $ gitt admin set-treasury 5Hxxx...
     [/dim]
     """
+    confirm_or_abort(f'Change treasury hotkey to {new_treasury}?', yes)
+
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     require_valid_ss58(new_treasury, 'new_treasury')
@@ -247,7 +261,8 @@ def admin_set_treasury(
 @click.argument('hotkey', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
-def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str):
+@with_cli_behavior_options(include_yes=True)
+def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False):
     """Add a validator to the voting whitelist (owner only).
 
     [dim]Whitelisted validators can vote on solutions and issue cancellations.
@@ -261,7 +276,9 @@ def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, 
         $ gitt admin add-vali 5Hxxx...
     [/dim]
     """
-    contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
+    confirm_or_abort(f'Add validator {hotkey} to whitelist?', yes)
+
+    contract_addr, ws_endpoint
 
     require_valid_ss58(hotkey, 'hotkey')
 
@@ -295,8 +312,9 @@ def admin_add_validator(hotkey: str, network: str, rpc_url: str, contract: str, 
 @click.argument('hotkey', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address')
+@with_cli_behavior_options(include_yes=True)
 def admin_remove_validator(
-    hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str
+    hotkey: str, network: str, rpc_url: str, contract: str, wallet_name: str, wallet_hotkey: str, yes: bool = False
 ):
     """Remove a validator from the voting whitelist (owner only).
 
@@ -310,6 +328,8 @@ def admin_remove_validator(
         $ gitt admin remove-vali 5Hxxx...
     [/dim]
     """
+    confirm_or_abort(f'Remove validator {hotkey} from whitelist?', yes)
+
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     require_valid_ss58(hotkey, 'hotkey')

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -158,6 +158,15 @@ def with_cli_behavior_options(
 
     return apply_click_options(*decorators)
 
+def confirm_or_abort(prompt: str, yes: bool) -> None:
+    """Show a y/n confirmation prompt unless --yes was passed or stdin is not a TTY."""
+    import sys
+
+    if yes or not sys.stdin.isatty():
+        return
+    if not click.confirm(prompt, default=False):
+        raise SystemExit(0)
+
 
 def format_alpha(raw_amount: int, decimals: int = 2) -> str:
     """Format raw token amount (9-decimal) as human-readable ALPHA string.

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -158,6 +158,7 @@ def with_cli_behavior_options(
 
     return apply_click_options(*decorators)
 
+
 def confirm_or_abort(prompt: str, yes: bool) -> None:
     """Show a y/n confirmation prompt unless --yes was passed or stdin is not a TTY."""
     import sys

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -29,6 +29,7 @@ from .helpers import (
     require_valid_issue_id,
     validate_issue_id,
     validate_ss58_address,
+    confirm_or_abort,
     with_cli_behavior_options,
     with_network_contract_options,
     with_wallet_options,
@@ -70,7 +71,6 @@ def vote():
     """
     pass
 
-
 @vote.command('solution')
 @click.argument('issue_id', type=int)
 @click.argument('solver_hotkey', type=str)
@@ -78,6 +78,7 @@ def vote():
 @click.argument('pr_number_or_url', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
+@with_cli_behavior_options(include_yes=True)
 def val_vote_solution(
     issue_id: int,
     solver_hotkey: str,
@@ -88,6 +89,7 @@ def val_vote_solution(
     network: str,
     rpc_url: str,
     contract: str,
+    yes: bool = False,
 ):
     """Vote for a solution on an active issue (triggers auto-payout on consensus).
 
@@ -103,6 +105,8 @@ def val_vote_solution(
         $ gitt vote solution 1 5Hxxx... 5Hyyy... https://github.com/.../pull/123
     [/dim]
     """
+    confirm_or_abort(f'Vote solution for issue #{issue_id}?', yes)
+
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     try:
@@ -151,6 +155,7 @@ def val_vote_solution(
 @click.argument('reason', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
+@with_cli_behavior_options(include_yes=True)
 def val_vote_cancel_issue(
     issue_id: int,
     reason: str,
@@ -159,6 +164,7 @@ def val_vote_cancel_issue(
     network: str,
     rpc_url: str,
     contract: str,
+    yes: bool = False,
 ):
     """Vote to cancel an issue (works on Registered or Active).
 
@@ -172,7 +178,9 @@ def val_vote_cancel_issue(
         $ gitt vote cancel 42 "Issue invalid"
     [/dim]
     """
-    contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
+    confirm_or_abort(f'Vote to cancel issue #{issue_id}?', yes)
+
+    contract_addr, ws_endpoint
 
     require_valid_issue_id(issue_id)
 

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -21,6 +21,7 @@ from .helpers import (
     _handle_command_error,
     _make_contract_client,
     _resolve_contract_and_network,
+    confirm_or_abort,
     console,
     emit_json,
     print_error,
@@ -29,7 +30,6 @@ from .helpers import (
     require_valid_issue_id,
     validate_issue_id,
     validate_ss58_address,
-    confirm_or_abort,
     with_cli_behavior_options,
     with_network_contract_options,
     with_wallet_options,
@@ -70,6 +70,7 @@ def vote():
     These commands are used by validators to manage issue bounty payouts.
     """
     pass
+
 
 @vote.command('solution')
 @click.argument('issue_id', type=int)

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -181,7 +181,7 @@ def val_vote_cancel_issue(
     """
     confirm_or_abort(f'Vote to cancel issue #{issue_id}?', yes)
 
-    contract_addr, ws_endpoint
+    contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
     require_valid_issue_id(issue_id)
 


### PR DESCRIPTION
Fixes #714

## Problem
Destructive CLI commands (`admin cancel`, `admin payout`, `admin set-owner`,
`admin set-treasury`, `admin add-vali`, `admin remove-vali`, `vote solution`,
`vote cancel`) execute immediately without any confirmation, making accidental
execution easy — especially `admin set-owner` which permanently bricks the
contract if given a wrong address.

## Solution
Added a `confirm_or_abort(prompt, yes)` helper to `issue_commands/helpers.py`
that shows a y/n prompt unless:
- `--yes` / `-y` flag is passed (bypasses for scripts/CI)
- `stdin` is not a TTY (auto-skips for non-interactive environments)

Applied `@with_cli_behavior_options(include_yes=True)` decorator and
`confirm_or_abort` call to all 8 destructive commands. `admin set-owner`
also shows a red irreversibility warning before prompting.

## Changes
- `gittensor/cli/issue_commands/helpers.py` — added `confirm_or_abort` helper
- `gittensor/cli/issue_commands/admin.py` — added confirmations to 6 commands
- `gittensor/cli/issue_commands/vote.py` — added confirmations to 2 commands