### PR TITLE
fix: block stale cache fallback on GraphQL PAT auth failures

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -38,6 +38,15 @@ from gittensor.validator.utils.load_weights import RepositoryConfig
 # Beyond this many CHANGES_REQUESTED reviews the quality multiplier is already 0
 _MAX_CHANGES_REQUESTED_REVIEWS = ceil(1 / REVIEW_PENALTY_RATE)
 
+_GRAPHQL_PAT_AUTH_SCOPE_FAILED_REASON = 'GitHub GraphQL PAT auth/scope failure'
+_GRAPHQL_PAT_AUTH_SCOPE_ERROR_MARKERS = (
+    'resource not accessible by personal access token',
+    'bad credentials',
+    'requires authentication',
+    'not have the required scopes',
+    'not been granted the required scopes',
+)
+
 # core github graphql query
 QUERY = """
     query($userId: ID!, $limit: Int!, $cursor: String, $maxChangesRequestedReviews: Int!) {
@@ -723,6 +732,18 @@ def _has_resource_limit_errors(data: Dict) -> bool:
     return any(isinstance(e, dict) and e.get('type') == 'RESOURCE_LIMITS_EXCEEDED' for e in errors)
 
 
+def _graphql_pat_auth_scope_error_message(errors: List[Dict]) -> Optional[str]:
+    """Return the first GraphQL PAT auth/scope error message, if present."""
+    for error in errors:
+        if not isinstance(error, dict):
+            continue
+        message = str(error.get('message') or '')
+        normalized = message.lower()
+        if any(marker in normalized for marker in _GRAPHQL_PAT_AUTH_SCOPE_ERROR_MARKERS):
+            return message
+    return None
+
+
 def try_add_open_or_closed_pr(
     miner_eval: MinerEvaluation,
     pr_raw: Dict,
@@ -908,7 +929,12 @@ def load_miners_prs(
             if 'errors' in data:
                 non_resource_errors = [e for e in data['errors'] if e.get('type') != 'RESOURCE_LIMITS_EXCEEDED']
                 if non_resource_errors:
-                    bt.logging.error(f'GraphQL errors: {non_resource_errors}')
+                    auth_scope_error = _graphql_pat_auth_scope_error_message(non_resource_errors)
+                    if auth_scope_error:
+                        bt.logging.error(f'GraphQL PAT auth/scope failure: {auth_scope_error}')
+                        miner_eval.failed_reason = _GRAPHQL_PAT_AUTH_SCOPE_FAILED_REASON
+                    else:
+                        bt.logging.error(f'GraphQL errors: {non_resource_errors}')
                     miner_eval.github_pr_fetch_failed = True
                     break
 

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -38,15 +38,6 @@ from gittensor.validator.utils.load_weights import RepositoryConfig
 # Beyond this many CHANGES_REQUESTED reviews the quality multiplier is already 0
 _MAX_CHANGES_REQUESTED_REVIEWS = ceil(1 / REVIEW_PENALTY_RATE)
 
-_GRAPHQL_PAT_AUTH_SCOPE_FAILED_REASON = 'GitHub GraphQL PAT auth/scope failure'
-_GRAPHQL_PAT_AUTH_SCOPE_ERROR_MARKERS = (
-    'resource not accessible by personal access token',
-    'bad credentials',
-    'requires authentication',
-    'not have the required scopes',
-    'not been granted the required scopes',
-)
-
 # core github graphql query
 QUERY = """
     query($userId: ID!, $limit: Int!, $cursor: String, $maxChangesRequestedReviews: Int!) {
@@ -732,18 +723,6 @@ def _has_resource_limit_errors(data: Dict) -> bool:
     return any(isinstance(e, dict) and e.get('type') == 'RESOURCE_LIMITS_EXCEEDED' for e in errors)
 
 
-def _graphql_pat_auth_scope_error_message(errors: List[Dict]) -> Optional[str]:
-    """Return the first GraphQL PAT auth/scope error message, if present."""
-    for error in errors:
-        if not isinstance(error, dict):
-            continue
-        message = str(error.get('message') or '')
-        normalized = message.lower()
-        if any(marker in normalized for marker in _GRAPHQL_PAT_AUTH_SCOPE_ERROR_MARKERS):
-            return message
-    return None
-
-
 def try_add_open_or_closed_pr(
     miner_eval: MinerEvaluation,
     pr_raw: Dict,
@@ -929,12 +908,9 @@ def load_miners_prs(
             if 'errors' in data:
                 non_resource_errors = [e for e in data['errors'] if e.get('type') != 'RESOURCE_LIMITS_EXCEEDED']
                 if non_resource_errors:
-                    auth_scope_error = _graphql_pat_auth_scope_error_message(non_resource_errors)
-                    if auth_scope_error:
-                        bt.logging.error(f'GraphQL PAT auth/scope failure: {auth_scope_error}')
-                        miner_eval.failed_reason = _GRAPHQL_PAT_AUTH_SCOPE_FAILED_REASON
-                    else:
-                        bt.logging.error(f'GraphQL errors: {non_resource_errors}')
+                    bt.logging.error(f'GraphQL errors: {non_resource_errors}')
+                    message = str(non_resource_errors[0].get('message') or 'unknown')[:200]
+                    miner_eval.failed_reason = f'GitHub GraphQL error: {message}'
                     miner_eval.github_pr_fetch_failed = True
                     break
 

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1208,6 +1208,46 @@ class TestLoadMinersPrsFetchFailureSignal:
 
         assert miner_eval.github_pr_fetch_failed is True
 
+    @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_graphql_pat_scope_error_sets_failed_reason(self, mock_logging, mock_graphql_query):
+        from gittensor.classes import MinerEvaluation
+        from gittensor.utils.github_api_tools import GraphQLPageResult
+
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            'errors': [{'message': 'Resource not accessible by personal access token'}],
+            'data': None,
+        }
+        mock_graphql_query.return_value = GraphQLPageResult(response=mock_response, page_size=100)
+
+        miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
+
+        load_miners_prs(miner_eval, {})
+
+        assert miner_eval.github_pr_fetch_failed is True
+        assert miner_eval.failed_reason == 'GitHub GraphQL PAT auth/scope failure'
+
+    @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_non_auth_graphql_error_does_not_set_failed_reason(self, mock_logging, mock_graphql_query):
+        from gittensor.classes import MinerEvaluation
+        from gittensor.utils.github_api_tools import GraphQLPageResult
+
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            'errors': [{'message': 'Something went wrong'}],
+            'data': None,
+        }
+        mock_graphql_query.return_value = GraphQLPageResult(response=mock_response, page_size=100)
+
+        miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
+
+        load_miners_prs(miner_eval, {})
+
+        assert miner_eval.github_pr_fetch_failed is True
+        assert miner_eval.failed_reason is None
+
 
 # ============================================================================
 # GraphQL Batch-Size Limit Tests

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1210,27 +1210,7 @@ class TestLoadMinersPrsFetchFailureSignal:
 
     @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
     @patch('gittensor.utils.github_api_tools.bt.logging')
-    def test_graphql_pat_scope_error_sets_failed_reason(self, mock_logging, mock_graphql_query):
-        from gittensor.classes import MinerEvaluation
-        from gittensor.utils.github_api_tools import GraphQLPageResult
-
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            'errors': [{'message': 'Resource not accessible by personal access token'}],
-            'data': None,
-        }
-        mock_graphql_query.return_value = GraphQLPageResult(response=mock_response, page_size=100)
-
-        miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
-
-        load_miners_prs(miner_eval, {})
-
-        assert miner_eval.github_pr_fetch_failed is True
-        assert miner_eval.failed_reason == 'GitHub GraphQL PAT auth/scope failure'
-
-    @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
-    @patch('gittensor.utils.github_api_tools.bt.logging')
-    def test_non_auth_graphql_error_does_not_set_failed_reason(self, mock_logging, mock_graphql_query):
+    def test_graphql_error_sets_failed_reason(self, mock_logging, mock_graphql_query):
         from gittensor.classes import MinerEvaluation
         from gittensor.utils.github_api_tools import GraphQLPageResult
 
