### PR TITLE
refactor: inline single-use _reconnect_subtensor helper

### DIFF
--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -97,11 +97,6 @@ class BaseNeuron(ABC):
         )
         self.step = 0
 
-    def _reconnect_subtensor(self):
-        """Recreate subtensor connection when WebSocket goes stale."""
-        bt.logging.info('Reconnecting subtensor...')
-        self.subtensor = bt.Subtensor(config=self.config)
-
     @abstractmethod
     async def forward(self, synapse: bt.Synapse) -> bt.Synapse: ...
 
@@ -143,7 +138,8 @@ class BaseNeuron(ABC):
                     f'WebSocket connection closed during check_registered (attempt {attempt + 1}/{max_retries}): {e}'
                 )
                 if attempt < max_retries - 1:
-                    self._reconnect_subtensor()
+                    bt.logging.info('Reconnecting subtensor...')
+                    self.subtensor = bt.Subtensor(config=self.config)
                     time.sleep(2**attempt)  # Exponential backoff: 1s, 2s, 4s
                 else:
                     raise


### PR DESCRIPTION
## Summary

\`_reconnect_subtensor\` in [neurons/base/neuron.py](neurons/base/neuron.py) was a 3-line method on \`BaseNeuron\` called from exactly one place — the \`ConnectionClosedError\` retry branch in \`check_registered\`. Inlining matches the merged #748 / #801 / #802 pattern (single-use private helper folded into its only caller); the inlined two lines (info log + Subtensor instantiation) read just as cleanly in the retry context.

\`grep -rn _reconnect_subtensor\` confirms no other call sites in \`gittensor/\`, \`neurons/\`, or \`tests/\`.

Net: **-6 / +2 lines**, one fewer private method on \`BaseNeuron\`. No behavior change.

## Related Issues

N/A — same family of cleanups as #641 / #748 / #801 / #802.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- \`grep -rn _reconnect_subtensor\` confirms a single call site.
- \`uv run --extra dev pytest tests/\` — all 652 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)