### PR TITLE
fix: sort solver candidates by parsed merged_at, not raw ISO string

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1088,7 +1088,16 @@ def find_solver_from_cross_references(
                 f'merged_at={candidate.get("merged_at")}'
             )
 
-    merged.sort(key=lambda p: (p.get('merged_at') or '', p.get('number') or 0))
+    # Parse merged_at to a datetime before sorting: lexicographic ISO-8601
+    # comparison breaks when GraphQL mixes second and sub-second precision
+    # ('2025-01-01T00:00:00.000Z' < '2025-01-01T00:00:00Z' as strings).
+    _min_dt = datetime.min.replace(tzinfo=timezone.utc)
+    merged.sort(
+        key=lambda p: (
+            parse_github_iso_to_utc(p['merged_at']) if p.get('merged_at') else _min_dt,
+            p.get('number') or 0,
+        )
+    )
     best = merged[0]
     bt.logging.debug(
         f'Solver via GraphQL cross-reference: PR#{best.get("number")}, '

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -939,6 +939,23 @@ class TestFindSolverFromCrossReferences:
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
     @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_mixed_precision_merged_at_sorts_by_real_time(self, mock_logging, mock_graphql):
+        """Sub-second and second-precision ISO strings at the same instant must compare equal,
+        so the deterministic pr_number tiebreaker decides — not lexical '.000Z' vs 'Z' order."""
+        mock_graphql.return_value = _graphql_response(
+            [
+                _pr_node(number=20, user_id=200, merged_at='2025-01-01T00:00:00.000Z', closing_issues=[12]),
+                _pr_node(number=10, user_id=100, merged_at='2025-01-01T00:00:00Z', closing_issues=[12]),
+            ]
+        )
+
+        solver_id, pr_number = find_solver_from_cross_references('owner/repo', 12, 'fake_token')
+
+        assert solver_id == 100
+        assert pr_number == 10
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
     def test_mixed_valid_and_invalid_candidates(self, mock_logging, mock_graphql):
         """Only valid candidates survive all filters (merged + same repo + closing ref)."""
         mock_graphql.return_value = _graphql_response(


### PR DESCRIPTION
Closes: #881
## Summary

`find_solver_from_cross_references` decides which merged PR is credited
as an issue's solver by sorting candidates by `merged_at` ascending,
with `pr.number` as a deterministic tiebreaker. The sort key was the
**raw ISO 8601 string** returned by GraphQL:

```python
merged.sort(key=lambda p: (p.get('merged_at') or '', p.get('number') or 0))
