### PR TITLE
refactor: skip scoring CLOSED PRs in score_miner_prs to save GitHub API budget

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -65,7 +65,9 @@ def score_miner_prs(
     pr_groups = [
         ('MERGED', miner_eval.merged_pull_requests),
         ('OPEN', miner_eval.open_pull_requests),
-        ('CLOSED', miner_eval.closed_pull_requests),
+        # CLOSED PRs are intentionally excluded: base_score is never used in
+        # reward calculation (only len(closed_prs) matters for credibility).
+        # Skipping them saves 2-3 GitHub API calls per closed PR.
     ]
 
     for label, prs in pr_groups:


### PR DESCRIPTION
Fixes #681

## Problem
`score_miner_prs` calls `score_pull_request` for every CLOSED PR,
triggering 2-3 GitHub API calls each (file changes + file contents +
merge-base resolution). The computed `base_score` for closed PRs is
never used in reward calculation:

- Reward aggregation (Phase 3) only sums `base_score` from
  `merged_pull_requests`
- Credibility (`calculate_credibility`) only uses `len(closed_prs)`,
  not their scores
- Eligibility gate counts closed PRs for credibility ratio but never
  reads `base_score`

## Fix
Removed `('CLOSED', miner_eval.closed_pull_requests)` from `pr_groups`
in `score_miner_prs`. Closed PRs are still loaded, counted for
credibility, and stored — they are just no longer scored, saving 2-3
GitHub API calls per closed PR with no effect on miner rewards.

## Changes
- `gittensor/validator/oss_contributions/scoring.py` — removed CLOSED
  PRs from `pr_groups` in `score_miner_prs`