### PR TITLE
refactor: bundle of small refactors

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -22,8 +22,6 @@ from gittensor.constants import (
 )
 from gittensor.utils.utils import parse_repo_name
 
-GITHUB_DOMAIN = 'https://github.com/'
-
 
 class PRState(Enum):
     """PR state for scoring"""

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -268,18 +268,13 @@ def confirm_or_abort(prompt: str, yes: bool, default: bool = False) -> bool:
     return False
 
 
-def get_github_pat() -> Optional[str]:
-    """Return GITTENSOR_MINER_PAT from environment, or None."""
-    return os.environ.get('GITTENSOR_MINER_PAT') or None
-
-
 def fetch_open_issue_pull_requests(
     repository_full_name: str,
     issue_number: int,
     as_json: bool,
 ) -> list:
     """Fetch open PR submissions for a GitHub issue."""
-    token = get_github_pat() or ''
+    token = os.environ.get('GITTENSOR_MINER_PAT') or ''
     if not token and not as_json:
         print_warning('No GitHub token found; set GITTENSOR_MINER_PAT to fetch GitHub issue submissions')
 

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -20,7 +20,7 @@ import requests
 from rich.console import Console
 
 from gittensor.cli.issue_commands.tables import build_pr_table
-from gittensor.constants import BASE_GITHUB_API_URL, NETWORK_MAP
+from gittensor.constants import BASE_GITHUB_API_URL, MAX_ISSUE_ID, NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
     ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
@@ -39,7 +39,6 @@ ALPHA_DECIMALS = 9
 ALPHA_RAW_UNIT = 10**ALPHA_DECIMALS
 MIN_BOUNTY_ALPHA = 10
 MAX_BOUNTY_ALPHA = 100_000_000
-MAX_ISSUE_ID = 1_000_000
 MAX_ISSUE_NUMBER = 2**32 - 1
 REPO_PATTERN = re.compile(r'^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$')
 GITHUB_API_TIMEOUT = 10

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -22,6 +22,7 @@ from rich.console import Console
 from gittensor.cli.issue_commands.tables import build_pr_table
 from gittensor.constants import BASE_GITHUB_API_URL, NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
+    ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
     decode_issue_from_storage,
     decode_packed_contract_storage,
@@ -801,7 +802,7 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
     for issue_id in range(1, next_issue_id):
         # SCALE encode u64 as little-endian 8 bytes
         encoded_id = struct.pack('<Q', issue_id)
-        lazy_key = compute_ink5_lazy_key('52789899', encoded_id)
+        lazy_key = compute_ink5_lazy_key(ISSUES_MAPPING_ROOT_KEY, encoded_id)
 
         val_result = substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
         if not val_result.get('result'):

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -20,7 +20,7 @@ import requests
 from rich.console import Console
 
 from gittensor.cli.issue_commands.tables import build_pr_table
-from gittensor.constants import NETWORK_MAP
+from gittensor.constants import BASE_GITHUB_API_URL, NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
     compute_ink5_lazy_key,
     decode_issue_from_storage,
