### PR TITLE
fix(cli): route --json commands through loading_context to skip the Rich spinner

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -27,6 +27,7 @@ from .helpers import (
     emit_json,
     format_alpha,
     handle_exception,
+    loading_context,
     print_network_header,
     read_issues_from_contract,
     with_cli_behavior_options,
@@ -68,7 +69,7 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
     if not as_json:
         print_network_header(network_name, contract_addr)
 
-    with console.status('[bold cyan]Reading issues from contract...', spinner='dots'):
+    with loading_context('Reading issues from contract...', as_json, color='bold cyan'):
         issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
 
     if as_json:
@@ -194,7 +195,7 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
     try:
         from substrateinterface import SubstrateInterface
 
-        with console.status('[bold cyan]Reading contract storage...', spinner='dots'):
+        with loading_context('Reading contract storage...', as_json, color='bold cyan'):
             substrate = SubstrateInterface(url=ws_endpoint)
             issues = _read_issues_from_child_storage(substrate, contract_addr, verbose)
 
@@ -243,7 +244,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
             IssueCompetitionContractClient,
         )
 
-        with console.status('[bold cyan]Reading treasury and contract data...', spinner='dots'):
+        with loading_context('Reading treasury and contract data...', as_json, color='bold cyan'):
             subtensor = bt.Subtensor(network=ws_endpoint)
             client = IssueCompetitionContractClient(
                 contract_address=contract_addr,
@@ -297,7 +298,7 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
     try:
         from substrateinterface import SubstrateInterface
 
-        with console.status('[bold cyan]Reading contract configuration...', spinner='dots'):
+        with loading_context('Reading contract configuration...', as_json, color='bold cyan'):
             substrate = SubstrateInterface(url=ws_endpoint)
             packed = _read_contract_packed_storage(substrate, contract_addr, verbose)
 

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -25,6 +25,7 @@ from .helpers import (
     console,
     emit_json,
     handle_exception,
+    loading_context,
     print_error,
     print_network_header,
     print_success,
@@ -237,7 +238,7 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
             IssueCompetitionContractClient,
         )
 
-        with console.status('[bold cyan]Reading validator whitelist...', spinner='dots'):
+        with loading_context('Reading validator whitelist...', as_json, color='bold cyan'):
             subtensor = bt.Subtensor(network=ws_endpoint)
             client = IssueCompetitionContractClient(
                 contract_address=contract_addr,

--- a/tests/cli/test_loading_context_json_safety.py
+++ b/tests/cli/test_loading_context_json_safety.py
@@ -1,0 +1,102 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Regression tests: --json-accepting commands must use loading_context, not console.status.
+
+The helper `loading_context(msg, as_json)` short-circuits to nullcontext when
+as_json=True, so the Rich spinner never runs in JSON mode. Bypassing the helper
+risks (a) spinner Unicode bytes polluting stdout for TTY operators, and
+(b) UnicodeEncodeError crashes on non-UTF-8 stdout (latin-1, Windows-1252).
+"""
+
+from contextlib import nullcontext
+from unittest.mock import patch
+
+from gittensor.cli.issue_commands.helpers import loading_context
+
+
+# ==========================================================================
+# Unit tests on loading_context itself
+# ==========================================================================
+
+
+class TestLoadingContextHelper:
+    """The helper that JSON-accepting commands must use instead of console.status."""
+
+    def test_json_mode_returns_nullcontext(self):
+        """as_json=True must short-circuit to a no-op context — no spinner, no stdout writes."""
+        ctx = loading_context('reading...', as_json=True)
+        # nullcontext is the only valid no-op context manager from the stdlib;
+        # implementation detail isn't strictly pinned, but the type is.
+        assert isinstance(ctx, type(nullcontext()))
+
+    def test_human_mode_returns_status(self):
+        """as_json=False must return a Rich status (not nullcontext)."""
+        ctx = loading_context('reading...', as_json=False)
+        assert not isinstance(ctx, type(nullcontext()))
+
+    def test_json_mode_is_silent(self, capsys):
+        """Entering and exiting the JSON-mode context must produce zero stdout/stderr."""
+        with loading_context('should be silent', as_json=True):
+            pass
+        captured = capsys.readouterr()
+        assert captured.out == ''
+        assert captured.err == ''
+
+
+# ==========================================================================
+# Integration: --json commands actually call loading_context (not console.status)
+# ==========================================================================
+
+
+FAKE_ISSUES = [
+    {
+        'id': 1,
+        'repository_full_name': 'owner/repo',
+        'issue_number': 10,
+        'bounty_amount': 50,
+        'target_bounty': 100,
+        'status': 'Active',
+    },
+]
+
+
+def test_issues_list_json_uses_loading_context(cli_root, runner):
+    """`gitt issues list --json` must funnel through loading_context — captured by mock."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+        patch('gittensor.cli.issue_commands.view.loading_context', wraps=loading_context) as mock_ctx,
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    # The command must call loading_context (not console.status directly).
+    assert mock_ctx.called
+    # And it must pass as_json=True so the helper short-circuits to nullcontext.
+    args, kwargs = mock_ctx.call_args
+    # Helper signature: loading_context(message, as_json, ...)
+    as_json_arg = kwargs.get('as_json', args[1] if len(args) >= 2 else None)
+    assert as_json_arg is True
+
+
+def test_issues_list_human_mode_passes_as_json_false(cli_root, runner):
+    """In human mode, loading_context must be called with as_json=False so the spinner runs."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+        patch('gittensor.cli.issue_commands.view.loading_context', wraps=loading_context) as mock_ctx,
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert mock_ctx.called
+    args, kwargs = mock_ctx.call_args
+    as_json_arg = kwargs.get('as_json', args[1] if len(args) >= 2 else None)
+    assert as_json_arg is False


### PR DESCRIPTION
## What

Five `--json`-accepting commands bypassed the existing `loading_context()` helper and called `console.status(...)` directly:

- `gitt issues list` — [view.py:71](gittensor/cli/issue_commands/view.py#L71)
- `gitt issues bounty-pool` — [view.py:197](gittensor/cli/issue_commands/view.py#L197)
- `gitt issues pending-harvest` — [view.py:246](gittensor/cli/issue_commands/view.py#L246)
- `gitt admin info` — [view.py:300](gittensor/cli/issue_commands/view.py#L300)
- `gitt vote list` — [vote.py:240](gittensor/cli/issue_commands/vote.py#L240)

Result: the Rich spinner runs in JSON mode, with two visible failure modes.

## Why

**Crash on non-UTF-8 terminals.** Spinner uses Braille (`⠇`, `⠏`, …). On latin-1 / cp1252 stdout:
```
$ gitt m check
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2807' in position 10
```
Operators in `--json` mode shouldn't have to set `PYTHONIOENCODING=utf-8`.

**Spinner frames in the buffer.** TTY operators copy-pasting or `tee`-ing JSON output get ANSI/Unicode mixed in:
```
$ gitt issues list --json | tee out.json | jq .issue_count
parse error: Invalid numeric literal at line 1, column 14
```

`loading_context(msg, as_json)` already returns `nullcontext()` when `as_json=True` — exactly the right behavior. The five callers just needed to use it.

## How

Mechanical swap at each site:
```python
# Before
with console.status('[bold cyan]Reading issues from contract...', spinner='dots'):
    ...

# After
with loading_context('Reading issues from contract...', as_json, color='bold cyan'):
    ...
```

`vote.py:145` (`vote solution`) and `vote.py:204` (`vote cancel`) keep direct `console.status` — those commands don't take `--json`.

## Tests

`tests/cli/test_loading_context_json_safety.py` — 5 cases:
- `loading_context(msg, as_json=True)` returns nullcontext, produces no stdout/stderr
- `loading_context(msg, as_json=False)` returns the Rich Status
- `gitt issues list --json` calls the helper with `as_json=True`
- `gitt issues list` (human mode) calls it with `as_json=False`

```
$ pytest tests/cli/test_loading_context_json_safety.py tests/cli/test_issues_list_json.py -v
7 passed in 0.17s
```

PR #335 regression coverage in `test_issues_list_json.py` keeps passing.

## Scope

3 files, +109 / −5. No API change, no JSON schema change, no human-mode behavior change. Routes existing callers through an existing helper.

## Related

- #786 (merged) — same shape: replace ad-hoc `deepcopy` with shared shallow-copy helpers in `MinerEvaluationCache`.
- #813 (merged) — same shape: route `gitt config set` through `click.Choice` for unknown-key rejection.
- #855 / #856 (open) — also touching `view.py:issues_list`, but at the `--id` parse gate. No conflict.