### PR TITLE
fix: thread PR identifier through OSS-scoring skip and fetch warnings

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -115,9 +115,15 @@ def score_mirror_pr(
 ) -> None:
     """Score a single mirror PR. Populates ScoredMirrorPR scoring fields in place."""
     pr = scored.pr
+    # PR-side identifier reused across every warning emitted by this function so
+    # a single skipped PR in a noisy multi-miner round can be traced back to its
+    # owning repo without cross-referencing the surrounding scoring log block.
+    # Mirror parity with the legacy `score_pull_request` warning shape.
+    pr_ctx = f'PR #{pr.pr_number} in {pr.repo_full_name}'
+
     repo_config = mirror_repos.get(pr.repo_full_name)
     if not repo_config:
-        bt.logging.warning(f'{pr.repo_full_name} not in mirror_repos. Skipping...')
+        bt.logging.warning(f'{pr_ctx}: repo not in mirror_repos. Skipping...')
         return
 
     # Eligibility gate for MERGED PRs already ran at LOAD time (see
@@ -134,12 +140,12 @@ def score_mirror_pr(
     try:
         files = client.get_pr_files(pr.repo_full_name, pr.pr_number).files
     except MirrorRequestError as e:
-        bt.logging.warning(f'Mirror file fetch failed for PR #{pr.pr_number}: {e}')
+        bt.logging.warning(f'Mirror file fetch failed for {pr_ctx}: {e}')
         return
     scored.files = files
 
     if not files:
-        bt.logging.warning(f'No files returned for PR #{pr.pr_number}')
+        bt.logging.warning(f'No files returned for {pr_ctx}')
         return
 
     file_changes, file_contents = mirror_files_to_legacy(pr.repo_full_name, pr.pr_number, files)
@@ -442,37 +448,44 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
       semantically — negative days means the issue closed before the PR merged,
       which means the PR wasn't the solver).
     """
+    # PR-side identifier reused across every skip warning so a single skipped
+    # issue in a noisy multi-miner round can be traced back to its owning PR.
+    # Legacy parity with `is_valid_issue` skip warnings.
+    pr_ctx = f'PR #{pr.pr_number} in {pr.repo_full_name}'
+
     if li.is_transferred:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - transferred')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - transferred')
         return False
 
     if li.author_github_id is None:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - missing author_github_id')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - missing author_github_id')
         return False
 
     if li.author_github_id == pr.author_github_id:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - same author as PR (self-issue)')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - same author as PR (self-issue)')
         return False
 
     if li.created_at and li.created_at > pr.created_at:
-        bt.logging.warning(f'Skipping linked issue #{li.number} - created after PR')
+        bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - created after PR')
         return False
 
     # Legacy parity: state_reason check applies regardless of PR state. Legacy's
     # _is_completed_when_closed returns True for OPEN issues, False for CLOSED
     # issues with non-COMPLETED state_reason. Applies to OPEN-PR collateral too.
     if li.state == 'CLOSED' and li.state_reason != 'COMPLETED':
-        bt.logging.warning(f'Skipping linked issue #{li.number} - state_reason={li.state_reason} (need COMPLETED)')
+        bt.logging.warning(
+            f'Skipping linked issue #{li.number} ({pr_ctx}) - state_reason={li.state_reason} (need COMPLETED)'
+        )
         return False
 
     is_merged = pr.state == 'MERGED'
     if is_merged and pr.merged_at:
         if pr.edited_after_merge:
-            bt.logging.warning(f'Skipping linked issue #{li.number} - PR edited after merge')
+            bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - PR edited after merge')
             return False
 
         if li.state != 'CLOSED':
-            bt.logging.warning(f'Skipping linked issue #{li.number} - state {li.state} (need CLOSED)')
+            bt.logging.warning(f'Skipping linked issue #{li.number} ({pr_ctx}) - state {li.state} (need CLOSED)')
             return False
 
         if li.closed_at:
@@ -482,7 +495,7 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
             days_diff = (li.closed_at - pr.merged_at).total_seconds() / SECONDS_PER_DAY
             if days_diff > MAX_ISSUE_CLOSE_WINDOW_DAYS or days_diff < 0:
                 bt.logging.warning(
-                    f'Skipping linked issue #{li.number} - closed {days_diff:+.2f}d from merge '
+                    f'Skipping linked issue #{li.number} ({pr_ctx}) - closed {days_diff:+.2f}d from merge '
                     f'(max {MAX_ISSUE_CLOSE_WINDOW_DAYS})'
                 )
                 return False

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -82,14 +82,16 @@ def score_pull_request(
 
     repo_config = master_repositories.get(pr.repository_full_name)
     if not repo_config:
-        bt.logging.warning(f'{pr.repository_full_name} not in master repositories. Skipping...')
+        bt.logging.warning(
+            f'PR #{pr.number} in {pr.repository_full_name}: repo not in master repositories. Skipping...'
+        )
         return
 
     # Only fetch file changes from GitHub if not already loaded (they are preloaded for testing only)
     if not pr.file_changes:
         file_changes = get_pull_request_file_changes(pr.repository_full_name, pr.number, miner_eval.github_pat)
         if not file_changes:
-            bt.logging.warning('No file changes found.')
+            bt.logging.warning(f'No file changes found for PR #{pr.number} in {pr.repository_full_name}.')
             return
         pr.set_file_changes(file_changes)
 
@@ -120,7 +122,7 @@ def fetch_file_contents_for_pr(pr: PullRequest, github_pat: str) -> Dict[str, Fi
 
     parts = pr.repository_full_name.split('/')
     if len(parts) != 2:
-        bt.logging.warning(f'Invalid repository name format: {pr.repository_full_name}')
+        bt.logging.warning(f'Invalid repository name format for PR #{pr.number}: {pr.repository_full_name!r}')
         return {}
 
     owner, repo_name = parts
@@ -432,12 +434,13 @@ def calculate_issue_multiplier(pr: PullRequest) -> float:
     return multiplier
 
 
-def _is_completed_when_closed(issue: Issue) -> bool:
+def _is_completed_when_closed(issue: Issue, pr_ctx: Optional[str] = None) -> bool:
     if issue.state != 'CLOSED':
         return True
     if issue.state_reason != 'COMPLETED':
+        ctx = f' ({pr_ctx})' if pr_ctx else ''
         bt.logging.warning(
-            f'Skipping issue #{issue.number} - state_reason={issue.state_reason}, only COMPLETED grants multiplier'
+            f'Skipping issue #{issue.number}{ctx} - state_reason={issue.state_reason}, only COMPLETED grants multiplier'
         )
         return False
     return True
@@ -447,35 +450,46 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
     """Check if issue is valid for bonus calculation (works for both merged and open PRs)."""
     is_merged = pr.pr_state == PRState.MERGED
 
+    # PR-side identifier appended to every skip warning so a single skipped
+    # issue in a noisy multi-miner round can be traced back to its owning PR
+    # without cross-referencing the surrounding `calculate_issue_multiplier`
+    # log line. Mirror parity with `_is_valid_linked_issue` skip warnings.
+    pr_ctx = f'PR #{pr.number} in {pr.repository_full_name}'
+
     if not issue.author_login:
-        bt.logging.warning(f'Skipping issue #{issue.number} - Issue is missing author information')
+        bt.logging.warning(f'Skipping issue #{issue.number} ({pr_ctx}) - Issue is missing author information')
         return False
 
     if issue.author_login == pr.author_login:
-        bt.logging.warning(f'Skipping issue #{issue.number} - Issue has same author as PR (self-created issue)')
+        bt.logging.warning(
+            f'Skipping issue #{issue.number} ({pr_ctx}) - Issue has same author as PR (self-created issue)'
+        )
         return False
 
     if issue.created_at and pr.created_at and issue.created_at > pr.created_at:
-        bt.logging.warning(f'Skipping issue #{issue.number} - Issue was created after PR was created')
+        bt.logging.warning(f'Skipping issue #{issue.number} ({pr_ctx}) - Issue was created after PR was created')
         return False
 
-    if not _is_completed_when_closed(issue):
+    if not _is_completed_when_closed(issue, pr_ctx):
         return False
 
     if is_merged and pr.merged_at:
         if pr.last_edited_at and pr.last_edited_at > pr.merged_at:
-            bt.logging.warning(f'Skipping issue #{issue.number} - PR was edited after merge')
+            bt.logging.warning(f'Skipping issue #{issue.number} ({pr_ctx}) - PR was edited after merge')
             return False
 
         if issue.state and issue.state != 'CLOSED':
-            bt.logging.warning(f'Skipping issue #{issue.number} - Issue state not CLOSED (state: {issue.state})')
+            bt.logging.warning(
+                f'Skipping issue #{issue.number} ({pr_ctx}) - Issue state not CLOSED (state: {issue.state})'
+            )
             return False
 
         if issue.closed_at and pr.merged_at:
             days_diff = (issue.closed_at - pr.merged_at).total_seconds() / SECONDS_PER_DAY
             if days_diff > MAX_ISSUE_CLOSE_WINDOW_DAYS or days_diff < 0:
                 bt.logging.warning(
-                    f'Skipping issue #{issue.number} - Issue closed {days_diff:+.2f}d from merge (max: {MAX_ISSUE_CLOSE_WINDOW_DAYS})'
+                    f'Skipping issue #{issue.number} ({pr_ctx}) - Issue closed {days_diff:+.2f}d from merge '
+                    f'(max: {MAX_ISSUE_CLOSE_WINDOW_DAYS})'
                 )
                 return False
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -16,7 +16,7 @@ Token-scoring base_score is exercised indirectly via the existing legacy tests
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -597,6 +597,34 @@ class TestLinkedIssueValidity:
         scored = ScoredMirrorPR(pr=_pr(state='OPEN'))
         li = MirrorLinkedIssue.from_dict(_linked_issue(state='OPEN', state_reason=None, closed_at=None))
         assert _is_valid_linked_issue(li, scored.pr) is True
+
+
+class TestLinkedIssueSkipWarningsCarryPRContext:
+    """Each skip warning in `_is_valid_linked_issue` must include the PR number
+    and repository so a single skipped issue in a noisy multi-miner round can
+    be traced back without cross-referencing the surrounding multiplier log
+    line. Mirror parity with `is_valid_issue` skip warnings."""
+
+    def _assert_warning_has_pr_context(self, mock_logging, pr):
+        warning_calls = list(mock_logging.warning.call_args_list)
+        assert warning_calls, 'expected at least one warning'
+        msg = warning_calls[-1].args[0]
+        assert f'PR #{pr.pr_number}' in msg, msg
+        assert pr.repo_full_name in msg, msg
+
+    @patch('gittensor.validator.oss_contributions.mirror.scoring.bt.logging')
+    def test_self_authored_warning_includes_pr_context(self, mock_logging):
+        scored = ScoredMirrorPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(author_github_id='218712309'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+        self._assert_warning_has_pr_context(mock_logging, scored.pr)
+
+    @patch('gittensor.validator.oss_contributions.mirror.scoring.bt.logging')
+    def test_close_window_warning_includes_pr_context(self, mock_logging):
+        scored = ScoredMirrorPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(closed_at='2026-04-12T00:00:00Z'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+        self._assert_warning_has_pr_context(mock_logging, scored.pr)
 
 
 class TestIssueMultiplierPreference:

--- a/tests/validator/test_is_valid_issue.py
+++ b/tests/validator/test_is_valid_issue.py
@@ -11,6 +11,7 @@ DUPLICATE, None) is rejected.
 """
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
@@ -119,3 +120,116 @@ class TestIsValidIssueOpenPRCollateral:
         )
 
         assert is_valid_issue(issue, pr) is True
