### PR TITLE
fix: isolate malformed mirror PR child rows

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -21,6 +21,34 @@ from gittensor.validator.utils.datetime_utils import (
 )
 
 
+def _parse_mirror_labels(raw_labels: list[dict], parent_identifier: str) -> list['MirrorLabel']:
+    labels: list[MirrorLabel] = []
+    for raw in raw_labels or []:
+        try:
+            labels.append(MirrorLabel.from_dict(raw))
+        except Exception as e:
+            name = raw.get('name', '?') if isinstance(raw, dict) else '?'
+            bt.logging.warning(
+                f'Skipping malformed mirror label {name} on {parent_identifier}: {e}'
+            )
+    return labels
+
+
+def _parse_mirror_linked_issues(
+    raw_issues: list[dict], pr_identifier: str
+) -> list['MirrorLinkedIssue']:
+    linked_issues: list[MirrorLinkedIssue] = []
+    for raw in raw_issues or []:
+        try:
+            linked_issues.append(MirrorLinkedIssue.from_dict(raw))
+        except Exception as e:
+            identifier = raw.get('number', '?') if isinstance(raw, dict) else '?'
+            bt.logging.warning(
+                f'Skipping malformed mirror linked issue {identifier} on {pr_identifier}: {e}'
+            )
+    return linked_issues
+
+
 @dataclass
 class MirrorLabel:
     """A label applied to a PR or issue, with the actor who applied it.
@@ -94,6 +122,7 @@ class MirrorLinkedIssue:
         # str-typed field so downstream `==` comparisons with author_github_id
         # from MirrorPullRequest don't silently mismatch on type.
         author_github_id = data.get('author_github_id')
+        issue_identifier = f'linked issue {data.get("number", "?")}'
         return cls(
             number=data['number'],
             title=data.get('title', ''),
@@ -106,7 +135,7 @@ class MirrorLinkedIssue:
             updated_at=parse_optional_github_iso_to_utc(data.get('updated_at')),
             is_transferred=bool(data.get('is_transferred', False)),
             solved_by_pr=data.get('solved_by_pr'),
-            labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
+            labels=_parse_mirror_labels(data.get('labels') or [], issue_identifier),
         )
 
 
@@ -156,6 +185,7 @@ class MirrorPullRequest:
         # union with the legacy lowercased path) is case-correct without each
         # call site re-applying .lower().
         head_repo = data.get('head_repo_full_name')
+        pr_identifier = f'{data.get("repo_full_name", "?")}#{data.get("pr_number", "?")}'
         return cls(
             repo_full_name=data['repo_full_name'].lower(),
             pr_number=data['pr_number'],
@@ -184,8 +214,10 @@ class MirrorPullRequest:
             commits_count=int(data.get('commits_count', 0)),
             scoring_data_stored=bool(data.get('scoring_data_stored', False)),
             review_summary=MirrorReviewSummary.from_dict(data.get('review_summary') or {}),
-            labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
-            linked_issues=[MirrorLinkedIssue.from_dict(issue) for issue in data.get('linked_issues') or []],
+            labels=_parse_mirror_labels(data.get('labels') or [], pr_identifier),
+            linked_issues=_parse_mirror_linked_issues(
+                data.get('linked_issues') or [], pr_identifier
+            ),
         )
 
 

--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -28,24 +28,18 @@ def _parse_mirror_labels(raw_labels: list[dict], parent_identifier: str) -> list
             labels.append(MirrorLabel.from_dict(raw))
         except Exception as e:
             name = raw.get('name', '?') if isinstance(raw, dict) else '?'
-            bt.logging.warning(
-                f'Skipping malformed mirror label {name} on {parent_identifier}: {e}'
-            )
+            bt.logging.warning(f'Skipping malformed mirror label {name} on {parent_identifier}: {e}')
     return labels
 
 
-def _parse_mirror_linked_issues(
-    raw_issues: list[dict], pr_identifier: str
-) -> list['MirrorLinkedIssue']:
+def _parse_mirror_linked_issues(raw_issues: list[dict], pr_identifier: str) -> list['MirrorLinkedIssue']:
     linked_issues: list[MirrorLinkedIssue] = []
     for raw in raw_issues or []:
         try:
             linked_issues.append(MirrorLinkedIssue.from_dict(raw))
         except Exception as e:
             identifier = raw.get('number', '?') if isinstance(raw, dict) else '?'
-            bt.logging.warning(
-                f'Skipping malformed mirror linked issue {identifier} on {pr_identifier}: {e}'
-            )
+            bt.logging.warning(f'Skipping malformed mirror linked issue {identifier} on {pr_identifier}: {e}')
     return linked_issues
 
 
@@ -215,9 +209,7 @@ class MirrorPullRequest:
             scoring_data_stored=bool(data.get('scoring_data_stored', False)),
             review_summary=MirrorReviewSummary.from_dict(data.get('review_summary') or {}),
             labels=_parse_mirror_labels(data.get('labels') or [], pr_identifier),
-            linked_issues=_parse_mirror_linked_issues(
-                data.get('linked_issues') or [], pr_identifier
-            ),
+            linked_issues=_parse_mirror_linked_issues(data.get('linked_issues') or [], pr_identifier),
         )
 
 

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -12,6 +12,7 @@ Covers from_dict parsing for each response dataclass:
 """
 
 from datetime import datetime, timezone
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
@@ -481,6 +482,50 @@ class TestMirrorPullRequestsResponse:
         assert len(resp.pull_requests) == 1
         assert resp.pull_requests[0].pr_number == 518
         mock_logging.warning.assert_called()
