### PR TITLE
fix: classify Android androidTest and JS e2e paths as test files

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -80,6 +80,9 @@ class FileChange:
         test_dir_patterns = [
             r'(^|/)tests?/',
             r'(^|/)__tests?__/',
+            r'(^|/)androidtest[a-z]*/',
+            r'(^|/)integrationtest/',
+            r'(^|/)e2e/',
         ]
         if any(re.search(pattern, filename_lower) for pattern in test_dir_patterns):
             return True
@@ -92,6 +95,8 @@ class FileChange:
             r'\.test\.[^.]+$',
             r'\.tests\.[^.]+$',
             r'\.spec\.[^.]+$',
+            r'\.e2e-spec\.[^.]+$',
+            r'\.e2e-test\.[^.]+$',
             r'^test\.[^.]+$',
             r'^tests\.[^.]+$',
         ]

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,4 +1,77 @@
-from gittensor.classes import PullRequest
+import pytest
+
+from gittensor.classes import FileChange, PullRequest
+
+
+def _file(filename: str) -> FileChange:
+    return FileChange(
+        pr_number=0,
+        repository_full_name='owner/repo',
+        filename=filename,
+        changes=1,
+        additions=1,
+        deletions=0,
+        status='added',
+    )
+
+
+class TestIsTestFile:
+    @pytest.mark.parametrize(
+        'path',
+        [
+            # Existing directory patterns (regression coverage)
+            'tests/test_foo.py',
+            'test/foo.py',
+            '__tests__/x.tsx',
+            'src/__test__/y.ts',
+            # Existing filename patterns (regression coverage)
+            'pkg/test_module.py',
+            'pkg/spec_module.rb',
+            'internal/foo_test.go',
+            'internal/foo_tests.go',
+            'src/foo.test.ts',
+            'src/foo.tests.ts',
+            'src/foo.spec.ts',
+            'src/test.py',
+            'src/tests.py',
+            # Android Gradle source sets (closes #765)
+            'app/src/androidTest/java/com/owncloud/android/UploadIT.java',
+            'app/src/androidTestGeneric/java/com/example/Foo.kt',
+            'app/src/androidTestGplay/java/com/example/Bar.kt',
+            'app/src/integrationTest/java/com/example/Baz.java',
+            # JavaScript / TypeScript e2e conventions
+            'e2e/src/api/specs/duplicate.e2e-spec.ts',
+            'e2e/src/utils.ts',
+            'cypress/e2e/login.cy.ts',
+            'apps/web/e2e/checkout.spec.ts',
+            'src/foo.e2e-spec.ts',
+            'src/foo.e2e-test.ts',
+        ],
+    )
+    def test_classified_as_test(self, path: str) -> None:
+        assert _file(path).is_test_file() is True
+
+    @pytest.mark.parametrize(
+        'path',
+        [
+            # Production sources that must NOT be classified as tests
+            'src/main.py',
+            'app/src/main/java/com/example/MainActivity.java',
+            'lib/server.go',
+            'src/index.ts',
+            # Guard against the IT-suffix false-positive trap (Edit, Audit, Commit etc.)
+            # described in #765. A naive r'it\.(java|kt)$' would match these.
+            'src/Edit.java',
+            'src/Audit.java',
+            'lib/Commit.kt',
+            'lib/Permit.java',
+            'lib/Submit.kt',
+            'lib/Init.kt',
+            'lib/Visit.kt',
+        ],
+    )
+    def test_classified_as_production(self, path: str) -> None:
+        assert _file(path).is_test_file() is False
 
 
 def test_pull_request_handles_deleted_label_event():


### PR DESCRIPTION
## Summary
- Adds five directory patterns and two filename patterns to `FileChange.is_test_file()` so Android Gradle source sets (`androidTest/`, `androidTestGeneric/`, `integrationTest/`) and JS/TS e2e conventions (`e2e/` directory, `*.e2e-spec.*` / `*.e2e-test.*`) are classified as tests instead of production code.
- Real impact in two whitelisted repos:
  - `nextcloud/android` (repo weight 0.0778) — `app/src/androidTest/java/com/owncloud/android/UploadIT.java` and ~15 sibling `*IT.{java,kt}` files.
  - `immich-app/immich` (repo weight 0.0587) — `e2e/src/api/specs/*.e2e-spec.ts` and the rest of the `e2e/` tree.
  - Each token in those files is currently scored at `lang_weight × 1.0` instead of `lang_weight × TEST_FILE_CONTRIBUTION_WEIGHT (0.05)` — a 20× over-score per token.
- Adds the first unit-test coverage for `is_test_file`, including regression cases for the existing patterns and explicit negatives that guard against the `IT`-suffix false-positive trap noted in #765 (`Edit.java`, `Audit.java`, `Commit.kt`, etc.).
- Same shape as the merged precedent #311 → #314 (Rust / Zig / D inline-test detection).

## Related Issues
Closes #765.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [x] Tests added/updated
- [x] Manually tested

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)