### PR TITLE
cli: filter low-stake validators from PAT broadcast/check

### DIFF
--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -24,7 +24,6 @@ from .helpers import (
     _require_registered,
     _require_validator_axons,
     _resolve_endpoint,
-    _resolve_validator_filters,
     _status,
 )
 
@@ -47,14 +46,16 @@ _PAT_CHECK_STATUS_MARKUP = {
 @click.option(
     '--min-vtrust',
     type=float,
-    default=None,
-    help=f'Minimum validator_trust to probe. Default {DEFAULT_MIN_VALIDATOR_VTRUST}.',
+    default=DEFAULT_MIN_VALIDATOR_VTRUST,
+    show_default=True,
+    help='Minimum validator_trust to probe.',
 )
 @click.option(
     '--min-stake',
     type=float,
-    default=None,
-    help=f'Minimum validator stake (α) to probe. Default {DEFAULT_MIN_VALIDATOR_STAKE:,.0f}.',
+    default=DEFAULT_MIN_VALIDATOR_STAKE,
+    show_default=True,
+    help='Minimum validator stake (α) to probe.',
 )
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, min_vtrust, min_stake, json_mode):
@@ -88,9 +89,8 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, min_vtrust
     _require_registered(wallet, metagraph, netuid, json_mode)
 
     # 3. Find active validator axons (vtrust + serving + stake threshold)
