### PR TITLE
fix: close all sessions in session_scope even when one close() raises (follow-up of #687)

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -202,8 +202,15 @@ def session_scope() -> Iterator[None]:
     finally:
         cache = _session_cache
         _session_cache = None
+        first_exc: Optional[Exception] = None
         for s in cache.values():
-            s.close()
+            try:
+                s.close()
+            except Exception as exc:
+                if first_exc is None:
+                    first_exc = exc
+        if first_exc is not None:
+            raise first_exc
 
 
 def _build_session(token: str) -> requests.Session:

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1645,6 +1645,28 @@ class TestSessionScope:
 
         assert github_api_tools._session_cache is None
 
+    def test_all_sessions_closed_even_when_first_close_raises(self, monkeypatch):
+        built: list = []
+
+        def fake_build_session(token):
+            session = Mock()
+            session.headers = {}
+            built.append(session)
+            return session
+
+        monkeypatch.setattr(github_api_tools, '_build_session', fake_build_session)
+
+        with pytest.raises(RuntimeError, match='first boom'):
+            with _real_session_scope():
+                _real_get_session('tokenA')
+                _real_get_session('tokenB')
+                built[0].close.side_effect = RuntimeError('first boom')
+
+        assert len(built) == 2
+        built[0].close.assert_called_once()
+        built[1].close.assert_called_once()
+        assert github_api_tools._session_cache is None
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Follow-up to #687. Closes #858.

## Problem

In `session_scope()`'s `finally` block, if the first `session.close()` raises, the loop aborts and every remaining session in the cache is leaked:

```python
for s in cache.values():
    s.close()  # raises here → remaining sessions never closed
```

## Fix

Wrap each `close()` individually so all sessions are always attempted. The first exception, if any, is re-raised after the full iteration:

```python
first_exc: Optional[Exception] = None
for s in cache.values():
    try:
        s.close()
    except Exception as exc:
        if first_exc is None:
            first_exc = exc
if first_exc is not None:
    raise first_exc
```

## Test

Adds `test_all_sessions_closed_even_when_first_close_raises` to `TestSessionScope`: two sessions are created, the first `close()` is made to raise, and the test asserts both sessions had `close()` called and `_session_cache` is `None`.
