### PR TITLE
fix: handle null repository owner in parse_repo_name to prevent TypeError on deleted fork-owner accounts

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -237,6 +237,8 @@ class PullRequest:
         from gittensor.validator.utils.datetime_utils import parse_github_timestamp_to_cst
 
         repository_full_name = parse_repo_name(pr_data['repository'])
+        if repository_full_name is None:
+            raise ValueError(f'PR #{pr_data.get("number")} has null repository owner — skipping')
         pr_state = PRState(pr_data['state'])
         is_merged = pr_state == PRState.MERGED
 
@@ -418,23 +420,22 @@ class MinerEvaluation:
 
     def add_merged_pull_request(self, raw_pr: Dict):
         """Add a merged pull request that will be factored into scoring."""
-        bt.logging.info(
-            f"Accepting MERGED PR #{raw_pr['number']} in {parse_repo_name(raw_pr['repository'])} -> '{raw_pr['baseRefName']}'"
-        )
+        repo_name = parse_repo_name(raw_pr['repository']) or '<unknown>'
+        bt.logging.info(f"Accepting MERGED PR #{raw_pr['number']} in {repo_name} -> '{raw_pr['baseRefName']}'")
         self.merged_pull_requests.append(
             PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
         )
 
     def add_open_pull_request(self, raw_pr: Dict):
         """Add an open pull request that will be factored into scoring."""
-        bt.logging.info(f'Counting OPEN PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])}')
+        repo_name = parse_repo_name(raw_pr['repository']) or '<unknown>'
+        bt.logging.info(f'Counting OPEN PR #{raw_pr["number"]} in {repo_name}')
         self.open_pull_requests.append(PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id))
 
     def add_closed_pull_request(self, raw_pr: Dict):
         """Add a closed pull request that will be factored into scoring."""
-        bt.logging.info(
-            f'CLOSED PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])} counting towards credibility'
-        )
+        repo_name = parse_repo_name(raw_pr['repository']) or '<unknown>'
+        bt.logging.info(f'CLOSED PR #{raw_pr["number"]} in {repo_name} counting towards credibility')
         self.closed_pull_requests.append(
             PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
         )

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -866,7 +866,7 @@ def should_skip_merged_pr(
     # This check ONLY applies to internal PRs (same repository), as fork branch names are arbitrary.
     # Supports wildcard patterns (e.g., '*-dev' matches '3.0-dev', '3.1-dev', etc.)
     head_repo = pr_raw.get('headRepository')
-    if head_repo and parse_repo_name(head_repo) == repository_full_name:
+    if head_repo and (parse_repo_name(head_repo) or '') == repository_full_name:
         if branch_matches_pattern(head_ref, acceptable_branches):
             return (
                 True,
@@ -963,6 +963,11 @@ def load_miners_prs(
             for pr_raw in prs:
                 try:
                     repository_full_name = parse_repo_name(pr_raw['repository'])
+                    if repository_full_name is None:
+                        bt.logging.warning(
+                            f'Skipping PR #{pr_raw.get("number")} — repository owner is null (deleted account)'
+                        )
+                        continue
                     pr_state = pr_raw['state']
 
                     if repository_full_name not in master_repositories:

--- a/gittensor/utils/utils.py
+++ b/gittensor/utils/utils.py
@@ -3,12 +3,17 @@ GitTensor Utilities
 """
 
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 
-def parse_repo_name(repo_data: Dict):
-    """Normalizes and converts repository name from dict"""
-    return f'{repo_data["owner"]["login"]}/{repo_data["name"]}'.lower()
+def parse_repo_name(repo_data: Dict) -> Optional[str]:
+    """Normalizes and converts repository name from dict.
+
+    Returns None if owner is missing (e.g. deleted fork-owner account).
+    """
+    owner = (repo_data.get('owner') or {}).get('login')
+    name = repo_data.get('name')
+    return f'{owner}/{name}'.lower() if owner and name else None
 
 
 def get_contract_address() -> str:


### PR DESCRIPTION
Fixes #794

## Problem
`parse_repo_name` in `gittensor/utils/utils.py` dereferences
`repo_data["owner"]["login"]` without a null check. When a PR's
repository has `owner: null` — which GitHub's GraphQL API returns when
the fork owner's account was deleted — this raises
`TypeError: 'NoneType' object is not subscriptable`.

The crash occurs at the top of `PullRequest.from_graphql_response`
before any per-PR try/except, so the entire PR is silently dropped
from scoring. Honest miners whose PR history includes a fork whose
owner later deleted their GitHub account have those PRs dropped.

## Fix

### `gittensor/utils/utils.py`
Changed `parse_repo_name` to return `Optional[str]` — returns `None`
when `owner` or `name` is missing, instead of crashing.

### `gittensor/classes.py`
- Line 239 (`from_graphql_response`): raise `ValueError` on `None`
  result so the caller's try/except logs and skips the PR cleanly
- Lines 422, 430, 436 (log call sites): guard with `or '<unknown>'`
  so logging never crashes even if called before the ValueError path

### `gittensor/utils/github_api_tools.py`
- Line 869: guard `parse_repo_name(head_repo)` with `or ''` so the
  equality check against `repository_full_name` never crashes
- Line 965: add explicit `None` check after `parse_repo_name` call,
  log a warning and `continue` to skip the PR cleanly

## Changes
- `gittensor/utils/utils.py` — `parse_repo_name` returns `Optional[str]`
- `gittensor/classes.py` — null guards at all 4 call sites
- `gittensor/utils/github_api_tools.py` — null guards at both call sites