### PR TITLE
refactor: inline single-use get_github_user into get_github_id

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -178,13 +178,14 @@ def make_graphql_headers(token: str) -> Dict[str, str]:
     return {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
 
 
-def get_github_user(token: str) -> Optional[Dict[str, Any]]:
-    """Fetch GitHub user data for a PAT with retry.
+def get_github_id(token: str) -> Optional[str]:
+    """Get GitHub numeric user id (as string) using a PAT.
 
     Args:
-        token (str): Github pat
+        token (str): GitHub personal access token.
+
     Returns:
-        Optional[Dict[str, Any]]: Parsed JSON user object on success, or None on failure.
+        Optional[str]: Numeric user id as a string, or None if it cannot be determined.
     """
     if not token:
         return None
@@ -202,7 +203,8 @@ def get_github_user(token: str) -> Optional[Dict[str, Any]]:
                     bt.logging.warning(f'Failed to parse GitHub /user JSON response: {e}')
                     return None
 
-                return user_data
+                user_id = user_data.get('id')
+                return str(user_id) if user_id is not None else None
 
             bt.logging.warning(
                 f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
@@ -216,26 +218,6 @@ def get_github_user(token: str) -> Optional[Dict[str, Any]]:
                 time.sleep(2)
 
     return None
-
-
-def get_github_id(token: str) -> Optional[str]:
-    """Get GitHub numeric user id (as string) using a PAT.
-
-    Args:
-        token (str): GitHub personal access token.
-
-    Returns:
-        Optional[str]: Numeric user id as a string, or None if it cannot be determined.
-    """
-    user_data = get_github_user(token)
-    if not user_data:
-        return None
-
-    user_id = user_data.get('id')
-    if user_id is None:
-        return None
-
-    return str(user_id)
 
 
 def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

\`get_github_user\` in \`gittensor/utils/github_api_tools.py\` has exactly one caller — \`get_github_id\`, which just extracts the \`id\` field, coerces it to \`str\`, and returns \`None\` otherwise. Inlining removes a single-use indirection matching the pattern from #641 (which inlined \`find_solver_from_timeline\` into its only caller).

No behavior change: \`get_github_id\` still performs the same 6-attempt retry loop against \`/user\` with the same timeout, warning logs, and sleep intervals. Existing retry-logic tests (which patch \`requests.get\`) continue to cover the full path through \`get_github_id\`.

\`grep -rn get_github_user\` confirms no other call sites in \`gittensor/\`, \`neurons/\`, or \`tests/\`, so removing the public-level helper is safe.

Net: **-25 / +7 lines**, one fewer public function on \`github_api_tools\`.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- \`uv run --extra dev pytest tests/\` — all 429 tests pass.
- \`uv run --extra dev pytest tests/utils/test_github_api_tools.py::TestOtherGitHubAPIFunctions::test_get_github_id_retry_logic\` — the dedicated retry test still passes (it patches \`requests.get\`, not the removed helper).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)