### PR TITLE
fix(cli): emit consensus_threshold=0 in vote list JSON when whitelist is empty

### DIFF
--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -246,7 +246,7 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
             validators = client.get_validators()
 
         n = len(validators)
-        required = (n // 2) + 1
+        required = (n // 2) + 1 if n > 0 else 0
 
         if as_json:
             emit_json(


### PR DESCRIPTION
## Summary

Closes #753.

\`gitt vote list --json\` ([cli/issue_commands/vote.py:248-249](gittensor/cli/issue_commands/vote.py#L248-L249)) computed \`required = (n // 2) + 1\` unconditionally, so an empty validator whitelist produced \`{\"count\": 0, \"consensus_threshold\": 1}\` — a 1-of-0 threshold that no integer vote count can satisfy.

JSON consumers (dashboards, monitoring scripts) could not detect the empty-whitelist edge case from this field alone, even though the human-mode branch already prints \"No validators whitelisted.\" and skips the threshold line entirely.

Now: \`consensus_threshold == 0\` when no validators are whitelisted; the existing \`(n // 2) + 1\` majority is preserved for non-empty whitelists.

## Related Issues

Closes #753.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- New \`tests/cli/test_vote_list_consensus.py\` covers three cases:
  - empty whitelist → \`consensus_threshold == 0\`
  - 3 validators → \`consensus_threshold == 2\`
  - 1 validator → \`consensus_threshold == 1\`
- \`uv run --extra dev pytest tests/\` — 446 tests pass (443 baseline + 3 new).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)