### PR TITLE
weights: add release branches for jupyterlab, zed, monero, nextcloud, FastGPT

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -318,12 +318,18 @@
     "weight": 0.0837
   },
   "jupyterlab/jupyterlab": {
+    "additional_acceptable_branches": [
+      "4.5.x"
+    ],
     "weight": 0.1755
   },
   "keras-team/keras": {
     "weight": 0.1091
   },
   "labring/FastGPT": {
+    "additional_acceptable_branches": [
+      "v4.14.x"
+    ],
     "weight": 0.0633
   },
   "langchain-ai/langchain": {
@@ -431,6 +437,9 @@
     "weight": 0.0445
   },
   "monero-project/monero": {
+    "additional_acceptable_branches": [
+      "release-v0.18"
+    ],
     "weight": 0.0792
   },
   "mrdoob/three.js": {
@@ -446,9 +455,18 @@
     "weight": 0.0778
   },
   "nextcloud/desktop": {
+    "additional_acceptable_branches": [
+      "stable-33.0",
+      "stable-4.0"
+    ],
     "weight": 0.0771
   },
   "nextcloud/server": {
+    "additional_acceptable_branches": [
+      "stable33",
+      "stable32",
+      "stable31"
+    ],
     "weight": 0.0764
   },
   "nginx/nginx": {
@@ -717,6 +735,9 @@
     "weight": 0.0638
   },
   "zed-industries/zed": {
+    "additional_acceptable_branches": [
+      "v0.234.x"
+    ],
     "weight": 0.1564
   }
 }


### PR DESCRIPTION
## Summary
Add active release/stable branches as `additional_acceptable_branches` for six whitelisted repos so merged contributions targeting LTS / patch-release branches are recognized in miner accounting.

Bundled per @anderdc's note on #787 ("No reason for separation").

## Why
Each of these repos cuts release branches that receive substantial merged-PR traffic. Without these overrides, valid merges to release/stable branches are not currently scoreable since only the default branch is recognized.

`jupyterlab/jupyterlab` (last 100 merged):
- 16 merges into `4.5.x`, most recent [#18794](https://github.com/jupyterlab/jupyterlab/pull/18794) on 2026-04-25

`zed-industries/zed` (last 100 merged):
- 11 merges into `v0.234.x`, most recent [#55031](https://github.com/zed-industries/zed/pull/55031) on 2026-04-27 (current preview cycle)

`monero-project/monero` (last 100 merged):
- 43 merges into `release-v0.18`, most recent [#10469](https://github.com/monero-project/monero/pull/10469) on 2026-04-27

`nextcloud/server` (last 100 merged):
- 19 merges into `stable33`, most recent [#59927](https://github.com/nextcloud/server/pull/59927) on 2026-04-27
- 17 merges into `stable32`, most recent [#59926](https://github.com/nextcloud/server/pull/59926) on 2026-04-27
- 11 merges into `stable31`, most recent [#59904](https://github.com/nextcloud/server/pull/59904) on 2026-04-27

`nextcloud/desktop` (last 100 merged):
- 38 merges into `stable-33.0`, most recent [#9917](https://github.com/nextcloud/desktop/pull/9917) on 2026-04-27
- 18 merges into `stable-4.0`, most recent [#9916](https://github.com/nextcloud/desktop/pull/9916) on 2026-04-27

`labring/FastGPT` (last 100 merged):
- 16 merges into `v4.14.x`, most recent [#6790](https://github.com/labring/FastGPT/pull/6790) on 2026-04-21

## Change
```json
"jupyterlab/jupyterlab": {
  "additional_acceptable_branches": [
    "4.5.x"
  ],
  "weight": 0.1755
},
"zed-industries/zed": {
  "additional_acceptable_branches": [
    "v0.234.x"
  ],
  "weight": 0.1564
},
"monero-project/monero": {
  "additional_acceptable_branches": [
    "release-v0.18"
  ],
  "weight": 0.0792
},
"nextcloud/server": {
  "additional_acceptable_branches": [
    "stable33",
    "stable32",
    "stable31"
  ],
  "weight": 0.0764
},
"nextcloud/desktop": {
  "additional_acceptable_branches": [
    "stable-33.0",
    "stable-4.0"
  ],
  "weight": 0.0771
},
"labring/FastGPT": {
  "additional_acceptable_branches": [
    "v4.14.x"
  ],
  "weight": 0.0633
}
```
