### PR TITLE
fix: refresh stale-OPEN pull_requests rows for closed-out-of-window PRs

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -371,6 +371,12 @@ class MinerEvaluation:
     open_pull_requests: List[PullRequest] = field(default_factory=list)
     closed_pull_requests: List[PullRequest] = field(default_factory=list)
 
+    # CLOSED PRs created before the scoring lookback window. Not factored into
+    # scoring, eligibility, credibility, or the total_*_prs counts (preserves
+    # #406 intent). Only used to refresh the pull_requests row pr_state so an
+    # earlier OPEN scan doesn't leave a phantom row on the dashboard.
+    stale_closed_pull_requests: List[PullRequest] = field(default_factory=list)
+
     # Populated by gittensor.validator.oss_contributions.mirror.combine.combine
     # when the mirror scoring path runs. Empty for legacy-only evaluations.
     mirror_merged_prs: List['ScoredMirrorPR'] = field(default_factory=list)
@@ -478,6 +484,16 @@ class MinerEvaluation:
             f'CLOSED PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])} counting towards credibility'
         )
         self.closed_pull_requests.append(
+            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
+        )
+
+    def add_stale_closed_pull_request(self, raw_pr: Dict):
+        """Track a CLOSED PR outside the scoring lookback window so its
+        pull_requests row is refreshed to its real GitHub state. Not factored
+        into scoring or credibility — preserves the #406 fix that prevents a
+        fresh credibility penalty when miners close old backlog PRs.
+        """
+        self.stale_closed_pull_requests.append(
             PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
         )
 

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -832,9 +832,11 @@ def try_add_open_or_closed_pr(
         closed_dt = parse_github_iso_to_utc(closed_at)
         created_dt = parse_github_iso_to_utc(created_at)
 
-        # Ignore stale PRs that were created before the scoring lookback window.
-        # This allows users to close old PRs without receiving a fresh credibility penalty.
+        # PRs created before the scoring lookback window are excluded from
+        # credibility math (#406) but still need their pull_requests row
+        # refreshed so an earlier OPEN scan doesn't leave a phantom row.
         if created_dt < lookback_date_filter:
+            miner_eval.add_stale_closed_pull_request(pr_raw)
             return
 
         if closed_dt >= lookback_date_filter:

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -78,6 +78,12 @@ class DatabaseStorage:
             result.stored_counts['closed_pull_requests'] = self.repo.store_pull_requests_bulk(
                 miner_eval.closed_pull_requests + _adapt_mirror(miner_eval.mirror_closed_prs)
             )
+            # Refresh stale-OPEN rows for PRs that closed after their creation aged
+            # out of the lookback window. Reuses the same UPSERT; scoring columns
+            # land at their default-zero values, which is correct for a closed PR.
+            result.stored_counts['stale_closed_pull_requests'] = self.repo.store_pull_requests_bulk(
+                miner_eval.stale_closed_pull_requests
+            )
             result.stored_counts['issues'] = self.repo.store_issues_bulk(miner_eval.get_all_issues())
             result.stored_counts['file_changes'] = self.repo.store_file_changes_bulk(miner_eval.get_all_file_changes())
             # Clean up stale data if this github_id was previously registered under a different uid/hotkey

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -33,6 +33,7 @@ get_merge_base_sha = github_api_tools.get_merge_base_sha
 find_prs_for_issue = github_api_tools.find_prs_for_issue
 execute_graphql_query = github_api_tools.execute_graphql_query
 check_github_issue_closed = github_api_tools.check_github_issue_closed
+try_add_open_or_closed_pr = github_api_tools.try_add_open_or_closed_pr
 
 
 # ============================================================================
@@ -1664,6 +1665,66 @@ class TestSessionScope:
                 _real_get_session('tokenA')
 
         assert github_api_tools._session_cache is None
+
+
+class TestTryAddOpenOrClosedPR:
+    """Routing checks for try_add_open_or_closed_pr.
+
+    The early-return for CLOSED PRs created before the lookback window keeps
+    them out of credibility/scoring math (#406) but must still hand the row to
+    storage, otherwise an earlier OPEN scan leaves a phantom row.
+    """
+
+    @staticmethod
+    def _eval():
+        from gittensor.classes import MinerEvaluation
+
+        return MinerEvaluation(uid=1, hotkey='5Hotkey', github_id='123')
+
+    @staticmethod
+    def _closed_pr_raw(created_at: str, closed_at: str) -> Dict:
+        return {
+            'number': 42,
+            'repository': {'owner': {'login': 'grafana'}, 'name': 'grafana'},
+            'state': 'CLOSED',
+            'closingIssuesReferences': {'nodes': []},
+            'bodyText': '',
+            'lastEditedAt': None,
+            'mergedAt': None,
+            'closedAt': closed_at,
+            'timelineItems': {'nodes': []},
+            'title': 'closed without merge',
+            'author': {'login': 'miner'},
+            'authorAssociation': 'CONTRIBUTOR',
+            'createdAt': created_at,
+            'additions': 1,
+            'deletions': 1,
+            'commits': {'totalCount': 1},
+            'headRefOid': 'abc',
+            'baseRefOid': 'def',
+        }
+
+    def test_stale_closed_routes_to_log_only_bucket(self):
+        miner_eval = self._eval()
+        lookback = datetime(2026, 3, 25, tzinfo=timezone.utc)
+        pr_raw = self._closed_pr_raw(created_at='2026-03-07T00:00:00Z', closed_at='2026-04-23T00:00:00Z')
+
+        github_api_tools.try_add_open_or_closed_pr(miner_eval, pr_raw, 'CLOSED', lookback)
+
+        assert len(miner_eval.stale_closed_pull_requests) == 1
+        assert miner_eval.stale_closed_pull_requests[0].number == 42
+        assert miner_eval.closed_pull_requests == []
+        assert miner_eval.total_closed_prs == 0
+
+    def test_in_window_closed_routes_to_scored_bucket(self):
+        miner_eval = self._eval()
+        lookback = datetime(2026, 3, 25, tzinfo=timezone.utc)
+        pr_raw = self._closed_pr_raw(created_at='2026-04-01T00:00:00Z', closed_at='2026-04-20T00:00:00Z')
+
+        github_api_tools.try_add_open_or_closed_pr(miner_eval, pr_raw, 'CLOSED', lookback)
+
+        assert len(miner_eval.closed_pull_requests) == 1
+        assert miner_eval.stale_closed_pull_requests == []
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #768.

## Summary

`try_add_open_or_closed_pr` (`gittensor/utils/github_api_tools.py:818`) returns early for CLOSED PRs whose `created_dt < lookback_date_filter` to keep them out of credibility math (#406). The same early-return also dropped them from `store_pull_requests_bulk`, so any earlier OPEN scan left a phantom row at `pr_state='OPEN'` for the dashboard PR list at `/miners/{id}/prs`.

## Fix

Add a log-only `stale_closed_pull_requests` bucket on `MinerEvaluation` that:
- the storage layer upserts via the existing `BULK_UPSERT_PULL_REQUESTS` (refreshes `pr_state`),
- scoring, eligibility, credibility, and the `total_*_prs` properties all ignore.

That preserves #406 intent (no fresh credibility penalty for closing old backlog PRs) and leaves the dashboard's `minerStats.totalOpenPrs` tile count unchanged. The only DB-visible change is that frozen-OPEN rows for these PRs flip to CLOSED on the next scan.

I dropped the issue's "extend `total_*_prs` to include the bucket" prescription — that would inflate the dashboard tile count, which is currently correct.

## Notes on the upsert

The reused `BULK_UPSERT_PULL_REQUESTS` zeroes out scoring columns (`earned_score`, `token_score`, `collateral_score`, multipliers) on conflict. For a PR that was previously OPEN with collateral and is now CLOSED-not-merged, zero is the semantically correct value — the PR no longer provides collateral. No partial-update query needed.

## Test plan

- [x] `pytest tests/utils/test_github_api_tools.py::TestTryAddOpenOrClosedPR` — 2 new cases (stale → log-only bucket, in-window → scored bucket)
- [x] `pytest tests/` — full suite green except one pre-existing unrelated failure in `tests/cli/test_cli_helpers.py::TestCliRegisterLogicalFailures::test_register_exits_non_zero_when_contract_metadata_missing` (also fails on `test` without this branch)
- [x] `ruff check`, `ruff format`, `pyright` — all clean on the changed files