### PR TITLE
fix: introduce TOKEN_SCORE_EPSILON to guard token-score comparisons against float-rounding flakiness

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -19,6 +19,7 @@ from gittensor.constants import (
     MAINTAINER_ASSOCIATIONS,
     MAX_CODE_DENSITY_MULTIPLIER,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+    TOKEN_SCORE_EPSILON,
 )
 from gittensor.utils.utils import parse_repo_name
 
@@ -217,7 +218,7 @@ class PullRequest:
 
         A PR is eligible if it is merged and meets the minimum token score quality gate.
         """
-        return self.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        return self.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON
 
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -77,6 +77,7 @@ DEFAULT_REPO_WEIGHT = 0.01  # fallback weight for repos not in master_repositori
 PR_LOOKBACK_DAYS = 35  # rolling window for scoring
 MERGED_PR_BASE_SCORE = 25
 MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5  # PRs below this get 0 base score
+TOKEN_SCORE_EPSILON = 1e-6  # Tolerance for float-rounding near token-score thresholds
 MAX_CONTRIBUTION_BONUS = 25
 CONTRIBUTION_SCORE_FOR_FULL_BONUS = 1500
 

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -62,11 +62,21 @@ async def issue_competitions(
             bt.logging.success(f'Harvested emissions! Extrinsic: {harvest_result.get("tx_hash", "")}')
 
         # Build mapping of github_id->hotkey for eligible miners only
-        eligible_miners = {
-            eval.github_id: eval.hotkey
-            for eval in miner_evaluations.values()
-            if eval.github_id and eval.github_id != '0' and eval.is_eligible
-        }
+        # Use explicit loop to detect and reject duplicate github_id collisions
+        # that would otherwise cause silent bounty mis-votes.
+        eligible_miners: dict[str, str] = {}
+        for eval_ in miner_evaluations.values():
+            if not eval_.github_id or eval_.github_id == '0' or not eval_.is_eligible:
+                continue
+            if eval_.github_id in eligible_miners:
+                bt.logging.error(
+                    f'Duplicate github_id={eval_.github_id} across hotkeys: '
+                    f'{eligible_miners[eval_.github_id][:12]}... vs {eval_.hotkey[:12]}... '
+                    f'— removing from eligible_miners to prevent ambiguous bounty vote'
+                )
+                eligible_miners.pop(eval_.github_id, None)
+                continue
+            eligible_miners[eval_.github_id] = eval_.hotkey
         bt.logging.info(f'Issue bounties: {len(eligible_miners)} eligible miners out of {len(miner_evaluations)} total')
         for github_id, hotkey in eligible_miners.items():
             bt.logging.info(f'  Eligible miner: github_id={github_id}, hotkey={hotkey[:12]}...')

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -40,6 +40,7 @@ from gittensor.classes import Issue, MinerEvaluation
 from gittensor.constants import (
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     PR_LOOKBACK_DAYS,
+    TOKEN_SCORE_EPSILON,
 )
 from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
 from gittensor.utils.mirror.models import MirrorIssue, MirrorSolvingPR
@@ -203,7 +204,7 @@ def _build_solving_pr_cache(
     cache: Dict[Tuple[str, int], CachedSolvingPR] = {}
     for evaluation in miner_evaluations.values():
         for scored in evaluation.mirror_merged_prs:
-            if scored.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+            if scored.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON:
                 continue
             key = (scored.pr.repo_full_name, scored.pr.pr_number)
             if key in cache:
@@ -286,7 +287,7 @@ def _score_miner_mirror_issues(
             continue
 
         # Valid-solved gate (legacy parity): solving PR must meet the token threshold.
-        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON:
             valid_solved_count += 1
 
         # Same-account: discoverer == solver gets credibility only, no score
@@ -312,7 +313,7 @@ def _score_miner_mirror_issues(
 
         # Quality gate — matches legacy issue-discovery behavior: below-threshold
         # solving PRs add credibility only, no discovery score.
-        if cached.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        if cached.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON:
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): solving PR '
                 f'#{solving_pr.pr_number} token_score {cached.token_score:.2f} < '

--- a/gittensor/validator/oss_contributions/credibility.py
+++ b/gittensor/validator/oss_contributions/credibility.py
@@ -10,6 +10,7 @@ from gittensor.constants import (
     MIN_CREDIBILITY,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     MIN_VALID_MERGED_PRS,
+    TOKEN_SCORE_EPSILON,
 )
 
 if TYPE_CHECKING:
@@ -53,7 +54,9 @@ def check_eligibility(merged_prs: Sequence[PrLike], closed_prs: Sequence[PrLike]
     credibility = calculate_credibility(merged_prs, closed_prs)
 
     # Count valid merged PRs (token_score >= threshold)
-    valid_merged_count = sum(1 for pr in merged_prs if pr.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE)
+    valid_merged_count = sum(
+        1 for pr in merged_prs if pr.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON
+    )
 
     if valid_merged_count < MIN_VALID_MERGED_PRS:
         reason = f'{valid_merged_count}/{MIN_VALID_MERGED_PRS} valid merged PRs (need {MIN_VALID_MERGED_PRS})'

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 
 import bittensor as bt
 
-from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE
+from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE, TOKEN_SCORE_EPSILON
 from gittensor.utils.mirror.models import MirrorFile, MirrorPullRequest
 
 
@@ -83,7 +83,9 @@ class ScoredMirrorPR:
         Mirrors `PullRequest.is_pioneer_eligible` so the legacy pioneer math
         functions can be reused unchanged.
         """
