### PR TITLE
fix: return None instead of [] on persistent failure in get_pull_request_file_changes

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -377,7 +377,7 @@ def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -
     bt.logging.error(
         f'File changes request for PR #{pr_number} in {repository} failed after {max_attempts} attempts: {last_error}'
     )
-    return []
+    return none
 
 
 # GraphQL fragment used by both issue submissions and solver detection.

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -377,7 +377,7 @@ def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -
     bt.logging.error(
         f'File changes request for PR #{pr_number} in {repository} failed after {max_attempts} attempts: {last_error}'
     )
-    return none
+    return None
 
 
 # GraphQL fragment used by both issue submissions and solver detection.

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -439,7 +439,7 @@ class TestFileChangesRetryLogic:
 
         assert mock_get.call_count == 3
         assert mock_sleep.call_count == 2, 'Should sleep between attempts but not after the last one'
-        assert result == []
+        assert result is None
         mock_logging.error.assert_called()
 
     @patch('gittensor.utils.github_api_tools.requests.get')
@@ -458,7 +458,7 @@ class TestFileChangesRetryLogic:
 
         assert mock_get.call_count == 2
         assert mock_sleep.call_count == 1
-        assert result == []
+        assert result ==[]
 
     @patch('gittensor.utils.github_api_tools.requests.get')
     @patch('gittensor.utils.github_api_tools.time.sleep')
@@ -472,7 +472,7 @@ class TestFileChangesRetryLogic:
         result = get_pull_request_file_changes('owner/repo', 1, 'fake_token')
 
         assert mock_get.call_count == 3
-        assert result == []
+        assert result is None
         mock_logging.error.assert_called()
 
     @patch('gittensor.utils.github_api_tools.requests.get')
@@ -615,7 +615,7 @@ class TestFileChangesPagination:
 
         result = get_pull_request_file_changes('owner/repo', 1, 'fake_token')
 
-        assert result == []
+        assert result is None
         assert mock_get.call_count == 1
 
     @patch('gittensor.utils.github_api_tools.requests.get')
@@ -708,7 +708,7 @@ class TestFileChangesPagination:
 
         result = get_pull_request_file_changes('owner/repo', 1, 'fake_token')
 
-        assert result == []
+        assert result is None
         assert mock_get.call_count == 3
         mock_logging.error.assert_called()
 
@@ -794,7 +794,7 @@ def test_find_prs_uses_all_state_for_non_open_only(mock_graphql, mock_rest):
 
     result = find_prs_for_issue('owner/repo', 12, open_only=False, token='fake_token')
 
-    assert result == []
+    assert result is None
     assert mock_rest.call_count == 2
     assert mock_rest.call_args_list[0].kwargs == {'token': 'fake_token', 'state': 'all'}
     assert mock_rest.call_args_list[1].kwargs == {'token': None, 'state': 'all'}


### PR DESCRIPTION
Fixes #752

## Problem
`get_pull_request_file_changes` is typed `Optional[List[FileChange]]`
and its docstring states it returns `None` on error. But on persistent
failure after `max_attempts=3` retries, it returned `[]` instead of
`None`.

`[]` is also the value for a PR with no file changes, so callers cannot
distinguish "GitHub API unavailable" from "PR legitimately has no diff".
Transient API errors were silently treated as no-op contributions.

Sibling helpers in the same module return `None` on persistent failure:
`get_merge_base_sha` (line 294) and `_search_issue_referencing_prs_graphql`
(line 446).

## Fix
Changed `return []` to `return None` on the persistent-failure path,
matching the docstring, type annotation, and sibling helper behavior.

## Changes
- `gittensor/utils/github_api_tools.py` — return `None` instead of `[]`
  on persistent failure in `get_pull_request_file_changes`