### PR TITLE
fix: skip non-dict entries in load_master_repo_weights instead of collapsing to {}

### DIFF
--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -112,6 +112,14 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         # Parse JSON data into RepositoryConfig objects
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
+            if not isinstance(metadata, dict):
+                if isinstance(metadata, (int, float)):
+                    normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata))
+                else:
+                    bt.logging.warning(
+                        f'Skipping repo {repo_name}: expected dict config, got {type(metadata).__name__}'
+                    )
+                continue
             try:
                 config = RepositoryConfig(
                     weight=float(metadata.get('weight', 0.01)),
@@ -121,8 +129,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:
                 bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
-                # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+                normalized_data
 
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data


### PR DESCRIPTION
Fixes #750

## Problem
`load_master_repo_weights` assumed every value in `master_repositories.json`
is a dict and called `metadata.get('weight', 0.01)` directly. A non-dict
entry (e.g. `"owner/repo": 0.1`) raises `AttributeError`, which escapes
the per-entry `except (ValueError, TypeError)` block and is caught by the
outer `except Exception`, causing the entire function to return `{}`.

A `{}` return causes `load_miners_prs` to skip every PR as
`"not in master repositories"` — every miner scores zero with only one
cryptic log line as the signal.

The companion loader `load_programming_language_weights` already guards
with `isinstance(config, dict)` and supports plain-float back-compat.
`load_master_repo_weights` did not.

## Fix
Added `isinstance(metadata, dict)` check inside the per-entry loop:
- Plain numeric values (`int`/`float`) are treated as back-compat weight
  shorthand and loaded as `RepositoryConfig(weight=float(metadata))`
- Any other non-dict type is skipped with a per-entry warning naming the
  offending repo
- Well-formed dict entries continue to load normally

## Changes
- `gittensor/validator/utils/load_weights.py` — added non-dict guard
  to per-entry loop in `load_master_repo_weights`