### PR TITLE
feat: support HTTP ETag cache for GitHub REST GETs

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -27,6 +27,9 @@ GRAPHQL_VIEWER_QUERY = '{ viewer { login } }'
 MAX_FILE_SIZE_BYTES = 1_000_000
 # Too many object lookups in one GraphQL query can trigger 502 errors and lose all results.
 MAX_FILES_PER_GRAPHQL_BATCH = 50
+# On-disk ETag cache for GitHub REST GETs - 304 responses do not consume rate quota.
+ETAG_CACHE_TTL_DAYS = 30
+ETAG_CACHE_DEFAULT_PATH = '~/.gittensor/cache/github_etag'
 
 # =============================================================================
 # das-github-mirror (https://mirror.gittensor.io)

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 import bittensor as bt
 import requests
+from requests.structures import CaseInsensitiveDict
 
 from gittensor.classes import (
     FileChange,
@@ -30,6 +31,7 @@ from gittensor.constants import (
     PR_LOOKBACK_DAYS,
     REVIEW_PENALTY_RATE,
 )
+from gittensor.utils.github_etag_cache import build_request_key, get_default_cache, record_hit, record_miss
 from gittensor.utils.models import PRInfo
 from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
 from gittensor.validator.utils.load_weights import RepositoryConfig
@@ -177,6 +179,53 @@ def make_graphql_headers(token: str) -> Dict[str, str]:
     return {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
 
 
+def _synthesize_304_response(url: str, body: bytes, content_type: Optional[str]) -> requests.Response:
+    """Build a Response-shaped object from cached body for a 304 hit."""
+    resp = requests.Response()
+    resp.status_code = 200
+    resp.url = url
+    resp._content = body
+    resp.encoding = 'utf-8'
+    headers = CaseInsensitiveDict({'X-Gittensor-Cache': 'hit'})
+    if content_type:
+        headers['Content-Type'] = content_type
+    resp.headers = headers
+    return resp
+
+
+def cached_github_get(
+    url: str,
+    headers: Dict[str, str],
+    params: Optional[Dict[str, Any]] = None,
+    timeout: int = GITHUB_HTTP_TIMEOUT_SECONDS,
+) -> requests.Response:
+    """GET wrapped in the on-disk ETag cache - 304 returns a Response from cache."""
+    cache = get_default_cache()
+    cache_key = build_request_key(url, params)
+    cached = cache.lookup(cache_key)
+
+    if cached is not None:
+        request_headers = dict(headers)
+        request_headers['If-None-Match'] = cached.etag
+    else:
+        request_headers = headers
+
+    response = requests.get(url, headers=request_headers, params=params, timeout=timeout)
+
+    if cached is not None and response.status_code == 304:
+        record_hit()
+        return _synthesize_304_response(response.url or url, cached.body, cached.content_type)
+
+    record_miss()
+
+    if response.status_code == 200:
+        etag = response.headers.get('ETag')
+        if isinstance(etag, str) and etag:
+            cache.store(cache_key, etag, response.content, response.headers.get('Content-Type'))
+
+    return response
+
+
 def get_github_id(token: str) -> Optional[str]:
     """Get GitHub numeric user id (as string) using a PAT.
 
@@ -240,7 +289,7 @@ def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str
 
     for attempt in range(max_attempts):
         try:
-            response = requests.get(
+            response = cached_github_get(
                 f'{BASE_GITHUB_API_URL}/repos/{repository}/compare/{base_sha}...{head_sha}',
                 headers=headers,
                 timeout=15,
@@ -302,7 +351,7 @@ def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -
 
     while attempt < max_attempts:
         try:
-            response = requests.get(
+            response = cached_github_get(
                 f'{BASE_GITHUB_API_URL}/repos/{repository}/pulls/{pr_number}/files',
                 headers=headers,
                 params={'per_page': per_page, 'page': page},
@@ -495,7 +544,7 @@ def _search_issue_referencing_prs_rest(
     max_attempts = 3
     for attempt in range(max_attempts):
         try:
-            resp = requests.get(
+            resp = cached_github_get(
                 f'{BASE_GITHUB_API_URL}/search/issues',
                 params={'q': f'repo:{repo} type:pr{state_clause} {issue_number} in:title,body', 'per_page': '50'},
                 headers=headers,
@@ -1067,7 +1116,7 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
     headers = make_headers(token)
 
     try:
-        response = requests.get(
+        response = cached_github_get(
             f'{BASE_GITHUB_API_URL}/repos/{repo}/issues/{issue_number}',
             headers=headers,
             timeout=15,

--- a/gittensor/utils/github_etag_cache.py
+++ b/gittensor/utils/github_etag_cache.py
@@ -1,0 +1,115 @@
+# Entrius 2025
+"""On-disk ETag cache for GitHub REST GETs - 304s do not consume rate quota."""
+
+import os
+import threading
+from pathlib import Path
+from typing import NamedTuple, Optional, Tuple, cast
+from urllib.parse import urlencode
+
+import diskcache
+
+from gittensor.constants import ETAG_CACHE_DEFAULT_PATH, ETAG_CACHE_TTL_DAYS
+
+_DISABLED_ENV = 'GITTENSOR_ETAG_CACHE_DISABLED'
+_PATH_ENV = 'GITTENSOR_ETAG_CACHE_PATH'
+
+
+class CacheEntry(NamedTuple):
+    etag: str
+    body: bytes
+    content_type: Optional[str]
+
+
+_counter_lock = threading.Lock()
+_hits = 0
+_misses = 0
+
+
+def record_hit() -> None:
+    global _hits
+    with _counter_lock:
+        _hits += 1
+
+
+def record_miss() -> None:
+    global _misses
+    with _counter_lock:
+        _misses += 1
+
+
+def snapshot_and_reset() -> Tuple[int, int]:
+    """Return (hits, misses) since the last call and reset both counters."""
+    global _hits, _misses
+    with _counter_lock:
+        h, m = _hits, _misses
+        _hits = 0
+        _misses = 0
+    return h, m
+
+
+def _is_disabled() -> bool:
+    return os.environ.get(_DISABLED_ENV) == '1'
+
+
+def _resolved_root() -> Path:
+    raw = os.environ.get(_PATH_ENV) or ETAG_CACHE_DEFAULT_PATH
+    return Path(os.path.expanduser(raw))
+
+
+def build_request_key(url: str, params: Optional[dict] = None) -> str:
+    """Canonical cache key. PAT excluded so cross-PAT reuse works on public data."""
+    query = urlencode(sorted((params or {}).items()), doseq=True)
+    return f'GET {url}?{query}' if query else f'GET {url}'
+
+
+class GithubEtagCache:
+    """diskcache-backed (etag, body, content_type) store keyed by request URL."""
+
+    def __init__(self, root: Optional[Path] = None, ttl_days: Optional[int] = None) -> None:
+        if _is_disabled():
+            self._cache = None
+            self._ttl_seconds = 0
+            return
+        path = root if root is not None else _resolved_root()
+        self._cache = diskcache.Cache(str(path))
+        self._ttl_seconds = (ttl_days if ttl_days is not None else ETAG_CACHE_TTL_DAYS) * 86400
+
+    def lookup(self, cache_key: str) -> Optional[CacheEntry]:
+        if self._cache is None:
+            return None
+        return cast(Optional[CacheEntry], self._cache.get(cache_key))
+
+    def store(self, cache_key: str, etag: str, body: bytes, content_type: Optional[str]) -> None:
+        if self._cache is None or not etag:
+            return
+        self._cache.set(cache_key, CacheEntry(etag, body, content_type), expire=self._ttl_seconds)
+
+    def prune_expired(self) -> int:
+        """Proactively delete expired entries; lookups also self-clean. Returns count removed."""
+        if self._cache is None:
+            return 0
+        return self._cache.expire()
+
+    def close(self) -> None:
+        if self._cache is not None:
+            self._cache.close()
+
+
+_default_cache: Optional[GithubEtagCache] = None
+
+
+def get_default_cache() -> GithubEtagCache:
+    """Return the process-wide singleton cache, constructing it on first call."""
+    global _default_cache
+    if _default_cache is None:
+        _default_cache = GithubEtagCache()
+    return _default_cache
+
+
+def reset_default_cache_for_tests() -> None:
+    """Drop the singleton so the next get_default_cache() re-reads env vars."""
+    global _default_cache
+    if _default_cache is not None:
+        _default_cache.close()
+    _default_cache = None

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -16,6 +16,7 @@ from gittensor.constants import (
     RECYCLE_EMISSION_SHARE,
     RECYCLE_UID,
 )
+from gittensor.utils.github_etag_cache import snapshot_and_reset as snapshot_etag_cache
 from gittensor.utils.uids import get_all_uids
 from gittensor.validator.issue_competitions.forward import issue_competitions
 from gittensor.validator.issue_discovery.mirror_scan import run_mirror_issue_discovery
@@ -81,6 +82,11 @@ async def forward(self: 'Validator') -> None:
         rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
 
         self.update_scores(rewards, miner_uids)
+
+        hits, misses = snapshot_etag_cache()
+        total = hits + misses
+        if total:
+            bt.logging.info(f'etag cache: hits={hits} misses={misses} hit_rate={hits / total:.1%}')
 
     await asyncio.sleep(VALIDATOR_WAIT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "bittensor-commit-reveal==0.4.0",
     "bittensor-wallet==4.0.0",
     "click",
+    "diskcache==5.6.3",
     "levenshtein==0.27.3",
     "psycopg2-binary==2.9.10",
     "python-dotenv==1.2.1",

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -5,3 +5,19 @@
 """
 Pytest configuration for utils tests.
 """
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_github_etag_cache(tmp_path, monkeypatch):
+    """Point the ETag cache at a per-test tmp path so tests never touch ~/.gittensor."""
+    monkeypatch.setenv('GITTENSOR_ETAG_CACHE_PATH', str(tmp_path / 'etag'))
+    monkeypatch.delenv('GITTENSOR_ETAG_CACHE_DISABLED', raising=False)
+
+    github_etag_cache = pytest.importorskip('gittensor.utils.github_etag_cache')
+    github_etag_cache.reset_default_cache_for_tests()
+    github_etag_cache.snapshot_and_reset()
+    yield
+    github_etag_cache.reset_default_cache_for_tests()
+    github_etag_cache.snapshot_and_reset()

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1583,5 +1583,149 @@ class TestFetchFileContentsForPrMergeBase:
         assert call_args[0][2] == 'base_branch_tip_sha', 'Should fall back to base_ref_oid'
 
 
+# ============================================================================
+# cached_github_get / ETag cache integration
+# ============================================================================
+
+
+class TestCachedGithubGet:
+    """Covers the cache-aware GET wrapper in github_api_tools.cached_github_get."""
+
+    def _resp(self, status_code=200, body=b'{"ok":true}', etag=None, content_type='application/json'):
+        headers = {}
+        if etag is not None:
+            headers['ETag'] = etag
+        if content_type is not None:
+            headers['Content-Type'] = content_type
+        r = Mock()
+        r.status_code = status_code
+        r.headers = headers
+        r.content = body
+        r.url = 'https://api.github.com/x'
+        r.json.return_value = {'ok': True} if body == b'{"ok":true}' else {}
+        return r
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    def test_first_call_stores_etag_no_conditional_header_sent(self, mock_get):
+        mock_get.return_value = self._resp(200, etag='W/"v1"')
+        resp = github_api_tools.cached_github_get(
+            'https://api.github.com/x', {'Authorization': 'token x'}, params={'a': 1}, timeout=5
+        )
+
+        assert resp.status_code == 200
+        mock_get.assert_called_once()
+        sent_headers = mock_get.call_args.kwargs['headers']
+        assert 'If-None-Match' not in sent_headers
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    def test_second_call_sends_if_none_match_and_serves_cached_body_on_304(self, mock_get):
+        first = self._resp(200, body=b'{"v":1}', etag='W/"v1"')
+        not_modified = Mock(status_code=304, headers={}, url='https://api.github.com/x')
+        mock_get.side_effect = [first, not_modified]
+
+        github_api_tools.cached_github_get('https://api.github.com/x', {}, params={'a': 1})
+        resp2 = github_api_tools.cached_github_get('https://api.github.com/x', {}, params={'a': 1})
+
+        assert mock_get.call_count == 2
+        second_headers = mock_get.call_args_list[1].kwargs['headers']
+        assert second_headers.get('If-None-Match') == 'W/"v1"'
+
+        assert resp2.status_code == 200
+        assert resp2.content == b'{"v":1}'
+        assert resp2.headers.get('X-Gittensor-Cache') == 'hit'
+        assert resp2.json() == {'v': 1}
+
+        from gittensor.utils.github_etag_cache import snapshot_and_reset
+
+        hits, misses = snapshot_and_reset()
+        assert hits == 1 and misses == 1
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    def test_200_without_etag_is_not_cached(self, mock_get):
+        mock_get.side_effect = [self._resp(200, etag=None), self._resp(200, etag=None)]
+
+        github_api_tools.cached_github_get('https://api.github.com/x', {})
+        github_api_tools.cached_github_get('https://api.github.com/x', {})
+
+        for c in mock_get.call_args_list:
+            assert 'If-None-Match' not in c.kwargs['headers']
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    def test_500_falls_through_and_does_not_poison_cache(self, mock_get):
+        server_error = Mock(status_code=500, headers={}, url='https://api.github.com/x', content=b'boom')
+        server_error.json.side_effect = ValueError
+        mock_get.side_effect = [server_error, self._resp(200, etag='W/"v1"')]
+
+        resp = github_api_tools.cached_github_get('https://api.github.com/x', {})
+        assert resp.status_code == 500
+
+        github_api_tools.cached_github_get('https://api.github.com/x', {})
+        for c in mock_get.call_args_list:
+            assert 'If-None-Match' not in c.kwargs['headers']
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    def test_cached_entry_replaced_when_server_returns_200_with_new_etag(self, mock_get):
+        # Resource changed between rounds: cached W/"v1" but server now returns 200 + W/"v2".
+        # Wrapper must (a) return the fresh body unmodified, (b) not flag it as a cache hit,
+        # (c) update the stored entry so the next If-None-Match uses the new etag.
+        first = self._resp(200, body=b'{"v":1}', etag='W/"v1"')
+        changed = self._resp(200, body=b'{"v":2}', etag='W/"v2"')
+        revalidated = Mock(status_code=304, headers={}, url='https://api.github.com/x')
+        mock_get.side_effect = [first, changed, revalidated]
+
+        github_api_tools.cached_github_get('https://api.github.com/x', {})
+
+        resp_changed = github_api_tools.cached_github_get('https://api.github.com/x', {})
+        assert resp_changed.content == b'{"v":2}'
+        assert 'X-Gittensor-Cache' not in resp_changed.headers
+
+        resp_after = github_api_tools.cached_github_get('https://api.github.com/x', {})
+        assert mock_get.call_args_list[1].kwargs['headers'].get('If-None-Match') == 'W/"v1"'
+        assert mock_get.call_args_list[2].kwargs['headers'].get('If-None-Match') == 'W/"v2"'
+        assert resp_after.headers.get('X-Gittensor-Cache') == 'hit'
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    def test_caller_headers_not_mutated(self, mock_get):
+        first = self._resp(200, body=b'{}', etag='W/"v1"')
+        not_modified = Mock(status_code=304, headers={}, url='https://api.github.com/x')
+        mock_get.side_effect = [first, not_modified]
+
+        caller_headers = {'Authorization': 'token x'}
+        github_api_tools.cached_github_get('https://api.github.com/x', caller_headers)
+        github_api_tools.cached_github_get('https://api.github.com/x', caller_headers)
+
+        assert caller_headers == {'Authorization': 'token x'}
+
+
+class TestSynthesize304Response:
+    """Direct unit tests for the synthesized-from-cache Response builder."""
+
+    def test_constructs_response_with_body_and_headers(self):
+        resp = github_api_tools._synthesize_304_response('https://api.github.com/x', b'{"hi":1}', 'application/json')
+
+        assert resp.status_code == 200
+        assert resp.content == b'{"hi":1}'
+        assert resp.json() == {'hi': 1}
+        assert resp.text == '{"hi":1}'
+        assert resp.url == 'https://api.github.com/x'
+        assert resp.headers['X-Gittensor-Cache'] == 'hit'
+        assert resp.headers['Content-Type'] == 'application/json'
+
+    def test_omits_content_type_when_none(self):
+        resp = github_api_tools._synthesize_304_response('https://x', b'data', None)
+
+        assert resp.status_code == 200
+        assert resp.content == b'data'
+        assert resp.headers.get('X-Gittensor-Cache') == 'hit'
+        assert 'Content-Type' not in resp.headers
+
+    def test_headers_are_case_insensitive(self):
+        resp = github_api_tools._synthesize_304_response('https://x', b'', 'text/plain')
+
+        # Real requests.Response uses CaseInsensitiveDict; verify cached responses behave the same.
+        assert resp.headers['x-gittensor-cache'] == 'hit'
+        assert resp.headers['CONTENT-TYPE'] == 'text/plain'
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/utils/test_github_etag_cache.py
+++ b/tests/utils/test_github_etag_cache.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Unit tests for the on-disk GitHub ETag cache."""
+
+import time
+
+import pytest
+
+github_etag_cache = pytest.importorskip(
+    'gittensor.utils.github_etag_cache', reason='Requires gittensor package with all dependencies'
+)
+
+GithubEtagCache = github_etag_cache.GithubEtagCache
+build_request_key = github_etag_cache.build_request_key
+snapshot_and_reset = github_etag_cache.snapshot_and_reset
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    snapshot_and_reset()
+    yield
+    snapshot_and_reset()
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch):
+    monkeypatch.delenv('GITTENSOR_ETAG_CACHE_DISABLED', raising=False)
+    c = GithubEtagCache(root=tmp_path / 'etag', ttl_days=30)
+    yield c
+    c.close()
+
+
+class TestBuildRequestKey:
+    def test_sorts_params_for_stable_key(self):
+        k1 = build_request_key('https://api.github.com/x', {'b': 1, 'a': 2})
+        k2 = build_request_key('https://api.github.com/x', {'a': 2, 'b': 1})
+        assert k1 == k2
+
+    def test_no_params_omits_query(self):
+        assert build_request_key('https://api.github.com/x') == 'GET https://api.github.com/x'
+
+
+class TestStoreAndLookup:
+    def test_round_trip_with_non_ascii(self, cache):
+        body = b'\xc3\xa9\x00\xff binary content'
+        cache.store('GET https://api.github.com/x', 'W/"abc"', body, 'application/json')
+
+        result = cache.lookup('GET https://api.github.com/x')
+        assert result is not None
+        assert result.etag == 'W/"abc"'
+        assert result.body == body
+        assert result.content_type == 'application/json'
+
+    def test_miss_returns_none(self, cache):
+        assert cache.lookup('GET https://api.github.com/missing') is None
+
+    def test_empty_etag_is_not_stored(self, cache):
+        cache.store('GET https://api.github.com/x', '', b'body', 'text/plain')
+        assert cache.lookup('GET https://api.github.com/x') is None
+
+    def test_overwrite_replaces_entry(self, cache):
+        key = 'GET https://api.github.com/x'
+        cache.store(key, 'v1', b'one', 'text/plain')
+        cache.store(key, 'v2', b'two', 'text/plain')
+
+        result = cache.lookup(key)
+        assert result is not None
+        assert result.etag == 'v2' and result.body == b'two'
+
+
+class TestTtl:
+    def test_expired_entry_returns_none(self, tmp_path):
+        # ttl_days=0 yields 0-second expiry → next lookup sees expired entry.
+        cache = GithubEtagCache(root=tmp_path / 'etag', ttl_days=0)
+        cache.store('GET https://x/k', 'e', b'body', 'text/plain')
+        time.sleep(0.01)
+        assert cache.lookup('GET https://x/k') is None
+        cache.close()
+
+    def test_prune_expired_drops_entries(self, tmp_path):
+        cache = GithubEtagCache(root=tmp_path / 'etag', ttl_days=0)
+        cache.store('GET https://x/a', 'a', b'one', 'text/plain')
+        cache.store('GET https://x/b', 'b', b'two', 'text/plain')
+        time.sleep(0.01)
+
+        cache.prune_expired()
+        assert cache.lookup('GET https://x/a') is None
+        assert cache.lookup('GET https://x/b') is None
+        cache.close()
+
+
+class TestDisabled:
+    def test_disabled_store_and_lookup_are_noops(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('GITTENSOR_ETAG_CACHE_DISABLED', '1')
+        cache = GithubEtagCache(root=tmp_path / 'etag', ttl_days=30)
+
+        cache.store('GET https://x/y', 'e', b'body', 'text/plain')
+        assert cache.lookup('GET https://x/y') is None
+        cache.close()
+
+    def test_disabled_skips_disk_allocation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('GITTENSOR_ETAG_CACHE_DISABLED', '1')
+        root = tmp_path / 'etag'
+
+        cache = GithubEtagCache(root=root, ttl_days=30)
+        cache.store('GET https://x', 'e', b'body', 'text/plain')
+        cache.prune_expired()
+        cache.close()
+
+        assert not root.exists()
+
+
+class TestCounters:
+    def test_record_hit_and_miss(self):
+        github_etag_cache.record_hit()
+        github_etag_cache.record_hit()
+        github_etag_cache.record_miss()
+        assert snapshot_and_reset() == (2, 1)
+
+    def test_snapshot_resets_counters(self):
+        github_etag_cache.record_hit()
+        github_etag_cache.record_miss()
+        snapshot_and_reset()
+        assert snapshot_and_reset() == (0, 0)

--- a/uv.lock
+++ b/uv.lock
@@ -668,6 +668,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -884,6 +893,7 @@ dependencies = [
     { name = "bittensor-commit-reveal" },
     { name = "bittensor-wallet" },
     { name = "click" },
+    { name = "diskcache" },
     { name = "levenshtein" },
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
@@ -916,6 +926,7 @@ requires-dist = [
     { name = "bittensor-wallet", specifier = "==4.0.0" },
     { name = "click" },
     { name = "debugpy", marker = "extra == 'debug'", specifier = "==1.8.11" },
+    { name = "diskcache", specifier = "==5.6.3" },
     { name = "fastapi", marker = "extra == 'debug'", specifier = "==0.110.1" },
     { name = "levenshtein", specifier = "==0.27.3" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },


### PR DESCRIPTION
Closes #833

## Summary

Add an on-disk ETag cache for GitHub REST GETs so repeat round-to-round calls return `304 Not Modified` (which [does not consume primary rate quota](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate)). Wraps four hot-path REST functions and emits per-round hit/miss telemetry from the validator forward loop.

Cache is implemented using [Apache DiskCache](https://github.com/grantjenks/python-diskcache) library

## Before / After

**Before**: every REST call from `oss_contributions/scoring.py` and `issue_competitions/forward.py` consumes rate-limit quota even if the underlying resource has not changed since the last round.

**After**: first call stores the ETag in `~/.gittensor/cache/github_etag/`; subsequent calls send `If-None-Match`, GitHub returns 304, and the cached body is replayed via a synthesized `requests.Response` (with `X-Gittensor-Cache: hit`). Each scoring round logs `etag cache: hits=X misses=Y hit_rate=Z%` so the savings are observable.

## Tests

- `tests/utils/test_github_etag_cache.py` covers store/lookup/TTL/disabled-mode/counters
- `TestCachedGithubGet` in `tests/utils/test_github_api_tools.py` covers 200+ETag store, 304 hit, no-ETag no-cache, 5xx falls through
- `tests/utils/conftest.py` autouse fixture isolates the cache to `tmp_path`.

## Design notes

- Always-revalidate behavior: every call sends `If-None-Match` if there is a stored ETag; 304 → return cached body, 200 → refresh. The cache only converts 200s into 304s and never serves stale data.
- Disabling: `GITTENSOR_ETAG_CACHE_DISABLED=1` short-circuits to no-op (the SQLite DB is never opened). Used for debugging and scoring-parity verification. `GITTENSOR_ETAG_CACHE_PATH` overrides the default location.
- Storage: a single `diskcache.Cache` directory at `~/.gittensor/cache/github_etag/` (SQLite + WAL). For a hard reset: `rm -rf ~/.gittensor/cache/github_etag/`.
