### PR TITLE
fix(cli): exit non-zero when miner post / miner check report success: false

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -134,3 +134,9 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
 
         console.print(table)
         console.print(f'\n[bold]{valid_count}/{len(results)} validators have a valid PAT stored.[/bold]')
+
+    # Exit non-zero when no validator reports a valid stored PAT so shell
+    # pipelines / CI can detect the logical failure (matches the JSON `success`
+    # field and the family fixed in #707 / #724).
+    if valid_count == 0:
+        sys.exit(1)

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -167,6 +167,12 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
         console.print(table)
         console.print(f'\n[bold]{accepted_count}/{len(results)} validators accepted your PAT.[/bold]')
 
+    # Exit non-zero when the broadcast was rejected by every validator so shell
+    # pipelines / CI can detect the logical failure (matches the JSON `success`
+    # field and the family fixed in #707 / #724).
+    if accepted_count == 0:
+        sys.exit(1)
+
 
 def _validate_pat_locally(pat: str) -> bool:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -3,7 +3,7 @@
 """Tests for gitt miner post and gitt miner check CLI commands."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -11,6 +11,23 @@ from click.testing import CliRunner
 from gittensor import __version__
 from gittensor.cli.main import cli
 from gittensor.cli.miner_commands.helpers import _pat_check_aggregate_counts
+
+
+def _fake_axon(hotkey: str = 'hk' * 16) -> MagicMock:
+    """Build a minimal validator axon stand-in for `--json-output` tests."""
+    axon = MagicMock()
+    axon.hotkey = hotkey
+    return axon
+
+
+def _fake_response(**fields) -> MagicMock:
+    """Build a minimal Synapse response stand-in for `--json-output` tests."""
+    resp = MagicMock()
+    for name, value in fields.items():
+        setattr(resp, name, value)
+    resp.dendrite = MagicMock()
+    resp.dendrite.status_code = 200
+    return resp
 
 
 @pytest.fixture
@@ -76,6 +93,152 @@ class TestCliVersion:
         result = runner.invoke(cli, ['--version'])
         assert result.exit_code == 0
         assert result.output == f'gittensor, version {__version__}\n'
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning:_pytest")
+class TestMinerPostExitCodeOnZeroAccepted:
+    """Regression tests for #841: `gitt miner post` must exit non-zero when no validator accepts.
+
+    Suppresses the harmless "coroutine never awaited" RuntimeWarning that fires
+    because we patch asyncio.run, so the inner _broadcast coroutine object never
+    gets awaited — irrelevant to the exit-code contract under test.
+    """
+
+    @patch('asyncio.run')
+    @patch('gittensor.cli.miner_commands.post._require_validator_axons')
+    @patch('gittensor.cli.miner_commands.post._require_registered')
+    @patch('gittensor.cli.miner_commands.post._connect_bittensor')
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=True)
+    def test_post_exits_non_zero_when_all_validators_reject(
+        self,
+        _validate,
+        connect,
+        _require_reg,
+        require_axons,
+        async_run,
+        runner,
+        monkeypatch,
+    ):
+        monkeypatch.setenv('GITTENSOR_MINER_PAT', 'ghp_fake')
+        connect.return_value = (MagicMock(), MagicMock(), MagicMock(), MagicMock())
+        require_axons.return_value = ([_fake_axon('hk1' * 16), _fake_axon('hk2' * 16)], [1, 2])
+        async_run.return_value = [
+            _fake_response(accepted=False, rejection_reason='Account too young'),
+            _fake_response(accepted=False, rejection_reason='Org-restricted PAT'),
+        ]
+
+        result = runner.invoke(
+            cli,
+            ['miner', 'post', '--json-output', '--wallet', 'test', '--hotkey', 'test'],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload['success'] is False
+        assert payload['accepted'] == 0
+        assert payload['rejected'] == 2
+
+    @patch('asyncio.run')
+    @patch('gittensor.cli.miner_commands.post._require_validator_axons')
+    @patch('gittensor.cli.miner_commands.post._require_registered')
+    @patch('gittensor.cli.miner_commands.post._connect_bittensor')
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=True)
+    def test_post_exits_zero_when_at_least_one_validator_accepts(
+        self,
+        _validate,
+        connect,
+        _require_reg,
+        require_axons,
+        async_run,
+        runner,
+        monkeypatch,
+    ):
+        monkeypatch.setenv('GITTENSOR_MINER_PAT', 'ghp_fake')
+        connect.return_value = (MagicMock(), MagicMock(), MagicMock(), MagicMock())
+        require_axons.return_value = ([_fake_axon('hk1' * 16), _fake_axon('hk2' * 16)], [1, 2])
+        async_run.return_value = [
+            _fake_response(accepted=True, rejection_reason=None),
+            _fake_response(accepted=False, rejection_reason='Org-restricted PAT'),
+        ]
+
+        result = runner.invoke(
+            cli,
+            ['miner', 'post', '--json-output', '--wallet', 'test', '--hotkey', 'test'],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload['success'] is True
+        assert payload['accepted'] == 1
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning:_pytest")
+class TestMinerCheckExitCodeOnZeroValid:
+    """Regression tests for #842: `gitt miner check` must exit non-zero when no validator has a valid PAT.
+
+    Same RuntimeWarning suppression rationale as TestMinerPostExitCodeOnZeroAccepted.
+    """
+
+    @patch('asyncio.run')
+    @patch('gittensor.cli.miner_commands.check._require_validator_axons')
+    @patch('gittensor.cli.miner_commands.check._require_registered')
+    @patch('gittensor.cli.miner_commands.check._connect_bittensor')
+    def test_check_exits_non_zero_when_no_validator_has_valid_pat(
+        self,
+        connect,
+        _require_reg,
+        require_axons,
+        async_run,
+        runner,
+    ):
+        connect.return_value = (MagicMock(), MagicMock(), MagicMock(), MagicMock())
+        require_axons.return_value = ([_fake_axon('hk1' * 16), _fake_axon('hk2' * 16)], [1, 2])
+        async_run.return_value = [
+            _fake_response(has_pat=False, pat_valid=False, rejection_reason=None),
+            _fake_response(has_pat=None, pat_valid=None, rejection_reason=None),
+        ]
+
+        result = runner.invoke(
+            cli,
+            ['miner', 'check', '--json-output', '--wallet', 'test', '--hotkey', 'test'],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload['success'] is False
+        assert payload['valid'] == 0
+
+    @patch('asyncio.run')
+    @patch('gittensor.cli.miner_commands.check._require_validator_axons')
+    @patch('gittensor.cli.miner_commands.check._require_registered')
+    @patch('gittensor.cli.miner_commands.check._connect_bittensor')
+    def test_check_exits_zero_when_at_least_one_validator_has_valid_pat(
+        self,
+        connect,
+        _require_reg,
+        require_axons,
+        async_run,
+        runner,
+    ):
+        connect.return_value = (MagicMock(), MagicMock(), MagicMock(), MagicMock())
+        require_axons.return_value = ([_fake_axon('hk1' * 16)], [1])
+        async_run.return_value = [
+            _fake_response(has_pat=True, pat_valid=True, rejection_reason=None),
+        ]
+
+        result = runner.invoke(
+            cli,
+            ['miner', 'check', '--json-output', '--wallet', 'test', '--hotkey', 'test'],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload['success'] is True
+        assert payload['valid'] == 1
 
 
 class TestPatCheckAggregateCounts:


### PR DESCRIPTION
## Summary

\`gitt miner post\` and \`gitt miner check\` already encode their logical outcome in the JSON \`success\` field (\`accepted_count > 0\` / \`valid_count > 0\`), but the process exit code stayed \`0\` even when every validator rejected the broadcast or no validator had a valid stored PAT. Shell pipelines and CI steps that ran \`gitt miner post && next-step\` or used the exit code as a health-check signal silently treated total failure as success.

After this change both commands \`sys.exit(1)\` when their respective count is zero — matching the JSON \`success\` field and the family already fixed for \`gitt admin\` / \`gitt vote\` / \`gitt harvest\` in #707 and \`gitt issues list --id\` / miner-check JSON aggregate counts in #724.

The fix is minimal: 6 lines in [post.py](gittensor/cli/miner_commands/post.py) and 6 lines in [check.py](gittensor/cli/miner_commands/check.py), each guarded so the success exit code stays \`0\`.

## Related Issues

Closes #841 (\`gitt miner post\`)
Closes #842 (\`gitt miner check\`)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- New \`TestMinerPostExitCodeOnZeroAccepted\` — 2 cases (zero-accepted exits 1, at-least-one-accepted exits 0).
- New \`TestMinerCheckExitCodeOnZeroValid\` — 2 cases (zero-valid exits 1, at-least-one-valid exits 0).
- The harmless \"coroutine never awaited\" RuntimeWarning that fires because we patch \`asyncio.run\` is filtered at class scope.
- \`uv run --extra dev pytest tests/\` — 647 tests pass (643 baseline + 4 new).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)