### PR TITLE
fix: reject unrecognised --network values in gitt miner commands

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -12,6 +12,7 @@ from rich.table import Table
 
 from .helpers import (
     NETUID_DEFAULT,
+    NETWORK_CHOICE,
     _connect_bittensor,
     _error,
     _load_config_value,
@@ -29,7 +30,7 @@ console = Console()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
-@click.option('--network', default=None, help='Network name (local, test, finney).')
+@click.option('--network', default=None, type=NETWORK_CHOICE, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode):

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -14,6 +14,8 @@ from rich.console import Console
 
 from gittensor.constants import NETWORK_MAP
 
+NETWORK_CHOICE = click.Choice(['finney', 'test', 'local'], case_sensitive=False)
+
 console = Console()
 
 NETUID_DEFAULT = 74
@@ -43,17 +45,33 @@ def _load_config_value(key: str):
 
 
 def _resolve_endpoint(network: str | None, rpc_url: str | None) -> str:
-    """Resolve the subtensor endpoint from CLI args or config."""
+    """Resolve the subtensor endpoint from CLI args or config.
+
+    Raises click.BadParameter if network is not a recognised name and is not
+    a WebSocket URL (i.e. does not start with 'ws://' or 'wss://').
+    """
     if rpc_url:
         return rpc_url
     if network:
-        return NETWORK_MAP.get(network.lower(), network)
+        endpoint = NETWORK_MAP.get(network.lower())
+        if endpoint is None and not network.startswith(('ws://', 'wss://')):
+            raise click.BadParameter(
+                f"'{network}' is not a recognised network name. Use one of: finney, test, local — or pass a WebSocket URL via --rpc-url.",
+                param_hint="'--network'",
+            )
+        return endpoint or network
     config_network = _load_config_value('network')
     config_endpoint = _load_config_value('ws_endpoint')
     if config_endpoint:
         return config_endpoint
     if config_network:
-        return NETWORK_MAP.get(config_network.lower()) or config_network
+        endpoint = NETWORK_MAP.get(config_network.lower())
+        if endpoint is None and not config_network.startswith(('ws://', 'wss://')):
+            raise click.BadParameter(
+                f"Config network '{config_network}' is not recognised. Use one of: finney, test, local — or set ws_endpoint instead.",
+                param_hint="'--network'",
+            )
+        return endpoint or config_network
     return NETWORK_MAP['finney']
 
 

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -16,6 +16,7 @@ from rich.table import Table
 
 from gittensor.cli.miner_commands.helpers import (
     NETUID_DEFAULT,
+    NETWORK_CHOICE,
     _connect_bittensor,
     _error,
     _load_config_value,
@@ -35,7 +36,7 @@ console = Console()
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
-@click.option('--network', default=None, help='Network name (local, test, finney).')
+@click.option('--network', default=None, type=NETWORK_CHOICE, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
 @click.option(
     '--pat',


### PR DESCRIPTION
Fixes #795

## Problem
`gitt miner post` and `gitt miner check` accepted any string for
`--network` without validation. A typo like `--network finny` was
silently forwarded to `bt.Subtensor(network='finny')`, which produced
an obscure connection error instead of a clear "unknown network"
message.

The root cause was two-fold:
1. `--network` in `post.py` and `check.py` used a plain `str` Click
   option with no `type=` constraint, so Click accepted any value
2. `_resolve_endpoint` fell back to the raw string via
   `NETWORK_MAP.get(network.lower(), network)` when the name was
   unrecognised

By contrast, `issue_commands` already defined `NETWORK_CHOICE =
click.Choice(...)` and applied it to all `--network` options — which
is why that path was safe.

The same gap existed for config-file typos: `gitt config set network
finny` followed by `gitt miner post` bypassed Click entirely and hit
the same fallback in `_resolve_endpoint`.

## Fix

### `gittensor/cli/miner_commands/helpers.py`
- Added `NETWORK_CHOICE = click.Choice(['finney', 'test', 'local'],
  case_sensitive=False)` mirroring `issue_commands/helpers.py`
- Rewrote `_resolve_endpoint` to raise `click.BadParameter` when the
  network name is not in `NETWORK_MAP` and is not a WebSocket URL
  (`ws://` or `wss://`). Raw WebSocket URLs are still accepted for
  custom devnet setups

### `gittensor/cli/miner_commands/post.py` and `check.py`
- Added `NETWORK_CHOICE` to imports
- Applied `type=NETWORK_CHOICE` to the `--network` Click option so
  Click rejects typos at parse time before any code runs

## Changes
- `gittensor/cli/miner_commands/helpers.py` — added `NETWORK_CHOICE`,
  rewrote `_resolve_endpoint` with strict validation
- `gittensor/cli/miner_commands/post.py` — `type=NETWORK_CHOICE` on
  `--network`
- `gittensor/cli/miner_commands/check.py` — `type=NETWORK_CHOICE` on
  `--network`