### PR TITLE
fix(cli): abort on corrupt config.json instead of falling through to mainnet defaults

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -599,7 +599,14 @@ def load_config() -> Dict[str, Any]:
         try:
             with open(CONFIG_FILE, 'r') as f:
                 return json.load(f)
-        except (json.JSONDecodeError, IOError):
+        except json.JSONDecodeError as e:
+            print_error(
+                f'Config file at {CONFIG_FILE} is not valid JSON ({e}). '
+                f'Inspect or remove the file before re-running. '
+                f'Refusing to fall through to defaults to avoid silently retargeting the wrong network/contract.'
+            )
+            raise SystemExit(1)
+        except IOError:
             pass
     return {}
 

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -124,13 +124,23 @@ def config_set(key: str, value: str):
     # Ensure config directory exists
     GITTENSOR_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Load existing config or start fresh
+    # Load existing config or start fresh.
+    # On JSONDecodeError refuse to overwrite — the file may contain values the
+    # operator still relies on (network, contract_address, ws_endpoint, hotkey).
+    # Silently writing a fresh single-key config would erase those and fall
+    # through to mainnet defaults on the next read. Mirrors load_config's
+    # read-side fix (PR #817 / #816).
     config = {}
     if CONFIG_FILE.exists():
         try:
             config = json.loads(CONFIG_FILE.read_text())
-        except json.JSONDecodeError:
-            console.print('[yellow]Warning: Existing config was invalid, starting fresh[/yellow]')
+        except json.JSONDecodeError as e:
+            console.print(
+                f'[red]Error: Config file at {CONFIG_FILE} is not valid JSON ({e}).[/red]\n'
+                f'[red]Refusing to overwrite — inspect or move the file aside before retrying[/red]\n'
+                f'[red]so previously-configured keys (network, contract_address, ws_endpoint, ...) are not lost.[/red]'
+            )
+            raise SystemExit(1)
 
     # Set the value
     old_value = config.get(key)

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -40,7 +40,14 @@ def _load_config_value(key: str):
     try:
         config = json.loads(config_file.read_text())
         return config.get(key)
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError as e:
+        console.print(
+            f'\n[red]✗ Config file at {config_file} is not valid JSON ({e}). '
+            f'Inspect or remove the file before re-running. '
+            f'Refusing to fall through to defaults to avoid silently retargeting the wrong network/contract.[/red]\n'
+        )
+        sys.exit(1)
+    except OSError:
         return None
 
 

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -976,6 +976,59 @@ class TestCliRuntimeExceptions:
         assert 'boom-harvest' in result.output
 
 