-    resolved_vtrust, resolved_stake = _resolve_validator_filters(min_vtrust, min_stake)
     validator_axons, validator_uids, excluded = _require_validator_axons(
-        metagraph, json_mode, min_vtrust=resolved_vtrust, min_stake=resolved_stake
+        metagraph, json_mode, min_vtrust=min_vtrust, min_stake=min_stake
     )
 
     # 4. Send check probes

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -11,6 +11,8 @@ from rich.console import Console
 from rich.table import Table
 
 from .helpers import (
+    DEFAULT_MIN_VALIDATOR_STAKE,
+    DEFAULT_MIN_VALIDATOR_VTRUST,
     NETUID_DEFAULT,
     _connect_bittensor,
     _error,
@@ -18,9 +20,11 @@ from .helpers import (
     _pat_check_aggregate_counts,
     _pat_check_row_category,
     _print,
+    _render_skipped_validators,
     _require_registered,
     _require_validator_axons,
     _resolve_endpoint,
+    _resolve_validator_filters,
     _status,
 )
 
@@ -40,8 +44,20 @@ _PAT_CHECK_STATUS_MARKUP = {
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
 @click.option('--network', default=None, help='Network name (local, test, finney).')
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
+@click.option(
+    '--min-vtrust',
+    type=float,
+    default=None,
+    help=f'Minimum validator_trust to probe. Default {DEFAULT_MIN_VALIDATOR_VTRUST}.',
+)
+@click.option(
+    '--min-stake',
+    type=float,
+    default=None,
+    help=f'Minimum validator stake (α) to probe. Default {DEFAULT_MIN_VALIDATOR_STAKE:,.0f}.',
+)
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
-def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode):
+def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, min_vtrust, min_stake, json_mode):
     """Check how many validators have your PAT stored.
 
     Sends a lightweight probe to each validator — no PAT is transmitted.
@@ -71,8 +87,11 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
     # Verify miner is registered
     _require_registered(wallet, metagraph, netuid, json_mode)
 
-    # 3. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode)
+    # 3. Find active validator axons (vtrust + serving + stake threshold)
+    resolved_vtrust, resolved_stake = _resolve_validator_filters(min_vtrust, min_stake)
+    validator_axons, validator_uids, excluded = _require_validator_axons(
+        metagraph, json_mode, min_vtrust=resolved_vtrust, min_stake=resolved_stake
+    )
 
     # 4. Send check probes
     synapse = PatCheckSynapse()
@@ -115,6 +134,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
                     'success': valid_count > 0,
                     'total_validators': len(results),
                     **counts,
+                    'skipped': excluded,
                     'results': results,
                 },
                 indent=2,
@@ -134,3 +154,4 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, json_mode)
 
         console.print(table)
         console.print(f'\n[bold]{valid_count}/{len(results)} validators have a valid PAT stored.[/bold]')
+        _render_skipped_validators(excluded, json_mode)

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -13,23 +13,51 @@ from typing import Any
 
 import click
 from rich.console import Console
+from rich.table import Table
 
 from gittensor.constants import NETWORK_MAP
 
 console = Console()
 
 NETUID_DEFAULT = 74
+DEFAULT_MIN_VALIDATOR_VTRUST = 0.25
+DEFAULT_MIN_VALIDATOR_STAKE = 15_000.0
 
 
-def _get_validator_axons(metagraph) -> tuple[list, list]:
-    """Return (axons, uids) for all active validators (vtrust > 0.1, serving)."""
-    axons = []
-    uids = []
+def _get_validator_axons(
+    metagraph,
+    *,
+    min_vtrust: float = DEFAULT_MIN_VALIDATOR_VTRUST,
+    min_stake: float = DEFAULT_MIN_VALIDATOR_STAKE,
+) -> tuple[list, list, list[dict]]:
+    """Return (axons, uids, excluded) for active validators.
+
+    A validator is broadcast to when vtrust > min_vtrust AND axon.is_serving
+    AND stake >= min_stake. UIDs failing only the latter two checks are
+    surfaced in `excluded` so miners can see why a high-vtrust validator
+    was skipped. Sub-vtrust UIDs are dropped silently — they are not
+    validators.
+    """
+    axons: list = []
+    uids: list[int] = []
+    excluded: list[dict] = []
     for uid in range(metagraph.n):
-        if metagraph.validator_trust[uid] > 0.1 and metagraph.axons[uid].is_serving:
-            axons.append(metagraph.axons[uid])
-            uids.append(uid)
-    return axons, uids
+        vt = float(metagraph.validator_trust[uid])
+        if vt <= min_vtrust:
+            continue
+        serving = bool(metagraph.axons[uid].is_serving)
+        stake = float(metagraph.S[uid])
+        reasons: list[str] = []
+        if not serving:
+            reasons.append('not serving an axon')
+        if stake < min_stake:
+            reasons.append(f'stake {stake:,.0f} α below {min_stake:,.0f} α threshold')
+        if reasons:
+            excluded.append({'uid': uid, 'vtrust': vt, 'stake': stake, 'reasons': reasons})
+            continue
+        axons.append(metagraph.axons[uid])
+        uids.append(uid)
+    return axons, uids, excluded
 
 
 def _load_config_value(key: str):
@@ -96,13 +124,51 @@ def _require_registered(wallet, metagraph, netuid: int, json_mode: bool) -> None
         sys.exit(1)
 
 
-def _require_validator_axons(metagraph, json_mode: bool) -> tuple[list, list]:
-    """Return validator (axons, uids), or exit with error if none found."""
-    validator_axons, validator_uids = _get_validator_axons(metagraph)
+def _require_validator_axons(
+    metagraph,
+    json_mode: bool,
+    *,
+    min_vtrust: float = DEFAULT_MIN_VALIDATOR_VTRUST,
+    min_stake: float = DEFAULT_MIN_VALIDATOR_STAKE,
+) -> tuple[list, list, list[dict]]:
+    """Return validator (axons, uids, excluded), or exit with error if no axons match."""
+    validator_axons, validator_uids, excluded = _get_validator_axons(
+        metagraph, min_vtrust=min_vtrust, min_stake=min_stake
+    )
     if not validator_axons:
         _error('No reachable validator axons found on the network.', json_mode)
         sys.exit(1)
-    return validator_axons, validator_uids
+    return validator_axons, validator_uids, excluded
+
+
+def _resolve_validator_filters(min_vtrust: float | None, min_stake: float | None) -> tuple[float, float]:
+    """Resolve filter thresholds: CLI flag > config file > default."""
+    resolved_vtrust = min_vtrust if min_vtrust is not None else _load_config_value('min_validator_vtrust')
+    if resolved_vtrust is None:
+        resolved_vtrust = DEFAULT_MIN_VALIDATOR_VTRUST
+    resolved_stake = min_stake if min_stake is not None else _load_config_value('min_validator_stake')
+    if resolved_stake is None:
+        resolved_stake = DEFAULT_MIN_VALIDATOR_STAKE
+    return float(resolved_vtrust), float(resolved_stake)
+
+
+def _render_skipped_validators(excluded: list[dict], json_mode: bool) -> None:
+    """Print a 'Skipped Validators' table when any high-vtrust UIDs were filtered."""
+    if json_mode or not excluded:
+        return
+    table = Table(title='Skipped Validators')
+    table.add_column('UID', style='cyan', justify='right')
+    table.add_column('vtrust', justify='right')
+    table.add_column('stake (α)', justify='right')
+    table.add_column('Reason', style='dim')
+    for e in excluded:
+        table.add_row(
+            str(e['uid']),
+            f'{e["vtrust"]:.4f}',
+            f'{e["stake"]:,.0f}',
+            '; '.join(e['reasons']),
+        )
+    console.print(table)
 
 
 def _pat_check_row_category(row: dict[str, Any]) -> str:

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -141,17 +141,6 @@ def _require_validator_axons(
     return validator_axons, validator_uids, excluded
 
 
-def _resolve_validator_filters(min_vtrust: float | None, min_stake: float | None) -> tuple[float, float]:
-    """Resolve filter thresholds: CLI flag > config file > default."""
-    resolved_vtrust = min_vtrust if min_vtrust is not None else _load_config_value('min_validator_vtrust')
-    if resolved_vtrust is None:
-        resolved_vtrust = DEFAULT_MIN_VALIDATOR_VTRUST
-    resolved_stake = min_stake if min_stake is not None else _load_config_value('min_validator_stake')
-    if resolved_stake is None:
-        resolved_stake = DEFAULT_MIN_VALIDATOR_STAKE
-    return float(resolved_vtrust), float(resolved_stake)
-
-
 def _render_skipped_validators(excluded: list[dict], json_mode: bool) -> None:
     """Print a 'Skipped Validators' table when any high-vtrust UIDs were filtered."""
     if json_mode or not excluded:

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -15,14 +15,18 @@ from rich.console import Console
 from rich.table import Table
 
 from gittensor.cli.miner_commands.helpers import (
+    DEFAULT_MIN_VALIDATOR_STAKE,
+    DEFAULT_MIN_VALIDATOR_VTRUST,
     NETUID_DEFAULT,
     _connect_bittensor,
     _error,
     _load_config_value,
     _print,
+    _render_skipped_validators,
     _require_registered,
     _require_validator_axons,
     _resolve_endpoint,
+    _resolve_validator_filters,
     _status,
 )
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
@@ -42,8 +46,20 @@ console = Console()
     default=None,
     help='GitHub Personal Access Token. If not provided, falls back to GITTENSOR_MINER_PAT env var or interactive prompt.',
 )
+@click.option(
+    '--min-vtrust',
+    type=float,
+    default=None,
+    help=f'Minimum validator_trust to broadcast to. Default {DEFAULT_MIN_VALIDATOR_VTRUST}.',
+)
+@click.option(
+    '--min-stake',
+    type=float,
+    default=None,
+    help=f'Minimum validator stake (α) to broadcast to. Default {DEFAULT_MIN_VALIDATOR_STAKE:,.0f}.',
+)
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
-def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_mode):
+def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, json_mode):
     """Broadcast your GitHub PAT to all validators on the network.
 
     Validators will validate your PAT (test GitHub API access, check account age),
