### PR TITLE
perf(storage): bump execute_values page_size to reduce PG round-trips

### DIFF
--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -209,7 +209,7 @@ class Repository(BaseRepository):
                     BULK_UPSERT_PULL_REQUESTS.replace('VALUES %s', 'VALUES %s'),
                     values,
                     template=None,
-                    page_size=100,
+                    page_size=1000,
                 )
                 self.db.commit()
                 return len(values)
@@ -264,7 +264,7 @@ class Repository(BaseRepository):
                 from psycopg2.extras import execute_values
 
                 execute_values(
-                    cursor, BULK_UPSERT_ISSUES.replace('VALUES %s', 'VALUES %s'), values, template=None, page_size=100
+                    cursor, BULK_UPSERT_ISSUES.replace('VALUES %s', 'VALUES %s'), values, template=None, page_size=1000
                 )
                 self.db.commit()
                 return len(values)
@@ -308,12 +308,15 @@ class Repository(BaseRepository):
                 # Use psycopg2's execute_values for efficient bulk insert
                 from psycopg2.extras import execute_values
 
+                # file_changes carries the variable-size patch column, so we keep
+                # page_size lower than the PR/issue bulk paths to bound the per-batch
+                # SQL string size when patches are large.
                 execute_values(
                     cursor,
                     BULK_UPSERT_FILE_CHANGES.replace('VALUES %s', 'VALUES %s'),
                     values,
                     template=None,
-                    page_size=100,
+                    page_size=200,
                 )
                 self.db.commit()
                 return len(values)


### PR DESCRIPTION
`Repository.store_pull_requests_bulk` and `store_issues_bulk` used `execute_values(..., page_size=100)`. A 10k-row insert needs ~100 PG round-trips at that setting; on managed PostgreSQL (~1-3 ms RTT) that's seconds of pure protocol overhead per scoring round.

Bump page_size to 1000 for the PR/issue paths, which carry only bounded-size scalar columns. Keep page_size=200 for store_file_changes_bulk because each row carries the raw `patch` column (variable, can be MB); 1000 there could build a multi-MB SQL string under heavy diffs.

No semantic change — same SQL, same data, same ON CONFLICT behavior; only the chunking changes.

Fixes #890 