+
+
+class TestIsValidIssueSkipWarningsCarryPRContext:
+    """Each skip warning in `is_valid_issue` (and its `_is_completed_when_closed`
+    helper) must include the PR number and repository so a single skipped issue
+    in a noisy multi-miner round can be traced back without cross-referencing
+    the surrounding `calculate_issue_multiplier` log line. Mirror parity with
+    `_is_valid_linked_issue` and same observability shape as the recently merged
+    PR #743 (`calculate_review_quality_multiplier` PR-context)."""
+
+    def _assert_warning_has_pr_context(self, mock_logging, pr):
+        warning_calls = list(mock_logging.warning.call_args_list)
+        assert warning_calls, 'expected at least one warning'
+        msg = warning_calls[-1].args[0]
+        assert f'PR #{pr.number}' in msg, msg
+        assert pr.repository_full_name in msg, msg
+
+    @patch('gittensor.validator.oss_contributions.scoring.bt.logging')
+    def test_self_authored_warning_includes_pr_context(self, mock_logging, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'miner_user'
+        pr.created_at = now - timedelta(days=1)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_login='miner_user',  # same author → self-issue rejection
+            created_at=now - timedelta(days=5),
+            closed_at=now,
+            state='CLOSED',
+            state_reason='COMPLETED',
+        )
+
+        assert is_valid_issue(issue, pr) is False
+        self._assert_warning_has_pr_context(mock_logging, pr)
+
+    @patch('gittensor.validator.oss_contributions.scoring.bt.logging')
+    def test_close_window_warning_includes_pr_context(self, mock_logging, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'miner_user'
+        pr.created_at = now - timedelta(days=2)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_login='other_user',
+            created_at=now - timedelta(days=5),
+            closed_at=now + timedelta(days=MAX_ISSUE_CLOSE_WINDOW_DAYS, seconds=1),
+            state='CLOSED',
+            state_reason='COMPLETED',
+        )
+
+        assert is_valid_issue(issue, pr) is False
+        self._assert_warning_has_pr_context(mock_logging, pr)
+
+    @patch('gittensor.validator.oss_contributions.scoring.bt.logging')
+    def test_state_reason_warning_includes_pr_context(self, mock_logging, pr_factory, issue_factory):
+        # Routes through `_is_completed_when_closed`; the helper accepts
+        # `pr_ctx` so its warning line is consistent with the rest.
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'miner_user'
+        pr.created_at = now - timedelta(days=1)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_login='other_user',
+            created_at=now - timedelta(days=5),
+            closed_at=now,
+            state='CLOSED',
+            state_reason='NOT_PLANNED',
+        )
+
+        assert is_valid_issue(issue, pr) is False
+        self._assert_warning_has_pr_context(mock_logging, pr)
+
+    @patch('gittensor.validator.oss_contributions.scoring.bt.logging')
+    def test_missing_author_login_warning_includes_pr_context(self, mock_logging, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'miner_user'
+        pr.created_at = now - timedelta(days=1)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_login='',  # missing author triggers the first skip
+            created_at=now - timedelta(days=5),
+            closed_at=now,
+            state='CLOSED',
+            state_reason='COMPLETED',
+        )
+
+        assert is_valid_issue(issue, pr) is False
+        self._assert_warning_has_pr_context(mock_logging, pr)
+
+    @patch('gittensor.validator.oss_contributions.scoring.bt.logging')
+    def test_issue_created_after_pr_warning_includes_pr_context(self, mock_logging, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'miner_user'
+        pr.created_at = now - timedelta(days=5)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_login='other_user',
+            created_at=now - timedelta(days=2),  # AFTER pr.created_at (which is days=5 ago)
+            closed_at=now,
+            state='CLOSED',
+            state_reason='COMPLETED',
+        )
+
+        assert is_valid_issue(issue, pr) is False
+        self._assert_warning_has_pr_context(mock_logging, pr)


