### PR TITLE
fix(mirror): drop issues missing created_at from discovery scoring

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -138,6 +138,7 @@ async def run_mirror_issue_discovery(
     skipped_failed = 0
     fetch_errors = 0
     no_issues = 0
+    malformed_issues = 0
 
     for uid, evaluation in miner_evaluations.items():
         if not evaluation.github_id or evaluation.github_id == '0':
@@ -154,7 +155,20 @@ async def run_mirror_issue_discovery(
             fetch_errors += 1
             continue
 
-        filtered = [i for i in response.issues if i.repo_full_name in enabled_names]
+        filtered = []
+        for issue in response.issues:
+            if issue.repo_full_name not in enabled_names:
+                continue
+            # Quarantine malformed issues with no created_at — without it we can't
+            # apply the lookback window, time decay, or one-issue-per-PR ordering,
+            # so treat as bad mirror data rather than letting it score.
+            if issue.created_at is None:
+                bt.logging.warning(
+                    f'Mirror issue {issue.repo_full_name}#{issue.issue_number} missing created_at — skipping'
+                )
+                malformed_issues += 1
+                continue
+            filtered.append(issue)
         if not filtered:
             no_issues += 1
             continue
@@ -182,7 +196,8 @@ async def run_mirror_issue_discovery(
     bt.logging.info('')
     bt.logging.info(
         f'Issue discovery complete | {processed} processed | {no_issues} no mirror issues | '
-        f'{fetch_errors} fetch errors | {skipped_no_gh} no github_id | {skipped_failed} prior OSS failure'
+        f'{fetch_errors} fetch errors | {skipped_no_gh} no github_id | {skipped_failed} prior OSS failure | '
+        f'{malformed_issues} malformed (missing created_at)'
     )
     bt.logging.info(
         f'Solving-PR cache: {cache_stats.hits} hits | {cache_stats.misses} misses '
@@ -242,13 +257,11 @@ def _score_miner_mirror_issues(
     # later issues closed by the same PR add credibility only.
     pr_scored_keys: Set[Tuple[str, int]] = set()
 
+    # created_at is guaranteed non-None here — run_mirror_issue_discovery
+    # filters out malformed issues with missing created_at before this runs.
     issues_sorted = sorted(
         issues,
-        key=lambda i: (
-            i.repo_full_name,
-            i.solved_by_pr or 0,
-            i.created_at or datetime.max.replace(tzinfo=timezone.utc),
-        ),
+        key=lambda i: (i.repo_full_name, i.solved_by_pr or 0, i.created_at),
     )
 
     for issue in issues_sorted:

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -350,6 +350,57 @@ class TestRunMirrorIssueDiscovery:
         )
         assert eval_.total_solved_issues == 0
 
+    def test_missing_created_at_is_dropped_not_treated_as_newest(self):
+        """Mirror issues with created_at=None must be quarantined, not silently
+        sorted to the newest bucket via a datetime.max sentinel — that path
+        previously bypassed the lookback window and let stale/corrupt mirror
+        data leak into discovery scoring."""
+        malformed = _issue_dict(issue_number=42)
+        malformed['created_at'] = None  # simulate corrupt mirror payload
+        healthy = _issue_dict(issue_number=43)
+
+        client = Mock()
+        client.get_miner_issues.return_value = _response([malformed, healthy])
+        eval_ = _eval()
+        eval_.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Only the healthy issue counted; malformed was excluded entirely
+        assert eval_.total_solved_issues == 1
+        assert eval_.total_valid_solved_issues == 1
+
+    def test_only_malformed_issues_yields_no_processing(self):
+        """If every issue is malformed, the miner falls into the no-issues
+        bucket — no zeroed evaluation row is produced."""
+        malformed = _issue_dict(issue_number=42)
+        malformed['created_at'] = None
+
+        client = Mock()
+        client.get_miner_issues.return_value = _response([malformed])
+        eval_ = _eval()
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        assert eval_.total_solved_issues == 0
+        assert eval_.total_open_issues == 0
+
     def test_mirror_request_error_does_not_abort_other_miners(self):
         client = Mock()
 


### PR DESCRIPTION
## Summary

`mirror_scan.py` defaulted missing `issue.created_at` to `datetime.max.replace(tzinfo=timezone.utc)`, which sorted un-dated
issues into the "newest" bucket and bypassed the lookback-window intent — letting stale/corrupt mirror payloads leak into discovery scoring and risk overcrediting.

This PR quarantines malformed issues at `run_mirror_issue_discovery`:

- Skip any `MirrorIssue` whose `created_at is None` after the   `enabled_names` filter, log a `bt.logging.warning` per occurrence,
  and bump a new cycle-level `malformed_issues` counter surfaced in   the end-of-phase summary.
- Filter before computing `open_issue_count`, so corrupt payloads   can't inflate the open-issue spam-multiplier signal either.
- Drop the now-unreachable `datetime.max` fallback in the   `_score_miner_mirror_issues` sort key.

## Related Issues

Fixes #877

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added two regression tests in
`tests/validator/issue_discovery/test_mirror_scan.py`:

- `test_missing_created_at_is_dropped_not_treated_as_newest` — a  malformed issue alongside a healthy one is excluded from solved  counts; the healthy issue still scores normally.
- `test_only_malformed_issues_yields_no_processing` — an all-malformed miner falls into the no-issues bucket with zeroed
  counters.
