### PR TITLE
refactor: add IssueStateReason StrEnum and replace state_reason string literals

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -13,6 +13,7 @@ from gittensor.constants import (
     MAINTAINER_ASSOCIATIONS,
     MAX_CODE_DENSITY_MULTIPLIER,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+    IssueStateReason,
 )
 from gittensor.utils.utils import parse_repo_name
 
@@ -124,7 +125,7 @@ class Issue:
 
     # Issue discovery fields
     author_github_id: Optional[str] = None  # Issue author's GitHub user ID (for miner matching)
-    state_reason: Optional[str] = None  # "COMPLETED", "NOT_PLANNED", "TRANSFERRED", or None (legacy)
+    state_reason: Optional[str] = None  # IssueStateReason values, or None (legacy)
     updated_at: Optional[datetime] = None
     body_or_title_edited_at: Optional[datetime] = None
     discovery_base_score: float = 0.0
@@ -138,7 +139,7 @@ class Issue:
     @property
     def is_transferred(self) -> bool:
         """Convenience accessor. Prefer gating on `state_reason` directly in new code."""
-        return self.state_reason == 'TRANSFERRED'
+        return self.state_reason == IssueStateReason.TRANSFERRED
 
 
 @dataclass

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -1,6 +1,7 @@
 # Entrius 2025
 import re
-from typing import Dict
+from enum import StrEnum
+from typing import Dict, Optional
 
 # =============================================================================
 # General
@@ -27,6 +28,24 @@ GRAPHQL_VIEWER_QUERY = '{ viewer { login } }'
 MAX_FILE_SIZE_BYTES = 1_000_000
 # Too many object lookups in one GraphQL query can trigger 502 errors and lose all results.
 MAX_FILES_PER_GRAPHQL_BATCH = 50
+
+# GitHub REST / GraphQL `stateReason` for closed issues (stable string contract)
+class IssueStateReason(StrEnum):
+    COMPLETED = "COMPLETED"
+    NOT_PLANNED = "NOT_PLANNED"
+    TRANSFERRED = "TRANSFERRED"
+
+
+def normalize_issue_state_reason(value: Optional[str]) -> Optional[str]:
+    """Uppercase `state_reason`; return canonical value for known reasons, else pass-through."""
+    t = (value or "").upper() or None
+    if t is None:
+        return None
+    try:
+        return IssueStateReason(t).value
+    except ValueError:
+        return t
+
 
 # =============================================================================
 # Language & File Scoring

--- a/gittensor/validator/issue_discovery/repo_scan.py
+++ b/gittensor/validator/issue_discovery/repo_scan.py
@@ -24,6 +24,7 @@ from gittensor.constants import (
     REPO_SCAN_CONCURRENCY,
     REPO_SCAN_GLOBAL_CAP,
     REPO_SCAN_PER_REPO_CAP,
+    normalize_issue_state_reason,
 )
 from gittensor.utils.github_api_tools import find_solver_from_cross_references
 from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
@@ -207,7 +208,7 @@ async def _scan_repo(
             author_login=user.get('login'),
             author_github_id=author_github_id,
             state='CLOSED',
-            state_reason=(issue_raw.get('state_reason') or '').upper() or None,
+            state_reason=normalize_issue_state_reason(issue_raw.get('state_reason')),
         )
 
         if solver_id is not None:

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -18,6 +18,7 @@ from gittensor.constants import (
     MIN_VALID_SOLVED_ISSUES,
     OPEN_ISSUE_SPAM_BASE_THRESHOLD,
     OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
+    IssueStateReason,
 )
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import RepositoryConfig, resolve_repo_weight
@@ -232,7 +233,7 @@ def _collect_issues_from_prs(
                 # NOT_PLANNED, TRANSFERRED, and None all route to closed_count. None is
                 # effectively unreachable inside the 35-day lookback (GitHub auto-populates
                 # stateReason on close), but treating it as not-solved is the safer default.
-                if issue.state_reason != 'COMPLETED':
+                if issue.state_reason != IssueStateReason.COMPLETED:
                     bt.logging.info(
                         f'Issue #{issue.number} state_reason={issue.state_reason} — 0 score, counts as closed'
                     )
@@ -309,7 +310,7 @@ def _merge_scan_issues(
         for issue in issues:
             # Anti-gaming: only explicitly COMPLETED closures count as solved.
             # NOT_PLANNED, TRANSFERRED, and None all route to closed_count.
-            if issue.state_reason != 'COMPLETED':
+            if issue.state_reason != IssueStateReason.COMPLETED:
                 bt.logging.info(f'Scan issue #{issue.number} state_reason={issue.state_reason} — counts as closed')
                 data.closed_count += 1
                 continue

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -34,6 +34,7 @@ from gittensor.constants import (
     REVIEW_PENALTY_RATE,
     SECONDS_PER_DAY,
     STANDARD_ISSUE_MULTIPLIER,
+    IssueStateReason,
 )
 from gittensor.utils.github_api_tools import (
     FileContentPair,
@@ -462,9 +463,9 @@ def calculate_issue_multiplier(pr: PullRequest) -> float:
 def _is_completed_when_closed(issue: Issue) -> bool:
     if issue.state != 'CLOSED':
         return True
-    if issue.state_reason != 'COMPLETED':
+    if issue.state_reason != IssueStateReason.COMPLETED:
         bt.logging.warning(
-            f'Skipping issue #{issue.number} - state_reason={issue.state_reason}, only COMPLETED grants multiplier'
+            f'Skipping issue #{issue.number} - state_reason={issue.state_reason}, only {IssueStateReason.COMPLETED} grants multiplier'
         )
         return False
     return True


### PR DESCRIPTION
## Summary

Replaces ad-hoc `'COMPLETED'`, `'NOT_PLANNED'`, and `'TRANSFERRED'` checks on GitHub issue `state_reason` with a single source of truth: `gittensor.constants.IssueStateReason` (see [issue #779](https://github.com/entrius/gittensor/issues/779)). Adds `normalize_issue_state_reason()` for REST `state_reason` so known values are canonical; unknown non-empty values still pass through unchanged.

## Motivation

Literal strings at multiple call sites are easy to typo and hard to search; GitHub’s `stateReason` values are a stable contract—an enum makes usage obvious and refactors safer.

## Changes

| Area | Update |
|------|--------|
| `gittensor/constants.py` | `IssueStateReason` (`StrEnum`) + `normalize_issue_state_reason()` |
| `gittensor/validator/issue_discovery/scoring.py` | Compare to `IssueStateReason.COMPLETED` |
| `gittensor/validator/oss_contributions/scoring.py` | Same in `is_valid_issue` |
| `gittensor/validator/issue_discovery/repo_scan.py` | Use normalizer when building `Issue` from REST |
| `gittensor/classes.py` | `is_transferred` uses `IssueStateReason.TRANSFERRED` |

## Testing

- `pytest`: issue discovery scoring, `is_valid_issue`, repo-scan related tests (20 passed)

## Closes

- Closes #779