### PR TITLE
fix: reject PATs whose GraphQL viewer is null and guard empty errors list

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -163,6 +163,16 @@ def _test_pat_against_repo(pat: str) -> Optional[str]:
 
     Scoring uses the GraphQL API to fetch miner PRs, so this mirrors the real path.
     Returns an error string on failure, None on success.
+
+    The PAT is considered valid only when:
+      1. The HTTP response is 200.
+      2. The body has no non-empty `errors` list.
+      3. The `data.viewer` payload is non-null. A fine-grained PAT that
+         authenticates but lacks the `Public Repositories (read-only)` scope
+         responds with `{"data": {"viewer": null}}` — HTTP 200, no `errors`
+         key — which would otherwise be silently accepted and only surface
+         a round later when scoring drops the miner with
+         `"No Github id found for miner X's PAT"`.
     """
     headers = {'Authorization': f'Bearer {pat}', 'Accept': 'application/json'}
     try:
@@ -175,8 +185,20 @@ def _test_pat_against_repo(pat: str) -> Optional[str]:
         if response.status_code != 200:
             return f'GitHub GraphQL API returned {response.status_code}'
         data = response.json()
-        if 'errors' in data:
-            return f'GraphQL error: {data["errors"][0].get("message", "unknown")}'
+        # Truthy check — covers both `[]` (empty list returned by some
+        # upstream proxies, which is "no errors") and `None`. Avoids the
+        # IndexError that `data["errors"][0]` would raise on `[]`.
+        errors = data.get('errors')
+        if errors:
+            first = errors[0] if isinstance(errors[0], dict) else {}
+            return f'GraphQL error: {first.get("message", "unknown")}'
+        viewer = (data.get('data') or {}).get('viewer')
+        if viewer is None:
+            return (
+                'PAT lacks GraphQL viewer access. Fine-grained PATs need '
+                '"Public Repositories (read-only)" permission; classic PATs '
+                'need the read:user scope.'
+            )
         return None
     except requests.RequestException as e:
         return str(e)

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -11,6 +11,7 @@ from bittensor.core.synapse import TerminalInfo
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.validator import pat_storage
 from gittensor.validator.pat_handler import (
+    _test_pat_against_repo,
     blacklist_pat_broadcast,
     blacklist_pat_check,
     handle_pat_broadcast,
@@ -223,3 +224,72 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is False
         assert 'PAT expired' in (result.rejection_reason or '')
+
+
+# ---------------------------------------------------------------------------
+# _test_pat_against_repo unit tests (regressions for #751)
+# ---------------------------------------------------------------------------
+
+
+def _mock_graphql_response(status_code: int, body: dict) -> MagicMock:
+    """Build a fake `requests.Response` for `requests.post` patches."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    return resp
+
+
+class TestTestPatAgainstRepo:
+    """Direct unit tests for the GraphQL probe used by PAT broadcast/check."""
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_accepts_pat_when_viewer_has_login(self, mock_post):
+        mock_post.return_value = _mock_graphql_response(
+            200, {'data': {'viewer': {'login': 'alice'}}}
+        )
+        assert _test_pat_against_repo('ghp_ok') is None
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_rejects_pat_when_viewer_is_null(self, mock_post):
+        # Fine-grained PAT without `Public Repositories (read-only)` permission:
+        # GitHub returns HTTP 200 with `data.viewer == null` and no `errors` key.
+        mock_post.return_value = _mock_graphql_response(
+            200, {'data': {'viewer': None}}
+        )
+        result = _test_pat_against_repo('ghp_no_scope')
+        assert result is not None
+        assert 'viewer' in result.lower()
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_rejects_pat_when_data_is_missing(self, mock_post):
+        # Defensive: if the response shape is unexpected, treat as invalid
+        # rather than silently accepting.
+        mock_post.return_value = _mock_graphql_response(200, {})
+        assert _test_pat_against_repo('ghp_weird') is not None
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_treats_empty_errors_list_as_no_error(self, mock_post):
+        # Some upstream proxies respond with `errors: []`. The previous
+        # implementation reached `data["errors"][0]` and raised IndexError.
+        mock_post.return_value = _mock_graphql_response(
+            200, {'data': {'viewer': {'login': 'bob'}}, 'errors': []}
+        )
+        # Should NOT raise IndexError, and should accept the PAT because the
+        # viewer is populated.
+        assert _test_pat_against_repo('ghp_empty_errors') is None
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_surfaces_first_error_message(self, mock_post):
+        mock_post.return_value = _mock_graphql_response(
+            200, {'errors': [{'message': 'API rate limit exceeded'}]}
+        )
+        result = _test_pat_against_repo('ghp_throttled')
+        assert result is not None
+        assert 'API rate limit exceeded' in result
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_rejects_non_200_status(self, mock_post):
+        mock_post.return_value = _mock_graphql_response(401, {})
+        result = _test_pat_against_repo('ghp_unauth')
+        assert result is not None
+        assert '401' in result