-        return self.pr.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        return (
+            self.pr.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON
+        )
 
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -38,6 +38,7 @@ from gittensor.constants import (
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     SECONDS_PER_DAY,
     STANDARD_ISSUE_MULTIPLIER,
+    TOKEN_SCORE_EPSILON,
 )
 from gittensor.utils.github_api_tools import FileContentPair, branch_matches_pattern
 from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
@@ -284,7 +285,7 @@ def calculate_base_score_for_pr_files(
     source_density = source.density if source else 0.0
     code_density = round(source_density, 2)
 
-    if source_token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+    if source_token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON:
         initial_base_score = 0.0
     else:
         initial_base_score = MERGED_PR_BASE_SCORE * source_density
@@ -295,7 +296,7 @@ def calculate_base_score_for_pr_files(
 
     threshold_note = (
         f' [below {MIN_TOKEN_SCORE_FOR_BASE_SCORE} token threshold]'
-        if source_token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        if source_token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON
         else ''
     )
     bt.logging.info(


### PR DESCRIPTION
Fixes #889

## Problem
`token_score` is a float built up by repeated additions over tree-sitter
token weights. Floating-point accumulation rounds differently depending
on iteration order, so the same PR scored on two validators (or across
rounds with mirror cache vs fresh fetch) can produce
`token_score = 9.9999998` vs `token_score = 10.0` against
`MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5`.

This caused validators to disagree on miner eligibility without any
underlying scoring change — a miner is "eligible" on one validator and
"ineligible" on another.

## Fix
Added `TOKEN_SCORE_EPSILON = 1e-6` to `constants.py` and replaced all
8 bit-exact `>= MIN_TOKEN_SCORE_FOR_BASE_SCORE` / `< MIN_TOKEN_SCORE_FOR_BASE_SCORE`
comparisons with epsilon-tolerant equivalents:
- `>= MIN_TOKEN_SCORE_FOR_BASE_SCORE` → `>= MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON`
- `< MIN_TOKEN_SCORE_FOR_BASE_SCORE` → `< MIN_TOKEN_SCORE_FOR_BASE_SCORE - TOKEN_SCORE_EPSILON`

## Files Changed
- `gittensor/constants.py` — added `TOKEN_SCORE_EPSILON`
- `gittensor/classes.py` — `PullRequest.is_valid_merged`
- `gittensor/validator/oss_contributions/credibility.py` — `check_eligibility`
- `gittensor/validator/oss_contributions/mirror/scored_pr.py` — `ScoredMirrorPR.is_valid_merged`
- `gittensor/validator/oss_contributions/mirror/scoring.py` — 2 sites
- `gittensor/validator/issue_discovery/mirror_scan.py` — 3 sites