### PR TITLE
weights: add release-13.0.2 as acceptable base branch for grafana/grafana

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -257,6 +257,9 @@
     "weight": 0.0853
   },
   "grafana/grafana": {
+    "additional_acceptable_branches": [
+      "release-13.0.2"
+    ],
     "weight": 0.1136
   },
   "GraphiteAI/Graphite-Subnet": {


### PR DESCRIPTION
## Summary
Add `release-13.0.2` as an `additional_acceptable_branch` for `grafana/grafana` so merged contributions targeting the active patch-release line are recognized in miner accounting.

## Why
Grafana cuts patch-release branches that receive substantial merged-PR traffic. Without this override, valid merges to `release-13.0.2` are not currently scoreable since only the `main` branch is recognized.

`grafana/grafana` (last 100 merged): 15 merges into `release-13.0.2`, most recent [#123558](https://github.com/grafana/grafana/pull/123558) on 2026-04-24.

Sample recent merges:
- [#123558](https://github.com/grafana/grafana/pull/123558) (2026-04-24)
- [#123504](https://github.com/grafana/grafana/pull/123504) (2026-04-24)
- [#123490](https://github.com/grafana/grafana/pull/123490) (2026-04-24)
- [#123469](https://github.com/grafana/grafana/pull/123469) (2026-04-24)

## Change
```json
"grafana/grafana": {
  "additional_acceptable_branches": [
    "release-13.0.2"
  ],
  "weight": 0.1136
}
```
