### PR TITLE
fix: add PR context to mirror linked-issue skip warnings

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -442,37 +442,44 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
       semantically — negative days means the issue closed before the PR merged,
       which means the PR wasn't the solver).
     """
+    # PR-side context appended to every skip warning so a single skipped issue
+    # in a noisy multi-miner round can be traced back to its PR without
+    # cross-referencing the surrounding _calculate_issue_multiplier log line.
+    pr_ctx = f'PR #{pr.pr_number} in {pr.repo_full_name}'
+
     if li.is_transferred:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - transferred')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - transferred')
         return False
 
     if li.author_github_id is None:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - missing author_github_id')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - missing author_github_id')
         return False
 
     if li.author_github_id == pr.author_github_id:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - same author as PR (self-issue)')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - same author as PR (self-issue)')
         return False
 
     if li.created_at and li.created_at > pr.created_at:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - created after PR')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - created after PR')
         return False
 
     # Legacy parity: state_reason check applies regardless of PR state. Legacy's
     # _is_completed_when_closed returns True for OPEN issues, False for CLOSED
     # issues with non-COMPLETED state_reason. Applies to OPEN-PR collateral too.
     if li.state == 'CLOSED' and li.state_reason != 'COMPLETED':
-        bt.logging.warning(f'Skipping linked issue #{li.number} - state_reason={li.state_reason} (need COMPLETED)')
+        bt.logging.warning(
+            f'Skipping linked issue #{li.number} ({pr_ctx}) - state_reason={li.state_reason} (need COMPLETED)'
+        )
         return False
 
     is_merged = pr.state == 'MERGED'
     if is_merged and pr.merged_at:
         if pr.edited_after_merge:
-            bt.logging.warning(f'Skipping linked issue #{li.number} - PR edited after merge')
+            bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - PR edited after merge')
             return False
 
         if li.state != 'CLOSED':
-            bt.logging.warning(f'Skipping linked issue #{li.number} - state {li.state} (need CLOSED)')
+            bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - state {li.state} (need CLOSED)')
             return False
 
         if li.closed_at:
@@ -482,7 +489,7 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
             days_diff = (li.closed_at - pr.merged_at).total_seconds() / SECONDS_PER_DAY
             if days_diff > MAX_ISSUE_CLOSE_WINDOW_DAYS or days_diff < 0:
                 bt.logging.warning(
-                    f'Skipping linked issue #{li.number} - closed {days_diff:+.2f}d from merge '
+                    f'Skipping linked issue #{li.number} ({pr_ctx}) - closed {days_diff:+.2f}d from merge '
                     f'(max {MAX_ISSUE_CLOSE_WINDOW_DAYS})'
                 )
                 return False

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -16,7 +16,7 @@ Token-scoring base_score is exercised indirectly via the existing legacy tests
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -597,6 +597,41 @@ class TestLinkedIssueValidity:
         scored = ScoredMirrorPR(pr=_pr(state='OPEN'))
         li = MirrorLinkedIssue.from_dict(_linked_issue(state='OPEN', state_reason=None, closed_at=None))
         assert _is_valid_linked_issue(li, scored.pr) is True
+
+
+class TestLinkedIssueSkipWarningsCarryPRContext:
+    """Each skip warning in `_is_valid_linked_issue` must include the PR number
+    and repo so a single skipped issue in a noisy multi-miner round can be
+    traced without cross-referencing the surrounding multiplier log line.
+    Mirrors the observability pattern from PR #711 (file-content fetch warning)."""
+
+    def _assert_warning_has_pr_context(self, mock_logging, pr):
+        warning_calls = [c for c in mock_logging.warning.call_args_list]
+        assert warning_calls, 'expected at least one warning'
+        msg = warning_calls[-1].args[0]
+        assert f'PR #{pr.pr_number}' in msg, msg
+        assert pr.repo_full_name in msg, msg
+
+    @patch('gittensor.validator.oss_contributions.mirror.scoring.bt.logging')
+    def test_transferred_warning_includes_pr_context(self, mock_logging):
+        scored = ScoredMirrorPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(is_transferred=True))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+        self._assert_warning_has_pr_context(mock_logging, scored.pr)
+
+    @patch('gittensor.validator.oss_contributions.mirror.scoring.bt.logging')
+    def test_self_authored_warning_includes_pr_context(self, mock_logging):
+        scored = ScoredMirrorPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(author_github_id='218712309'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+        self._assert_warning_has_pr_context(mock_logging, scored.pr)
+
+    @patch('gittensor.validator.oss_contributions.mirror.scoring.bt.logging')
+    def test_close_window_warning_includes_pr_context(self, mock_logging):
+        scored = ScoredMirrorPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(closed_at='2026-04-12T00:00:00Z'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+        self._assert_warning_has_pr_context(mock_logging, scored.pr)
 
 
 class TestIssueMultiplierPreference:


### PR DESCRIPTION
```
## Summary

The eight `bt.logging.warning` calls in `_is_valid_linked_issue`
(`gittensor/validator/oss_contributions/mirror/scoring.py:445-488`)
log only the issue number when the issue is skipped from the
multiplier calculation. In a noisy multi-miner round dozens of
issues from unrelated PRs may all skip on the same condition (e.g.
`self-issue` or `closed too far from merge`), making it impossible
to trace a single skip back to its PR without grepping the
surrounding `_calculate_issue_multiplier` log line and reconstructing
the order.

## Fix

Same observability shape as the recently merged PR #711
("fix: add PR number context to file-content fetch failure
warning"): extend each warning with `PR #{pr_number} in
{repo_full_name}` context derived once at function entry as
`pr_ctx`. No behaviour change — the gate decisions and return values
are identical, only the log surface gains the context.

```python
pr_ctx = f'PR #{pr.pr_number} in {pr.repo_full_name}'

if li.is_transferred:
    bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - transferred')
    return False
# ...same pattern for the other seven skip warnings
```