### PR TITLE
feat(cli): add `gitt config unset <key>` subcommand

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -138,6 +138,39 @@ def config_set(key: str, value: str):
         console.print(f'[green]Set {key}:[/green] {value}')
 
 
+@config_group.command('unset')
+@click.argument('key', type=str)
+def config_unset(key: str):
+    """Remove a configuration value.
+
+    [dim]Deletes KEY from `~/.gittensor/config.json`. Exits non-zero if the
+    config file is missing, the JSON is invalid, or KEY is not set, so
+    shell scripts can detect the missing key.[/dim]
+
+    [dim]Examples:
+        $ gitt config unset wallet
+        $ gitt config unset contract_address
+    [/dim]
+    """
+    if not CONFIG_FILE.exists():
+        console.print('[red]Error: No config file found at ~/.gittensor/config.json[/red]')
+        raise SystemExit(1)
+
+    try:
+        config = json.loads(CONFIG_FILE.read_text())
+    except json.JSONDecodeError:
+        console.print('[red]Error: Invalid JSON in config file[/red]')
+        raise SystemExit(1)
+
+    if key not in config:
+        console.print(f'[red]Error: Key {key!r} is not set in config[/red]')
+        raise SystemExit(1)
+
+    old_value = config.pop(key)
+    CONFIG_FILE.write_text(json.dumps(config, indent=2))
+    console.print(f'[green]Unset {key}:[/green] {old_value}')
+
+
 def _detect_shell():
     """Detect the current shell from the SHELL environment variable"""
     shell_path = os.environ.get('SHELL', '')

--- a/tests/cli/test_config_unset.py
+++ b/tests/cli/test_config_unset.py
@@ -1,0 +1,60 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for `gitt config unset <key>` CLI command."""
+
+import json
+from unittest.mock import patch
+
+
+def test_config_unset_removes_key_and_persists(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'config.json'
+    config_file.write_text(json.dumps({'wallet': 'alice', 'network': 'finney'}))
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'unset', 'wallet'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert 'wallet' in result.output
+
+    # File now contains only the unrelated key.
+    assert json.loads(config_file.read_text()) == {'network': 'finney'}
+
+
+def test_config_unset_exits_non_zero_when_key_missing(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'config.json'
+    original = {'wallet': 'alice'}
+    config_file.write_text(json.dumps(original))
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'unset', 'unset_key'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'unset_key' in result.output
+    # File is left untouched on a no-op.
+    assert json.loads(config_file.read_text()) == original
+
+
+def test_config_unset_exits_non_zero_when_config_file_missing(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'nope.json'
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'unset', 'wallet'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'config' in result.output.lower()
+    assert not config_file.exists()
+
+
+def test_config_unset_exits_non_zero_when_config_file_invalid_json(cli_root, runner, tmp_path):
+    config_file = tmp_path / 'config.json'
+    invalid = '{not valid json'
+    config_file.write_text(invalid)
+
+    with patch('gittensor.cli.main.CONFIG_FILE', config_file):
+        result = runner.invoke(cli_root, ['config', 'unset', 'wallet'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'invalid json' in result.output.lower()
+    # Don't clobber the file when we can't parse it.
+    assert config_file.read_text() == invalid


### PR DESCRIPTION
## Summary

Completes the standard CLI config triplet. \`gitt config\` already shows all values and \`gitt config set <k> <v>\` writes one, but there was no way to remove a stale key short of editing the JSON by hand. Add \`gitt config unset <key>\` to fill the gap, mirroring the convention from \`git config --unset\`, \`kubectl config unset\`, \`gh config clear-cache\`, etc.

\`\`\`
$ gitt config unset wallet
Unset wallet: alice

$ gitt config unset not_set; echo \$?
Error: Key 'not_set' is not set in config
1
\`\`\`

Implementation notes:
- Removes KEY from \`~/.gittensor/config.json\` and persists the trimmed config; prints the old value so the operator can see what was cleared.
- Exits non-zero with a clear error when the config file is missing, the JSON is invalid, or KEY is not set — so shell scripts can detect no-op invocations.
- Leaves the file untouched on the invalid-JSON path, instead of silently clobbering unparsable content (verified by a test).
- Lives next to \`config_set\` in [gittensor/cli/main.py](gittensor/cli/main.py) and slots into the existing \`config_group\`, so \`gitt config --help\` lists \`unset\` automatically.

## Related Issues

N/A.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- New \`tests/cli/test_config_unset.py\` covers the four exit paths (key removed, key missing, file missing, invalid JSON).
- \`uv run --extra dev pytest tests/\` — all 447 tests pass (443 baseline + 4 new).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)