### PR DESCRIPTION
```
## Summary

Bundles the legacy + mirror parity for the observability pattern that
PR #743 ("fix: improve review quality multiplier observability +
harden is_valid_issue", merged with `anderdc` as co-author) and PR
#711 ("fix: add PR number context to file-content fetch failure
warning") established. Many sibling warning sites still emit only the
issue number or only the repository name without the PR identifier,
which makes a single skipped PR in a multi-miner scoring round
impossible to trace without grepping the surrounding scoring log
block and reconstructing the order.

This PR threads `PR #{pr.number} in {pr.repository_full_name}` (or the
mirror analogue `PR #{pr.pr_number} in {pr.repo_full_name}`) through
every remaining skip / fetch-failure / repo-resolution warning across
the OSS scoring stack — 21 warning sites in total.

## Changes

`gittensor/validator/oss_contributions/scoring.py`
- `score_pull_request`: 2 warnings (`repo not in master_repositories`,
  `No file changes found`) gain PR-side context.
- `fetch_file_contents_for_pr`: 1 warning (`Invalid repository name
  format`) gains PR number.
- `is_valid_issue`: 7 skip warnings gain `(PR #N in owner/repo)` —
  routed through a single `pr_ctx` local computed once at function
  entry. Optional `pr_ctx` parameter added to
  `_is_completed_when_closed` so its single warning is consistent.

