### PR TITLE
perf(cache): replace deepcopy in MinerEvaluationCache with shallow copy

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -1,5 +1,5 @@
+import copy
 import re
-from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -655,7 +655,7 @@ class MinerEvaluationCache:
         if not evaluation.hotkey or not evaluation.github_id or evaluation.github_id == '0':
             return
 
-        cached_eval = self.create_lightweight_copy(evaluation)
+        cached_eval = self._build_cache_entry(evaluation)
 
         self._cache[evaluation.uid] = CachedEvaluation(
             hotkey=evaluation.hotkey,
@@ -690,17 +690,44 @@ class MinerEvaluationCache:
 
         bt.logging.debug(f'Cache hit for UID {uid} (cached at {cached.cached_at.isoformat()})')
 
-        return deepcopy(cached.evaluation)
+        return self._isolate_for_downstream(cached.evaluation)
 
-    def create_lightweight_copy(self, evaluation: 'MinerEvaluation') -> 'MinerEvaluation':
-        """Create a memory-efficient copy, stripping file patches."""
-        light_eval = deepcopy(evaluation)
+    @staticmethod
+    def _build_cache_entry(evaluation: 'MinerEvaluation') -> 'MinerEvaluation':
+        # Cached evaluations feed only the GitHub-fetch-failure fallback path
+        # (issue_competitions + issue discovery scoring), which never reads
+        # file_changes. Drop them at store time to save memory and avoid
+        # copying thousands of FileChange objects per miner.
+        cached = copy.copy(evaluation)
+        cached.github_pat = None
+        cached.unique_repos_contributed_to = set(evaluation.unique_repos_contributed_to)
+        cached.merged_pull_requests = [_pr_for_cache(pr) for pr in evaluation.merged_pull_requests]
+        cached.open_pull_requests = [_pr_for_cache(pr) for pr in evaluation.open_pull_requests]
+        cached.closed_pull_requests = [_pr_for_cache(pr) for pr in evaluation.closed_pull_requests]
+        return cached
 
-        for pr in light_eval.merged_pull_requests + light_eval.open_pull_requests + light_eval.closed_pull_requests:
-            if pr.file_changes:
-                for fc in pr.file_changes:
-                    fc.patch = None
+    @staticmethod
+    def _isolate_for_downstream(cached_eval: 'MinerEvaluation') -> 'MinerEvaluation':
+        # Downstream scoring mutates top-level scalar fields on MinerEvaluation
+        # and discovery_* fields on Issue. Everything else (PR metadata) is
+        # read-only on the cache-fallback path, so we can share it.
+        copy_eval = copy.copy(cached_eval)
+        copy_eval.unique_repos_contributed_to = set(cached_eval.unique_repos_contributed_to)
+        copy_eval.merged_pull_requests = [_pr_with_fresh_issues(pr) for pr in cached_eval.merged_pull_requests]
+        copy_eval.open_pull_requests = [_pr_with_fresh_issues(pr) for pr in cached_eval.open_pull_requests]
+        copy_eval.closed_pull_requests = [_pr_with_fresh_issues(pr) for pr in cached_eval.closed_pull_requests]
+        return copy_eval
 
-        light_eval.github_pat = None
 
-        return light_eval
+def _pr_for_cache(pr: 'PullRequest') -> 'PullRequest':
+    pr_copy = copy.copy(pr)
+    pr_copy.file_changes = None
+    pr_copy.issues = [copy.copy(issue) for issue in pr.issues] if pr.issues else None
+    return pr_copy
+
+
+def _pr_with_fresh_issues(pr: 'PullRequest') -> 'PullRequest':
+    pr_copy = copy.copy(pr)
+    if pr.issues is not None:
+        pr_copy.issues = [copy.copy(issue) for issue in pr.issues]
+    return pr_copy

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import cast
 
-from gittensor.classes import MinerEvaluation, MinerEvaluationCache, PRState, PullRequest
+from gittensor.classes import FileChange, Issue, MinerEvaluation, MinerEvaluationCache, PRState, PullRequest
 from neurons.validator import Validator
 
 
@@ -79,3 +79,99 @@ class TestStoreOrUseCachedEvaluation:
         cached_eval = validator.evaluation_cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
         assert cached_eval is not None
         assert cached_eval.total_prs == 2
+
+
+class TestCacheIsolation:
+    """Lock down the invariants required by the non-deepcopy copy strategy:
+    caller mutations must not leak into the cache, and heavy file_changes
+    must not be retained on cached PRs."""
+
+    def _eval_with_issue(self) -> MinerEvaluation:
+        now = datetime.now(timezone.utc)
+        pr = PullRequest(
+            number=7,
+            repository_full_name='owner/repo',
+            uid=1,
+            hotkey='hotkey_1',
+            github_id='12345',
+            title='pr',
+            author_login='miner',
+            merged_at=now,
+            created_at=now,
+            pr_state=PRState.MERGED,
+            file_changes=[
+                FileChange(
+                    pr_number=7,
+                    repository_full_name='owner/repo',
+                    filename='a.py',
+                    changes=1,
+                    additions=1,
+                    deletions=0,
+                    status='added',
+                    patch='heavy patch contents',
+                )
+            ],
+            issues=[
+                Issue(
+                    number=42,
+                    pr_number=7,
+                    repository_full_name='owner/repo',
+                    title='issue',
+                    author_github_id='99',
+                )
+            ],
+        )
+        ev = MinerEvaluation(uid=1, hotkey='hotkey_1', github_id='12345', github_pat='secret')
+        ev.merged_pull_requests = [pr]
+        return ev
+
+    def test_cache_drops_file_changes_and_pat(self):
+        cache = MinerEvaluationCache()
+        source = self._eval_with_issue()
+
+        cache.store(source)
+
+        # Source must be untouched — downstream DB storage still needs patches.
+        assert source.github_pat == 'secret'
+        source_file_changes = source.merged_pull_requests[0].file_changes
+        assert source_file_changes is not None
+        assert source_file_changes[0].patch == 'heavy patch contents'
+
+        cached = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert cached is not None
+        assert cached.github_pat is None
+        assert cached.merged_pull_requests[0].file_changes is None
+
+    def test_get_returns_isolated_issues(self):
+        cache = MinerEvaluationCache()
+        cache.store(self._eval_with_issue())
+
+        first = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert first is not None
+        first_issues = first.merged_pull_requests[0].issues
+        assert first_issues is not None
+        first_issues[0].discovery_earned_score = 999.0
+        first.issue_discovery_score = 123.0
+
+        second = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert second is not None
+        second_issues = second.merged_pull_requests[0].issues
+        assert second_issues is not None
+        assert second_issues[0].discovery_earned_score == 0.0
+        assert second.issue_discovery_score == 0.0
+
+    def test_store_isolates_cache_from_source_issue_mutations(self):
+        cache = MinerEvaluationCache()
+        source = self._eval_with_issue()
+        cache.store(source)
+
+        # Simulate downstream scoring mutating the source eval's Issue.
+        source_issues = source.merged_pull_requests[0].issues
+        assert source_issues is not None
+        source_issues[0].discovery_earned_score = 42.0
+
+        cached = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert cached is not None
+        cached_issues = cached.merged_pull_requests[0].issues
+        assert cached_issues is not None
+        assert cached_issues[0].discovery_earned_score == 0.0


### PR DESCRIPTION
Closes: #785


## Summary
- `MinerEvaluationCache.get` and `create_lightweight_copy` were running `copy.deepcopy` over the full evaluation tree (PRs + thousands of FileChanges + Issues) on every cache hit and every cache store. For miners with hundreds of PRs this cost hundreds of ms per UID per round.
- Cached evals only feed the GitHub-fetch-failure fallback path (issue bounties + issue discovery scoring), which never reads `file_changes` — so `store` now drops `file_changes` at cache time, and both `store` and `get` shallow-copy the evaluation + PRs while creating fresh `Issue` instances to isolate the cache from downstream `discovery_*` mutations.
- Net: copy cost drops from O(FileChanges) (with full patch bodies) to O(PRs + Issues).

## What changed
- `gittensor/classes.py`: replaced `deepcopy` in `MinerEvaluationCache` with two targeted helpers (`_build_cache_entry`, `_isolate_for_downstream`) plus PR-level shallow-copy helpers. Removed the now-unused `create_lightweight_copy` public method.
- `tests/validator/test_validator_cache_fallback.py`: added `TestCacheIsolation` locking down the three invariants the new strategy relies on — cache drops `file_changes`/`github_pat`, `get()` results are isolated from each other, and post-`store` mutations on the source eval don't leak into the cache.

## Test plan
- [x] `uv run pytest tests/validator/test_validator_cache_fallback.py` (6 passed, incl. 3 new)
- [x] `uv run pytest tests/` (444 passed)
- [x] `uv run ruff check` + `ruff format --check` on touched files