### PR TITLE
fix(cli): validate --id on `gitt issues list` (#854)

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -29,6 +29,7 @@ from .helpers import (
     handle_exception,
     print_network_header,
     read_issues_from_contract,
+    validate_issue_id,
     with_cli_behavior_options,
     with_network_contract_options,
 )
@@ -58,6 +59,15 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
         $ gitt i list --json
     [/dim]
     """
+    # Range-check --id at parse time so we don't waste an RPC round-trip on
+    # 0 / negatives / out-of-u32 values, and so the error matches every
+    # other command that takes an issue ID. See #210, #854.
+    if issue_id is not None:
+        try:
+            validate_issue_id(issue_id, 'id')
+        except click.BadParameter as e:
+            handle_exception(as_json, str(e), 'bad_parameter')
+
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(
         contract,
         network,

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -51,3 +51,101 @@ def test_issues_list_human_missing_issue_exits_non_zero(cli_root, runner):
     assert result.exit_code != 0
     assert '999' in result.output
     assert 'not found' in result.output.lower()
+
+
+# Regression tests for #854: --id input validation must match the rest of the
+# CLI (mutations.py / vote.py / submissions.py — all of which call
+# validate_issue_id) and reject 0, negatives, and out-of-u32 values *before*
+# any contract read.
+def test_issues_list_id_zero_rejected_at_parse(cli_root, runner):
+    """--id 0 must fail with the standard validate_issue_id message and not touch the chain."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+        ) as resolve,
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as read_chain,
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--id', '0'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'must be between 1 and 999999' in result.output
+    assert '(got 0)' in result.output
+    # Validation must happen before any contract / network resolution.
+    resolve.assert_not_called()
+    read_chain.assert_not_called()
+
+
+def test_issues_list_id_negative_rejected_at_parse(cli_root, runner):
+    """--id -1 must fail at validation, not be passed through to on-chain lookup."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+        ) as resolve,
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as read_chain,
+    ):
+        # click parses '--id -1' as the option `-1`, so use --id=-1 syntax
+        # (the form the user has to use for negative ints).
+        result = runner.invoke(cli_root, ['issues', 'list', '--id=-1'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'must be between 1 and 999999' in result.output
+    assert '(got -1)' in result.output
+    resolve.assert_not_called()
+    read_chain.assert_not_called()
+
+
+def test_issues_list_id_out_of_range_rejected_at_parse(cli_root, runner):
+    """An ID well above the u32-friendly cap must be rejected at parse time."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+        ) as resolve,
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as read_chain,
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--id', '99999999999999'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'must be between 1 and 999999' in result.output
+    resolve.assert_not_called()
+    read_chain.assert_not_called()
+
+
+def test_issues_list_id_zero_json_returns_bad_parameter(cli_root, runner):
+    """JSON callers must get a structured `bad_parameter` error, not a network attempt."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+        ) as resolve,
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as read_chain,
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json', '--id', '0'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'bad_parameter'
+    assert 'must be between 1 and 999999' in payload['error']['message']
+    resolve.assert_not_called()
+    read_chain.assert_not_called()
+
+
+def test_issues_list_valid_id_still_reaches_chain(cli_root, runner):
+    """Sanity: a valid --id still resolves the contract and reads the chain (no regression on #335)."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ) as resolve,
+        patch(
+            'gittensor.cli.issue_commands.view.read_issues_from_contract',
+            return_value=FAKE_ISSUES,
+        ) as read_chain,
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json', '--id', '1'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload['success'] is True
+    assert payload['issue']['id'] == 1
+    resolve.assert_called_once()
+    read_chain.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #854.

`gitt i list --id <N>` was the only command that accepts an on-chain issue ID without range-checking it. The mutations / vote / admin / submissions paths all run `validate_issue_id` (which enforces `1 <= id < 1_000_000` and raises `click.BadParameter`), matching the contract laid out in #210 / #211. `view.py` was missed because #210's file list didn't include it.

That meant `--id 0`, `--id=-1`, or `--id 99999999999999` would silently do an on-chain lookup and report \"Issue <N> not found on-chain\" — a misleading error (the issue isn't missing, the ID is invalid) and a wasted RPC round-trip.

This PR gates `issue_id` on the existing `validate_issue_id` helper as soon as it's bound, calling `handle_exception` so the JSON error shape matches `bad_parameter` like every other validated command. PR #335's not-found JSON behaviour for valid-but-missing IDs is unchanged: validation runs *before* the contract read, but the not-found path is still reached for IDs in `1..999_999` that don't exist on-chain.

## CLI before/after (per CONTRIBUTING.md)

Before (from the issue reproduction):

```
$ gitt i list --id 0
Network: finney • Contract: ...
✗ Issue 0 not found on-chain.

$ gitt i list --id -1
Network: finney • Contract: ...
✗ Issue -1 not found on-chain.

$ gitt i list --id 99999999999999
Network: finney • Contract: ...
✗ Issue 99999999999999 not found on-chain.
```

After (this PR — captured locally with \`python3 -m uv run gitt …\`):

```
$ gitt i list --id 0
✗ id must be between 1 and 999999 (got 0)

$ gitt i list --id=-1
✗ id must be between 1 and 999999 (got -1)

$ gitt i list --id 99999999999999
✗ id must be between 1 and 999999 (got 99999999999999)

$ gitt i list --json --id 0
{\"success\": false, \"error\": {\"type\": \"bad_parameter\",
 \"message\": \"id must be between 1 and 999999 (got 0)\"}}
```

The contract is now identical to what `gitt i submissions --id 0`, `gitt vote solution 0 …`, etc. already produce.

## Tests

`tests/cli/test_issues_list_json.py` gains five new cases:

- `--id 0` → \`bad_parameter\`, no contract resolve, no chain read
- `--id=-1` (click's required syntax for negatives) → same
- `--id 99999999999999` → same
- `--json --id 0` → structured \`bad_parameter\` JSON payload
- `--id 1` → still resolves and reads the chain (#335 regression guard)

The two original tests from #335 continue to pass — the not-found JSON shape and human-mode non-zero exit are unchanged for valid-but-missing IDs.

## Test plan

- [x] \`uv run pytest tests/cli/test_issues_list_json.py -v\` — 7/7 pass
- [x] \`uv run pytest\` — 657 passed
- [x] \`uv run ruff check gittensor/cli/issue_commands/view.py tests/cli/test_issues_list_json.py\` — clean
- [x] \`uv run ruff format --check\` — clean