@@ -1246,7 +1226,7 @@ class TestLoadMinersPrsFetchFailureSignal:
         load_miners_prs(miner_eval, {})
 
         assert miner_eval.github_pr_fetch_failed is True
-        assert miner_eval.failed_reason is None
+        assert miner_eval.failed_reason == 'GitHub GraphQL error: Something went wrong'
 
 
 # ============================================================================

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -91,13 +91,13 @@ class TestStoreOrUseCachedEvaluation:
         assert cached_eval.total_prs == 2
 
     @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
-    def test_graphql_pat_scope_failure_does_not_use_cache(self, mock_graphql_query):
+    def test_graphql_error_does_not_use_cache(self, mock_graphql_query):
         validator = _DummyValidator()
         validator.evaluation_cache.store(_build_eval(uid=1, merged_prs=1, fetch_failed=False))
 
         response = Mock()
         response.json.return_value = {
-            'errors': [{'message': 'Resource not accessible by personal access token'}],
+            'errors': [{'message': 'Something went wrong'}],
             'data': None,
         }
         mock_graphql_query.return_value = GraphQLPageResult(response=response, page_size=100)
@@ -109,7 +109,7 @@ class TestStoreOrUseCachedEvaluation:
         cached_uids = Validator.store_or_use_cached_evaluation(cast(Validator, validator), miner_evaluations)
 
         assert current_eval.github_pr_fetch_failed is True
