### PR TITLE
refactor: inline single-use _get_contract_info_value helper

### DIFF
--- a/gittensor/validator/issue_competitions/storage_utils.py
+++ b/gittensor/validator/issue_competitions/storage_utils.py
@@ -34,14 +34,9 @@ class DecodedIssueStorage:
     registered_at_block: int
 
 
-def _get_contract_info_value(contract_info):
-    """Normalize substrate contract info wrapper values."""
-    return contract_info.value if hasattr(contract_info, 'value') else contract_info
-
-
 def _extract_trie_id_bytes(contract_info) -> Optional[bytes]:
     """Extract contract trie ID bytes from substrate contract info."""
-    info = _get_contract_info_value(contract_info)
+    info = contract_info.value if hasattr(contract_info, 'value') else contract_info
     if not info or 'trie_id' not in info:
         return None
 


### PR DESCRIPTION
## Summary

\`_get_contract_info_value\` in [gittensor/validator/issue_competitions/storage_utils.py](gittensor/validator/issue_competitions/storage_utils.py) was a 3-line wrapper around \`contract_info.value if hasattr(contract_info, 'value') else contract_info\`, called from exactly one place — \`_extract_trie_id_bytes\`. Inlining matches the pattern from #748 and #641 (\"inline single-use helper into its only caller\").

The \`hasattr\` fallback is preserved verbatim so all three substrate \`trie_id\` shapes (string / bytes / list) covered by \`test_get_contract_child_storage_key_accepts_multiple_trie_id_formats\` still resolve identically. No behaviour change.

\`grep -rn _get_contract_info_value\` confirms no other call sites in \`gittensor/\`, \`neurons/\`, or \`tests/\`.

Net: **-6 / +1 lines**, one fewer private helper in \`storage_utils.py\`.

## Related Issues

N/A — same family of cleanups as #641 / #748.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- \`grep -rn _get_contract_info_value\` confirms only one call site.
- \`uv run --extra dev pytest tests/utils/test_issue_competitions_storage_utils.py -v\` — all 14 tests pass, including the multi-format \`trie_id\` test.
- \`uv run --extra dev pytest tests/\` — full suite (443 tests) passes.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)