### PR TITLE
fix(storage): rollback store_evaluation on sub-write failure sentinels

### DIFF
--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -111,7 +111,7 @@ class Repository(BaseRepository):
         params = (miner.uid, miner.hotkey, miner.github_id)
         return self.set_entity(SET_MINER, params, commit=commit)
 
-    def cleanup_stale_miner_data(self, evaluation: MinerEvaluation, commit: bool = True) -> None:
+    def cleanup_stale_miner_data(self, evaluation: MinerEvaluation, commit: bool = True) -> bool:
         """
         Remove stale evaluation data when a miner re-registers on a new uid/hotkey.
 
@@ -121,27 +121,31 @@ class Repository(BaseRepository):
 
         Args:
             evaluation: The current MinerEvaluation being stored
+
+        Returns:
+            True if cleanup was skipped or every cleanup statement succeeded, False otherwise.
         """
         # Skip cleanup for penalized / pre-validation-failed evals — running it
         # for a penalized eval whose github_id is preserved would tug stale rows
         # between two duplicate-share UIDs, removing each other's records.
         if evaluation.failed_reason is not None:
-            return
+            return True
         if not evaluation.github_id or evaluation.github_id == '0':
-            return
+            return True
 
         params = (evaluation.github_id, evaluation.uid, evaluation.hotkey)
         eval_params = params + (evaluation.evaluation_timestamp,)
 
-        # Clean up when same github_id re-registers on a new uid/hotkey
-        self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS, eval_params, commit=commit)
-        self.execute_command(CLEANUP_STALE_MINERS, params, commit=commit)
-
-        # Clean up when same (uid, hotkey) re-links to a new github_id
         reverse_params = (evaluation.uid, evaluation.hotkey, evaluation.github_id)
         reverse_eval_params = reverse_params + (evaluation.evaluation_timestamp,)
-        self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY, reverse_eval_params, commit=commit)
-        self.execute_command(CLEANUP_STALE_MINERS_BY_HOTKEY, reverse_params, commit=commit)
+
+        cleanup_results = [
+            self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS, eval_params, commit=commit),
+            self.execute_command(CLEANUP_STALE_MINERS, params, commit=commit),
+            self.execute_command(CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY, reverse_eval_params, commit=commit),
+            self.execute_command(CLEANUP_STALE_MINERS_BY_HOTKEY, reverse_params, commit=commit),
+        ]
+        return all(cleanup_results)
 
     def store_pull_requests_bulk(self, pull_requests: List[PullRequest], commit: bool = True) -> int:
         """

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -27,6 +27,16 @@ class DatabaseStorage:
     def is_enabled(self) -> bool:
         return self.db_connection is not None
 
+    @staticmethod
+    def _require_success(write_name: str, succeeded: bool) -> None:
+        if not succeeded:
+            raise RuntimeError(f'{write_name} write failed')
+
+    @staticmethod
+    def _require_bulk_success(write_name: str, item_count: int, stored_count: int) -> None:
+        if item_count > 0 and not stored_count:
+            raise RuntimeError(f'{write_name} bulk write failed for {item_count} item(s)')
+
     def store_evaluation(self, miner_eval: MinerEvaluation) -> StorageResult:
         """
         Store all evaluation data in an optimized manner with proper error handling.
@@ -60,28 +70,54 @@ class DatabaseStorage:
                     for s in scored_list
                 ]
 
+            merged_pull_requests = miner_eval.merged_pull_requests + _adapt_mirror(miner_eval.mirror_merged_prs)
+            open_pull_requests = miner_eval.open_pull_requests + _adapt_mirror(miner_eval.mirror_open_prs)
+            closed_pull_requests = miner_eval.closed_pull_requests + _adapt_mirror(miner_eval.mirror_closed_prs)
+            issues = miner_eval.get_all_issues()
+            file_changes = miner_eval.get_all_file_changes()
+
             with self.db_connection.pipeline():
-                result.stored_counts['miners'] = self.repo.set_miner(miner, commit=False)
+                miner_stored = self.repo.set_miner(miner, commit=False)
+                result.stored_counts['miners'] = 1 if miner_stored else 0
+                self._require_success('miner', miner_stored)
+
                 result.stored_counts['merged_pull_requests'] = self.repo.store_pull_requests_bulk(
-                    miner_eval.merged_pull_requests + _adapt_mirror(miner_eval.mirror_merged_prs), commit=False
+                    merged_pull_requests, commit=False
+                )
+                self._require_bulk_success(
+                    'merged pull requests', len(merged_pull_requests), result.stored_counts['merged_pull_requests']
                 )
                 result.stored_counts['open_pull_requests'] = self.repo.store_pull_requests_bulk(
-                    miner_eval.open_pull_requests + _adapt_mirror(miner_eval.mirror_open_prs), commit=False
+                    open_pull_requests, commit=False
+                )
+                self._require_bulk_success(
+                    'open pull requests', len(open_pull_requests), result.stored_counts['open_pull_requests']
                 )
                 result.stored_counts['closed_pull_requests'] = self.repo.store_pull_requests_bulk(
-                    miner_eval.closed_pull_requests + _adapt_mirror(miner_eval.mirror_closed_prs), commit=False
+                    closed_pull_requests, commit=False
+                )
+                self._require_bulk_success(
+                    'closed pull requests', len(closed_pull_requests), result.stored_counts['closed_pull_requests']
                 )
                 result.stored_counts['stale_closed_pull_requests'] = self.repo.store_pull_requests_bulk(
                     miner_eval.stale_closed_pull_requests, commit=False
                 )
