### PR TITLE
fix(cli): exit non-zero on admin info packed storage read failure

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -322,8 +322,9 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
             msg = 'Could not read contract configuration.'
             if as_json:
                 emit_error_json(msg, error_type='read_failed')
-                raise SystemExit(1)
-            console.print(f'[yellow]{msg}[/yellow]')
-            console.print('[dim]Try running with --verbose to see debug details.[/dim]')
+            else:
+                console.print(f'[yellow]{msg}[/yellow]')
+                console.print('[dim]Try running with --verbose to see debug details.[/dim]')
+            raise SystemExit(1)
     except Exception as e:
         handle_exception(as_json=as_json, message=str(e))

--- a/tests/cli/test_cli_json_error_output.py
+++ b/tests/cli/test_cli_json_error_output.py
@@ -66,3 +66,19 @@ def test_admin_info_emits_json_on_soft_read_failure(cli_root, runner):
     payload = json.loads(result.output)
     assert payload['success'] is False
     assert payload['error']['type'] == 'read_failed'
+
+
+def test_admin_info_human_mode_exits_non_zero_on_soft_read_failure(cli_root, runner):
+    """`admin info` (human mode) must exit non-zero when packed storage read returns None."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('substrateinterface.SubstrateInterface', return_value=object()),
+        patch('gittensor.cli.issue_commands.view._read_contract_packed_storage', return_value=None),
+    ):
+        result = runner.invoke(cli_root, ['admin', 'info'], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert 'Could not read contract configuration' in result.output


### PR DESCRIPTION
## Summary

When `_read_contract_packed_storage` returns `None` in `gitt admin info`, JSON mode already exits 1 via `emit_error_json` + `SystemExit`, but human mode printed a yellow warning and exited 0 — the same class of JSON/human exit-code mismatch fixed for `issues list --id` in #724.

Consolidate both paths so they always `raise SystemExit(1)`; JSON mode still emits the structured `read_failed` error payload, human mode still prints the friendly \"try --verbose\" hint.

## Related Issues

N/A — follow-on to #724.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- Added `test_admin_info_human_mode_exits_non_zero_on_soft_read_failure` next to the existing JSON-mode regression test.
- `uv run --extra dev pytest tests/` — all 430 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)