@@ -409,7 +409,7 @@ def validate_repository(
     if verify_exists:
         try:
             resp = requests.get(
-                f'https://api.github.com/repos/{owner}/{repo_name}',
+                f'{BASE_GITHUB_API_URL}/repos/{owner}/{repo_name}',
                 headers={'User-Agent': 'gittensor-cli'},
                 timeout=GITHUB_API_TIMEOUT,
             )
@@ -457,7 +457,7 @@ def validate_github_issue(
     """
     try:
         resp = requests.get(
-            f'https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}',
+            f'{BASE_GITHUB_API_URL}/repos/{owner}/{repo}/issues/{issue_number}',
             headers={'User-Agent': 'gittensor-cli'},
             timeout=GITHUB_API_TIMEOUT,
         )

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -210,3 +210,4 @@ MAX_OPEN_PR_THRESHOLD = 30  # Maximum open PR threshold (base + bonus capped at 
 CONTRACT_ADDRESS = '5FWNdk8YNtNcHKrAx2krqenFrFAZG7vmsd2XN2isJSew3MrD'
 ISSUES_TREASURY_UID = 111  # UID of the smart contract neuron, if set to RECYCLE_UID then it's disabled
 ISSUES_TREASURY_EMISSION_SHARE = 0.15  # % of emissions allocated to funding issues treasury
+MAX_ISSUE_ID = 1_000_000  # sanity-check upper bound for any real deployment

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -166,11 +166,6 @@ OPEN_ISSUE_SPAM_BASE_THRESHOLD = 5  # half the PR base of 10
 OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT = 300.0  # +1 allowed open issue per this much token score
 MAX_OPEN_ISSUE_THRESHOLD = 30
 
-# Repo-centric closed issue scan caps (validator PAT budget)
-REPO_SCAN_PER_REPO_CAP = 300  # max solver lookups per repo
-REPO_SCAN_GLOBAL_CAP = 1500  # max solver lookups per round
-REPO_SCAN_CONCURRENCY = 2  # concurrent solver lookup threads
-
 # =============================================================================
 # Collateral
 # =============================================================================

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -287,7 +287,7 @@ def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str
         try:
             response = session.get(
                 f'{BASE_GITHUB_API_URL}/repos/{repository}/compare/{base_sha}...{head_sha}',
-                timeout=15,
+                timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
             )
 
             if response.status_code == 200:
@@ -349,7 +349,7 @@ def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -
             response = session.get(
                 f'{BASE_GITHUB_API_URL}/repos/{repository}/pulls/{pr_number}/files',
                 params={'per_page': per_page, 'page': page},
-                timeout=15,
+                timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
             )
 
             if response.status_code == 200:
@@ -1040,7 +1040,7 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
     try:
         response = session.get(
             f'{BASE_GITHUB_API_URL}/repos/{repo}/issues/{issue_number}',
-            timeout=15,
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
 
         if response.status_code != 200:

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -15,6 +15,7 @@ import bittensor as bt
 from substrateinterface import Keypair
 from substrateinterface.exceptions import ExtrinsicNotFound
 
+from gittensor.constants import MAX_ISSUE_ID
 from gittensor.validator.issue_competitions.storage_utils import (
     ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
@@ -192,8 +193,7 @@ class IssueCompetitionContractClient:
             if next_issue_id <= 1:
                 return []
 
-            MAX_REASONABLE_ISSUE_ID = 1_000_000
-            if next_issue_id > MAX_REASONABLE_ISSUE_ID:
+            if next_issue_id > MAX_ISSUE_ID:
                 bt.logging.warning(f'next_issue_id ({next_issue_id}) unreasonably large')
                 return []
 

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -16,6 +16,7 @@ from substrateinterface import Keypair
 from substrateinterface.exceptions import ExtrinsicNotFound
 
 from gittensor.validator.issue_competitions.storage_utils import (
+    ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
     decode_issue_from_storage,
     get_contract_child_storage_key,
@@ -154,7 +155,7 @@ class IssueCompetitionContractClient:
 
         try:
             encoded_id = struct.pack('<Q', issue_id)
-            lazy_key = compute_ink5_lazy_key('52789899', encoded_id)
+            lazy_key = compute_ink5_lazy_key(ISSUES_MAPPING_ROOT_KEY, encoded_id)
 
             val_result = self.subtensor.substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
             if not val_result.get('result'):

--- a/gittensor/validator/issue_competitions/storage_utils.py
+++ b/gittensor/validator/issue_competitions/storage_utils.py
@@ -8,6 +8,9 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# ink! mapping selector for the issues storage map (matches the contract's storage layout).
+ISSUES_MAPPING_ROOT_KEY = '52789899'
+
 
 @dataclass
 class PackedContractStorage:

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -144,7 +144,15 @@ def score_mirror_pr(
 
     file_changes, file_contents = mirror_files_to_legacy(pr.repo_full_name, pr.pr_number, files)
 
-    scored.base_score = _calculate_base_score(scored, file_changes, file_contents, programming_languages, token_config)
+    result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
+    scored.token_score = result.token_score
+    scored.structural_count = result.structural_count
+    scored.structural_score = result.structural_score
+    scored.leaf_count = result.leaf_count
+    scored.leaf_score = result.leaf_score
+    scored.total_nodes_scored = result.total_nodes_scored
+    scored.code_density = result.code_density
+    scored.base_score = result.base_score
 
     _calculate_pr_multipliers(scored, repo_config)
 
@@ -314,25 +322,6 @@ def calculate_base_score_for_pr_files(
         total_nodes_scored=total_nodes_scored,
         code_density=code_density,
     )
-
-
-def _calculate_base_score(
-    scored: ScoredMirrorPR,
-    file_changes: List[FileChange],
-    file_contents: Dict[str, FileContentPair],
-    programming_languages: Dict[str, LanguageConfig],
-    token_config: TokenConfig,
-) -> float:
-    """Thin wrapper: run the shared helper and copy fields onto ScoredMirrorPR."""
-    result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
-    scored.token_score = result.token_score
-    scored.structural_count = result.structural_count
-    scored.structural_score = result.structural_score
-    scored.leaf_count = result.leaf_count
-    scored.leaf_score = result.leaf_score
-    scored.total_nodes_scored = result.total_nodes_scored
-    scored.code_density = result.code_density
-    return result.base_score
 
 
 # ============================================================================

--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -86,11 +86,6 @@ def parse_code(content: str, language: str) -> Optional[Tree]:
 NodeSignature = Union[Tuple[str, str], Tuple[str, str, str]]
 
 
-def is_comment_node(node: Node) -> bool:
-    """Check if a node is a comment."""
-    return node.type in COMMENT_NODE_TYPES
-
-
 def collect_node_signatures(
     tree: Tree,
     weights: TokenConfig,
@@ -115,7 +110,7 @@ def collect_node_signatures(
 
     def walk_node(node: Node) -> None:
         # Skip comments entirely
-        if is_comment_node(node):
+        if node.type in COMMENT_NODE_TYPES:
             return
 
         node_type = node.type

--- a/neurons/base/utils/weight_utils.py
+++ b/neurons/base/utils/weight_utils.py
@@ -4,7 +4,6 @@ import bittensor
 import numpy as np
 from numpy import complexfloating, dtype, floating, ndarray
 
-U32_MAX = 4294967295
 U16_MAX = 65535
 
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Set
 import bittensor as bt
 import wandb
 
-from gittensor.__init__ import __version__
+from gittensor import __version__
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.validator import pat_storage
 from gittensor.validator.forward import forward


### PR DESCRIPTION
## Summary

Per @anderdc's review, consolidating my open small refactor PRs into this one. #864 and #873 are mid-review and remain separate as previously requested. (Note: #873 has since merged — its work is built on by the last commit here.)

Each commit is preserved as a separate revision so the bundle can be reviewed commit-by-commit or squash-merged.

### Commits in this bundle (oldest → newest)

1. **#917** — `refactor: use BASE_GITHUB_API_URL constant in cli/issue_commands/helpers.py`
2. **#942** — `refactor: use GITHUB_HTTP_TIMEOUT_SECONDS at the three remaining timeout=15 sites`
3. **#943** — `refactor: remove unused REPO_SCAN_* constants`
4. **#948** — `refactor: inline single-use get_github_pat and is_comment_node helpers`
5. **#949** — `refactor: inline single-use _calculate_base_score adapter into score_mirror_pr`
6. **#952** — `refactor: centralize ink! issues-mapping selector as ISSUES_MAPPING_ROOT_KEY`
7. **#953** — `refactor: remove unused U32_MAX constant`
8. **#954** — `refactor: remove unused GITHUB_DOMAIN constant`
9. **#955** — `refactor: normalize __version__ import in neurons/validator.py`
10. **#1015** — `refactor: move MAX_ISSUE_ID to gittensor/constants.py and use it on the validator side` (follow-up to merged #873)

### Aggregate change

- 10 files changed, **+28 / -52 lines** (net **-24 lines**).
- No behaviour change in any commit.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` on the merged bundle — all **754 tests pass**.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)