### PR TITLE
fix: isolate malformed master_repositories entries instead of collapsing the loader

### DIFF
--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -113,21 +113,29 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
             bt.logging.error(f'Expected dict from {weights_file}, got {type(data)}')
             return {}
 
-        # Parse JSON data into RepositoryConfig objects
+        # Parse JSON data into RepositoryConfig objects.
+        # Companion loader load_programming_language_weights() also accepts a
+        # plain-float weight for back-compat; mirror that here so a malformed
+        # entry (or one written in the legacy short form) is isolated rather
+        # than collapsing the whole loader to {}.
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
             try:
-                config = RepositoryConfig(
-                    weight=float(metadata.get('weight', 0.01)),
-                    inactive_at=metadata.get('inactive_at'),
-                    additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
-                    mirror_enabled=bool(metadata.get('mirror_enabled', False)),
-                )
+                if isinstance(metadata, dict):
+                    config = RepositoryConfig(
+                        weight=float(metadata.get('weight', 0.01)),
+                        inactive_at=metadata.get('inactive_at'),
+                        additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
+                        mirror_enabled=bool(metadata.get('mirror_enabled', False)),
+                    )
+                else:
+                    # Plain-float weight: matches the back-compat path in
+                    # load_programming_language_weights().
+                    config = RepositoryConfig(weight=float(metadata))
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:
-                bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
-                # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+                bt.logging.warning(f'Could not parse config for {repo_name}: {metadata!r} - {e}; skipping entry')
+                continue
 
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -161,6 +161,128 @@ class TestRepositoryConfigMirrorFlag:
         assert repos['foo/explicit-off'].mirror_enabled is False
 
 
