### PR TITLE
weights: add release/13.28.0 and release/13.29.0 as acceptable base branches for MetaMask/metamask-extension

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -400,6 +400,10 @@
     "weight": 0.0455
   },
   "MetaMask/metamask-extension": {
+    "additional_acceptable_branches": [
+      "release/13.28.0",
+      "release/13.29.0"
+    ],
     "weight": 0.0806
   },
   "metanova-labs/nova": {


### PR DESCRIPTION
## Summary
Add `release/13.28.0` and `release/13.29.0` as `additional_acceptable_branches` for `MetaMask/metamask-extension` so merged contributions targeting the active release-runway branches are recognized in miner accounting.

## Why
MetaMask cuts release-runway branches that receive substantial cherry-pick traffic during each release cycle. Without these overrides, valid merges to `release/*` are not currently scoreable since only `main` is recognized.

`MetaMask/metamask-extension` (last 100 merged):
- 17 merges into `release/13.28.0`, most recent [#42097](https://github.com/MetaMask/metamask-extension/pull/42097) on 2026-04-23
- 6 merges into `release/13.29.0`, most recent [#42124](https://github.com/MetaMask/metamask-extension/pull/42124) on 2026-04-24 (current cycle)

Sample recent merges:
- [#42124](https://github.com/MetaMask/metamask-extension/pull/42124) (2026-04-24, release/13.29.0)
- [#42118](https://github.com/MetaMask/metamask-extension/pull/42118) (2026-04-24, release/13.29.0)
- [#42097](https://github.com/MetaMask/metamask-extension/pull/42097) (2026-04-23, release/13.28.0)
- [#42081](https://github.com/MetaMask/metamask-extension/pull/42081) (2026-04-23, release/13.28.0)

## Change
```json
"MetaMask/metamask-extension": {
  "additional_acceptable_branches": [
    "release/13.28.0",
    "release/13.29.0"
  ],
  "weight": 0.0806
}
```
