### PR TITLE
fix: exclude self-filed-and-self-solved issues from mirror valid-solved gate

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -285,12 +285,19 @@ def _score_miner_mirror_issues(
             )
             continue
 
+        is_self_solved = issue.author_github_id == solving_pr.author_github_id
+
         # Valid-solved gate (legacy parity): solving PR must meet the token threshold.
-        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        # Self-issues are excluded — the gate exists to verify the miner did real
+        # cross-account discovery work, and a self-filed-and-self-solved issue is
+        # not evidence of that. Without this exclusion, a miner with 6 real
+        # cross-account discoveries plus a single self-filed-and-self-solved issue
+        # would clear MIN_VALID_SOLVED_ISSUES (= 7) on padding rather than work.
+        if not is_self_solved and cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
             valid_solved_count += 1
 
         # Same-account: discoverer == solver gets credibility only, no score
-        if issue.author_github_id == solving_pr.author_github_id:
+        if is_self_solved:
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): same-account '
                 f'(discoverer == solver {issue.author_github_id}) — credibility only'

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -288,8 +288,53 @@ class TestRunMirrorIssueDiscovery:
             )
         )
         assert eval_.total_solved_issues == 1  # credibility counts
-        # But no discovery_earned_score because self-solve
+        # Self-issues must NOT count as "valid solved" — the gate measures
+        # cross-account discovery work, not self-engagement.
+        assert eval_.total_valid_solved_issues == 0
+        # And no discovery_earned_score because self-solve
         assert eval_.issue_discovery_score == 0
+
+    def test_self_issues_do_not_pad_valid_solved_gate(self):
+        """Anti-gaming: self-filed-and-self-solved issues must not push a miner
+        past MIN_VALID_SOLVED_ISSUES. With six legitimate cross-account valid
+        solves plus one self-issue solve, the gate should still fail because
+        only the six cross-account solves count toward the threshold."""
+        cross_issues = [
+            _issue_dict(
+                issue_number=10 + i,
+                author_github_id=f'OTHER{i}',
+                solving_pr_author='SELF',
+                solved_by_pr=200 + i,
+            )
+            for i in range(6)
+        ]
+        self_issue = _issue_dict(
+            issue_number=99,
+            author_github_id='SELF',
+            solving_pr_author='SELF',
+            solved_by_pr=300,
+        )
+        client = Mock()
+        client.get_miner_issues.return_value = _response(cross_issues + [self_issue])
+
+        eval_ = _eval(github_id='SELF')
+        # Pre-seed all seven solving PRs into the cache with token_score above the threshold.
+        eval_.mirror_merged_prs = [
+            _scored_mirror_pr('entrius/gittensor-ui', 200 + i, token_score=100.0) for i in range(6)
+        ] + [_scored_mirror_pr('entrius/gittensor-ui', 300, token_score=100.0)]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+        assert eval_.total_solved_issues == 7  # credibility counts both cross- and self-solves
+        assert eval_.total_valid_solved_issues == 6  # only cross-account solves count
+        assert eval_.is_issue_eligible is False  # 6 < MIN_VALID_SOLVED_ISSUES=7
 
     def test_not_planned_bumps_closed_count(self):
         client = Mock()


### PR DESCRIPTION
```
## Summary

The mirror issue-discovery path increments `valid_solved_count` before the
same-account (self-issue) check in `_score_miner_mirror_issues`
(`gittensor/validator/issue_discovery/mirror_scan.py:266-298`). A miner
who files an issue from their own GitHub account and solves it with a
PR from the same account currently has that solve count toward the
`MIN_VALID_SOLVED_ISSUES = 7` eligibility gate, even though the
discovery-score path correctly skips it (gives credibility only, no
score).

Result: a miner with six legitimate cross-account discoveries plus a
single self-filed-and-self-solved issue clears the gate on padding
rather than work — six real cross-account solves alone would fail it.
The seventh "solve" proves no cross-account discovery activity, which is
exactly what the gate exists to verify per the existing docstring of
`check_issue_eligibility` ("low-quality solves don't carry the miner
past the minimum").

## Fix

`mirror_scan.py:285-301`

Compute `is_self_solved` once and gate `valid_solved_count++` on it.
The same flag is reused for the existing same-account credibility-only
branch (no change to that branch's behaviour).

```python
is_self_solved = issue.author_github_id == solving_pr.author_github_id

# Self-issues are excluded from valid_solved — the gate exists to verify
# cross-account discovery work.
if not is_self_solved and cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
    valid_solved_count += 1

if is_self_solved:
    bt.logging.debug(...)
    continue
```