### PR TITLE
refactor: simplify get_all_uids — drop dead exclude param and redundant set() wrap

### DIFF
--- a/gittensor/utils/uids.py
+++ b/gittensor/utils/uids.py
@@ -1,20 +1,11 @@
-from typing import List
-
-
-def get_all_uids(self, exclude: List[int] = []) -> set[int]:
-    """Return all eligible miner UIDs for scoring.
-
-    Args:
-        exclude: UIDs to omit from the returned set.
+def get_all_uids(self) -> set[int]:
+    """Return all miner UIDs for scoring.
 
     Returns:
-        Set of miner UIDs that are serving and within the validator-permit TAO limit.
-        UID ``0`` is always included.
+        Set of miner UIDs in the metagraph. UID ``0`` is always included
+        (subnet requirement) so the empty-metagraph bootstrap case still
+        yields ``{0}`` rather than ``set()``.
     """
-    # Get all available miner UIDs, excluding specified ones
-    available_miner_uids = {uid for uid in range(self.metagraph.n.item()) if uid not in exclude}
-
-    # Ensure miner UID 0 is always included (subnet requirement)
+    available_miner_uids = set(range(self.metagraph.n.item()))
     available_miner_uids.add(0)
-
-    return set(available_miner_uids)
+    return available_miner_uids

--- a/tests/utils/test_uids.py
+++ b/tests/utils/test_uids.py
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for gittensor.utils.uids.get_all_uids."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gittensor.utils.uids import get_all_uids
+
+
+class _FakeMetagraphSize:
+    """Mimic the bittensor metagraph's `n.item()` interface."""
+
+    def __init__(self, n: int):
+        self._n = n
+
+    def item(self) -> int:
+        return self._n
+
+
+def _make_self(n: int) -> SimpleNamespace:
+    return SimpleNamespace(metagraph=SimpleNamespace(n=_FakeMetagraphSize(n)))
+
+
+def test_get_all_uids_returns_full_range():
+    result = get_all_uids(_make_self(5))
+    assert result == {0, 1, 2, 3, 4}
+    assert isinstance(result, set)
+
+
+def test_get_all_uids_always_includes_uid_zero_even_for_empty_metagraph():
+    """Bootstrap invariant: the empty-metagraph case must still yield {0}."""
+    result = get_all_uids(_make_self(0))
+    assert result == {0}
+
+
+def test_get_all_uids_for_single_uid_metagraph():
+    result = get_all_uids(_make_self(1))
+    assert result == {0}
+
+
+def test_get_all_uids_takes_no_extra_arguments():
+    """Regression guard: the dead `exclude` parameter must not return."""
+    with pytest.raises(TypeError):
+        get_all_uids(_make_self(3), exclude=[1])  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

Closes #861.

\`get_all_uids\` in [gittensor/utils/uids.py](gittensor/utils/uids.py) had three small but compounding issues:

1. **Mutable default argument** — \`exclude: List[int] = []\`. \`grep -rn get_all_uids\` confirms the lone caller (\`validator/forward.py\`) never passes \`exclude\`, so the parameter is dead.
2. **The exclude parameter is semantically broken even when used.** The function unconditionally re-adds UID 0 to the set, so a caller asking to exclude UID 0 would be silently betrayed.
3. **Redundant \`set()\` wrap.** The return value re-wraps an already-set value built from a set comprehension plus \`.add(0)\`.

After this change \`get_all_uids(self)\` returns \`set(range(n)) | {0}\`. The bootstrap invariant (\`n == 0\` still yields \`{0}\`) is preserved by an explicit \`.add(0)\`.

Net: **-16 / +5 lines** in the source file, plus a fresh \`tests/utils/test_uids.py\` that pins the contract.

## Related Issues

Closes #861.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

\`tests/utils/test_uids.py\` covers four cases:
- \`n=5\` → returns \`{0..4}\` (standard range).
- \`n=0\` → returns \`{0}\` (bootstrap invariant preserved).
- \`n=1\` → returns \`{0}\` (single-UID).
- regression guard ensuring \`exclude=\` is no longer accepted (\`TypeError\`).

\`uv run --extra dev pytest tests/\` — all 686 tests pass (682 baseline + 4 new).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)