-        assert current_eval.failed_reason == 'GitHub GraphQL PAT auth/scope failure'
+        assert current_eval.failed_reason == 'GitHub GraphQL error: Something went wrong'
         assert cached_uids == set()
         assert miner_evaluations[1] is current_eval
         assert miner_evaluations[1].total_prs == 0

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -2,8 +2,10 @@
 
 from datetime import datetime, timezone
 from typing import cast
+from unittest.mock import Mock, patch
 
 from gittensor.classes import FileChange, Issue, MinerEvaluation, MinerEvaluationCache, PRState, PullRequest
+from gittensor.utils.github_api_tools import GraphQLPageResult, load_miners_prs
 from gittensor.utils.mirror.models import MirrorFile, MirrorPullRequest, MirrorReviewSummary
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 from neurons.validator import Validator
@@ -87,6 +89,30 @@ class TestStoreOrUseCachedEvaluation:
         cached_eval = validator.evaluation_cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
         assert cached_eval is not None
         assert cached_eval.total_prs == 2
+
+    @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
+    def test_graphql_pat_scope_failure_does_not_use_cache(self, mock_graphql_query):
+        validator = _DummyValidator()
+        validator.evaluation_cache.store(_build_eval(uid=1, merged_prs=1, fetch_failed=False))
+
+        response = Mock()
+        response.json.return_value = {
+            'errors': [{'message': 'Resource not accessible by personal access token'}],
+            'data': None,
+        }
+        mock_graphql_query.return_value = GraphQLPageResult(response=response, page_size=100)
+
+        current_eval = MinerEvaluation(uid=1, hotkey='hotkey_1', github_id='12345', github_pat='bad_scope_pat')
+        load_miners_prs(current_eval, {})
+        miner_evaluations = {1: current_eval}
+
+        cached_uids = Validator.store_or_use_cached_evaluation(cast(Validator, validator), miner_evaluations)
+
+        assert current_eval.github_pr_fetch_failed is True
+        assert current_eval.failed_reason == 'GitHub GraphQL PAT auth/scope failure'
+        assert cached_uids == set()
+        assert miner_evaluations[1] is current_eval
+        assert miner_evaluations[1].total_prs == 0
 
 
 class TestMirrorFailureCacheFallback:


### PR DESCRIPTION
## Summary

Fixes stale cache fallback when a stored miner PAT passes REST `/user` validation but fails the PR GraphQL query used during scoring with an auth/scope error.

Previously, `load_miners_prs()` marked these GraphQL failures with `github_pr_fetch_failed=True` but left `failed_reason=None`. Since cache fallback only skips miners with `failed_reason`, validators could restore a previous successful cached evaluation and continue rewarding stale PRs even though the current PAT no longer had the GraphQL access required for scoring.

This change detects clear GraphQL PAT auth/scope errors, such as `Resource not accessible by personal access token`, marks the evaluation with a non-cacheable `failed_reason`, and preserves cache fallback for transient/non-auth GraphQL failures.

## Related Issues

Closes #904

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Commands run:

```bash
uv run pytest tests/utils/test_github_api_tools.py tests/validator/test_validator_cache_fallback.py -q
uv run pytest tests/ -q
uv run ruff check gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py tests/validator/test_validator_cache_fallback.py
uv run ruff format --check gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py tests/validator/test_validator_cache_fallback.py
uv run pyright gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py tests/validator/test_validator_cache_fallback.py
uv run pre-commit run --files gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py tests/validator/test_validator_cache_fallback.py
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