`gittensor/validator/oss_contributions/mirror/scoring.py`
- `score_mirror_pr`: 3 warnings (`repo not in mirror_repos`, `Mirror
  file fetch failed`, `No files returned`) gain PR-side context via a
  shared `pr_ctx` local.
- `_is_valid_linked_issue`: 8 skip warnings gain `(PR #N in
  owner/repo)` — same `pr_ctx` pattern as the legacy `is_valid_issue`.

## Tests

`tests/validator/test_is_valid_issue.py`
- New `TestIsValidIssueSkipWarningsCarryPRContext` class with five
  `@patch`-decorated cases covering the self-issue, close-window,
  state_reason (via `_is_completed_when_closed`), missing
  author_login, and issue-created-after-PR paths. Each asserts both
  `f'PR #{pr.number}'` and `pr.repository_full_name` appear in the
  emitted warning.

`tests/validator/oss_contributions/mirror/test_scoring.py`
- New `TestLinkedIssueSkipWarningsCarryPRContext` class with two
  `@patch`-decorated cases covering the self-issue and close-window
  paths on the mirror side; same shared assertion helper format.

## Reproduction (before / after)

Two miners both having a PR with a self-issue in the same multi-miner
round:

Before:
  Skipping issue #50 - Issue has same author as PR (self-created issue)
  Skipping issue #50 - Issue has same author as PR (self-created issue)
  Skipping linked issue #50 - same author as PR (self-issue)
  Skipping linked issue #50 - same author as PR (self-issue)

After:
  Skipping issue #50 (PR #100 in entrius/gittensor) - Issue has same author as PR (self-created issue)
  Skipping issue #50 (PR #143 in entrius/gittensor-ui) - Issue has same author as PR (self-created issue)
  Skipping linked issue #50 (PR #100 in entrius/gittensor) - same author as PR (self-issue)
  Skipping linked issue #50 (PR #143 in entrius/gittensor-ui) - same author as PR (self-issue)

## Notes

No behaviour change — gate decisions, return values, and downstream
multiplier math are identical, only the log surface gains context.

`ruff check` and `ruff format --check` are clean on all four files.

`is_valid_issue`'s existing `TestIsValidIssueStateReasonGate`,
`TestIsValidIssueCloseWindow`, and `TestIsValidIssueOpenPRCollateral`
continue to pass without modification.
```