### PR TITLE
fix: handle metagraph shrinkage symmetrically in resync_metagraph

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -288,19 +288,29 @@ class BaseValidatorNeuron(BaseNeuron):
             return
 
         bt.logging.info('Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages')
-        # Zero out all hotkeys that have been replaced.
-        for uid, hotkey in enumerate(self.hotkeys):
-            if hotkey != self.metagraph.hotkeys[uid]:
+        # Zero out all hotkeys that have been replaced. Cap iteration at the
+        # shorter of old/new — on shrinkage self.metagraph.hotkeys is smaller
+        # than self.hotkeys and indexing past its end would IndexError.
+        shared_len = min(len(self.hotkeys), len(self.metagraph.hotkeys))
+        for uid in range(shared_len):
+            if self.hotkeys[uid] != self.metagraph.hotkeys[uid]:
                 self.scores[uid] = 0  # hotkey has been replaced
 
-        # Check to see if the metagraph has changed size.
-        # If so, we need to add new hotkeys and moving averages.
+        # Resize the moving-average score array symmetrically — both grow and
+        # shrink. Shrinkage is rare (chain reset, governance UID removal,
+        # stale subtensor) but leaves self.scores stuck at the old length and
+        # the validator unable to set weights until restart.
         if len(self.hotkeys) < len(self.metagraph.hotkeys):
             # Update the size of the moving average scores.
             new_moving_average = np.zeros((self.metagraph.n))
             min_len = min(len(self.hotkeys), len(self.scores))
             new_moving_average[:min_len] = self.scores[:min_len]
             self.scores = new_moving_average
+        elif len(self.hotkeys) > len(self.metagraph.hotkeys):
+            # .copy() so downstream in-place mutations on self.scores don't
+            # alias the larger original buffer through a numpy view.
+            self.scores = self.scores[: self.metagraph.n].copy()
+            bt.logging.info(f'Metagraph shrank from {len(self.hotkeys)} to {self.metagraph.n}; truncated scores')
 
         # Update the hotkeys.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)