+
+    @patch('gittensor.utils.mirror.models.bt.logging')
+    def test_malformed_linked_issue_skipped_parent_pr_kept(
+        self, mock_logging, pull_request_dict
+    ):
+        payload = {
+            'github_id': '218712309',
+            'since': '2026-03-15T00:00:00Z',
+            'generated_at': '2026-04-21T15:00:00Z',
+            'pull_requests': [
+                {
+                    **deepcopy(pull_request_dict),
+                    'linked_issues': [{'number': 7, 'title': 'bad child'}],
+                }
+            ],
+        }
+        resp = MirrorPullRequestsResponse.from_dict(payload)
+        assert len(resp.pull_requests) == 1
+        assert resp.pull_requests[0].pr_number == 518
+        assert resp.pull_requests[0].linked_issues == []
+        mock_logging.warning.assert_called_once()
+        assert 'Skipping malformed mirror linked issue 7' in mock_logging.warning.call_args[0][0]
+
+    @patch('gittensor.utils.mirror.models.bt.logging')
+    def test_malformed_pr_label_skipped_parent_pr_kept(
+        self, mock_logging, pull_request_dict
+    ):
+        payload = {
+            'github_id': '218712309',
+            'since': '2026-03-15T00:00:00Z',
+            'generated_at': '2026-04-21T15:00:00Z',
+            'pull_requests': [
+                {
+                    **deepcopy(pull_request_dict),
+                    'labels': [{'actor_github_id': '61125407'}],
+                }
+            ],
+        }
+        resp = MirrorPullRequestsResponse.from_dict(payload)
+        assert len(resp.pull_requests) == 1
+        assert resp.pull_requests[0].pr_number == 518
+        assert resp.pull_requests[0].labels == []
+        mock_logging.warning.assert_called_once()
+        assert 'Skipping malformed mirror label ?' in mock_logging.warning.call_args[0][0]
 
 
 class TestMirrorIssuesResponse:

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -11,8 +11,8 @@ Covers from_dict parsing for each response dataclass:
 - Nested shapes (labels, linked_issues, solving_pr)
 """
 
-from datetime import datetime, timezone
 from copy import deepcopy
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -484,9 +484,7 @@ class TestMirrorPullRequestsResponse:
         mock_logging.warning.assert_called()
 
     @patch('gittensor.utils.mirror.models.bt.logging')
-    def test_malformed_linked_issue_skipped_parent_pr_kept(
-        self, mock_logging, pull_request_dict
-    ):
+    def test_malformed_linked_issue_skipped_parent_pr_kept(self, mock_logging, pull_request_dict):
         payload = {
             'github_id': '218712309',
             'since': '2026-03-15T00:00:00Z',
@@ -506,9 +504,7 @@ class TestMirrorPullRequestsResponse:
         assert 'Skipping malformed mirror linked issue 7' in mock_logging.warning.call_args[0][0]
 
     @patch('gittensor.utils.mirror.models.bt.logging')
-    def test_malformed_pr_label_skipped_parent_pr_kept(
-        self, mock_logging, pull_request_dict
-    ):
+    def test_malformed_pr_label_skipped_parent_pr_kept(self, mock_logging, pull_request_dict):
         payload = {
             'github_id': '218712309',
             'since': '2026-03-15T00:00:00Z',


### PR DESCRIPTION
## Summary

Fixes mirror PR parsing so malformed optional child rows do not drop an otherwise valid PR from OSS scoring.

This change isolates malformed nested `labels` and `linked_issues` rows during mirror PR parsing:
- keeps the parent `MirrorPullRequest` when required PR-level fields are valid
- skips only the malformed child row
- logs a warning for the skipped child

It also adds regression tests covering malformed PR child `linked_issues` and `labels`.

## Related Issues

Fixes #900

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Commands run:
- `.venv/bin/python -m pytest tests/utils/test_mirror_models.py -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
