### PR TITLE
weights: add release branches for cosmos-sdk, jellyfin, grafana, neovim, and metamask-extension

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -152,6 +152,10 @@
     "weight": 0.0926
   },
   "cosmos/cosmos-sdk": {
+    "additional_acceptable_branches": [
+      "release/v0.54.x",
+      "release/v0.53.x"
+    ],
     "weight": 0.0916
   },
   "CreativeBuilds/sn77": {
@@ -303,6 +307,9 @@
     "weight": 0.0704
   },
   "jellyfin/jellyfin": {
+    "additional_acceptable_branches": [
+      "release-10.11.z"
+    ],
     "weight": 0.0607
   },
   "jesseduffield/lazygit": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -265,6 +265,9 @@
     "weight": 0.0853
   },
   "grafana/grafana": {
+    "additional_acceptable_branches": [
+      "release-13.0.2"
+    ],
     "weight": 0.1136
   },
   "GraphiteAI/Graphite-Subnet": {
@@ -411,6 +414,10 @@
     "weight": 0.0455
   },
   "MetaMask/metamask-extension": {
+    "additional_acceptable_branches": [
+      "release/13.28.0",
+      "release/13.29.0"
+    ],
     "weight": 0.0806
   },
   "metanova-labs/nova": {
@@ -447,6 +454,9 @@
     "weight": 0.0542
   },
   "neovim/neovim": {
+    "additional_acceptable_branches": [
+      "release-0.12"
+    ],
     "weight": 0.0785
   },
   "nextcloud/android": {


### PR DESCRIPTION
## Summary
Add active release branches as `additional_acceptable_branches` for five whitelisted repos so merged contributions targeting LTS / patch releases are recognized in miner accounting.

Consolidated per @anderdc's note on #787 ("No reason for separation").

## Why
Each of these repos cuts release branches that receive substantial merged-PR traffic. Without these overrides, valid merges to `release/*` are not currently scoreable since only the default branch is recognized.

`cosmos/cosmos-sdk` (last 100 merged):
- 41 merges into `release/v0.54.x`, most recent [#26336](https://github.com/cosmos/cosmos-sdk/pull/26336) on 2026-04-23
- 4 merges into `release/v0.53.x`, most recent [#26308](https://github.com/cosmos/cosmos-sdk/pull/26308) on 2026-04-15

`jellyfin/jellyfin` (last 100 merged):
- 16 merges into `release-10.11.z`, most recent [#16540](https://github.com/jellyfin/jellyfin/pull/16540) on 2026-04-03

`grafana/grafana` (last 100 merged):
- 15 merges into `release-13.0.2`, most recent [#123558](https://github.com/grafana/grafana/pull/123558) on 2026-04-24

`neovim/neovim` (last 100 merged):
- 46 merges into `release-0.12`, most recent [#39377](https://github.com/neovim/neovim/pull/39377) on 2026-04-24

`MetaMask/metamask-extension` (last 100 merged):
- 17 merges into `release/13.28.0`, most recent [#42097](https://github.com/MetaMask/metamask-extension/pull/42097) on 2026-04-23
- 6 merges into `release/13.29.0`, most recent [#42124](https://github.com/MetaMask/metamask-extension/pull/42124) on 2026-04-24

## Change
```json
"cosmos/cosmos-sdk": {
  "additional_acceptable_branches": [
    "release/v0.54.x",
    "release/v0.53.x"
  ],
  "weight": 0.0916
},
"grafana/grafana": {
  "additional_acceptable_branches": [
    "release-13.0.2"
  ],
  "weight": 0.1136
},
"jellyfin/jellyfin": {
  "additional_acceptable_branches": [
    "release-10.11.z"
  ],
  "weight": 0.0607
},
"MetaMask/metamask-extension": {
  "additional_acceptable_branches": [
    "release/13.28.0",
    "release/13.29.0"
  ],
  "weight": 0.0806
},
"neovim/neovim": {
  "additional_acceptable_branches": [
    "release-0.12"
  ],
  "weight": 0.0785
}
```