--- a/tests/validator/test_resync_metagraph.py
+++ b/tests/validator/test_resync_metagraph.py
@@ -1,0 +1,197 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""
+Unit tests for BaseValidatorNeuron.resync_metagraph.
+
+Locks the symmetric grow/shrink invariant: when the metagraph changes size in
+either direction, self.hotkeys and self.scores must stay aligned with
+self.metagraph.n, and the hotkey-replacement walk must not IndexError into a
+shrunken metagraph.
+
+Run tests:
+    pytest tests/validator/test_resync_metagraph.py -v
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from neurons.base.validator import BaseValidatorNeuron
+
+
+def _make_metagraph(hotkeys: list, axons_token: str = 'a') -> Any:
+    """Return a stub metagraph object with the fields resync_metagraph touches.
+
+    `axons` is a sentinel value used only for the inequality check at the top
+    of resync_metagraph; differing tokens force the function to take the
+    re-sync path. Return type is Any so pyright accepts the duck-typed stub
+    where a bittensor.Metagraph is annotated.
+    """
+    return SimpleNamespace(
+        hotkeys=list(hotkeys),
+        n=len(hotkeys),
+        axons=axons_token,
+        sync=MagicMock(),  # called as self.metagraph.sync(subtensor=...) — no-op for tests
+    )
+
+
+def _make_validator_stub(prev_hotkeys: list, prev_scores: np.ndarray, new_hotkeys: list) -> Any:
+    """Build a minimal stub that resync_metagraph can run against without __init__.
+
+    self.metagraph starts with `new_hotkeys` already installed because we mock
+    metagraph.sync to be a no-op — the test pre-stages the post-sync state.
+    The pre-sync snapshot is recreated via copy.deepcopy in the function under
+    test, so we must seed self.metagraph.axons distinct from the pre-sync axon
+    token to force the function past its early-return guard.
+    """
+    stub = SimpleNamespace()
+    stub.hotkeys = list(prev_hotkeys)
+    stub.scores = prev_scores
+    stub.subtensor = MagicMock()
+    stub.metagraph = _make_metagraph(new_hotkeys, axons_token='post-sync')
+    # Inject a pre-sync axons token by patching copy.deepcopy at the call site
+    # is overkill — instead, just make the *current* metagraph's axons differ
+    # from what deepcopy will capture. Since we pre-installed new_hotkeys with
+    # axons='post-sync' and the real flow does `previous = deepcopy(self.metagraph)`
+    # then `self.metagraph.sync(...)`, after sync the axons token is unchanged
+    # in our stub. We force inequality by mutating it after the deepcopy step.
+    # Simpler: stub metagraph.sync to swap the axons token.
+
+    def _swap_axons_after_sync(*args, **kwargs):
+        stub.metagraph.axons = 'post-sync-changed'
+
+    stub.metagraph.sync = MagicMock(side_effect=_swap_axons_after_sync)
+    stub.metagraph.axons = 'pre-sync'  # deepcopy captures this; sync flips it
+    return stub
+
+
+class TestResyncMetagraphGrow:
+    """Pre-existing growth path — was uncovered by tests before this PR."""
+
+    def test_grow_extends_scores_and_hotkeys(self):
+        prev_hotkeys = ['a', 'b', 'c']
+        prev_scores = np.array([0.1, 0.2, 0.3])
+        new_hotkeys = ['a', 'b', 'c', 'd', 'e']
+        stub = _make_validator_stub(prev_hotkeys, prev_scores, new_hotkeys)
+
+        BaseValidatorNeuron.resync_metagraph(stub)
+
+        assert stub.hotkeys == new_hotkeys
+        assert stub.scores.shape == (5,)
+        # Old slots preserved, new slots zeroed.
+        assert stub.scores[0] == pytest.approx(0.1)
+        assert stub.scores[1] == pytest.approx(0.2)
+        assert stub.scores[2] == pytest.approx(0.3)
+        assert stub.scores[3] == 0.0
+        assert stub.scores[4] == 0.0
+
+
+class TestResyncMetagraphShrink:
+    """The bug this PR fixes: shrinkage was unhandled and IndexErrored."""
+
+    def test_shrink_truncates_scores_and_hotkeys(self):
+        prev_hotkeys = ['a', 'b', 'c', 'd', 'e']
+        prev_scores = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+        new_hotkeys = ['a', 'b', 'c']
+        stub = _make_validator_stub(prev_hotkeys, prev_scores, new_hotkeys)
+
+        BaseValidatorNeuron.resync_metagraph(stub)
+
+        assert stub.hotkeys == new_hotkeys
+        assert stub.scores.shape == (3,)
+        # Surviving slots preserved.
+        assert stub.scores[0] == pytest.approx(0.1)
+        assert stub.scores[1] == pytest.approx(0.2)
+        assert stub.scores[2] == pytest.approx(0.3)
+
+    def test_shrink_does_not_indexerror_on_replacement_walk(self):
+        """The pre-fix loop iterated over old hotkeys and indexed new — IndexError
+        on shrinkage. This test fails on the unfixed code with IndexError."""
+        prev_hotkeys = ['a', 'b', 'c', 'd', 'e']
+        prev_scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+        new_hotkeys = ['a', 'b']  # smaller and last-shared slot unchanged
+        stub = _make_validator_stub(prev_hotkeys, prev_scores, new_hotkeys)
+
+        # Should not raise.
+        BaseValidatorNeuron.resync_metagraph(stub)
+
+        assert stub.hotkeys == new_hotkeys
+        assert stub.scores.shape == (2,)
+
+    def test_shrink_returns_independent_buffer_not_view(self):
+        """Truncate must use .copy() so downstream in-place mutations on
+        self.scores (e.g. blacklisted_uids zeroing in update_scores) cannot
+        alias the larger original buffer through a numpy view."""
+        prev_scores = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+        stub = _make_validator_stub(
+            prev_hotkeys=['a', 'b', 'c', 'd', 'e'],
+            prev_scores=prev_scores,
+            new_hotkeys=['a', 'b', 'c'],
+        )
+
+        BaseValidatorNeuron.resync_metagraph(stub)
+
+        # Mutate the (now-detached) original; the truncated array must not change.
+        prev_scores[0] = 999.0
+        assert stub.scores[0] == pytest.approx(0.1)
+
+
+class TestResyncMetagraphReplacement:
+    """Hotkey-replacement walk: zero scores at slots whose hotkey changed."""
+
+    def test_replaced_hotkey_score_zeroed_within_shared_range(self):
+        prev_hotkeys = ['a', 'b', 'c']
+        prev_scores = np.array([0.1, 0.2, 0.3])
+        new_hotkeys = ['a', 'X', 'c']  # uid=1 replaced
+        stub = _make_validator_stub(prev_hotkeys, prev_scores, new_hotkeys)
+
+        BaseValidatorNeuron.resync_metagraph(stub)
+
+        assert stub.scores[0] == pytest.approx(0.1)
+        assert stub.scores[1] == 0.0
+        assert stub.scores[2] == pytest.approx(0.3)
+
+    def test_replacement_walk_capped_at_shorter_length_on_shrink(self):
+        """When metagraph shrinks AND a surviving slot was replaced, only the
+        shared-range replacements zero out; the truncated tail is dropped
+        regardless of replacement state."""
+        prev_hotkeys = ['a', 'b', 'c', 'd']
+        prev_scores = np.array([0.1, 0.2, 0.3, 0.4])
+        new_hotkeys = ['a', 'X']  # uid=1 replaced; uid=2,3 dropped
+        stub = _make_validator_stub(prev_hotkeys, prev_scores, new_hotkeys)
+
+        BaseValidatorNeuron.resync_metagraph(stub)
+
+        assert stub.hotkeys == new_hotkeys
+        assert stub.scores.shape == (2,)
+        assert stub.scores[0] == pytest.approx(0.1)
+        assert stub.scores[1] == 0.0
+
+
+class TestResyncMetagraphNoop:
+    """Same-size, same-hotkeys path — early return on unchanged axons."""
+
+    def test_unchanged_metagraph_returns_without_mutation(self):
+        prev_hotkeys = ['a', 'b', 'c']
+        prev_scores = np.array([0.1, 0.2, 0.3])
+
+        stub: Any = SimpleNamespace()
+        stub.hotkeys = list(prev_hotkeys)
+        stub.scores = prev_scores.copy()
+        stub.subtensor = MagicMock()
+        stub.metagraph = _make_metagraph(prev_hotkeys, axons_token='same')
+        # No side_effect — sync leaves axons unchanged, so equality check returns early.
+
+        BaseValidatorNeuron.resync_metagraph(stub)
+
+        # Untouched.
+        assert stub.hotkeys == prev_hotkeys
+        np.testing.assert_array_equal(stub.scores, prev_scores)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