+class TestLoadMasterRepoWeightsMalformedEntries:
+    """Per-entry malformed values must not collapse the whole loader to {}.
+
+    The companion loader load_programming_language_weights already isolates
+    malformed entries. This class pins down the same contract for
+    load_master_repo_weights so a single bad chunk of master_repositories.json
+    cannot zero-out an entire scoring round.
+    """
+
+    @staticmethod
+    def _write_master_repos(tmp_path, payload):
+        import json
+
+        (tmp_path / 'master_repositories.json').write_text(json.dumps(payload))
+
+    def test_non_dict_entry_isolated_other_entries_load(self, tmp_path, monkeypatch):
+        """A non-dict entry (e.g. list) is skipped; well-formed siblings still load."""
+        from gittensor.validator.utils import load_weights as lw
+
+        self._write_master_repos(
+            tmp_path,
+            {
+                'foo/good-one': {'weight': 0.5, 'mirror_enabled': True},
+                'foo/bad-list': ['not', 'a', 'dict'],
+                'foo/good-two': {'weight': 0.25},
+            },
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert 'foo/good-one' in repos
+        assert 'foo/good-two' in repos
+        assert 'foo/bad-list' not in repos
+        assert repos['foo/good-one'].weight == 0.5
+        assert repos['foo/good-one'].mirror_enabled is True
+        assert repos['foo/good-two'].weight == 0.25
+
+    def test_plain_float_entry_back_compat(self, tmp_path, monkeypatch):
+        """Plain-float weight loads as RepositoryConfig with default flags.
+
+        Mirrors the back-compat path already accepted by
+        load_programming_language_weights().
+        """
+        from gittensor.validator.utils import load_weights as lw
+
+        self._write_master_repos(
+            tmp_path,
+            {
+                'foo/dict-form': {'weight': 0.5},
+                'foo/legacy-float': 0.42,
+            },
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/legacy-float'].weight == 0.42
+        assert repos['foo/legacy-float'].mirror_enabled is False
+        assert repos['foo/legacy-float'].inactive_at is None
+
+    def test_unparseable_weight_skipped_others_survive(self, tmp_path, monkeypatch):
+        """A non-numeric weight in a dict entry is skipped, not promoted to default."""
+        from gittensor.validator.utils import load_weights as lw
+
+        self._write_master_repos(
+            tmp_path,
+            {
+                'foo/good': {'weight': 0.5},
+                'foo/bad-weight': {'weight': 'not-a-number'},
+                'foo/good-two': {'weight': 0.1},
+            },
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert 'foo/good' in repos
+        assert 'foo/good-two' in repos
+        assert 'foo/bad-weight' not in repos
+
+    def test_string_entry_isolated(self, tmp_path, monkeypatch):
+        """String values are not float-coercible and must skip cleanly."""
+        from gittensor.validator.utils import load_weights as lw
+
+        self._write_master_repos(
+            tmp_path,
+            {
+                'foo/good': {'weight': 0.5},
+                'foo/bad-string': 'oops',
+            },
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert 'foo/good' in repos
+        assert 'foo/bad-string' not in repos
+        assert len(repos) == 1
+
+    def test_only_malformed_entries_returns_empty_dict_not_outer_except(self, tmp_path, monkeypatch):
+        """All-malformed JSON yields {} via the per-entry skip path, not the outer except.
+
+        Regression: previously an AttributeError on the first non-dict entry escaped
+        through to the outer ``except Exception`` block, so a payload with one bad
+        entry plus many good ones returned {} for the *whole* file.
+        """
+        from gittensor.validator.utils import load_weights as lw
+
+        self._write_master_repos(
+            tmp_path,
+            {
+                'foo/bad-list': ['x'],
+                'foo/bad-string': 'x',
+            },
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+        assert repos == {}
+
+
 class TestBannedOrganizations:
     """Tests ensuring banned organizations are not active in the repository list.
 


### PR DESCRIPTION
## Summary

A single malformed entry in `master_repositories.json` zeroes out the entire scoring round.

The per-entry `try/except` in `load_master_repo_weights` only catches `(ValueError, TypeError)`, so an `AttributeError` raised by `metadata.get('weight', 0.01)` against a non-dict entry escapes to the function-level `except Exception:` and the loader returns `{}`. `load_miners_prs` then logs `Skipping PR #N in <repo> - ineligible repo` for *every* PR; `oss_rewards` ends up all zero. The only signal is one log line — `Unexpected error loading repository weights: 'float' object has no attribute 'get'`.

The sibling loader `load_programming_language_weights` already gets this right (`isinstance(config, dict)` guard with a plain-float back-compat path). This PR mirrors that pattern in the repo loader.

## What changes

- `isinstance(metadata, dict)` guard around the dict-form parsing.
- Plain-float back-compat (`'owner/repo': 0.1` → `RepositoryConfig(weight=0.1, …defaults)`), matching `load_programming_language_weights`.
- The per-entry `except` now skips the malformed entry with a warning that includes the offending value, instead of silently retrying `metadata.get('weight', 0.01)` — which itself `AttributeError`'d on the non-dict path that triggered this in the first place.
- The function-level `except Exception` block stays as the JSON-decode / file-not-found / truly-unexpected catch-all; it's no longer reached on a per-entry typo.

No behavior change for well-formed JSON. The live `master_repositories.json` continues to load identically (verified by the existing `test_master_repositories_not_empty` and `test_mirror_enabled_field_present_on_live_configs` tests).

## Tests

New `TestLoadMasterRepoWeightsMalformedEntries` class in `tests/validator/test_load_weights.py` — 5 cases:

- `test_non_dict_entry_isolated_other_entries_load` — list entry skipped, dict siblings load.
- `test_plain_float_entry_back_compat` — plain-float weight loads with default `mirror_enabled=False` / `inactive_at=None`.
- `test_unparseable_weight_skipped_others_survive` — `{'weight': 'not-a-number'}` is skipped, not promoted to default.
- `test_string_entry_isolated` — string entry skipped cleanly.
- `test_only_malformed_entries_returns_empty_dict_not_outer_except` — regression: an all-malformed file still returns `{}`, but via the per-entry skip path, not the outer `except Exception`.

All 33 tests in `tests/validator/test_load_weights.py` pass; ruff check + format clean.

## Test plan

- [x] `pytest tests/validator/test_load_weights.py` — 33 passed (5 new)
- [x] `ruff check gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py` — clean
- [x] `ruff format --check` — clean
- [x] Live `master_repositories.json` continues to load with the same entry count (existing `test_master_repositories_not_empty` is the regression sentinel)

Closes #750