-                result.stored_counts['issues'] = self.repo.store_issues_bulk(miner_eval.get_all_issues(), commit=False)
-                result.stored_counts['file_changes'] = self.repo.store_file_changes_bulk(
-                    miner_eval.get_all_file_changes(), commit=False
+                self._require_bulk_success(
+                    'stale closed pull requests',
+                    len(miner_eval.stale_closed_pull_requests),
+                    result.stored_counts['stale_closed_pull_requests'],
                 )
-                self.repo.cleanup_stale_miner_data(miner_eval, commit=False)
-                result.stored_counts['evaluations'] = (
-                    1 if self.repo.set_miner_evaluation(miner_eval, commit=False) else 0
+                result.stored_counts['issues'] = self.repo.store_issues_bulk(issues, commit=False)
+                self._require_bulk_success('issues', len(issues), result.stored_counts['issues'])
+                result.stored_counts['file_changes'] = self.repo.store_file_changes_bulk(file_changes, commit=False)
+                self._require_bulk_success('file changes', len(file_changes), result.stored_counts['file_changes'])
+                self._require_success(
+                    'stale miner cleanup', self.repo.cleanup_stale_miner_data(miner_eval, commit=False)
                 )
+
+                evaluation_stored = self.repo.set_miner_evaluation(miner_eval, commit=False)
+                result.stored_counts['evaluations'] = 1 if evaluation_stored else 0
+                self._require_success('miner evaluation', evaluation_stored)
 
             self.db_connection.commit()
             self.db_connection.autocommit = True

--- a/tests/validator/utils/test_storage_mirror.py
+++ b/tests/validator/utils/test_storage_mirror.py
@@ -15,6 +15,7 @@ storage_module = pytest.importorskip(
 classes = pytest.importorskip('gittensor.classes')
 mirror_models = pytest.importorskip('gittensor.utils.mirror.models')
 scored_pr_module = pytest.importorskip('gittensor.validator.oss_contributions.mirror.scored_pr')
+repository_module = pytest.importorskip('gittensor.validator.storage.repository')
 
 DatabaseStorage = storage_module.DatabaseStorage
 MinerEvaluation = classes.MinerEvaluation
@@ -22,6 +23,7 @@ PullRequest = classes.PullRequest
 PRState = classes.PRState
 MirrorPullRequest = mirror_models.MirrorPullRequest
 ScoredMirrorPR = scored_pr_module.ScoredMirrorPR
+Repository = repository_module.Repository
 
 
 def _legacy_pr(number: int, state: PRState = PRState.MERGED) -> PullRequest:
@@ -83,15 +85,28 @@ def _make_storage_with_mock_repo():
     """Build a DatabaseStorage with a mock DB connection + repo, bypassing __init__."""
     with patch.object(storage_module, 'create_database_connection', return_value=MagicMock()):
         with patch.object(storage_module, 'Repository') as mock_repo_cls:
+
+            def _store_bulk(items, commit=True):
+                return len(items)
+
             mock_repo = MagicMock()
-            mock_repo.set_miner.return_value = 1
-            mock_repo.store_pull_requests_bulk.return_value = 0  # actual count irrelevant
-            mock_repo.store_issues_bulk.return_value = 0
-            mock_repo.store_file_changes_bulk.return_value = 0
+            mock_repo.set_miner.return_value = True
+            mock_repo.store_pull_requests_bulk.side_effect = _store_bulk
+            mock_repo.store_issues_bulk.side_effect = _store_bulk
+            mock_repo.store_file_changes_bulk.side_effect = _store_bulk
+            mock_repo.cleanup_stale_miner_data.return_value = True
             mock_repo.set_miner_evaluation.return_value = True
             mock_repo_cls.return_value = mock_repo
             storage = DatabaseStorage()
             return storage, mock_repo
+
+
+def _empty_evaluation():
+    eval_obj = MinerEvaluation(uid=1, hotkey='hk', github_id='gh1')
+    eval_obj.mirror_merged_prs = []
+    eval_obj.mirror_open_prs = []
+    eval_obj.mirror_closed_prs = []
+    return eval_obj
 
 
 class TestStoreEvaluationCombinesBothLists:
@@ -208,10 +223,7 @@ def test_failure_after_cleanup_triggers_rollback():
     storage, mock_repo = _make_storage_with_mock_repo()
     mock_repo.set_miner_evaluation.side_effect = RuntimeError('DB write failed')
 
-    eval_obj = MinerEvaluation(uid=1, hotkey='hk', github_id='gh1')
-    eval_obj.mirror_merged_prs = []
-    eval_obj.mirror_open_prs = []
-    eval_obj.mirror_closed_prs = []
+    eval_obj = _empty_evaluation()
 
     with patch(
         'gittensor.validator.oss_contributions.mirror.adapters.mirror_scored_pr_to_legacy_pull_request',
@@ -222,3 +234,83 @@ def test_failure_after_cleanup_triggers_rollback():
     assert result.success is False
     storage.db_connection.rollback.assert_called_once()
     storage.db_connection.commit.assert_not_called()
+
+
+def test_required_write_false_triggers_rollback():
+    """A False repository result must fail the outer transaction even without an exception."""
+    storage, mock_repo = _make_storage_with_mock_repo()
+    mock_repo.set_miner.return_value = False
+
+    result = storage.store_evaluation(_empty_evaluation())
+
+    assert result.success is False
+    assert 'miner write failed' in result.errors[0]
+    storage.db_connection.rollback.assert_called_once()
+    storage.db_connection.commit.assert_not_called()
+    mock_repo.store_pull_requests_bulk.assert_not_called()
+
+
+def test_non_empty_bulk_return_zero_triggers_rollback():
+    """A non-empty bulk write returning 0 is a repository-level failure sentinel."""
+    storage, mock_repo = _make_storage_with_mock_repo()
+    mock_repo.store_pull_requests_bulk.side_effect = lambda _items, commit=True: 0
+
+    eval_obj = _empty_evaluation()
+    eval_obj.merged_pull_requests = [_legacy_pr(1)]
+
+    result = storage.store_evaluation(eval_obj)
+
+    assert result.success is False
+    assert 'merged pull requests bulk write failed' in result.errors[0]
+    storage.db_connection.rollback.assert_called_once()
+    storage.db_connection.commit.assert_not_called()
+    mock_repo.set_miner_evaluation.assert_not_called()
+
+
+def test_empty_bulk_return_zero_still_commits():
+    """Empty bulk inputs legitimately return 0 and should not poison the transaction."""
+    storage, _mock_repo = _make_storage_with_mock_repo()
+
+    result = storage.store_evaluation(_empty_evaluation())
+
+    assert result.success is True
+    storage.db_connection.commit.assert_called_once()
+    storage.db_connection.rollback.assert_not_called()
+
+
+def test_cleanup_false_triggers_rollback():
+    """cleanup_stale_miner_data failures are part of the same transaction."""
+    storage, mock_repo = _make_storage_with_mock_repo()
+    mock_repo.cleanup_stale_miner_data.return_value = False
+
+    result = storage.store_evaluation(_empty_evaluation())
+
+    assert result.success is False
+    assert 'stale miner cleanup write failed' in result.errors[0]
+    storage.db_connection.rollback.assert_called_once()
+    storage.db_connection.commit.assert_not_called()
+    mock_repo.set_miner_evaluation.assert_not_called()
+
+
+def test_evaluation_false_triggers_rollback():
+    """set_miner_evaluation returning False should rollback instead of committing success."""
+    storage, mock_repo = _make_storage_with_mock_repo()
+    mock_repo.set_miner_evaluation.return_value = False
+
+    result = storage.store_evaluation(_empty_evaluation())
+
+    assert result.success is False
+    assert 'miner evaluation write failed' in result.errors[0]
+    storage.db_connection.rollback.assert_called_once()
+    storage.db_connection.commit.assert_not_called()
+
+
+def test_cleanup_stale_returns_false_when_command_fails():
+    """Repository cleanup should surface execute_command failures to the outer storage flow."""
+    repo = Repository(MagicMock())
+    repo.execute_command = MagicMock(side_effect=[True, False, True, True])
+    eval_obj = _empty_evaluation()
+    eval_obj.evaluation_timestamp = object()
+
+    assert repo.cleanup_stale_miner_data(eval_obj, commit=False) is False
+    assert repo.execute_command.call_count == 4


### PR DESCRIPTION
## Summary

`DatabaseStorage.store_evaluation()` now treats repository failure return values as transaction failures, not successful stored counts.

Repository methods intentionally catch DB exceptions and return sentinels (`False` / `0`). After #778, inner commits were deferred correctly with `commit=False`, but the outer storage flow still committed when a sub-write returned a failure sentinel instead of raising.

## Changes

- Validate boolean repository writes and fail the outer transaction on `False`.
- Validate bulk writes and fail when a non-empty input returns `0`.
- Preserve valid empty-bulk behavior: empty inputs returning `0` still succeed.
- Make `cleanup_stale_miner_data()` return `False` if any internal cleanup command fails.
- Add regression coverage for:
  - required write returning `False`
  - non-empty bulk write returning `0`
  - empty bulk write returning `0`
  - stale cleanup returning `False`
  - miner evaluation returning `False`


## Testing

- `env UV_CACHE_DIR=/tmp/uv-cache uv run pre-commit run --files gittensor/validator/utils/storage.py gittensor/validator/storage/repository.py tests/validator/utils/test_storage_mirror.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/validator/utils/test_storage_mirror.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ -x -q`
