### PR TITLE
fix(cli): admin payout-issue reports success even when payout_bounty loses the amount

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -158,8 +158,15 @@ def admin_payout(
         with console.status('[bold cyan]Submitting payout...', spinner='dots'):
             result = client.payout_bounty(issue_id, wallet)
 
-        if result:
-            print_success(f'Payout successful! Amount: {format_alpha(result, 4)} ALPHA')
+        # `result is None` means the on-chain extrinsic failed. `result == 0`
+        # means the transaction succeeded but the contract client lost track
+        # of the payout amount (e.g. an RPC flake during the pre-payout
+        # get_issue inside payout_bounty). In that case we still report
+        # success — using the bounty we already read at line 139 — instead of
+        # mis-labelling a successful payout as a failure.
+        if result is not None:
+            paid_amount = result if result > 0 else issue.bounty_amount
+            print_success(f'Payout successful! Amount: {format_alpha(paid_amount, 4)} ALPHA')
         else:
             print_error('Payout failed.')
             raise SystemExit(1)

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -12,7 +12,7 @@ invocation with validation (no live network).
 import json
 from decimal import Decimal
 from typing import Any, Dict, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import click
 import pytest
@@ -786,6 +786,79 @@ class TestCliAdminValidation:
             )
         assert result.exit_code != 0
         assert 'between' in result.output or '1' in result.output
+
+
+class TestAdminPayoutSuccessWithUnknownAmount:
+    """Regression tests for #844: `gitt admin payout-issue` must report the
+    on-chain success even when `payout_bounty` returns 0 because its internal
+    pre-payout `get_issue` lost the bounty amount (RPC flake).
+    """
+
+    @staticmethod
+    def _patched_run(cli_root, runner, payout_return):
+        """Drive `gitt admin payout-issue 1 -y` with a stubbed contract client
+        whose `get_issue` returns a 42-ALPHA bounty and whose `payout_bounty`
+        returns ``payout_return``.
+        """
+        ALPHA_RAW_42 = 42 * 10**9
+        fake_issue = MagicMock()
+        fake_issue.repository_full_name = 'owner/repo'
+        fake_issue.issue_number = 7
+        fake_issue.status.name = 'Active'
+        fake_issue.bounty_amount = ALPHA_RAW_42
+        fake_client = MagicMock()
+        fake_client.get_issue.return_value = fake_issue
+        fake_client.payout_bounty.return_value = payout_return
+        fake_wallet = MagicMock()
+
+        with (
+            patch(
+                'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.admin._make_contract_client',
+                return_value=(fake_wallet, fake_client),
+            ),
+        ):
+            return runner.invoke(
+                cli_root,
+                ['admin', 'payout-issue', '1', '-y'],
+                catch_exceptions=False,
+            )
+
+    def test_payout_returning_zero_is_treated_as_success_with_local_amount(
+        self, cli_root, runner
+    ):
+        """`payout_bounty` returns 0 (success but unknown amount) — CLI must
+        report success and use the locally-known bounty for the message."""
+        result = self._patched_run(cli_root, runner, payout_return=0)
+
+        assert result.exit_code == 0
+        assert 'Payout successful' in result.output
+        assert '42.0000' in result.output  # bounty resolved from local issue
+
+    def test_payout_returning_none_is_treated_as_failure(self, cli_root, runner):
+        """`payout_bounty` returning None (extrinsic failed) must still exit
+        non-zero with the Payout failed message — the existing contract."""
+        result = self._patched_run(cli_root, runner, payout_return=None)
+
+        assert result.exit_code != 0
+        assert 'Payout failed' in result.output
+
+    def test_payout_returning_positive_int_uses_that_amount(self, cli_root, runner):
+        """When `payout_bounty` returns a positive amount, prefer it over the
+        locally-known bounty (forward-compatible with future re-read logic)."""
+        ALPHA_RAW_99 = 99 * 10**9
+        result = self._patched_run(cli_root, runner, payout_return=ALPHA_RAW_99)
+
+        assert result.exit_code == 0
+        assert 'Payout successful' in result.output
+        assert '99.0000' in result.output
 
 
 class TestCliVoteCancelValidation:


### PR DESCRIPTION
## Summary

Closes #844.

\`IssueCompetitionContractClient.payout_bounty\` returns three different values:

| Return | Meaning |
|---|---|
| positive int | success with known amount |
| \`0\` | success but the pre-payout \`get_issue\` couldn't reach the chain (RPC flake / dropped websocket), so the function lost track of the bounty even though the extrinsic succeeded |
| \`None\` | extrinsic failed |

\`gitt admin payout-issue\` collapsed the last two cases with \`if result:\` and printed \"Payout failed.\" — exiting non-zero — when the on-chain state had actually paid out. Operators retried the call and hit the contract's already-Completed revert, reinforcing the wrong belief.

The CLI already reads the issue once before submitting (line 139), so when \`payout_bounty\` returns \`0\` we can fall back to that locally-known bounty for the success message instead of mis-labelling the round as a failure.

After this change:
- \`if result is not None\` gates success/failure — \`0\` is correctly recognized as success.
- The success message prefers the contract client's amount when it's positive, and falls back to \`issue.bounty_amount\` when it's \`0\`.
- The contract_client API stays unchanged.

## Related Issues

Closes #844.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- New \`TestAdminPayoutSuccessWithUnknownAmount\` covers all three cases:
  - \`payout_bounty\` returns 0 → success message uses local bounty (\`42.0000 ALPHA\`)
  - \`payout_bounty\` returns None → \"Payout failed.\" + exit 1 (existing contract preserved)
  - \`payout_bounty\` returns positive → uses that amount (forward-compatible)
- \`uv run --extra dev pytest tests/\` — 646 tests pass (643 baseline + 3 new).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)