### PR TITLE
fix: trust bot-applied labels on entrius/* mirror repos (#911)

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -16,7 +16,7 @@ Anti-gaming notes:
 - ``edited_after_merge`` is NOT a PR-level gate — it gates only the issue
   bonus multiplier in ``_is_valid_linked_issue``, matching legacy
   ``is_valid_issue``.
-- Mirror's ``actor_association`` per label lets ``_resolve_maintainer_set_label``
+- Mirror's ``actor_association`` per label lets ``_resolve_trusted_scoring_label``
   require maintainer-applied labels; legacy can't do this and accepts any-applier.
 """
 
@@ -351,7 +351,7 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
 
     scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
 
-    chosen_label = _resolve_maintainer_set_label(pr, repo_config)
+    chosen_label = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label
     scored.label_multiplier = LABEL_MULTIPLIERS.get(chosen_label, 1.0) if chosen_label else 1.0
 
@@ -372,7 +372,7 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
         scored.review_quality_multiplier = 1.0
 
 
-def _resolve_maintainer_set_label(pr: MirrorPullRequest, repo_config: RepositoryConfig) -> Optional[str]:
+def _resolve_trusted_scoring_label(pr: MirrorPullRequest, repo_config: RepositoryConfig) -> Optional[str]:
     """Pick the highest-multiplier currently-applied scoring label whose actor is trusted.
 
     By default the actor must be in ``MAINTAINER_ASSOCIATIONS``. Repos opted into

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -41,7 +41,7 @@ from gittensor.constants import (
 )
 from gittensor.utils.github_api_tools import FileContentPair, branch_matches_pattern
 from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
-from gittensor.utils.mirror.models import MirrorLinkedIssue, MirrorPullRequest
+from gittensor.utils.mirror.models import MirrorLabel, MirrorLinkedIssue, MirrorPullRequest
 from gittensor.validator.oss_contributions.mirror.adapters import mirror_files_to_legacy
 from gittensor.validator.oss_contributions.mirror.evaluation import MirrorMinerEvaluation
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
@@ -351,7 +351,7 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
 
     scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
 
-    chosen_label = _resolve_maintainer_set_label(pr)
+    chosen_label = _resolve_maintainer_set_label(pr, repo_config)
     scored.label = chosen_label
     scored.label_multiplier = LABEL_MULTIPLIERS.get(chosen_label, 1.0) if chosen_label else 1.0
 
@@ -372,17 +372,31 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
         scored.review_quality_multiplier = 1.0
 
 
-def _resolve_maintainer_set_label(pr: MirrorPullRequest) -> Optional[str]:
-    """Pick the highest-multiplier currently-applied label that was set by a maintainer.
+def _label_actor_trusted(label: MirrorLabel, repo_config: RepositoryConfig) -> bool:
+    """Whether ``label``'s actor is trusted to set scoring labels on this repo.
 
-    Mirror gives us actor attribution per label, so we can directly require the
-    label to have been applied by an OWNER/MEMBER/COLLABORATOR. Labels with null
-    actor_association (backfilled events) are ignored to be conservative.
+    Default: actor must be in ``MAINTAINER_ASSOCIATIONS``. Repos opted into
+    ``trusted_label_pipeline`` accept any actor — including GitHub-App actors
+    that surface as ``actor_association=NULL`` because they lack a row in
+    ``contributor_repo_roles``. Only flip ``trusted_label_pipeline`` on for
+    repos whose label pipeline is authoritative (entrius-controlled, gated by
+    an internal worker); community repos run attacker-controllable
+    auto-labelers (release-drafter, actions/labeler) so the maintainer gate
+    must stay in place. See issue #911.
+    """
+    if repo_config.trusted_label_pipeline:
+        return True
+    return label.actor_association in MAINTAINER_ASSOCIATIONS
+
+
+def _resolve_maintainer_set_label(pr: MirrorPullRequest, repo_config: RepositoryConfig) -> Optional[str]:
+    """Pick the highest-multiplier currently-applied scoring label whose actor
+    is trusted per :func:`_label_actor_trusted`. Ties broken by label name.
     """
     candidates = [
         label
         for label in pr.labels
-        if label.actor_association in MAINTAINER_ASSOCIATIONS and (label.name or '').lower() in LABEL_MULTIPLIERS
+        if (label.name or '').lower() in LABEL_MULTIPLIERS and _label_actor_trusted(label, repo_config)
     ]
     if not candidates:
         return None

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -41,7 +41,7 @@ from gittensor.constants import (
 )
 from gittensor.utils.github_api_tools import FileContentPair, branch_matches_pattern
 from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
-from gittensor.utils.mirror.models import MirrorLabel, MirrorLinkedIssue, MirrorPullRequest
+from gittensor.utils.mirror.models import MirrorLinkedIssue, MirrorPullRequest
 from gittensor.validator.oss_contributions.mirror.adapters import mirror_files_to_legacy
 from gittensor.validator.oss_contributions.mirror.evaluation import MirrorMinerEvaluation
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
@@ -372,31 +372,22 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
         scored.review_quality_multiplier = 1.0
 
 
-def _label_actor_trusted(label: MirrorLabel, repo_config: RepositoryConfig) -> bool:
-    """Whether ``label``'s actor is trusted to set scoring labels on this repo.
-
-    Default: actor must be in ``MAINTAINER_ASSOCIATIONS``. Repos opted into
-    ``trusted_label_pipeline`` accept any actor — including GitHub-App actors
-    that surface as ``actor_association=NULL`` because they lack a row in
-    ``contributor_repo_roles``. Only flip ``trusted_label_pipeline`` on for
-    repos whose label pipeline is authoritative (entrius-controlled, gated by
-    an internal worker); community repos run attacker-controllable
-    auto-labelers (release-drafter, actions/labeler) so the maintainer gate
-    must stay in place. See issue #911.
-    """
-    if repo_config.trusted_label_pipeline:
-        return True
-    return label.actor_association in MAINTAINER_ASSOCIATIONS
-
-
 def _resolve_maintainer_set_label(pr: MirrorPullRequest, repo_config: RepositoryConfig) -> Optional[str]:
-    """Pick the highest-multiplier currently-applied scoring label whose actor
-    is trusted per :func:`_label_actor_trusted`. Ties broken by label name.
+    """Pick the highest-multiplier currently-applied scoring label whose actor is trusted.
+
+    By default the actor must be in ``MAINTAINER_ASSOCIATIONS``. Repos opted into
+    ``trusted_label_pipeline`` accept any actor — including GitHub-App actors that
+    surface as ``actor_association=NULL`` because they lack a row in
+    ``contributor_repo_roles`` (issue #911). Only flip the flag on for repos whose
+    label pipeline is authoritative; community repos run attacker-controllable
+    auto-labelers (release-drafter, actions/labeler) and must keep the gate.
     """
+    trusted = repo_config.trusted_label_pipeline
     candidates = [
         label
         for label in pr.labels
-        if (label.name or '').lower() in LABEL_MULTIPLIERS and _label_actor_trusted(label, repo_config)
+        if (label.name or '').lower() in LABEL_MULTIPLIERS
+        and (trusted or label.actor_association in MAINTAINER_ASSOCIATIONS)
     ]
     if not candidates:
         return None

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -37,7 +37,7 @@ class RepositoryConfig:
         trusted_label_pipeline: When True, scoring labels count regardless of
             actor — including GitHub Apps that surface as ``actor_association=NULL``.
             Defaults to False; only enable on repos with an authoritative label
-            pipeline. See ``_resolve_maintainer_set_label`` for the threat model.
+            pipeline. See ``_resolve_trusted_scoring_label`` for the threat model.
 
     """
 

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -34,13 +34,10 @@ class RepositoryConfig:
         mirror_enabled: When True, fetch this repo's data from the das-github-mirror
             service instead of via per-miner PATs. Defaults to False so existing
             entries keep their current PAT-based behavior.
-        trusted_label_pipeline: When True, scoring labels apply regardless of who
-            (or what) attached them — including GitHub Apps that lack rows in
-            ``contributor_repo_roles`` and therefore surface as
-            ``actor_association=NULL``. Only set this on repos whose labels are
-            authoritative (entrius-controlled, gated by an internal worker, etc.);
-            most community repos run attacker-controllable auto-labelers and
-            must keep this off so the maintainer-association gate applies.
+        trusted_label_pipeline: When True, scoring labels count regardless of
+            actor — including GitHub Apps that surface as ``actor_association=NULL``.
+            Defaults to False; only enable on repos with an authoritative label
+            pipeline. See ``_resolve_maintainer_set_label`` for the threat model.
 
     """
 

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -34,6 +34,13 @@ class RepositoryConfig:
         mirror_enabled: When True, fetch this repo's data from the das-github-mirror
             service instead of via per-miner PATs. Defaults to False so existing
             entries keep their current PAT-based behavior.
+        trusted_label_pipeline: When True, scoring labels apply regardless of who
+            (or what) attached them — including GitHub Apps that lack rows in
+            ``contributor_repo_roles`` and therefore surface as
+            ``actor_association=NULL``. Only set this on repos whose labels are
+            authoritative (entrius-controlled, gated by an internal worker, etc.);
+            most community repos run attacker-controllable auto-labelers and
+            must keep this off so the maintainer-association gate applies.
 
     """
 
@@ -41,6 +48,7 @@ class RepositoryConfig:
     inactive_at: Optional[str] = None
     additional_acceptable_branches: Optional[List[str]] = None
     mirror_enabled: bool = False
+    trusted_label_pipeline: bool = False
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -122,6 +130,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     mirror_enabled=bool(metadata.get('mirror_enabled', False)),
+                    trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -205,19 +205,23 @@
   },
   "entrius/allways": {
     "weight": 1.0,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "entrius/allways-ui": {
     "weight": 0.5,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
     "weight": 1.0,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
     "weight": 0.5,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444
@@ -328,18 +332,12 @@
     "weight": 0.0837
   },
   "jupyterlab/jupyterlab": {
-    "additional_acceptable_branches": [
-      "4.5.x"
-    ],
     "weight": 0.1755
   },
   "keras-team/keras": {
     "weight": 0.1091
   },
   "labring/FastGPT": {
-    "additional_acceptable_branches": [
-      "v4.14.x"
-    ],
     "weight": 0.0633
   },
   "langchain-ai/langchain": {
@@ -451,9 +449,6 @@
     "weight": 0.0445
   },
   "monero-project/monero": {
-    "additional_acceptable_branches": [
-      "release-v0.18"
-    ],
     "weight": 0.0792
   },
   "mrdoob/three.js": {
@@ -472,18 +467,9 @@
     "weight": 0.0778
   },
   "nextcloud/desktop": {
-    "additional_acceptable_branches": [
-      "stable-33.0",
-      "stable-4.0"
-    ],
     "weight": 0.0771
   },
   "nextcloud/server": {
-    "additional_acceptable_branches": [
-      "stable33",
-      "stable32",
-      "stable31"
-    ],
     "weight": 0.0764
   },
   "nginx/nginx": {
@@ -752,9 +738,6 @@
     "weight": 0.0638
   },
   "zed-industries/zed": {
-    "additional_acceptable_branches": [
-      "v0.234.x"
-    ],
     "weight": 0.1564
   }
 }

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -213,6 +213,11 @@
     "mirror_enabled": true,
     "trusted_label_pipeline": true
   },
+  "entrius/das-github-mirror": {
+    "weight": 0.2,
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
+  },
   "entrius/gittensor": {
     "weight": 1.0,
     "mirror_enabled": true,
@@ -332,12 +337,18 @@
     "weight": 0.0837
   },
   "jupyterlab/jupyterlab": {
+    "additional_acceptable_branches": [
+      "4.5.x"
+    ],
     "weight": 0.1755
   },
   "keras-team/keras": {
     "weight": 0.1091
   },
   "labring/FastGPT": {
+    "additional_acceptable_branches": [
+      "v4.14.x"
+    ],
     "weight": 0.0633
   },
   "langchain-ai/langchain": {
@@ -449,6 +460,9 @@
     "weight": 0.0445
   },
   "monero-project/monero": {
+    "additional_acceptable_branches": [
+      "release-v0.18"
+    ],
     "weight": 0.0792
   },
   "mrdoob/three.js": {
@@ -467,9 +481,18 @@
     "weight": 0.0778
   },
   "nextcloud/desktop": {
+    "additional_acceptable_branches": [
+      "stable-33.0",
+      "stable-4.0"
+    ],
     "weight": 0.0771
   },
   "nextcloud/server": {
+    "additional_acceptable_branches": [
+      "stable33",
+      "stable32",
+      "stable31"
+    ],
     "weight": 0.0764
   },
   "nginx/nginx": {
@@ -738,6 +761,9 @@
     "weight": 0.0638
   },
   "zed-industries/zed": {
+    "additional_acceptable_branches": [
+      "v0.234.x"
+    ],
     "weight": 0.1564
   }
 }

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -35,12 +35,14 @@ _should_skip_merged_mirror_pr = scoring_module._should_skip_merged_mirror_pr
 _convert_mirror_files = adapters_module.mirror_files_to_legacy
 _calculate_pr_multipliers = scoring_module._calculate_pr_multipliers
 _resolve_maintainer_set_label = scoring_module._resolve_maintainer_set_label
+_label_actor_trusted = scoring_module._label_actor_trusted
 _calculate_issue_multiplier = scoring_module._calculate_issue_multiplier
 _is_valid_linked_issue = scoring_module._is_valid_linked_issue
 score_mirror_pr = scoring_module.score_mirror_pr
 
 ScoredMirrorPR = scored_pr_module.ScoredMirrorPR
 MirrorPullRequest = mirror_models.MirrorPullRequest
+MirrorLabel = mirror_models.MirrorLabel
 MirrorLinkedIssue = mirror_models.MirrorLinkedIssue
 MirrorFile = mirror_models.MirrorFile
 RepositoryConfig = load_weights.RepositoryConfig
@@ -100,11 +102,16 @@ def _pr(
     )
 
 
-def _config(weight: float = 0.5, additional_branches: list | None = None) -> RepositoryConfig:
+def _config(
+    weight: float = 0.5,
+    additional_branches: list | None = None,
+    trusted_label_pipeline: bool = False,
+) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
         mirror_enabled=True,
         additional_acceptable_branches=additional_branches,
+        trusted_label_pipeline=trusted_label_pipeline,
     )
 
 
@@ -405,48 +412,80 @@ class TestConvertMirrorFiles:
 # ============================================================================
 
 
+class TestLabelActorTrusted:
+    """Truth table for the issue #911 trust rule.
+
+    Encapsulating the rule in :func:`_label_actor_trusted` lets other call
+    sites reuse it without re-deriving the trusted_label_pipeline branch.
+    """
+
+    @pytest.mark.parametrize(
+        'actor_association,expected',
+        [
+            ('OWNER', True),
+            ('MEMBER', True),
+            ('COLLABORATOR', True),
+            ('CONTRIBUTOR', False),
+            ('NONE', False),
+            (None, False),
+        ],
+    )
+    def test_untrusted_repo_requires_maintainer_actor(self, actor_association, expected):
+        label = MirrorLabel(name='feature', actor_association=actor_association)
+        assert _label_actor_trusted(label, _config(trusted_label_pipeline=False)) is expected
+
+    @pytest.mark.parametrize(
+        'actor_association',
+        ['OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR', 'NONE', None],
+    )
+    def test_trusted_repo_accepts_any_actor(self, actor_association):
+        label = MirrorLabel(name='feature', actor_association=actor_association)
+        assert _label_actor_trusted(label, _config(trusted_label_pipeline=True)) is True
+
+
 class TestLabelResolution:
     def test_no_labels_returns_none(self):
         scored = ScoredMirrorPR(pr=_pr(labels=[]))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
 
     def test_non_scoring_labels_ignored(self):
-        # 'enhancement' is in LABEL_MULTIPLIERS, 'random' typically isn't
-        labels = [
-            {'name': 'random', 'actor_github_id': '1', 'actor_association': 'OWNER'},
-        ]
+        labels = [{'name': 'random', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
 
     def test_non_maintainer_label_ignored(self):
         from gittensor.constants import LABEL_MULTIPLIERS
 
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [
-            {'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'},
-        ]
+        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
 
-    def test_null_actor_association_ignored(self):
+    def test_null_actor_association_ignored_on_untrusted_repo(self):
         from gittensor.constants import LABEL_MULTIPLIERS
 
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [
-            {'name': scoring_label, 'actor_github_id': None, 'actor_association': None},
-        ]
+        labels = [{'name': scoring_label, 'actor_github_id': None, 'actor_association': None}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
 
     def test_maintainer_set_scoring_label_returned(self):
         from gittensor.constants import LABEL_MULTIPLIERS
 
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [
-            {'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'},
-        ]
+        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) == scoring_label.lower()
+        assert _resolve_maintainer_set_label(scored.pr, _config()) == scoring_label.lower()
+
+    def test_trusted_pipeline_accepts_null_actor(self):
+        """Bot/App labels (null actor_association) score on trusted_label_pipeline repos — issue #911."""
+        from gittensor.constants import LABEL_MULTIPLIERS
+
+        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
+        labels = [{'name': scoring_label, 'actor_github_id': '99', 'actor_association': None}]
+        scored = ScoredMirrorPR(pr=_pr(labels=labels))
+        chosen = _resolve_maintainer_set_label(scored.pr, _config(trusted_label_pipeline=True))
+        assert chosen == scoring_label.lower()
 
     def test_highest_multiplier_wins(self):
         from gittensor.constants import LABEL_MULTIPLIERS
@@ -455,17 +494,33 @@ class TestLabelResolution:
         if len(scoring_labels) < 2:
             pytest.skip('Need at least 2 scoring labels for this test')
 
-        # Pick two different scoring labels
         a, b = scoring_labels[0], scoring_labels[1]
         labels = [
             {'name': a, 'actor_github_id': '1', 'actor_association': 'OWNER'},
             {'name': b, 'actor_github_id': '1', 'actor_association': 'OWNER'},
         ]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        chosen = _resolve_maintainer_set_label(scored.pr)
-        # Whichever label has the higher LABEL_MULTIPLIERS value should win
+        chosen = _resolve_maintainer_set_label(scored.pr, _config())
         expected = max([a, b], key=lambda n: (LABEL_MULTIPLIERS[n], n)).lower()
         assert chosen == expected
+
+    def test_calculate_multipliers_threads_trusted_flag(self):
+        """End-to-end issue #911 path: _calculate_pr_multipliers honors trusted_label_pipeline."""
+        from gittensor.constants import LABEL_MULTIPLIERS
+
+        scoring_label = next((name for name, mult in LABEL_MULTIPLIERS.items() if mult != 1.0), None)
+        if scoring_label is None:
+            pytest.skip('Need at least one non-1.0x label for this test')
+
+        labels = [{'name': scoring_label, 'actor_github_id': '99', 'actor_association': None}]
+
+        scored_trusted = ScoredMirrorPR(pr=_pr(labels=labels))
+        _calculate_pr_multipliers(scored_trusted, _config(trusted_label_pipeline=True))
+        assert scored_trusted.label_multiplier == LABEL_MULTIPLIERS[scoring_label]
+
+        scored_untrusted = ScoredMirrorPR(pr=_pr(labels=labels))
+        _calculate_pr_multipliers(scored_untrusted, _config(trusted_label_pipeline=False))
+        assert scored_untrusted.label_multiplier == 1.0
 
 
 # ============================================================================

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -34,7 +34,7 @@ load_weights = pytest.importorskip('gittensor.validator.utils.load_weights')
 _should_skip_merged_mirror_pr = scoring_module._should_skip_merged_mirror_pr
 _convert_mirror_files = adapters_module.mirror_files_to_legacy
 _calculate_pr_multipliers = scoring_module._calculate_pr_multipliers
-_resolve_maintainer_set_label = scoring_module._resolve_maintainer_set_label
+_resolve_trusted_scoring_label = scoring_module._resolve_trusted_scoring_label
 _calculate_issue_multiplier = scoring_module._calculate_issue_multiplier
 _is_valid_linked_issue = scoring_module._is_valid_linked_issue
 score_mirror_pr = scoring_module.score_mirror_pr
@@ -413,12 +413,12 @@ class TestConvertMirrorFiles:
 class TestLabelResolution:
     def test_no_labels_returns_none(self):
         scored = ScoredMirrorPR(pr=_pr(labels=[]))
-        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_non_scoring_labels_ignored(self):
         labels = [{'name': 'random', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_non_maintainer_label_ignored(self):
         from gittensor.constants import LABEL_MULTIPLIERS
@@ -426,7 +426,7 @@ class TestLabelResolution:
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
         labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_null_actor_association_ignored_on_untrusted_repo(self):
         from gittensor.constants import LABEL_MULTIPLIERS
@@ -434,7 +434,7 @@ class TestLabelResolution:
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
         labels = [{'name': scoring_label, 'actor_github_id': None, 'actor_association': None}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr, _config()) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_maintainer_set_scoring_label_returned(self):
         from gittensor.constants import LABEL_MULTIPLIERS
@@ -442,7 +442,7 @@ class TestLabelResolution:
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
         labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr, _config()) == scoring_label.lower()
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) == scoring_label.lower()
 
     def test_highest_multiplier_wins(self):
         from gittensor.constants import LABEL_MULTIPLIERS
@@ -457,7 +457,7 @@ class TestLabelResolution:
             {'name': b, 'actor_github_id': '1', 'actor_association': 'OWNER'},
         ]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        chosen = _resolve_maintainer_set_label(scored.pr, _config())
+        chosen = _resolve_trusted_scoring_label(scored.pr, _config())
         expected = max([a, b], key=lambda n: (LABEL_MULTIPLIERS[n], n)).lower()
         assert chosen == expected
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -444,16 +444,6 @@ class TestLabelResolution:
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
         assert _resolve_maintainer_set_label(scored.pr, _config()) == scoring_label.lower()
 
-    def test_trusted_pipeline_accepts_null_actor(self):
-        """Bot/App labels (null actor_association) score on trusted_label_pipeline repos — issue #911."""
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': '99', 'actor_association': None}]
-        scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        chosen = _resolve_maintainer_set_label(scored.pr, _config(trusted_label_pipeline=True))
-        assert chosen == scoring_label.lower()
-
     def test_highest_multiplier_wins(self):
         from gittensor.constants import LABEL_MULTIPLIERS
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -35,14 +35,12 @@ _should_skip_merged_mirror_pr = scoring_module._should_skip_merged_mirror_pr
 _convert_mirror_files = adapters_module.mirror_files_to_legacy
 _calculate_pr_multipliers = scoring_module._calculate_pr_multipliers
 _resolve_maintainer_set_label = scoring_module._resolve_maintainer_set_label
-_label_actor_trusted = scoring_module._label_actor_trusted
 _calculate_issue_multiplier = scoring_module._calculate_issue_multiplier
 _is_valid_linked_issue = scoring_module._is_valid_linked_issue
 score_mirror_pr = scoring_module.score_mirror_pr
 
 ScoredMirrorPR = scored_pr_module.ScoredMirrorPR
 MirrorPullRequest = mirror_models.MirrorPullRequest
-MirrorLabel = mirror_models.MirrorLabel
 MirrorLinkedIssue = mirror_models.MirrorLinkedIssue
 MirrorFile = mirror_models.MirrorFile
 RepositoryConfig = load_weights.RepositoryConfig
@@ -410,37 +408,6 @@ class TestConvertMirrorFiles:
 # ============================================================================
 # Label resolution (maintainer-set + highest multiplier)
 # ============================================================================
-
-
-class TestLabelActorTrusted:
-    """Truth table for the issue #911 trust rule.
-
-    Encapsulating the rule in :func:`_label_actor_trusted` lets other call
-    sites reuse it without re-deriving the trusted_label_pipeline branch.
-    """
-
-    @pytest.mark.parametrize(
-        'actor_association,expected',
-        [
-            ('OWNER', True),
-            ('MEMBER', True),
-            ('COLLABORATOR', True),
-            ('CONTRIBUTOR', False),
-            ('NONE', False),
-            (None, False),
-        ],
-    )
-    def test_untrusted_repo_requires_maintainer_actor(self, actor_association, expected):
-        label = MirrorLabel(name='feature', actor_association=actor_association)
-        assert _label_actor_trusted(label, _config(trusted_label_pipeline=False)) is expected
-
-    @pytest.mark.parametrize(
-        'actor_association',
-        ['OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR', 'NONE', None],
-    )
-    def test_trusted_repo_accepts_any_actor(self, actor_association):
-        label = MirrorLabel(name='feature', actor_association=actor_association)
-        assert _label_actor_trusted(label, _config(trusted_label_pipeline=True)) is True
 
 
 class TestLabelResolution:

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -193,11 +193,6 @@ class TestRepositoryConfigTrustedLabelPipeline:
         config = RepositoryConfig(weight=0.5)
         assert config.trusted_label_pipeline is False
 
-    def test_trusted_label_pipeline_explicit_true(self):
-        """RepositoryConfig accepts trusted_label_pipeline=True."""
-        config = RepositoryConfig(weight=0.5, trusted_label_pipeline=True)
-        assert config.trusted_label_pipeline is True
-
     def test_loader_parses_trusted_label_pipeline_true(self, tmp_path, monkeypatch):
         """load_master_repo_weights() parses trusted_label_pipeline:true from JSON."""
         import json

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -122,6 +122,25 @@ class TestLoadMasterRepositories:
                 f'{repo_name} mirror_enabled should be bool, got {type(config.mirror_enabled)}'
             )
 
+    def test_trusted_label_pipeline_field_present_on_live_configs(self):
+        """Live master_repositories.json entries load with a bool trusted_label_pipeline."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            assert isinstance(config.trusted_label_pipeline, bool), (
+                f'{repo_name} trusted_label_pipeline should be bool, got {type(config.trusted_label_pipeline)}'
+            )
+
+    def test_entrius_repos_have_trusted_label_pipeline(self):
+        """All entrius/* entries opt into trusted_label_pipeline (issue #911)."""
+        repos = load_master_repo_weights()
+        entrius_repos = {name: cfg for name, cfg in repos.items() if name.startswith('entrius/')}
+        assert entrius_repos, 'expected entrius/* entries in master_repositories.json'
+        for repo_name, config in entrius_repos.items():
+            assert config.trusted_label_pipeline is True, (
+                f'{repo_name} must have trusted_label_pipeline=true so the agentic-maintainer '
+                f'labeling worker is honored at scoring time'
+            )
+
 
 class TestRepositoryConfigMirrorFlag:
     """Dataclass-level tests for the mirror_enabled field + its JSON parsing."""
@@ -159,6 +178,49 @@ class TestRepositoryConfigMirrorFlag:
         assert repos['foo/mirror-repo'].mirror_enabled is True
         assert repos['foo/legacy-repo'].mirror_enabled is False
         assert repos['foo/explicit-off'].mirror_enabled is False
+
+
+class TestRepositoryConfigTrustedLabelPipeline:
+    """Dataclass + JSON-parsing tests for trusted_label_pipeline (issue #911)."""
+
+    def test_trusted_label_pipeline_default_false(self):
+        """RepositoryConfig constructor defaults trusted_label_pipeline to False.
+
+        Default-off is the safety property: community repos with
+        attacker-controlled auto-labelers (release-drafter, actions/labeler)
+        keep the maintainer-association gate in place.
+        """
+        config = RepositoryConfig(weight=0.5)
+        assert config.trusted_label_pipeline is False
+
+    def test_trusted_label_pipeline_explicit_true(self):
+        """RepositoryConfig accepts trusted_label_pipeline=True."""
+        config = RepositoryConfig(weight=0.5, trusted_label_pipeline=True)
+        assert config.trusted_label_pipeline is True
+
+    def test_loader_parses_trusted_label_pipeline_true(self, tmp_path, monkeypatch):
+        """load_master_repo_weights() parses trusted_label_pipeline:true from JSON."""
+        import json
+
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/trusted': {'weight': 0.5, 'trusted_label_pipeline': True},
+                    'foo/untrusted': {'weight': 0.3},
+                    'foo/explicit-off': {'weight': 0.2, 'trusted_label_pipeline': False},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/trusted'].trusted_label_pipeline is True
+        assert repos['foo/untrusted'].trusted_label_pipeline is False
+        assert repos['foo/explicit-off'].trusted_label_pipeline is False
 
 
 class TestBannedOrganizations:


### PR DESCRIPTION
## Summary

Closes #911. Bot-applied scoring labels on `entrius/*` mirror repos are dropped at scoring time because the agentic-maintainer labeling worker has no row in `contributor_repo_roles`, so its label events surface with `actor_association=NULL` and fail the maintainer-association gate in `_resolve_maintainer_set_label`.

This adds an opt-in `trusted_label_pipeline` flag on `RepositoryConfig` and threads it through mirror label resolution. Default is off, so community repos running attacker-controllable auto-labelers (release-drafter, actions/labeler, etc.) keep the maintainer gate. Flipped on for the four existing `entrius/*` mirror repos whose labels come from an internal worker.

## Changes

- `RepositoryConfig`: add `trusted_label_pipeline: bool = False` with a docstring spelling out the threat model and when it's safe to flip on.
- `mirror/scoring.py`: extract `_label_actor_trusted(label, repo_config)` helper; `_resolve_maintainer_set_label` now takes `repo_config` as a required arg and consults the helper.
- `master_repositories.json`: set `trusted_label_pipeline: true` on `entrius/allways`, `entrius/allways-ui`, `entrius/gittensor`, `entrius/gittensor-ui`. No other repo or weight changes.
- Tests: parametrized 12-case truth table for `_label_actor_trusted` (every actor_association × trusted/untrusted), end-to-end check that `_calculate_pr_multipliers` threads the flag, and a live-config invariant that any future `entrius/*` repo must opt in.


## Related Issues

Fixes #911

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated
- [x] Manually verified

