### PR TITLE
feat(cli): add `gitt config get <key>` subcommand

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -92,6 +92,38 @@ def show_config():
         console.print(f'[red]Error reading config: {e}[/red]')
 
 
+@config_group.command('get')
+@click.argument('key', type=str)
+def config_get(key: str):
+    """Print a single configuration value.
+
+    [dim]Reads `~/.gittensor/config.json` and prints the value for KEY to
+    stdout with no styling, so the output is safe to capture in shell
+    scripts. Exits non-zero if the config file is missing or KEY is unset.[/dim]
+
+    [dim]Examples:
+        $ gitt config get wallet
+        $ WALLET=$(gitt config get wallet)
+    [/dim]
+    """
+    if not CONFIG_FILE.exists():
+        console.print('[red]Error: No config file found at ~/.gittensor/config.json[/red]')
+        raise SystemExit(1)
+
+    try:
+        config = json.loads(CONFIG_FILE.read_text())
+    except json.JSONDecodeError:
+        console.print('[red]Error: Invalid JSON in config file[/red]')
+        raise SystemExit(1)
+
+    if key not in config:
+        console.print(f'[red]Error: Key {key!r} is not set in config[/red]')
+        raise SystemExit(1)
+
+    # click.echo writes plain text to stdout — script-friendly, no Rich styling.
+    click.echo(str(config[key]))
+
+
 @config_group.command('set')
 @click.argument('key', type=str)
 @click.argument('value', type=str)

--- a/tests/cli/test_config_get.py
+++ b/tests/cli/test_config_get.py
@@ -1,0 +1,52 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for `gitt config get <key>` CLI command."""
+
+import json
+from unittest.mock import patch
+
+
+def test_config_get_prints_value_when_key_exists(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'config.json'
+    config_file.write_text(json.dumps({'wallet': 'alice', 'network': 'finney'}))
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'get', 'wallet'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    # Output is the bare value plus a newline; no Rich styling that would
+    # break shell capture (`X=$(gitt config get wallet)`).
+    assert result.output.rstrip('\n') == 'alice'
+
+
+def test_config_get_exits_non_zero_when_key_missing(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'config.json'
+    config_file.write_text(json.dumps({'wallet': 'alice'}))
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'get', 'unset_key'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'unset_key' in result.output
+
+
+def test_config_get_exits_non_zero_when_config_file_missing(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'nope.json'
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'get', 'wallet'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'config' in result.output.lower()
+
+
+def test_config_get_exits_non_zero_when_config_file_invalid_json(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'config.json'
+    config_file.write_text('{not valid json')
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'get', 'wallet'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'invalid json' in result.output.lower()


### PR DESCRIPTION
## Summary

\`gitt config\` already shows all configured values as a styled table, and \`gitt config set\` writes them, but there was no scriptable read for a single value. Add \`gitt config get <key>\` to fill the gap.

\`\`\`
$ gitt config get wallet
alice

$ WALLET=\$(gitt config get wallet)   # captures \"alice\"

$ gitt config get not_set; echo \$?
Error: Key 'not_set' is not set in config
1
\`\`\`

Implementation notes:
- Output is written via \`click.echo\` (not Rich), so it is plain text suitable for shell capture and pipelines.
- Exits non-zero with a clear message when the config file is missing, the JSON is invalid, or the key is unset, so shell scripts can detect missing configuration.
- Lives next to \`config_set\` in [gittensor/cli/main.py](gittensor/cli/main.py) and slots into the existing \`config_group\`, so \`gitt config --help\` lists both \`get\` and \`set\` automatically.

## Related Issues

N/A.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- New \`tests/cli/test_config_get.py\` covers the four exit paths (key present, key missing, file missing, invalid JSON).
- \`uv run --extra dev pytest tests/\` — all 447 tests pass (443 baseline + 4 new).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)