+class TestLoadConfigCorruption:
+    """C7 — load_config must not silently fall through to defaults on corrupt JSON.
+
+    A silent {} return retargets every CLI command at finney mainnet + the hardcoded
+    contract address; operators running validator/admin commands non-interactively
+    (e.g. `gitt vote solution`) can miss the panel showing the resolved network.
+    """
+
+    def test_load_config_aborts_on_invalid_json(self, tmp_path, monkeypatch):
+        from gittensor.cli.issue_commands import helpers as issue_helpers
+
+        bad_config = tmp_path / 'config.json'
+        bad_config.write_text('{ "network": "test"')  # truncated, not valid JSON
+
+        monkeypatch.setattr(issue_helpers, 'CONFIG_FILE', bad_config)
+
+        with pytest.raises(SystemExit) as exc_info:
+            issue_helpers.load_config()
+        assert exc_info.value.code == 1
+
+    def test_load_config_returns_empty_when_file_missing(self, tmp_path, monkeypatch):
+        from gittensor.cli.issue_commands import helpers as issue_helpers
+
+        missing = tmp_path / 'does_not_exist.json'
+        monkeypatch.setattr(issue_helpers, 'CONFIG_FILE', missing)
+
+        assert issue_helpers.load_config() == {}
+
+    def test_load_config_returns_parsed_dict_when_valid(self, tmp_path, monkeypatch):
+        from gittensor.cli.issue_commands import helpers as issue_helpers
+
+        good = tmp_path / 'config.json'
+        good.write_text(json.dumps({'network': 'test', 'wallet': 'alice'}))
+
+        monkeypatch.setattr(issue_helpers, 'CONFIG_FILE', good)
+
+        assert issue_helpers.load_config() == {'network': 'test', 'wallet': 'alice'}
+
+    def test_miner_load_config_value_aborts_on_invalid_json(self, tmp_path, monkeypatch):
+        from gittensor.cli.miner_commands import helpers as miner_helpers
+
+        fake_home = tmp_path
+        config_dir = fake_home / '.gittensor'
+        config_dir.mkdir()
+        (config_dir / 'config.json').write_text('not json')
+
+        monkeypatch.setattr(miner_helpers.Path, 'home', staticmethod(lambda: fake_home))
+
+        with pytest.raises(SystemExit) as exc_info:
+            miner_helpers._load_config_value('network')
+        assert exc_info.value.code == 1
+
+
 class TestEmitJson:
     @pytest.mark.parametrize(
         'value',

--- a/tests/cli/test_config_set.py
+++ b/tests/cli/test_config_set.py
@@ -2,11 +2,17 @@
 # Copyright © 2025 Entrius
 
 """
-Tests for `gitt config set` key whitelist.
+Tests for `gitt config set`.
 
-Validates that only recognised CONFIG_KEYS are accepted by `gitt config set`,
-preventing typos like `wallet_name` from silently writing a dead entry that
-downstream commands (which read by canonical key name) will ignore.
+Covers two related guarantees:
+
+1. **Key whitelist (PR #813):** only recognised CONFIG_KEYS are accepted, so
+   typos like `wallet_name` cannot silently shadow the canonical names.
+2. **Corrupt-file refusal (PR #817 / issue #845):** a JSONDecodeError on the
+   existing config file aborts non-zero instead of clobbering the file with a
+   fresh single-key config. Operator's `network`, `contract_address`,
+   `ws_endpoint`, and `hotkey` would otherwise silently disappear and the next
+   `gitt issues ...` would fall through to finney mainnet.
 """
 
 import json
@@ -99,3 +105,57 @@ class TestConfigSetWhitelist:
         assert result.exit_code == 0, result.output
         assert 'alice' in result.output and 'bob' in result.output
         assert _read(config_file) == {'wallet': 'bob'}
+
+
+class TestConfigSetCorruption:
+    """`gitt config set` must not destroy other keys when the file is corrupt."""
+
+    def test_corrupt_config_aborts_with_nonzero_exit(self, temp_config_dir):
+        config_dir, config_file = temp_config_dir
+        config_dir.mkdir(parents=True)
+        # Truncated JSON — simulates an interrupted write or manual edit.
+        config_file.write_text('{"network": "test"')
+
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'hotkey', 'default'])
+
+        assert result.exit_code != 0
+        assert 'not valid JSON' in result.output
+        assert 'Refusing to overwrite' in result.output
+
+    def test_corrupt_config_preserves_existing_file(self, temp_config_dir):
+        """The whole point: the bad file is left alone, not clobbered."""
+        config_dir, config_file = temp_config_dir
+        config_dir.mkdir(parents=True)
+        original_bytes = b'{"network": "test"'
+        config_file.write_bytes(original_bytes)
+
+        runner = CliRunner()
+        runner.invoke(config_group, ['set', 'hotkey', 'default'])
+
+        # Byte-for-byte identical: the operator can recover the values they
+        # had configured before the corruption.
+        assert config_file.read_bytes() == original_bytes
+
+    def test_valid_config_still_round_trips(self, temp_config_dir):
+        """Non-corrupt files must still merge new keys without loss."""
+        config_dir, config_file = temp_config_dir
+        config_dir.mkdir(parents=True)
+        config_file.write_text(json.dumps({'network': 'test', 'wallet': 'alice'}))
+
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'hotkey', 'default'])
+
+        assert result.exit_code == 0, result.output
+        assert _read(config_file) == {'network': 'test', 'wallet': 'alice', 'hotkey': 'default'}
+
+    def test_missing_config_creates_fresh(self, temp_config_dir):
+        """First-run case: no existing file is fine — write a fresh one."""
+        _, config_file = temp_config_dir
+        assert not config_file.exists()
+
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'wallet', 'alice'])
+
+        assert result.exit_code == 0, result.output
+        assert _read(config_file) == {'wallet': 'alice'}


### PR DESCRIPTION
## Problem

`load_config()` in `gittensor/cli/issue_commands/helpers.py` and the parallel `_load_config_value()` in `gittensor/cli/miner_commands/helpers.py` both catch `json.JSONDecodeError` and return `{}` / `None` with **no log line, no warning, no exit code**. Every command that reads `~/.gittensor/config.json` then proceeds as if the operator had configured nothing.

This is a problem because the silent-empty-config path collapses to **mainnet**:

- `resolve_network()` walks through CLI arg → config → env → default; on empty config the chain ends at `NETWORK_MAP['finney']` (`gittensor/cli/issue_commands/helpers.py`).
- `get_contract_address()` falls through to the hardcoded mainnet `CONTRACT_ADDRESS` in `gittensor/constants.py`.

