### PR TITLE
feat(cli): add gitt miner status command for local eligibility-gate progress

### DIFF
--- a/gittensor/cli/miner_commands/__init__.py
+++ b/gittensor/cli/miner_commands/__init__.py
@@ -7,12 +7,14 @@ Command structure:
     gitt miner (alias: m)     - Miner management commands
         post                     Broadcast GitHub PAT to validators
         check                    Check how many validators have your PAT
+        status                   Check eligibility-gate progress locally
 """
 
 import click
 
 from .check import miner_check
 from .post import miner_post
+from .status import miner_status
 
 
 @click.group(name='miner')
@@ -23,12 +25,14 @@ def miner_group():
     Commands:
         post     Broadcast your GitHub PAT to validators
         check    Check how many validators have your PAT stored
+        status   Check eligibility-gate progress without waiting for the validator
     """
     pass
 
 
 miner_group.add_command(miner_post, name='post')
 miner_group.add_command(miner_check, name='check')
+miner_group.add_command(miner_status, name='status')
 
 
 def register_miner_commands(cli):

--- a/gittensor/cli/miner_commands/status.py
+++ b/gittensor/cli/miner_commands/status.py
@@ -1,0 +1,334 @@
+# Entrius 2025
+
+"""gitt miner status — Check eligibility-gate progress without waiting for the validator."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+
+import click
+import requests
+from rich.console import Console
+from rich.table import Table
+
+from gittensor.cli.miner_commands.helpers import (
+    NETUID_DEFAULT,
+    _connect_bittensor,
+    _error,
+    _load_config_value,
+    _print,
+    _resolve_endpoint,
+    _status,
+)
+from gittensor.constants import (
+    BASE_GITHUB_API_URL,
+    GITHUB_HTTP_TIMEOUT_SECONDS,
+    MIN_CREDIBILITY,
+    MIN_VALID_MERGED_PRS,
+    PR_LOOKBACK_DAYS,
+)
+from gittensor.utils.github_api_tools import make_headers
+from gittensor.validator.utils.load_weights import load_master_repo_weights
+
+console = Console()
+
+
+@dataclass
+class StatusReport:
+    """Local-only snapshot of a miner's eligibility-gate progress.
+
+    The validator's gate additionally requires each merged PR to clear
+    ``MIN_TOKEN_SCORE_FOR_BASE_SCORE`` after tree-sitter scoring, which
+    needs per-file content fetches and is too expensive to replay
+    client-side. The CLI therefore reports the *raw* merged count plus a
+    note that the validator gate is stricter.
+    """
+
+    uid: Optional[int]
+    github_login: str
+    network: str
+    netuid: int
+    merged_count: int
+    closed_count: int
+    credibility: float
+    eligible_by_count: bool
+    eligible_by_credibility: bool
+    lookback_start: str
+    incentivized_repos_only: bool
+
+
+def _resolve_pat_and_login(pat: Optional[str], json_mode: bool) -> Tuple[str, str]:
+    """Resolve PAT (flag → env var → prompt) and the login it identifies.
+
+    Exits with code 1 if the PAT is missing, invalid, or rejects the
+    `/user` probe. Returns ``(pat, login)`` on success.
+    """
+    pat = pat or os.environ.get('GITTENSOR_MINER_PAT')
+    if not pat:
+        if json_mode:
+            _error('--pat flag or GITTENSOR_MINER_PAT environment variable is required for JSON mode.', json_mode)
+            sys.exit(1)
+        pat = click.prompt('Enter your GitHub Personal Access Token', hide_input=True)
+
+    try:
+        resp = requests.get(
+            f'{BASE_GITHUB_API_URL}/user', headers=make_headers(pat), timeout=GITHUB_HTTP_TIMEOUT_SECONDS
+        )
+    except requests.RequestException as e:
+        _error(f'GitHub PAT verification failed: {e}', json_mode)
+        sys.exit(1)
+
+    if resp.status_code != 200:
+        _error(f'GitHub PAT rejected by /user (HTTP {resp.status_code}). Check token validity.', json_mode)
+        sys.exit(1)
+
+    login = resp.json().get('login')
+    if not login:
+        _error('GitHub /user response missing login field.', json_mode)
+        sys.exit(1)
+
+    return pat, login
+
+
+def _count_user_prs_in_window(
+    login: str,
+    pat: str,
+    since: datetime,
+    incentivized_repos: set[str],
+) -> Tuple[int, int]:
+    """Count merged + closed-not-merged PRs by ``login`` since ``since``.
+
+    Uses the GitHub Search API (one call per state) and filters
+    client-side to whitelisted ``incentivized_repos``. The validator
+    counts only PRs against incentivized repos in its gate, so this CLI
+    matches that scope by default.
+    """
+    since_iso = since.strftime('%Y-%m-%d')
+    merged = _search_count(f'is:pr author:{login} is:merged merged:>={since_iso}', pat, incentivized_repos)
+    closed = _search_count(f'is:pr author:{login} is:closed -is:merged closed:>={since_iso}', pat, incentivized_repos)
+    return merged, closed
+
+
+def _search_count(query: str, pat: str, incentivized_repos: set[str]) -> int:
+    """Run a Search API query and return the count of items in incentivized repos."""
+    total = 0
+    page = 1
+    while True:
+        resp = requests.get(
+            f'{BASE_GITHUB_API_URL}/search/issues',
+            headers=make_headers(pat),
+            params={'q': query, 'per_page': 100, 'page': page},
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
+        )
+        if resp.status_code != 200:
+            return total
+        body = resp.json()
+        items = body.get('items', [])
+        if not items:
+            break
+        for item in items:
+            url = item.get('repository_url', '')
+            # repository_url shape: https://api.github.com/repos/<owner>/<name>
+            slug = url.removeprefix('https://api.github.com/repos/').lower()
+            if slug in incentivized_repos:
+                total += 1
+        if len(items) < 100:
+            break
+        page += 1
+        if page > 10:  # safety cap; 1000 PRs in 35 days is already an extreme outlier
+            break
+    return total
+
+
+def _build_report(
+    *,
+    pat: str,
+    login: str,
+    wallet_hotkey_ss58: Optional[str],
+    metagraph,
+    network_endpoint: str,
+    netuid: int,
+) -> StatusReport:
+    """Pure aggregator: composes a StatusReport from already-resolved inputs."""
+    from gittensor.validator.oss_contributions.credibility import calculate_credibility
+
+    repo_weights = load_master_repo_weights()
+    incentivized = {name for name in repo_weights}
+
+    since = datetime.now(timezone.utc) - timedelta(days=PR_LOOKBACK_DAYS)
+    merged_count, closed_count = _count_user_prs_in_window(login, pat, since, incentivized)
+
+    # `calculate_credibility` works on Sequences with a length, not the raw
+    # count, so build minimal placeholders. We don't need the per-PR fields here.
+    merged_placeholders = [object()] * merged_count
+    closed_placeholders = [object()] * closed_count
+    credibility = calculate_credibility(merged_placeholders, closed_placeholders)
+
+    uid: Optional[int] = None
+    if metagraph is not None and wallet_hotkey_ss58 is not None:
+        if wallet_hotkey_ss58 in metagraph.hotkeys:
+            uid = metagraph.hotkeys.index(wallet_hotkey_ss58)
+
+    return StatusReport(
+        uid=uid,
+        github_login=login,
+        network=network_endpoint,
+        netuid=netuid,
+        merged_count=merged_count,
+        closed_count=closed_count,
+        credibility=credibility,
+        eligible_by_count=merged_count >= MIN_VALID_MERGED_PRS,
+        eligible_by_credibility=credibility >= MIN_CREDIBILITY,
+        lookback_start=since.strftime('%Y-%m-%d'),
+        incentivized_repos_only=True,
+    )
+
+
+def _render_json(report: StatusReport) -> str:
+    """Stable JSON envelope mirroring `miner check` / `miner post`."""
+    eligible = report.eligible_by_count and report.eligible_by_credibility
+    return json.dumps(
+        {
+            'success': eligible,
+            'uid': report.uid,
+            'github_login': report.github_login,
+            'network': report.network,
+            'netuid': report.netuid,
+            'merged_pull_requests': report.merged_count,
+            'closed_pull_requests': report.closed_count,
+            'credibility': round(report.credibility, 4),
+            'thresholds': {
+                'min_valid_merged_prs': MIN_VALID_MERGED_PRS,
+                'min_credibility': MIN_CREDIBILITY,
+                'pr_lookback_days': PR_LOOKBACK_DAYS,
+            },
+            'gates': {
+                'merged_count': report.eligible_by_count,
+                'credibility': report.eligible_by_credibility,
+            },
+            'lookback_start': report.lookback_start,
+            'note': (
+                'Validator additionally requires each merged PR to clear '
+                'token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE — not replayed locally.'
+            ),
+        },
+        indent=2,
+    )
+
+
+def _render_table(report: StatusReport) -> Table:
+    """Rich table for human-readable output (default mode)."""
+    table = Table(title='Miner Eligibility Status')
+    table.add_column('Metric', style='cyan')
+    table.add_column('Value', justify='right')
+    table.add_column('Threshold', justify='right', style='dim')
+    table.add_column('Status', justify='center')
+
+    def mark(ok: bool) -> str:
+        return '[green]✓[/green]' if ok else '[red]✗[/red]'
+
+    uid_str = str(report.uid) if report.uid is not None else '[yellow]not registered[/yellow]'
+    table.add_row('UID', uid_str, '—', '')
+    table.add_row('GitHub login', report.github_login, '—', '')
+    table.add_row('Network', report.network, '—', '')
+    table.add_row(
+        'Merged PRs (raw)',
+        str(report.merged_count),
+        f'≥ {MIN_VALID_MERGED_PRS}',
+        mark(report.eligible_by_count),
+    )
+    table.add_row('Closed (not merged)', str(report.closed_count), '—', '')
+    table.add_row(
+        'Credibility',
+        f'{report.credibility:.2f}',
+        f'≥ {MIN_CREDIBILITY:.2f}',
+        mark(report.eligible_by_credibility),
+    )
+    table.add_row('Lookback start', report.lookback_start, f'{PR_LOOKBACK_DAYS}d', '')
+    return table
+
+
+@click.command()
+@click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
+@click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
+@click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
+@click.option('--network', default=None, help='Network name (local, test, finney).')
+@click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
+@click.option(
+    '--pat',
+    default=None,
+    help='GitHub Personal Access Token. If not provided, falls back to GITTENSOR_MINER_PAT env var or interactive prompt.',
+)
+@click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
+def miner_status(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_mode):
+    """Check eligibility-gate progress without waiting for validator scoring.
+
+    Counts your merged + closed-not-merged PRs across incentivized repos in
+    the rolling lookback window, derives credibility locally, and reports
+    pass/fail against `MIN_VALID_MERGED_PRS` and `MIN_CREDIBILITY`.
+
+    The validator's gate additionally requires each merged PR to clear
+    `MIN_TOKEN_SCORE_FOR_BASE_SCORE` after tree-sitter scoring; that step
+    needs per-file content fetches and is too expensive to replay locally.
+    Raw merged count is shown as a ceiling — actual valid count may be
+    lower.
+
+    \b
+    Examples:
+        gitt miner status --wallet alice --hotkey default
+        gitt miner status --pat ghp_xxxx --json-output
+        gitt miner status --network test --pat ghp_xxxx
+    """
+    pat, login = _resolve_pat_and_login(pat, json_mode)
+
+    wallet_name = wallet_name or _load_config_value('wallet') or 'default'
+    wallet_hotkey = wallet_hotkey or _load_config_value('hotkey') or 'default'
+    ws_endpoint = _resolve_endpoint(network, rpc_url)
+
+    _print(
+        f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid} | GitHub: {login}[/dim]',
+        json_mode,
+    )
+
+    metagraph = None
+    wallet_hotkey_ss58 = None
+    with _status('[bold]Connecting to network...', json_mode):
+        try:
+            wallet, _subtensor, metagraph, _dendrite = _connect_bittensor(
+                wallet_name, wallet_hotkey, ws_endpoint, netuid
+            )
+            wallet_hotkey_ss58 = wallet.hotkey.ss58_address
+        except Exception as e:
+            # Network unreachable / wallet missing / unregistered — still report
+            # GitHub-side progress so the operator can fix one thing at a time.
+            _print(f'[yellow]Network connect failed ({e}); reporting GitHub-only metrics[/yellow]', json_mode)
+
+    with _status('[bold]Counting your PRs in incentivized repos...', json_mode):
+        report = _build_report(
+            pat=pat,
+            login=login,
+            wallet_hotkey_ss58=wallet_hotkey_ss58,
+            metagraph=metagraph,
+            network_endpoint=ws_endpoint,
+            netuid=netuid,
+        )
+
+    if json_mode:
+        click.echo(_render_json(report))
+    else:
+        console.print(_render_table(report))
+        eligible = report.eligible_by_count and report.eligible_by_credibility
+        if eligible:
+            console.print('\n[bold green]Eligible for validator scoring.[/bold green]')
+        else:
+            console.print(
+                '\n[bold red]Not yet eligible.[/bold red] Validator additionally checks token_score ≥ 5 per merged PR.'
+            )
+
+    if not (report.eligible_by_count and report.eligible_by_credibility):
+        sys.exit(1)

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -78,6 +78,112 @@ class TestCliVersion:
         assert result.output == f'gittensor, version {__version__}\n'
 
 
+class TestMinerStatus:
+    def test_help_text(self, runner):
+        result = runner.invoke(cli, ['miner', 'status', '--help'])
+        assert result.exit_code == 0
+        assert 'eligibility' in result.output.lower()
+
+    def test_status_alias(self, runner):
+        """gitt m status should work as alias for gitt miner status."""
+        result = runner.invoke(cli, ['m', 'status', '--help'])
+        assert result.exit_code == 0
+        assert 'eligibility' in result.output.lower()
+
+    def test_no_pat_json_mode_exits(self, runner, monkeypatch):
+        monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+        result = runner.invoke(cli, ['miner', 'status', '--json-output', '--wallet', 'test', '--hotkey', 'test'])
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output['success'] is False
+
+    @patch('gittensor.cli.miner_commands.status.requests.get')
+    def test_pat_rejected_exits(self, mock_get, runner, monkeypatch):
+        """Non-200 from /user must exit non-zero before any network calls."""
+        monkeypatch.setenv('GITTENSOR_MINER_PAT', 'ghp_invalid')
+        mock_get.return_value.status_code = 401
+        result = runner.invoke(cli, ['miner', 'status', '--json-output', '--wallet', 'test', '--hotkey', 'test'])
+        assert result.exit_code != 0
+        body = json.loads(result.output)
+        assert body['success'] is False
+        assert '401' in body['error']
+
+
+class TestStatusReportRendering:
+    """Pure-function tests for _render_json / _render_table.
+
+    Status command's network + GitHub paths are exercised end-to-end in a
+    separate integration suite; these tests pin the JSON shape and the
+    table semantics so dashboards/automation depending on the envelope
+    don't drift silently.
+    """
+
+    @pytest.fixture
+    def eligible_report(self):
+        from gittensor.cli.miner_commands.status import StatusReport
+
+        return StatusReport(
+            uid=42,
+            github_login='alice',
+            network='wss://test.finney.opentensor.ai:443',
+            netuid=74,
+            merged_count=7,
+            closed_count=1,
+            credibility=0.95,
+            eligible_by_count=True,
+            eligible_by_credibility=True,
+            lookback_start='2026-03-24',
+            incentivized_repos_only=True,
+        )
+
+    @pytest.fixture
+    def ineligible_report(self):
+        from gittensor.cli.miner_commands.status import StatusReport
+
+        return StatusReport(
+            uid=None,
+            github_login='bob',
+            network='wss://test.finney.opentensor.ai:443',
+            netuid=74,
+            merged_count=2,
+            closed_count=0,
+            credibility=1.0,
+            eligible_by_count=False,
+            eligible_by_credibility=True,
+            lookback_start='2026-03-24',
+            incentivized_repos_only=True,
+        )
+
+    def test_json_envelope_marks_eligible_when_both_gates_pass(self, eligible_report):
+        from gittensor.cli.miner_commands.status import _render_json
+
+        body = json.loads(_render_json(eligible_report))
+        assert body['success'] is True
+        assert body['gates'] == {'merged_count': True, 'credibility': True}
+        assert body['merged_pull_requests'] == 7
+        assert body['credibility'] == 0.95
+        assert body['thresholds']['min_valid_merged_prs'] == 5
+
+    def test_json_envelope_marks_ineligible_when_count_gate_fails(self, ineligible_report):
+        from gittensor.cli.miner_commands.status import _render_json
+
+        body = json.loads(_render_json(ineligible_report))
+        assert body['success'] is False
+        assert body['gates']['merged_count'] is False
+        assert body['gates']['credibility'] is True
+        assert body['uid'] is None
+
+    def test_table_marks_failed_gate_with_red_x(self, ineligible_report):
+        from gittensor.cli.miner_commands.status import _render_table
+
+        # Smoke test: the table builds without raising and has the expected shape.
+        # Rich's row objects don't carry the rendered text in a stable form; we
+        # rely on the JSON envelope tests above for status-string contracts.
+        table = _render_table(ineligible_report)
+        assert len(table.columns) == 4
+        assert len(list(table.rows)) == 7  # UID, login, network, merged, closed, credibility, lookback
+
+
 class TestPatCheckAggregateCounts:
     def test_splits_valid_no_pat_invalid_and_no_response(self):
         results = [


### PR DESCRIPTION
```
Closes #354.

## Summary

Adds `gitt miner status` (alias `gitt m status`) so a miner can inspect
their progress against the validator's eligibility gate without waiting
for the next scoring round.

## What it shows

- UID (resolved from wallet hotkey on the metagraph; null when not registered)
- GitHub login (resolved from PAT via /user)
- Network endpoint + netuid
- Merged-PR count over the rolling PR_LOOKBACK_DAYS window
- Closed-not-merged count over the same window
- Credibility ratio (calculate_credibility, mulligan applied)
- Pass/fail per gate against MIN_VALID_MERGED_PRS (5) and MIN_CREDIBILITY (0.80)
- Lookback start date

## How counts are gathered

/search/issues with two queries (is:merged merged:>=DATE and
is:closed -is:merged closed:>=DATE), filtered client-side to the
whitelisted incentivized repo set loaded from master_repositories.json.
This matches the validator's repo scope and avoids replaying any
per-PR fetch logic.

## Token-score gate is intentionally NOT replayed

The validator's gate additionally requires each merged PR to clear
MIN_TOKEN_SCORE_FOR_BASE_SCORE after tree-sitter scoring, which needs
per-file content fetches and is too expensive to replay client-side.
The command therefore reports the *raw* merged count as a ceiling and
prints a clear note that the validator-side gate is stricter. The JSON
envelope mirrors the same disclaimer.

## Failure modes

- Missing PAT in JSON mode → exit 1, structured {"success": false, "error": ...}
- Bad PAT (non-200 from /user) → exit 1 with HTTP code surfaced
- Network connect failure → continue with GitHub-only metrics (UID stays null)
- All gates pass → exit 0; otherwise exit 1 (mirrors miner post / miner check
  exit-code policy after #843)

## Tests

- Help-text, alias, no-PAT-in-JSON-mode, /user 401 paths in
  tests/cli/test_miner_commands.py::TestMinerStatus
- Pure-function tests for _render_json and _render_table over both
  eligible and ineligible StatusReport fixtures, pinning the JSON
  envelope shape (gates dict, thresholds dict, success bool, uid null)

ruff check + ruff format clean. Stand-alone harness for the pure
renderers passes.

Closes #354
```