@@ -99,8 +115,11 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
     # Verify miner is registered
     _require_registered(wallet, metagraph, netuid, json_mode)
 
-    # 4. Find active validator axons (vtrust > 0.1 = actively participating in consensus)
-    validator_axons, validator_uids = _require_validator_axons(metagraph, json_mode)
+    # 4. Find active validator axons (vtrust + serving + stake threshold)
+    resolved_vtrust, resolved_stake = _resolve_validator_filters(min_vtrust, min_stake)
+    validator_axons, validator_uids, excluded = _require_validator_axons(
+        metagraph, json_mode, min_vtrust=resolved_vtrust, min_stake=resolved_stake
+    )
 
     # 5. Broadcast
     synapse = PatBroadcastSynapse(github_access_token=pat)
@@ -143,6 +162,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
                     'total_validators': len(results),
                     'accepted': accepted_count,
                     'rejected': len(results) - accepted_count,
+                    'skipped': excluded,
                     'results': results,
                 },
                 indent=2,
@@ -166,6 +186,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, json_m
 
         console.print(table)
         console.print(f'\n[bold]{accepted_count}/{len(results)} validators accepted your PAT.[/bold]')
+        _render_skipped_validators(excluded, json_mode)
 
 
 def _validate_pat_locally(pat: str) -> bool:

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -26,7 +26,6 @@ from gittensor.cli.miner_commands.helpers import (
     _require_registered,
     _require_validator_axons,
     _resolve_endpoint,
-    _resolve_validator_filters,
     _status,
 )
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
@@ -49,14 +48,16 @@ console = Console()
 @click.option(
     '--min-vtrust',
     type=float,
-    default=None,
-    help=f'Minimum validator_trust to broadcast to. Default {DEFAULT_MIN_VALIDATOR_VTRUST}.',
+    default=DEFAULT_MIN_VALIDATOR_VTRUST,
+    show_default=True,
+    help='Minimum validator_trust to broadcast to.',
 )
 @click.option(
     '--min-stake',
     type=float,
-    default=None,
-    help=f'Minimum validator stake (α) to broadcast to. Default {DEFAULT_MIN_VALIDATOR_STAKE:,.0f}.',
+    default=DEFAULT_MIN_VALIDATOR_STAKE,
+    show_default=True,
+    help='Minimum validator stake (α) to broadcast to.',
 )
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, json_mode):
@@ -116,9 +117,8 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
     _require_registered(wallet, metagraph, netuid, json_mode)
 
     # 4. Find active validator axons (vtrust + serving + stake threshold)
