### PR TITLE
fix: strip mirror file contents in MinerEvaluationCache

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -708,6 +708,9 @@ class MinerEvaluationCache:
         cached.merged_pull_requests = [_pr_for_cache(pr) for pr in evaluation.merged_pull_requests]
         cached.open_pull_requests = [_pr_for_cache(pr) for pr in evaluation.open_pull_requests]
         cached.closed_pull_requests = [_pr_for_cache(pr) for pr in evaluation.closed_pull_requests]
+        cached.mirror_merged_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.mirror_merged_prs]
+        cached.mirror_open_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.mirror_open_prs]
+        cached.mirror_closed_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.mirror_closed_prs]
         return cached
 
     @staticmethod
@@ -735,3 +738,9 @@ def _pr_with_fresh_issues(pr: 'PullRequest') -> 'PullRequest':
     if pr.issues is not None:
         pr_copy.issues = [copy.copy(issue) for issue in pr.issues]
     return pr_copy
+
+
+def _scored_mirror_pr_for_cache(scored: 'ScoredMirrorPR') -> 'ScoredMirrorPR':
+    scored_copy = copy.copy(scored)
+    scored_copy.files = None
+    return scored_copy

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 from typing import cast
 
 from gittensor.classes import FileChange, Issue, MinerEvaluation, MinerEvaluationCache, PRState, PullRequest
+from gittensor.utils.mirror.models import MirrorFile, MirrorPullRequest, MirrorReviewSummary
+from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 from neurons.validator import Validator
 
 
@@ -175,3 +177,69 @@ class TestCacheIsolation:
         cached_issues = cached.merged_pull_requests[0].issues
         assert cached_issues is not None
         assert cached_issues[0].discovery_earned_score == 0.0
+
+
+def _make_mirror_pr_with_file_blob(blob: str, pr_number: int = 7) -> ScoredMirrorPR:
+    now = datetime.now(timezone.utc)
+    pr = MirrorPullRequest(
+        repo_full_name='owner/repo',
+        pr_number=pr_number,
+        title='cached mirror pr',
+        body=None,
+        state='MERGED',
+        author_github_id='12345',
+        author_login='miner',
+        author_association='CONTRIBUTOR',
+        created_at=now,
+        closed_at=None,
+        merged_at=now,
+        last_edited_at=None,
+        edited_after_merge=False,
+        hours_since_merge=0.0,
+        merged_by_login='maintainer',
+        base_ref='main',
+        head_ref='feature',
+        head_repo_full_name='owner/repo',
+        default_branch='main',
+        head_sha='abc',
+        base_sha='def',
+        merge_base_sha='def',
+        additions=1,
+        deletions=0,
+        commits_count=1,
+        scoring_data_stored=True,
+        review_summary=MirrorReviewSummary(),
+    )
+    scored = ScoredMirrorPR(pr=pr, base_score=8.0, token_score=12.0)
+    scored.files = [
+        MirrorFile(
+            filename='src/lib.py',
+            previous_filename=None,
+            status='modified',
+            additions=1,
+            deletions=0,
+            changes=1,
+            is_binary=False,
+            head_content=blob,
+            base_content=blob,
+        )
+    ]
+    return scored
+
+
+class TestMirrorCacheIsolation:
+    def test_cache_drops_mirror_files_without_mutating_source(self):
+        cache = MinerEvaluationCache()
+        source = MinerEvaluation(uid=1, hotkey='hotkey_1', github_id='12345', github_pat='secret')
+        source.mirror_merged_prs = [_make_mirror_pr_with_file_blob('A' * 10_000)]
+        cache.store(source)
+
+        assert source.github_pat == 'secret'
+        source_files = source.mirror_merged_prs[0].files
+        assert source_files is not None
+        assert source_files[0].head_content == 'A' * 10_000
+
+        cached = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert cached is not None
+        assert cached.github_pat is None
+        assert cached.mirror_merged_prs[0].files is None


### PR DESCRIPTION
## Summary

`MinerEvaluationCache` got shallow-copy helpers in #786, but they only cover the legacy `PullRequest` lists. The three mirror lists (`mirror_merged_prs`, `mirror_open_prs`, `mirror_closed_prs`) still get shared by reference, which causes two real problems:

- **Memory:** cached evaluations keep `ScoredMirrorPR.files[*].head_content` and `base_content` (whole head/base file blobs). Cache memory grows with every mirror-scored PR and never shrinks (#823).
- **Aliasing:** mutations on the source eval after `store()` leak into the cache, and back-to-back `get()` calls hand back the same `ScoredMirrorPR` / `MirrorPullRequest` / `MirrorLinkedIssue` / `MirrorLabel` objects.

This PR extends the same shallow-copy strategy from #786 to mirror PRs, via four small private helpers that mirror the existing `_pr_for_cache` / `_pr_with_fresh_issues` pair:

- `_build_cache_entry`: drop `ScoredMirrorPR.files` and shallow-copy the nested `MirrorPullRequest` (`review_summary`, `labels`, `linked_issues` + each linked issue's `labels`).
- `_isolate_for_downstream`: same nested-metadata copy on the way out, so successive `get()` calls return fully independent snapshots.

The cache-fallback path only runs issue competitions and issue discovery scoring, neither of which reads file contents — so dropping `files` outright is enough, no need to keep stripped `MirrorFile` placeholders.

## Related Issues

Closes #823

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Three new tests in `tests/validator/test_validator_cache_fallback.py::TestMirrorCacheIsolation`, one per invariant:

- `test_cache_drops_mirror_files_without_mutating_source` — `files` is `None` on the cached copy across all three mirror buckets, and the source eval is untouched.
- `test_store_isolates_cached_mirror_metadata_from_source_mutations` — mutating `source.mirror_merged_prs[i].pr.{title, review_summary, labels, linked_issues}` after `store()` does not affect the cached copy.
- `test_get_returns_isolated_mirror_metadata` — two consecutive `get()` calls return independent snapshots.

```
$ uv run pytest tests/validator/test_validator_cache_fallback.py -v
9 passed

$ uv run pytest tests/
all green

$ uv run ruff check && uv run ruff format --check
clean

$ uv run pyright gittensor/classes.py tests/validator/test_validator_cache_fallback.py
0 errors
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
