### PR TITLE
refactor: inline single-use _get_child_storage_key method

### DIFF
--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -124,14 +124,6 @@ class IssueCompetitionContractClient:
     # Query Functions (Read-only)
     # =========================================================================
 
-    def _get_child_storage_key(self) -> Optional[str]:
-        """Get the child storage key for the contract's trie."""
-        try:
-            return get_contract_child_storage_key(self.subtensor.substrate, self.contract_address)
-        except Exception as e:
-            bt.logging.debug(f'Error getting child storage key: {e}')
-            return None
-
     def _read_packed_storage(self) -> Optional[dict]:
         """Read the packed root storage from the contract"""
         try:
@@ -148,7 +140,11 @@ class IssueCompetitionContractClient:
 
     def read_issue_from_child_storage(self, issue_id: int) -> Optional[ContractIssue]:
         """Read a single issue from contract child storage."""
-        child_key = self._get_child_storage_key()
+        try:
+            child_key = get_contract_child_storage_key(self.subtensor.substrate, self.contract_address)
+        except Exception as e:
+            bt.logging.debug(f'Error getting child storage key: {e}')
+            return None
         if not child_key:
             return None
 


### PR DESCRIPTION
## Summary

\`_get_child_storage_key\` on \`IssueCompetitionContractClient\` ([gittensor/validator/issue_competitions/contract_client.py:127-133](gittensor/validator/issue_competitions/contract_client.py#L127-L133)) was a 7-line private method called from exactly one place: \`read_issue_from_child_storage\`. Same single-use-helper pattern as the merged #748, #801, and #802.

The inlined try/except is preserved verbatim and kept distinct from the existing decode-side try/except in the caller, so the per-stage debug log messages (\"Error getting child storage key\" vs \"Error reading issue {id}\") stay attributable to the right phase.

\`grep -rn _get_child_storage_key\` confirms no other call sites in \`gittensor/\`, \`neurons/\`, or \`tests/\`.

Net: **-9 / +5 lines**, one fewer private method on the contract client. No behavior change.

## Related Issues

N/A — same family of cleanups as #641 / #748 / #801 / #802.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- \`grep -rn _get_child_storage_key\` confirms a single call site.
- \`uv run --extra dev pytest tests/\` — all 652 tests pass.
- \`tests/utils/test_issue_competitions_storage_utils.py\` covers the underlying \`get_contract_child_storage_key\` and still passes.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)