### PR TITLE
fix: use closed_at as edit anchor to prevent auto-close false positives in post-merge edit detection

### DIFF
--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -248,7 +248,10 @@ def _collect_issues_from_prs(
 
                 # Anti-gaming: post-merge body/title edit detection
                 # Not issue.updated_at: it fires on bot comments, labels, reactions.
-                if issue.body_or_title_edited_at and pr.merged_at and issue.body_or_title_edited_at > pr.merged_at:
+                # Use closed_at as the anchor when available — edits between merged_at and
+                # closed_at are part of the normal auto-close flow, not post-merge gaming.
+                edit_anchor = issue.closed_at if issue.closed_at and issue.closed_at >= pr.merged_at else pr.merged_at
+                if issue.body_or_title_edited_at and issue.body_or_title_edited_at > edit_anchor:
                     bt.logging.info(
                         f'Issue #{issue.number} body/title edited after PR #{pr.number} merge — 0 score, counts as closed'
                     )


### PR DESCRIPTION
Fixes #443

## Problem
The post-merge edit detection in `_collect_issues_from_prs` used
`pr.merged_at` as the anchor for detecting post-merge body/title edits:

```python
if issue.body_or_title_edited_at > pr.merged_at:
When a PR merge auto-closes a linked issue, GitHub sets
body_or_title_edited_at to the close timestamp, which is always
slightly after merged_at (typically 1-5 seconds). This caused the
check to fire on the normal auto-close event, incorrectly penalizing
the discoverer by decrementing solved_count and incrementing
closed_count.
Real example: entrius/gittensor-ui#172 — PR merged at 19:05:04Z,
issue auto-closed at 19:05:06Z. The 2-second gap triggered the penalty.
Fix
Use closed_at as the edit anchor when it is available and occurs after
merged_at. This means only edits that happen after the issue was
closed are treated as post-merge gaming — the normal auto-close window
between merged_at and closed_at is excluded.
edit_anchor = issue.closed_at if issue.closed_at and issue.closed_at >= pr.merged_at else pr.merged_at
if issue.body_or_title_edited_at and issue.body_or_title_edited_at > edit_anchor:
If closed_at is unavailable, the behavior falls back to the original
merged_at anchor, preserving anti-gaming protection for legacy data.
Changes
gittensor/validator/issue_discovery/scoring.py — use closed_at
as edit anchor in post-merge edit detection