-    resolved_vtrust, resolved_stake = _resolve_validator_filters(min_vtrust, min_stake)
     validator_axons, validator_uids, excluded = _require_validator_axons(
-        metagraph, json_mode, min_vtrust=resolved_vtrust, min_stake=resolved_stake
+        metagraph, json_mode, min_vtrust=min_vtrust, min_stake=min_stake
     )
 
     # 5. Broadcast

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -3,6 +3,7 @@
 """Tests for gitt miner post and gitt miner check CLI commands."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -10,7 +11,24 @@ from click.testing import CliRunner
 
 from gittensor import __version__
 from gittensor.cli.main import cli
-from gittensor.cli.miner_commands.helpers import _pat_check_aggregate_counts
+from gittensor.cli.miner_commands.helpers import (
+    DEFAULT_MIN_VALIDATOR_STAKE,
+    DEFAULT_MIN_VALIDATOR_VTRUST,
+    _get_validator_axons,
+    _pat_check_aggregate_counts,
+    _resolve_validator_filters,
+)
+
+
+def _fake_metagraph(rows: list[tuple[float, bool, float]]):
+    """Build a metagraph stub from (vtrust, serving, stake) per UID."""
+    n = len(rows)
+    return SimpleNamespace(
+        n=n,
+        validator_trust=[vt for vt, _, _ in rows],
+        S=[stake for _, _, stake in rows],
+        axons=[SimpleNamespace(is_serving=serving, hotkey=f'5Hk{i:02d}') for i, (_, serving, _) in enumerate(rows)],
+    )
 
 
 @pytest.fixture
@@ -76,6 +94,64 @@ class TestCliVersion:
         result = runner.invoke(cli, ['--version'])
         assert result.exit_code == 0
         assert result.output == f'gittensor, version {__version__}\n'
+
+
+class TestValidatorAxonFilter:
+    def test_passes_when_all_thresholds_met(self):
+        mg = _fake_metagraph([(0.9, True, 50_000.0)])
+        axons, uids, excluded = _get_validator_axons(mg, min_vtrust=0.25, min_stake=15_000.0)
+        assert uids == [0]
+        assert len(axons) == 1
+        assert excluded == []
+
+    def test_silently_drops_below_vtrust(self):
+        # Sub-vtrust UIDs are not validators — never surfaced in `excluded`.
+        mg = _fake_metagraph([(0.1, True, 100_000.0)])
+        axons, uids, excluded = _get_validator_axons(mg, min_vtrust=0.25, min_stake=15_000.0)
+        assert uids == []
+        assert axons == []
+        assert excluded == []
+
+    def test_excludes_when_not_serving(self):
+        mg = _fake_metagraph([(0.99, False, 100_000.0)])
+        _, uids, excluded = _get_validator_axons(mg, min_vtrust=0.25, min_stake=15_000.0)
+        assert uids == []
+        assert len(excluded) == 1
+        assert excluded[0]['uid'] == 0
+        assert excluded[0]['reasons'] == ['not serving an axon']
+
+    def test_excludes_when_below_stake_threshold(self):
+        mg = _fake_metagraph([(0.99, True, 1_630.0)])
+        _, uids, excluded = _get_validator_axons(mg, min_vtrust=0.25, min_stake=15_000.0)
+        assert uids == []
+        assert len(excluded) == 1
+        assert excluded[0]['uid'] == 0
+        assert 'stake 1,630 α below 15,000 α threshold' in excluded[0]['reasons'][0]
+
+    def test_combines_reasons_when_both_fail(self):
+        mg = _fake_metagraph([(0.99, False, 1_000.0)])
+        _, _, excluded = _get_validator_axons(mg, min_vtrust=0.25, min_stake=15_000.0)
+        assert len(excluded[0]['reasons']) == 2
+
+    def test_resolve_filters_uses_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
+        vtrust, stake = _resolve_validator_filters(None, None)
+        assert vtrust == DEFAULT_MIN_VALIDATOR_VTRUST
+        assert stake == DEFAULT_MIN_VALIDATOR_STAKE
+
+    def test_resolve_filters_cli_overrides_config(self, tmp_path, monkeypatch):
+        monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
+        cfg_dir = tmp_path / '.gittensor'
+        cfg_dir.mkdir()
+        (cfg_dir / 'config.json').write_text(json.dumps({'min_validator_vtrust': 0.5, 'min_validator_stake': 30_000}))
+        # CLI flag wins over config
+        vtrust, stake = _resolve_validator_filters(0.4, 20_000.0)
+        assert vtrust == 0.4
+        assert stake == 20_000.0
+        # Without CLI flag, config wins over default
+        vtrust, stake = _resolve_validator_filters(None, None)
+        assert vtrust == 0.5
+        assert stake == 30_000.0
 
 
 class TestPatCheckAggregateCounts:

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -12,11 +12,8 @@ from click.testing import CliRunner
 from gittensor import __version__
 from gittensor.cli.main import cli
 from gittensor.cli.miner_commands.helpers import (
-    DEFAULT_MIN_VALIDATOR_STAKE,
-    DEFAULT_MIN_VALIDATOR_VTRUST,
     _get_validator_axons,
     _pat_check_aggregate_counts,
-    _resolve_validator_filters,
 )
 
 
@@ -132,26 +129,6 @@ class TestValidatorAxonFilter:
         mg = _fake_metagraph([(0.99, False, 1_000.0)])
         _, _, excluded = _get_validator_axons(mg, min_vtrust=0.25, min_stake=15_000.0)
         assert len(excluded[0]['reasons']) == 2
-
-    def test_resolve_filters_uses_defaults(self, tmp_path, monkeypatch):
-        monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
-        vtrust, stake = _resolve_validator_filters(None, None)
-        assert vtrust == DEFAULT_MIN_VALIDATOR_VTRUST
-        assert stake == DEFAULT_MIN_VALIDATOR_STAKE
-
-    def test_resolve_filters_cli_overrides_config(self, tmp_path, monkeypatch):
-        monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
-        cfg_dir = tmp_path / '.gittensor'
-        cfg_dir.mkdir()
-        (cfg_dir / 'config.json').write_text(json.dumps({'min_validator_vtrust': 0.5, 'min_validator_stake': 30_000}))
-        # CLI flag wins over config
-        vtrust, stake = _resolve_validator_filters(0.4, 20_000.0)
-        assert vtrust == 0.4
-        assert stake == 20_000.0
-        # Without CLI flag, config wins over default
-        vtrust, stake = _resolve_validator_filters(None, None)
-        assert vtrust == 0.5
-        assert stake == 30_000.0
 
 
 class TestPatCheckAggregateCounts:


### PR DESCRIPTION
## Summary

- `gitt miner post` / `gitt miner check` now require a validator to have **vtrust > 0.25** (was 0.1), be **serving an axon**, and hold **≥ 15,000 α stake** before being targeted with a PAT broadcast or probe.
- `--min-vtrust` / `--min-stake` CLI flags let a miner override the defaults; no config-file knob.
- New "Skipped Validators" table surfaces high-vtrust UIDs filtered by the stake or serving check, with per-UID reasons; JSON output gains a matching `skipped` field.

### Why

Low-stake weight-copiers can clear `vtrust > 0.1` and a serving axon yet have no operational need for miners' GitHub credentials. Receiving them just expands the credential blast radius. On netuid 74 today there is one such UID (147: vtrust 0.997, stake ~1,630 α). The new defaults cleanly exclude it without affecting any honest validator (the next-lowest serving validator sits at ~43k α, a ~26× headroom).

A miner running `gitt miner post` on finney now broadcasts to **7** validators (was 8) and sees an explanatory table for the 5 high-vtrust UIDs that get skipped (UID 147 by stake; UIDs 102/173/174/195 because they don't advertise an axon — pre-existing structural gap, now visible).

## Test plan

- [x] `ruff check` / `ruff format --check` clean on changed files (one pre-existing import-order issue in `neurons/validator.py` left alone)
- [x] `pyright` clean (0 errors / 0 warnings)
- [x] `pytest tests/cli/test_miner_commands.py` — 15 pass (6 new in `TestValidatorAxonFilter`: pass-all, silent sub-vtrust drop, not-serving, stake-below, multi-reason combo)
- [x] Full `pytest` — 701 pass; one unrelated failure (`test_register_exits_non_zero_when_contract_metadata_missing`) reproduces on `test` with this branch stashed
- [ ] Reviewer: optionally dry-run `gitt miner post --json-output --network finney` and verify the `skipped` array matches expectations