`BaseValidatorNeuron.resync_metagraph` (`neurons/base/validator.py:276-306`) only handled metagraph **growth**. On shrinkage — possible on chain reset, testnet rollover, governance UID removal, or stale-subtensor states — two failures cascaded:

1. **Immediate `IndexError` (line 293).** The hotkey-replacement loop iterated over `self.hotkeys` (the previous, larger snapshot) and indexed `self.metagraph.hotkeys[uid]` (the new, smaller list). For any `uid >= len(self.metagraph.hotkeys)`, the lookup raised `IndexError` before any size-handling could run.
2. **Sync-crash loop.** The exception propagated through `sync()` (`neurons/base/neuron.py:111-125`) up to `run()`'s top-level `except Exception` (`neurons/base/validator.py:167-169`), got logged, and execution continued — but `resync_metagraph` had crashed before line 306 (`self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)`), so `self.hotkeys` was never updated. The next sync iteration re-entered the same stale state and raised the same `IndexError`. The validator stopped setting weights until manually restarted.

This PR makes the function symmetric: the hotkey-replacement walk is capped at the shorter of old/new (so it cannot index past a shrunken metagraph), and a new `elif` branch truncates `self.scores` to `self.metagraph.n` with `.copy()` so downstream in-place mutations on `self.scores` (e.g. `update_scores` line 349, blacklisted-UID zeroing line 355) cannot alias the larger original buffer through a numpy view.