So a config file that exists but parses badly silently re-targets every CLI hot path at finney + mainnet contract.

## Location

`gittensor/cli/issue_commands/helpers.py` (the `load_config()` body):

```python
if CONFIG_FILE.exists():
    try:
        with open(CONFIG_FILE, 'r') as f:
            return json.load(f)
    except (json.JSONDecodeError, IOError):
        pass
return {}
```

Same shape in `gittensor/cli/miner_commands/helpers.py::_load_config_value()`. There are at least 8 commands (`vote`, `register`, `harvest`, `view`, `submissions`, `predict`, miner `post`, miner `check`) that go through one of these two functions.

## How the file becomes briefly invalid

The fix should defend against any of these — they're all real:

1. **Interrupted `gitt config set`.** The current writer is non-atomic (`Path.write_text` truncates first), so a Ctrl-C / OOM / host shutdown mid-write leaves the file partial. (This is the write-side half — see C6.)
2. **Manual edit error.** Operator opens `~/.gittensor/config.json` in `$EDITOR`, mistypes a comma or a quote, saves.
3. **External tool corruption.** `scp`, `rsync --partial`, sync-conflict tools, dotfile managers can produce a half-file at the destination.
4. **Host crash without `fsync`.** `Path.write_text` doesn't `fsync` — power loss within the writeback window leaves zeros / truncation.
5. **Permission flipping.** `chmod 0` on the config doesn't reach this branch (raises `IOError`, see below) — but a file that exists and is read-protected by a UID change while the validator is running still hits the broken path.

The point is that the operator did **configure** the CLI; the fall-through pretends they didn't.

## Why it's load-bearing

The CLI hot path includes operator-only commands: `gitt vote solution <issue_id> <solver_hotkey> <solver_coldkey> <bounty>` and `gitt issues register --repo … --bounty …`. These are typically run from automation (cron, scripts), where:

- `print_network_header(...)` prints the resolved network and contract, but it's one line in a Rich panel; non-interactive runs and CI output capture often miss it.
- `confirm_or_abort(...)` auto-skips on non-TTY, so the "are you sure?" guard isn't a backstop.
- The vote / register transactions are signed and submitted — at best they fail on the chain layer (wrong contract address); at worst they succeed against the wrong target.

There's no recovery from a vote committed to the wrong network.

## Distinction from related findings

- **C2 (typed `config set` whitelist)** — write-side input validation, doesn't touch reads.
- **C6 (`config set` parse-then-wipe + non-atomic write)** — write-side; closes the most common path **into** the corrupt state. Even after C6, paths 2–5 above still produce corrupt files, and C7's silent-read path still triggers.
- **#623 (consolidate CLI endpoint/config resolution)** — refactor / DRY-up of the two helper functions; doesn't claim the silent fallback is a bug.

So the read-side bug is independently exploitable and survives the fix to the write side.

## Fix

On `JSONDecodeError`, abort the CLI with a clear message that points at the file and instructs the operator to inspect or remove it. **Do not return `{}` / `None`.**

`IOError` / `OSError` (file genuinely unavailable — missing, permission-denied) is fine to treat as "no config" — those are legitimate "operator hasn't configured this yet" states. The asymmetry is the point: a file that does not exist is "no config"; a file that exists and parses badly is **operator data corruption** and must not be silently ignored.

Suggested message: name the path, name the parse error, instruct the operator to inspect/remove, and exit non-zero. Roughly five lines added per call site.

## btcli precedent

btcli upstream PR [latent-to/btcli#800](https://github.com/latent-to/btcli/pull/800) ("fix: JSON output empty for `btcli subnets list --json-out`") was caused by the same shape — an exception was silently swallowed and produced empty output instead of an error. btcli's own `Config.__init__` reads YAML and lets parse errors **propagate** with no `try/except` around the load. Gittensor's CLI is strictly more silent than btcli on the same surface.

## Dup-check

Searched closed + open issues and PRs for: `load_config`, `JSONDecodeError config`, `config silent`, `resolve_network finney fallback`, `mainnet fallback`, `config in:title`. The closest neighbour is #623 (refactor; doesn't address behaviour). No issue currently claims the silent fallback is a correctness bug.

Fixes #816 

before:
<img width="1304" height="191" alt="image" src="https://github.com/user-attachments/assets/11a43d47-3e2f-44d1-9a6e-192137824582" />

after:
<img width="1314" height="133" alt="image" src="https://github.com/user-attachments/assets/99fb6bed-2578-43a9-a50e-cb9b1c274d9c" />
