### PR TITLE
weights: add release-0.12 as acceptable base branch for neovim/neovim

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -436,6 +436,9 @@
     "weight": 0.0542
   },
   "neovim/neovim": {
+    "additional_acceptable_branches": [
+      "release-0.12"
+    ],
     "weight": 0.0785
   },
   "nextcloud/android": {


### PR DESCRIPTION
## Summary
Add `release-0.12` as an `additional_acceptable_branch` for `neovim/neovim` so merged contributions targeting the active LTS line are recognized in miner accounting.

## Why
Neovim runs an active LTS branch for the 0.12.x series with continuous backport-bot cherry-picks landing daily. Without this override, valid merges to `release-0.12` are not currently scoreable since only `master` is recognized.

`neovim/neovim` (last 100 merged): 46 merges into `release-0.12`, most recent [#39377](https://github.com/neovim/neovim/pull/39377) on 2026-04-24.

Sample recent merges:
- [#39377](https://github.com/neovim/neovim/pull/39377) (2026-04-24)
- [#39376](https://github.com/neovim/neovim/pull/39376) (2026-04-24)
- [#39371](https://github.com/neovim/neovim/pull/39371) (2026-04-24)
- [#39356](https://github.com/neovim/neovim/pull/39356) (2026-04-23)
- [#39353](https://github.com/neovim/neovim/pull/39353) (2026-04-23)

## Change
```json
"neovim/neovim": {
  "additional_acceptable_branches": [
    "release-0.12"
  ],
  "weight": 0.0785
}
```
