### PR TITLE
fix(cli): config set refuses to overwrite a corrupt config.json

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -117,13 +117,22 @@ def config_set(key: str, value: str):
     # Ensure config directory exists
     GITTENSOR_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Load existing config or start fresh
+    # Load existing config or start fresh. If the file exists but is unparsable,
+    # refuse to overwrite — silently writing only the new key would destroy
+    # every other configured value (network, contract_address, ws_endpoint, …)
+    # and quietly retarget downstream commands at finney mainnet defaults.
+    # Same refuse-to-overwrite invariant as #781 (PATs file) and the read-side
+    # equivalent fixed in #817.
     config = {}
     if CONFIG_FILE.exists():
         try:
             config = json.loads(CONFIG_FILE.read_text())
-        except json.JSONDecodeError:
-            console.print('[yellow]Warning: Existing config was invalid, starting fresh[/yellow]')
+        except json.JSONDecodeError as e:
+            console.print(
+                f'[red]Error: Existing config file at {CONFIG_FILE} is not valid JSON ({e}).\n'
+                f'Refusing to overwrite — inspect or remove the file before re-running.[/red]'
+            )
+            raise SystemExit(1)
 
     # Set the value
     old_value = config.get(key)

--- a/tests/cli/test_config_set_corruption.py
+++ b/tests/cli/test_config_set_corruption.py
@@ -1,0 +1,95 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Regression tests for #845: gitt config set must refuse to overwrite a corrupt config.json.
+
+Same family as #781 (pat_storage refusal) and #817 (load_config refusal on read).
+The write path was the missing piece — without this fix, a single corrupt-config
+event silently destroys every previously configured key.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_config(tmp_path: Path):
+    """Redirect CONFIG_FILE / GITTENSOR_DIR to a temp directory for one test."""
+    config_dir = tmp_path / '.gittensor'
+    config_file = config_dir / 'config.json'
+    with (
+        patch('gittensor.cli.main.GITTENSOR_DIR', config_dir),
+        patch('gittensor.cli.main.CONFIG_FILE', config_file),
+    ):
+        yield config_dir, config_file
+
+
+def test_config_set_aborts_on_corrupt_existing_json(runner, temp_config):
+    from gittensor.cli.main import config_group
+
+    _config_dir, config_file = temp_config
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    corrupt_payload = '{"network": "test"'  # truncated, not valid JSON
+    config_file.write_text(corrupt_payload)
+
+    result = runner.invoke(
+        config_group,
+        ['set', 'wallet', 'alice'],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert 'not valid JSON' in result.output or 'Refusing to overwrite' in result.output
+    # Critical invariant: the corrupt file must remain on disk untouched so
+    # the operator can inspect/repair it. The refused write path must NOT
+    # have replaced it with a fresh single-key dict.
+    assert config_file.read_text() == corrupt_payload
+
+
+def test_config_set_preserves_existing_keys_when_appending(runner, temp_config):
+    """Sanity check the happy path: a normal `set` on a valid file must keep every other key."""
+    from gittensor.cli.main import config_group
+
+    _config_dir, config_file = temp_config
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(json.dumps({'network': 'test', 'contract_address': '5XYZ...'}))
+
+    result = runner.invoke(
+        config_group,
+        ['set', 'wallet', 'alice'],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    written = json.loads(config_file.read_text())
+    assert written == {
+        'network': 'test',
+        'contract_address': '5XYZ...',
+        'wallet': 'alice',
+    }
+
+
+def test_config_set_creates_file_when_missing(runner, temp_config):
+    """When the file doesn't exist, `set` should still write a fresh single-key config."""
+    from gittensor.cli.main import config_group
+
+    _config_dir, config_file = temp_config
+    assert not config_file.exists()
+
+    result = runner.invoke(
+        config_group,
+        ['set', 'wallet', 'alice'],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(config_file.read_text()) == {'wallet': 'alice'}


### PR DESCRIPTION
## Summary

Closes #845.

\`gitt config set\` previously caught \`json.JSONDecodeError\` on the existing config, printed a yellow \"starting fresh\" warning, then wrote back a fresh dict containing only the new key — silently destroying every other configured value (\`network\`, \`contract_address\`, \`ws_endpoint\`, \`hotkey\`, …) on a single mid-write crash or on-disk corruption.

After this change the JSONDecodeError branch raises \`SystemExit(1)\` with a clear error pointing at the file, leaving the corrupt bytes on disk so the operator can inspect or remove them before re-running. Same refuse-to-overwrite invariant as #781 (PATs file) and the read-side fix in #817 (\`load_config\` + \`_load_config_value\`).

\`\`\`
$ gitt config set wallet alice
Error: Existing config file at /home/me/.gittensor/config.json is not valid JSON (Expecting value: line 1 column 1 (char 0)).
Refusing to overwrite — inspect or remove the file before re-running.
$ echo \$?
1
\`\`\`

## Related Issues

Closes #845. Same family as #781 (write side, PATs) and #817 (read side, this same file).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- New \`tests/cli/test_config_set_corruption.py\` covers three cases:
  - corrupt existing JSON → exit 1, file untouched on disk (the critical invariant — the corrupt bytes must remain intact for inspection).
  - valid existing JSON → existing keys preserved when appending a new key.
  - missing file → fresh single-key config written.
- \`uv run --extra dev pytest tests/\` — 646 tests pass (643 baseline + 3 new).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)