### PR TITLE
feat: add --repo filter to gitt issues list

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -42,13 +42,22 @@ from .helpers import (
     type=int,
     help='View a specific issue by ID',
 )
+@click.option(
+    '--repo',
+    'repo_filter',
+    default=None,
+    type=str,
+    help='Filter issues to a specific repository (owner/name).',
+)
 @with_cli_behavior_options(
     include_verbose=True,
     include_json=True,
     verbose_help='Show debug output for contract reads',
 )
 @with_network_contract_options('Contract address (uses default if empty)')
-def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool):
+def issues_list(
+    issue_id: int, repo_filter: str, network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool
+):
     """List issues or view a specific issue.
 
     [dim]Examples:
@@ -76,6 +85,11 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
         for issue in issues:
             issue['bounty_alpha'] = format_alpha(issue.get('bounty_amount', 0), 4)
             issue['target_alpha'] = format_alpha(issue.get('target_bounty', 0), 4)
+
+        # Apply --repo filter before rendering (--id takes precedence)
+        if repo_filter and issue_id is None:
+            issues = [i for i in issues if i.get('repository_full_name', '').lower() == repo_filter.lower()]
+
         if issue_id is not None:
             issue = next((i for i in issues if i['id'] == issue_id), None)
             if issue is None:
@@ -109,6 +123,10 @@ def issues_list(issue_id: int, network: str, rpc_url: str, contract: str, verbos
         else:
             handle_exception(as_json, f'Issue {issue_id} not found on-chain.', 'not_found')
         return
+
+    # Apply --repo filter before table render (--id takes precedence)
+    if repo_filter and issue_id is None:
+        issues = [i for i in issues if i.get('repository_full_name', '').lower() == repo_filter.lower()]
 
     # Table view of all issues
     console.print('[bold cyan]Available Issues[/bold cyan]\n')

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -61,12 +61,23 @@ async def issue_competitions(
         if harvest_result and harvest_result.get('status') == 'success':
             bt.logging.success(f'Harvested emissions! Extrinsic: {harvest_result.get("tx_hash", "")}')
 
-        # Build mapping of github_id->hotkey for eligible miners only
-        eligible_miners = {
-            eval.github_id: eval.hotkey
-            for eval in miner_evaluations.values()
-            if eval.github_id and eval.github_id != '0' and eval.is_eligible
-        }
+        # Build mapping of github_id->hotkey for eligible miners only.
+        # Duplicate github_id entries are removed entirely rather than
+        # picked arbitrarily — a silent arbitrary pick would cause a
+        # mis-vote or a stuck Active issue.
+        eligible_miners: dict[str, str] = {}
+        for eval_ in miner_evaluations.values():
+            if not eval_.github_id or eval_.github_id == '0' or not eval_.is_eligible:
+                continue
+            if eval_.github_id in eligible_miners:
+                bt.logging.error(
+                    f'Duplicate github_id={eval_.github_id} across hotkeys: '
+                    f'{eligible_miners[eval_.github_id][:12]}... vs {eval_.hotkey[:12]}... '
+                    f'— removing from eligible_miners to prevent ambiguous bounty vote'
+                )
+                eligible_miners.pop(eval_.github_id, None)
+                continue
+            eligible_miners[eval_.github_id] = eval_.hotkey
         bt.logging.info(f'Issue bounties: {len(eligible_miners)} eligible miners out of {len(miner_evaluations)} total')
         for github_id, hotkey in eligible_miners.items():
             bt.logging.info(f'  Eligible miner: github_id={github_id}, hotkey={hotkey[:12]}...')

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -61,23 +61,12 @@ async def issue_competitions(
         if harvest_result and harvest_result.get('status') == 'success':
             bt.logging.success(f'Harvested emissions! Extrinsic: {harvest_result.get("tx_hash", "")}')
 
-        # Build mapping of github_id->hotkey for eligible miners only.
-        # Duplicate github_id entries are removed entirely rather than
-        # picked arbitrarily — a silent arbitrary pick would cause a
-        # mis-vote or a stuck Active issue.
-        eligible_miners: dict[str, str] = {}
-        for eval_ in miner_evaluations.values():
-            if not eval_.github_id or eval_.github_id == '0' or not eval_.is_eligible:
-                continue
-            if eval_.github_id in eligible_miners:
-                bt.logging.error(
-                    f'Duplicate github_id={eval_.github_id} across hotkeys: '
-                    f'{eligible_miners[eval_.github_id][:12]}... vs {eval_.hotkey[:12]}... '
-                    f'— removing from eligible_miners to prevent ambiguous bounty vote'
-                )
-                eligible_miners.pop(eval_.github_id, None)
-                continue
-            eligible_miners[eval_.github_id] = eval_.hotkey
+        # Build mapping of github_id->hotkey for eligible miners only
+        eligible_miners = {
+            eval.github_id: eval.hotkey
+            for eval in miner_evaluations.values()
+            if eval.github_id and eval.github_id != '0' and eval.is_eligible
+        }
         bt.logging.info(f'Issue bounties: {len(eligible_miners)} eligible miners out of {len(miner_evaluations)} total')
         for github_id, hotkey in eligible_miners.items():
             bt.logging.info(f'  Eligible miner: github_id={github_id}, hotkey={hotkey[:12]}...')


### PR DESCRIPTION
Fixes #892

## Problem
`gitt issues list` renders every on-chain issue with no way to filter
by repository. With 100+ tracked repos and unbounded issue growth,
operators contributing to one repo are forced to scroll through
unrelated issues or resort to shell workarounds like `jq` or `grep`.

## Fix
Added `--repo <owner/name>` option to `issues_list` in `view.py`.
The filter is applied client-side after the contract read, before
rendering — both in JSON mode and table mode. `--id` takes precedence
over `--repo` (the existing single-issue path is unchanged).
The filter is case-insensitive.

## Changes
- `gittensor/cli/issue_commands/view.py` — added `--repo` option and
  two filter lines (JSON path and table path)