### PR TITLE
fix: add PR number context to merge-base compare API warnings   

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -238,7 +238,9 @@ def get_github_id(token: str) -> Optional[str]:
     return str(user_id)
 
 
-def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str) -> Optional[str]:
+def get_merge_base_sha(
+    repository: str, base_sha: str, head_sha: str, token: str, pr_number: Optional[int] = None
+) -> Optional[str]:
     """
     Get the merge-base commit SHA between two refs using GitHub's compare API.
 
@@ -250,12 +252,14 @@ def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str
         base_sha: Base branch ref OID
         head_sha: Head branch ref OID
         token: GitHub PAT
+        pr_number: Optional PR number, included in warning logs for traceability
 
     Returns:
         Merge-base commit SHA, or None if the request fails
     """
     headers = make_headers(token)
     max_attempts = 3
+    ctx = f' (PR #{pr_number})' if pr_number else ''
 
     for attempt in range(max_attempts):
         try:
@@ -270,13 +274,13 @@ def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str
                 merge_base = (data.get('merge_base_commit') or {}).get('sha')
                 if merge_base:
                     return merge_base
-                bt.logging.warning(f'Compare API returned 200 but no merge_base_commit for {repository}')
+                bt.logging.warning(f'Compare API returned 200 but no merge_base_commit for {repository}{ctx}')
                 return None
 
             if attempt < max_attempts - 1:
                 backoff_delay = min(5 * (2 ** (attempt)), 30)
                 bt.logging.warning(
-                    f'Compare API for {repository} failed with status {response.status_code} '
+                    f'Compare API for {repository}{ctx} failed with status {response.status_code} '
                     f'(attempt {attempt + 1}/{max_attempts}), retrying in {backoff_delay}s...'
                 )
                 time.sleep(backoff_delay)
@@ -285,12 +289,14 @@ def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str
             if attempt < max_attempts - 1:
                 backoff_delay = min(5 * (2 ** (attempt)), 30)
                 bt.logging.warning(
-                    f'Compare API error for {repository} (attempt {attempt + 1}/{max_attempts}): {e}, '
+                    f'Compare API error for {repository}{ctx} (attempt {attempt + 1}/{max_attempts}): {e}, '
                     f'retrying in {backoff_delay}s...'
                 )
                 time.sleep(backoff_delay)
 
-    bt.logging.warning(f'Compare API for {repository} failed after {max_attempts} attempts. Will use base_ref_oid.')
+    bt.logging.warning(
+        f'Compare API for {repository}{ctx} failed after {max_attempts} attempts. Will use base_ref_oid.'
+    )
     return None
 
 

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -131,7 +131,9 @@ def fetch_file_contents_for_pr(pr: PullRequest, github_pat: str) -> Dict[str, Fi
 
     # Resolve merge-base to avoid scoring unrelated changes from the base branch.
     # baseRefOid is the base branch tip, which may include commits not in this PR.
-    merge_base = get_merge_base_sha(pr.repository_full_name, pr.base_ref_oid, pr.head_ref_oid, github_pat)
+    merge_base = get_merge_base_sha(
+        pr.repository_full_name, pr.base_ref_oid, pr.head_ref_oid, github_pat, pr_number=pr.number
+    )
     base_sha = merge_base if merge_base else pr.base_ref_oid
     if merge_base and merge_base != pr.base_ref_oid:
         bt.logging.debug(

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1487,6 +1487,35 @@ class TestGetMergeBaseSha:
         assert result is None
         assert mock_get.call_count == 3
 
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_warning_includes_pr_number_when_provided(self, mock_logging, mock_sleep, mock_get):
+        """pr_number context is threaded into warning logs so failures are attributable to a PR."""
+        mock_500 = Mock(status_code=500, text='Internal Server Error')
+        mock_get.return_value = mock_500
+
+        result = get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token', pr_number=42)
+
+        assert result is None
+        warning_messages = [call.args[0] for call in mock_logging.warning.call_args_list]
+        assert warning_messages, 'expected at least one warning to be emitted'
+        assert all('PR #42' in msg for msg in warning_messages), warning_messages
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_warning_omits_pr_number_when_absent(self, mock_logging, mock_get):
+        """Warning text remains unchanged for callers that don't supply pr_number."""
+        mock_response = Mock(status_code=200)
+        mock_response.json.return_value = {'status': 'ahead'}
+        mock_get.return_value = mock_response
+
+        get_merge_base_sha('owner/repo', 'base_sha', 'head_sha', 'fake_token')
+
+        warning_messages = [call.args[0] for call in mock_logging.warning.call_args_list]
+        assert warning_messages
+        assert all('PR #' not in msg for msg in warning_messages), warning_messages
+
 
 # ============================================================================
 # fetch_file_contents_for_pr Merge Base Integration Tests
@@ -1534,7 +1563,9 @@ class TestFetchFileContentsForPrMergeBase:
 
         fetch_file_contents_for_pr(pr, 'fake_token')
 
-        mock_merge_base.assert_called_once_with('owner/repo', 'base_branch_tip_sha', 'head_sha', 'fake_token')
+        mock_merge_base.assert_called_once_with(
+            'owner/repo', 'base_branch_tip_sha', 'head_sha', 'fake_token', pr_number=1
+        )
         # Verify merge-base SHA was passed, not the original base_ref_oid
         mock_fetch.assert_called_once()
         call_args = mock_fetch.call_args


### PR DESCRIPTION
 ## Summary                                                                                                                                                                            
                                                                                                                                                                                        
  - Adds optional `pr_number` argument to `get_merge_base_sha` so the four warning
    messages it emits identify the PR that failed.                                                                                                                                      
  - Threads `pr.number` from `fetch_file_contents_for_pr` through the call.
  - Adds regression tests verifying PR# appears in warnings when provided and is                                                                                                        
    absent otherwise.                                                                                                                                                                   
                                                                                                                                                                                        
  Mirrors #711, which applied the same pattern to the downstream                                                                                                                        
  `fetch_file_contents_with_base` warning.                                                                                                                                              
                                                                                                                                                                                        
  ## Problem      
                                                                                                                                                                                        
  When validator scoring processes many PRs per round, a warning like
  `Compare API for owner/repo failed after 3 attempts. Will use base_ref_oid.`                                                                                                          
  can't be attributed to any specific PR, making transient compare-API        
  failures hard to diagnose.                                                                                                                                                            
                                                                                                                                                                                        
  ## Type of Change                                                                                                                                                                     
                                                                                                                                                                                        
  - [x] Bug fix (observability)
  - [ ] New feature                                                                                                                                                                     
  - [ ] Refactor   
  - [ ] Documentation
  - [ ] Other                                                                                                                                                                           
             
  ## Testing                                                                                                                                                                            
                  
  - [x] Tests added (`test_warning_includes_pr_number_when_provided`,
    `test_warning_omits_pr_number_when_absent`)                                                                                                                                         
  - [x] Updated existing `assert_called_once_with` to match new signature
  - [x] `uv run pre-commit run --all-files --hook-stage pre-push` — all 431 tests pass  