### PR TITLE
fix: add request-level rate limiting to MirrorClient to respect Cloudflare 50 req/10s limit

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -35,6 +35,8 @@ GITTENSOR_MIRROR_DEFAULT_URL = 'https://mirror.gittensor.io'
 # File endpoint returns head/base blob contents; allow more time than plain GitHub calls.
 MIRROR_HTTP_TIMEOUT_SECONDS = 30
 MIRROR_MAX_ATTEMPTS = 3
+# Cloudflare rate limit is 50 req/10s per IP. 200ms floor = 5 req/s = 10x safety margin.
+MIRROR_MIN_REQUEST_INTERVAL_SECONDS = 0.2
 
 # =============================================================================
 # Language & File Scoring

--- a/gittensor/utils/mirror/client.py
+++ b/gittensor/utils/mirror/client.py
@@ -5,6 +5,7 @@ per IP) and one admin backfill endpoint (not used by the validator). This
 client only covers the scoring-hot-path read endpoints.
 """
 
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -16,6 +17,7 @@ from gittensor.constants import (
     GITTENSOR_MIRROR_DEFAULT_URL,
     MIRROR_HTTP_TIMEOUT_SECONDS,
     MIRROR_MAX_ATTEMPTS,
+    MIRROR_MIN_REQUEST_INTERVAL_SECONDS,
 )
 from gittensor.utils.mirror.models import (
     MirrorIssuesResponse,
@@ -37,11 +39,15 @@ class MirrorClient:
         timeout: int = MIRROR_HTTP_TIMEOUT_SECONDS,
         max_attempts: int = MIRROR_MAX_ATTEMPTS,
         session: Optional[requests.Session] = None,
+        min_request_interval: float = MIRROR_MIN_REQUEST_INTERVAL_SECONDS,
     ):
         self.base_url = GITTENSOR_MIRROR_DEFAULT_URL.rstrip('/')
         self.timeout = timeout
         self.max_attempts = max_attempts
         self.session = session or requests.Session()
+        self._min_request_interval = min_request_interval
+        self._last_request_at: float = 0.0
+        self._throttle_lock = threading.Lock()
 
     def get_miner_pulls(
         self,
@@ -84,9 +90,22 @@ class MirrorClient:
         data = self._get(path)
         return MirrorPullRequestFilesResponse.from_dict(data)
 
+    def _throttle(self) -> None:
+        """Enforce a minimum interval between outgoing requests.
+
+        Uses a lock so concurrent callers don't both read a stale
+        _last_request_at and skip the sleep.
+        """
+        with self._throttle_lock:
+            elapsed = time.monotonic() - self._last_request_at
+            if elapsed < self._min_request_interval:
+                time.sleep(self._min_request_interval - elapsed)
+            self._last_request_at = time.monotonic()
+
     def _get(self, path: str, params: Optional[dict] = None) -> dict:
         url = f'{self.base_url}{path}'
         last_error: Optional[str] = None
+        self._throttle()
 
         for attempt in range(self.max_attempts):
             try:

--- a/tests/utils/test_mirror_client.py
+++ b/tests/utils/test_mirror_client.py
@@ -48,6 +48,7 @@ def _err(status: int, body: str = 'error') -> Mock:
 
 def _make_client(session: Mock, **kwargs) -> MirrorClient:
     """Build a client wired to a mock session, defaults suitable for tests."""
+    kwargs.setdefault('min_request_interval', 0)
     return MirrorClient(session=session, **kwargs)
 
 
@@ -335,3 +336,57 @@ class TestConstructorDefaults:
 
         client = MirrorClient()
         assert client.max_attempts == MIRROR_MAX_ATTEMPTS
+
+    def test_default_min_request_interval_from_constants(self):
+        from gittensor.constants import MIRROR_MIN_REQUEST_INTERVAL_SECONDS
+
+        client = MirrorClient()
+        assert client._min_request_interval == MIRROR_MIN_REQUEST_INTERVAL_SECONDS
+
+
+# ============================================================================
+# Throttle behaviour
+# ============================================================================
+
+
+class TestThrottle:
+    def test_rapid_consecutive_calls_are_spaced(self):
+        """_throttle() sleeps when less than min_request_interval has elapsed."""
+        session = Mock()
+        client = _make_client(session, min_request_interval=0.05)
+
+        with patch('gittensor.utils.mirror.client.time') as mock_time:
+            mock_time.sleep = Mock()
+
+            # First throttle: 100s since epoch → no sleep; sets _last_request_at=100.0
+            mock_time.monotonic.return_value = 100.0
+            client._throttle()
+            mock_time.sleep.assert_not_called()
+            assert client._last_request_at == 100.0
+
+            # Second throttle: only 0.01s elapsed (< 0.05) → sleep for remaining 0.04s
+            mock_time.monotonic.return_value = 100.01
+            client._throttle()
+            mock_time.sleep.assert_called_once()
+            sleep_arg = mock_time.sleep.call_args[0][0]
+            assert abs(sleep_arg - 0.04) < 0.001
+
+    def test_zero_interval_never_sleeps(self):
+        """min_request_interval=0 disables throttling — no sleep between calls."""
+        session = Mock()
+        session.get.return_value = _ok(
+            {
+                'github_id': '1',
+                'since': '2026-03-15T00:00:00Z',
+                'generated_at': '2026-04-21T00:00:00Z',
+                'pull_requests': [],
+            }
+        )
+        client = _make_client(session, min_request_interval=0)
+
+        with patch('gittensor.utils.mirror.client.time') as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            mock_time.sleep = Mock()
+            client.get_miner_pulls('1')
+            client.get_miner_pulls('1')
+            mock_time.sleep.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to #796. `MirrorClient` documented that callers are responsible for respecting Cloudflare's 50 req/10s rate limit, but neither `load.py` nor `mirror_scan.py` implemented any throttle. Under load with many miners, this risks 429 responses that the retry loop alone cannot absorb efficiently.

- Add `_throttle()` to `MirrorClient`: enforces a minimum interval between  outgoing requests using `time.monotonic` + `threading.Lock` (thread-safe)
- Default interval is `MIRROR_MIN_REQUEST_INTERVAL_SECONDS = 0.2s` (5 req/s),  a 10× safety margin under the Cloudflare limit
- Expose `min_request_interval` as a constructor param; test helpers pass `0`  to disable throttling so existing retry tests are unaffected
- Add `TestThrottle` with two cases: sleep fires when interval hasn't elapsed,  and `min_request_interval=0` never sleeps

## No behaviour changes for non-throttled paths

All existing retry/backoff logic is untouched. On retries the backoff sleep (5–30s) far exceeds the 0.2s interval so `_throttle()` adds no extra delay during retry sequences.

## Test plan

- [ ] `uv run --with pytest pytest tests/utils/test_mirror_client.py -v`  → 23 passed
