### PR TITLE
fix: consult CLOSED_EVENT timeline to prevent reopen-based credibility bypass

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -134,6 +134,13 @@ QUERY = """
                   }
                 }
               }
+              closedEvents: timelineItems(itemTypes: [CLOSED_EVENT], last: 3) {
+                nodes {
+                  ... on ClosedEvent {
+                    createdAt
+                  }
+                }
+              }
             }
           }
         }
@@ -756,6 +763,23 @@ def _has_resource_limit_errors(data: Dict) -> bool:
     return any(isinstance(e, dict) and e.get('type') == 'RESOURCE_LIMITS_EXCEEDED' for e in errors)
 
 
+def _has_closed_event_within_lookback(pr_raw: Dict, lookback_date_filter: datetime) -> bool:
+    """Return True if the PR has any ClosedEvent with `createdAt >= lookback_date_filter`.
+
+    GitHub clears `closedAt` when a PR is reopened, so a snapshot of the current
+    state cannot tell us whether an OPEN PR was previously closed within the
+    scoring window. The `closedEvents` timeline preserves that history.
+    """
+    closed_events = pr_raw.get('closedEvents') or {}
+    for node in closed_events.get('nodes') or []:
+        created_at = node.get('createdAt')
+        if not created_at:
+            continue
+        if parse_github_iso_to_utc(created_at) >= lookback_date_filter:
+            return True
+    return False
+
+
 def try_add_open_or_closed_pr(
     miner_eval: MinerEvaluation,
     pr_raw: Dict,
@@ -776,7 +800,19 @@ def try_add_open_or_closed_pr(
         return
 
     if pr_state == PRState.OPEN.value:
+        # A PR currently OPEN may have been closed and reopened within the lookback
+        # window. Consult CLOSED_EVENT timeline to catch reopens the state snapshot
+        # hides (see L815 carve-out for the symmetric stale-PR case below).
+        created_at = pr_raw.get('createdAt')
+        if created_at:
+            created_dt = parse_github_iso_to_utc(created_at)
+            if created_dt >= lookback_date_filter and _has_closed_event_within_lookback(
+                pr_raw, lookback_date_filter
+            ):
+                miner_eval.add_closed_pull_request(pr_raw)
+                return
         miner_eval.add_open_pull_request(pr_raw)
+        return
 
     if pr_state == PRState.CLOSED.value:
         closed_at = pr_raw.get('closedAt')

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -33,6 +33,7 @@ get_merge_base_sha = github_api_tools.get_merge_base_sha
 find_prs_for_issue = github_api_tools.find_prs_for_issue
 execute_graphql_query = github_api_tools.execute_graphql_query
 check_github_issue_closed = github_api_tools.check_github_issue_closed
+try_add_open_or_closed_pr = github_api_tools.try_add_open_or_closed_pr
 
 
 # ============================================================================
@@ -1581,6 +1582,123 @@ class TestFetchFileContentsForPrMergeBase:
         # Should fall back to base_ref_oid
         call_args = mock_fetch.call_args
         assert call_args[0][2] == 'base_branch_tip_sha', 'Should fall back to base_ref_oid'
+
+
+class TestTryAddOpenOrClosedPr:
+    """Tests for try_add_open_or_closed_pr routing, including the reopen-bypass fix (#767)."""
+
+    NOW = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    LOOKBACK_DAYS = 35
+
+    def _lookback_cutoff(self):
+        return self.NOW - timedelta(days=self.LOOKBACK_DAYS)
+
+    def _iso(self, offset_days: int) -> str:
+        return (self.NOW + timedelta(days=offset_days)).isoformat().replace('+00:00', 'Z')
+
+    def _make_raw_pr(
+        self,
+        state: str = 'OPEN',
+        created_offset_days: int = -10,
+        closed_at_offset_days: Optional[int] = None,
+        closed_event_offsets: Optional[list] = None,
+    ) -> Dict:
+        closed_events_nodes = [
+            {'createdAt': self._iso(offset)} for offset in (closed_event_offsets or [])
+        ]
+        return {
+            'number': 1,
+            'title': 'PR',
+            'state': state,
+            'merged': state == 'MERGED',
+            'mergedAt': None,
+            'createdAt': self._iso(created_offset_days),
+            'closedAt': self._iso(closed_at_offset_days) if closed_at_offset_days is not None else None,
+            'lastEditedAt': None,
+            'bodyText': '',
+            'additions': 50,
+            'deletions': 5,
+            'commits': {'totalCount': 1},
+            'repository': {
+                'name': 'gittensor', 'owner': {'login': 'entrius'},
+                'defaultBranchRef': {'name': 'main'},
+            },
+            'headRepository': {'name': 'gittensor', 'owner': {'login': 'test_user'}},
+            'baseRefName': 'main', 'baseRefOid': 'abc',
+            'headRefName': 'feat', 'headRefOid': 'def',
+            'author': {'login': 'test_user'},
+            'authorAssociation': 'CONTRIBUTOR',
+            'mergedBy': None,
+            'closingIssuesReferences': {'nodes': []},
+            'reviews': {'nodes': []},
+            'closedEvents': {'nodes': closed_events_nodes},
+        }
+
+    def _make_eval(self):
+        from gittensor.classes import MinerEvaluation
+        return MinerEvaluation(uid=1, hotkey='h', github_id='gh', github_pat='pat')
+
+    def test_open_with_no_closed_events_routes_to_open(self):
+        """OPEN PR that has never been closed → open_pull_requests."""
+        ev = self._make_eval()
+        raw = self._make_raw_pr(state='OPEN', created_offset_days=-10, closed_event_offsets=[])
+        try_add_open_or_closed_pr(ev, raw, 'OPEN', self._lookback_cutoff())
+        assert len(ev.open_pull_requests) == 1
+        assert len(ev.closed_pull_requests) == 0
+
+    def test_open_with_closed_event_inside_lookback_routes_to_closed(self):
+        """OPEN PR closed 3 days ago then reopened → closed_pull_requests (fixes #767 bypass)."""
+        ev = self._make_eval()
+        raw = self._make_raw_pr(state='OPEN', created_offset_days=-20, closed_event_offsets=[-3])
+        try_add_open_or_closed_pr(ev, raw, 'OPEN', self._lookback_cutoff())
+        assert len(ev.closed_pull_requests) == 1
+        assert len(ev.open_pull_requests) == 0
+
+    def test_open_with_closed_event_outside_lookback_routes_to_open(self):
+        """OPEN PR whose only closure is older than lookback → open_pull_requests."""
+        ev = self._make_eval()
+        raw = self._make_raw_pr(state='OPEN', created_offset_days=-20, closed_event_offsets=[-40])
+        try_add_open_or_closed_pr(ev, raw, 'OPEN', self._lookback_cutoff())
+        assert len(ev.open_pull_requests) == 1
+        assert len(ev.closed_pull_requests) == 0
+
+    def test_open_created_before_lookback_preserves_carveout(self):
+        """OPEN PR created before lookback with recent closure → open_pull_requests (L815 carve-out)."""
+        ev = self._make_eval()
+        raw = self._make_raw_pr(state='OPEN', created_offset_days=-50, closed_event_offsets=[-5])
+        try_add_open_or_closed_pr(ev, raw, 'OPEN', self._lookback_cutoff())
+        assert len(ev.open_pull_requests) == 1
+        assert len(ev.closed_pull_requests) == 0
+
+    def test_open_with_multiple_closures_any_inside_lookback_routes_to_closed(self):
+        """OPEN PR with mixed closures; one inside lookback is enough to flag it."""
+        ev = self._make_eval()
+        raw = self._make_raw_pr(
+            state='OPEN', created_offset_days=-30, closed_event_offsets=[-29, -10]
+        )
+        try_add_open_or_closed_pr(ev, raw, 'OPEN', self._lookback_cutoff())
+        assert len(ev.closed_pull_requests) == 1
+        assert len(ev.open_pull_requests) == 0
+
+    def test_closed_inside_lookback_routes_to_closed(self):
+        """CLOSED PR with closedAt inside lookback → closed_pull_requests (existing behavior)."""
+        ev = self._make_eval()
+        raw = self._make_raw_pr(
+            state='CLOSED', created_offset_days=-20, closed_at_offset_days=-3
+        )
+        try_add_open_or_closed_pr(ev, raw, 'CLOSED', self._lookback_cutoff())
+        assert len(ev.closed_pull_requests) == 1
+        assert len(ev.open_pull_requests) == 0
+
+    def test_closed_created_before_lookback_preserves_carveout(self):
+        """CLOSED PR created before lookback → skipped (existing carve-out)."""
+        ev = self._make_eval()
+        raw = self._make_raw_pr(
+            state='CLOSED', created_offset_days=-50, closed_at_offset_days=-3
+        )
+        try_add_open_or_closed_pr(ev, raw, 'CLOSED', self._lookback_cutoff())
+        assert len(ev.closed_pull_requests) == 0
+        assert len(ev.open_pull_requests) == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #767.

## Summary

Implements Option A from the issue: extends the PR GraphQL query with a `CLOSED_EVENT` timeline lookup and teaches `try_add_open_or_closed_pr` to route a currently-OPEN PR into `closed_pull_requests` whenever any ClosedEvent falls within the scoring lookback window.

This blocks the bypass path where a miner at the credibility gate closes → reopens their own PRs: GitHub clears `closedAt` on reopen, so the old snapshot-only routing treated reopened PRs as if they had never been closed. The ClosedEvent timeline is preserved by GitHub even after reopen, so consulting it restores the correct credibility accounting.

The stale-PR carve-out at `gittensor/utils/github_api_tools.py:815` (PRs created before lookback are ignored to avoid fresh penalty for old closures) is preserved symmetrically for the new OPEN path — a PR created before lookback stays in `open_pull_requests` regardless of any recent ClosedEvent.

## Changes

**`gittensor/utils/github_api_tools.py`** (+30 LoC)

1. PR GraphQL query — added aliased sibling timeline query:
   ```graphql
   closedEvents: timelineItems(itemTypes: [CLOSED_EVENT], last: 3) {
     nodes {
       ... on ClosedEvent { createdAt }
     }
   }
   ```
   `last: 3` over `first: 3` catches the most-recent closures, which are the relevant ones for within-lookback detection on PRs with multiple close-reopen cycles.

2. New private helper `_has_closed_event_within_lookback(pr_raw, lookback_date_filter) -> bool` that iterates over the closedEvents nodes.

3. `try_add_open_or_closed_pr` OPEN branch now:
   - Reads `createdAt`.
   - If `createdAt` is inside lookback AND any ClosedEvent is inside lookback → routes to `add_closed_pull_request`.
   - Otherwise (no ClosedEvent in lookback, or createdAt outside lookback) → existing `add_open_pull_request` behavior.

The CLOSED branch is unchanged.

**`tests/utils/test_github_api_tools.py`** (+118 LoC)

New `TestTryAddOpenOrClosedPr` class with 7 test cases covering:
- `test_open_with_no_closed_events_routes_to_open` — never-closed OPEN PR unchanged.
- `test_open_with_closed_event_inside_lookback_routes_to_closed` — the #767 fix itself.
- `test_open_with_closed_event_outside_lookback_routes_to_open` — old closures don't trigger.
- `test_open_created_before_lookback_preserves_carveout` — carve-out preserved symmetrically.
- `test_open_with_multiple_closures_any_inside_lookback_routes_to_closed` — multi-cycle PRs still detected.
- `test_closed_inside_lookback_routes_to_closed` — existing CLOSED behavior unaffected.
- `test_closed_created_before_lookback_preserves_carveout` — existing CLOSED carve-out unaffected.

## Verification

- All 7 new tests pass.
- Full existing `tests/` suite: **436 passed, 0 regressions** (2 pre-existing pydantic warnings unrelated).
- External regression repro (`/tmp/repro_crossfile_reopen_fixed.py`) reproduces the bypass scenario end-to-end against `calculate_credibility` + `check_eligibility` and confirms credibility 0.71 / eligibility False in both baseline and reopen scenarios (bypass blocked).

## GraphQL budget

One additional `timelineItems` sub-query per PR node with `last: 3`. PR nodes already include `timelineItems(itemTypes: [LABELED_EVENT], last: 5)` and several `closingIssuesReferences` subqueries, so the incremental cost is small and well within GitHub's secondary rate limits.

## Notes

- I'm happy to switch to Option B (populating a `historic_close_count_within_lookback` field on `PullRequest` in `gittensor/classes.py`) if you'd prefer the logic live at the dataclass layer rather than at the fetcher. Option A was chosen here because it keeps the routing decision co-located with the existing `closedAt`/`createdAt` branching and touches fewer layers.
- Happy to iterate on the ClosedEvent `last: 3` parameter choice or the helper's placement if anything feels off architecturally.
- Note: the mirror path at `mirror/load.py:107-115` (introduced in #796) follows the same snapshot-based routing pattern. This PR addresses the legacy path only; happy to extend coverage to mirror in a follow-up if useful.