The asymmetry is the same shape as the maintainer-merged symmetric-paths fixes `#691` (apply `is_valid_issue` state_reason gate to open PR collateral) and `#689` (keep scan issues out of valid-solved gate), one layer up.

Changes:
- `neurons/base/validator.py:290-318` — replace the unbounded `for uid, hotkey in enumerate(self.hotkeys)` loop with a `range(min(...))` walk; add the shrink branch with `.copy()` and a log line that mirrors the existing growth-path style.
- `tests/validator/test_resync_metagraph.py` (new) — 7 tests across 4 classes covering grow, shrink (3 cases including the IndexError regression), replacement-walk semantics within the shared range, and the same-size early-return path. Prior to this PR there was zero test coverage on `resync_metagraph` (`grep -rn resync_metagraph tests/` returned nothing).

## Related Issues
Closes #814 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

Reachable failure mode that halts emissions until manual restart on metagraph shrinkage events.

## Testing

- [x] Tests added/updated
- [x] Manually tested

**Test results**

```
============================== 7 passed in 0.05s ===============================
```

`tests/validator/test_resync_metagraph.py` — all 7 new tests pass:

- `TestResyncMetagraphGrow::test_grow_extends_scores_and_hotkeys` — locks the pre-existing growth path (was uncovered before).
- `TestResyncMetagraphShrink::test_shrink_truncates_scores_and_hotkeys` — primary regression for this PR.
- `TestResyncMetagraphShrink::test_shrink_does_not_indexerror_on_replacement_walk` — fails on the unfixed code with `IndexError` from the line-293 lookup.
- `TestResyncMetagraphShrink::test_shrink_returns_independent_buffer_not_view` — proves `.copy()` is load-bearing: mutating the original `prev_scores` after the call must not affect `stub.scores`.
- `TestResyncMetagraphReplacement::test_replaced_hotkey_score_zeroed_within_shared_range` — replacement zeroing within the same-size case.
- `TestResyncMetagraphReplacement::test_replacement_walk_capped_at_shorter_length_on_shrink` — shrinkage + replacement combined; confirms the loop cap and the truncation cooperate.
- `TestResyncMetagraphNoop::test_unchanged_metagraph_returns_without_mutation` — early-return path on unchanged axons.

**Pyright clean**

```
$ uv run pyright neurons/base/validator.py tests/validator/test_resync_metagraph.py
0 errors, 0 warnings, 0 informations
```

The test stubs are typed `Any` rather than `BaseValidatorNeuron` because `BaseValidatorNeuron.__init__` constructs a real subtensor / wallet / axon and cannot be instantiated in unit tests. Calling the unbound method against a duck-typed `SimpleNamespace` is the cleanest path to coverage; `Any` is the honest annotation for "this is deliberately not the real type."

**Manual verification**

- Walked the call chain: `sync` → `resync_metagraph` → outer `except Exception` in `run()`. Confirmed the unfixed code reaches `run()`'s exception handler on shrinkage, logs, and never updates `self.hotkeys`, so the next loop iteration re-enters the same crash. The new code completes the resync cleanly and falls through to `set_weights`.
- Symmetric-paths PRs `#691` (`efaa915`) and `#689` (`a7c557e`) are present in `git log`, validating the framing.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