### PR DESCRIPTION
```
## Summary

Closes #751.

`_test_pat_against_repo` (gittensor/validator/pat_handler.py) accepts
a PAT as valid whenever the GraphQL response is HTTP 200 and lacks an
`errors` field. It does not verify that the `viewer` query actually
returned data. Two distinct defects fall out of that:

1. A fine-grained PAT that authenticates but lacks the
   `Public Repositories (read-only)` scope responds with
   `{"data": {"viewer": null}}` — HTTP 200, no `errors` key. The
   current code passes through to `return None` (success). The
   validator stores the PAT as valid; the next scoring round drops
   the miner with `"No Github id found for miner X's PAT"`. The miner
   sees `pat_valid=True` from `gitt miner check` for the same PAT and
   has no actionable signal to fix the scope before scoring bites.

2. `data["errors"][0].get("message", "unknown")` raises `IndexError`
   when `errors` is `[]`. Some upstream proxies return `{"errors": []}`
   (a non-canonical but observed shape). The `IndexError` is not
   caught and propagates out of the synapse handler.

## Fix

Tighten the success condition to require all of:

  1. HTTP 200 (existing).
  2. `errors` is empty / absent. The check now uses a truthy test
     (`if errors:`) so an empty list and `None` are both treated as
     "no errors" — fixes the `IndexError` AND matches the spec
     semantics. The first-error extraction also guards against
     non-dict entries.
  3. `data.viewer` is non-null. A new branch returns a descriptive
     error message that points the miner at the missing scope, so
     `gitt miner post` and `gitt miner check` surface a clear reason
     at broadcast time instead of leaking it as an opaque evaluation
     drop a round later.

The error message wording mirrors the one already printed by
`cli/miner_commands/post.py:189-191` so the validator-side rejection
is consistent with what miners see locally.

## Tests

Added `TestTestPatAgainstRepo` to
`tests/validator/test_pat_handler.py` with six unit tests directly
invoking `_test_pat_against_repo` against a `requests.post` mock:

  - viewer with login → accepted
  - viewer == null → rejected, error message mentions "viewer"
  - missing `data` key → rejected
  - empty errors list + valid viewer → accepted, no IndexError
  - non-empty errors → first error message surfaced
  - non-200 status → status code surfaced

The existing eight tests that mock `_test_pat_against_repo` itself
continue to pass because the function's signature and contract are
unchanged (still `Optional[str]`, error-string-or-None semantics
preserved).

## Reproduction

For the viewer-null defect (from the issue body):

1. Generate a fine-grained PAT with no permissions selected (or
   scoped to a private repo with no `read:user`).
2. `gitt miner post --pat <pat>` against a validator.
3. Before: `handle_pat_broadcast` accepts; one round later the miner
   is dropped with `"No Github id found for miner X's PAT"` while
   `gitt miner check` still reports `pat_valid=True`.
4. After: broadcast is rejected immediately with the new descriptive
   error, no broken state stored.

For the empty-errors-list defect:

1. Mock `requests.post` to return `{"data": null, "errors": []}`.
2. Before: `_test_pat_against_repo` reaches `data["errors"][0]` and
   raises `IndexError`, which propagates out of the handler.
3. After: empty list is treated as "no errors", function falls
   through to the viewer check and returns the viewer-null error.

## Closes

Closes #751.
```