### PR TITLE
fix: gate MERGED solving PRs missing merged_at in mirror issue discovery

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -12,6 +12,7 @@ emission blending / normalization doesn't change.
 Anti-gaming gates (all applied):
 - solved_by_pr must be populated
 - solving_pr.state == 'MERGED'
+- solving_pr.merged_at is not None (anti-corruption)
 - not solving_pr.edited_after_merge
 - issue.last_edited_at <= solving_pr.merged_at (anti-spec-rewrite)
 - issue.state_reason == 'COMPLETED' (not NOT_PLANNED, not null)
@@ -493,6 +494,15 @@ def _classify_issue(issue: MirrorIssue) -> str:
         bt.logging.debug(
             f'  issue #{issue.issue_number} ({issue.repo_full_name}): closed-not-solved '
             f'(solving PR #{sp.pr_number} state={sp.state}, not MERGED)'
+        )
+        return 'not-solved-closed'
+
+    # Reject MERGED PRs with null merged_at — unscoreable and would otherwise
+    # inflate total_valid_solved_issues past the eligibility floor.
+    if sp.merged_at is None:
+        bt.logging.debug(
+            f'  issue #{issue.issue_number} ({issue.repo_full_name}): closed-not-solved '
+            f'(solving PR #{sp.pr_number} MERGED but missing merged_at)'
         )
         return 'not-solved-closed'
 

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -205,6 +205,13 @@ class TestClassifyIssue:
         issue = MirrorIssue.from_dict(_issue_dict(solving_pr_state='OPEN'))
         assert _classify_issue(issue) == 'not-solved-closed'
 
+    def test_solving_pr_merged_with_null_merged_at_counts_as_closed(self):
+        # MERGED + null merged_at is unscoreable; gate it before the counters bump.
+        raw = _issue_dict()
+        raw['solving_pr']['merged_at'] = None
+        issue = MirrorIssue.from_dict(raw)
+        assert _classify_issue(issue) == 'not-solved-closed'
+
     def test_solving_pr_edited_after_merge_counts_as_closed(self):
         issue = MirrorIssue.from_dict(_issue_dict(solving_pr_edited_after_merge=True))
         assert _classify_issue(issue) == 'not-solved-closed'
@@ -368,6 +375,31 @@ class TestRunMirrorIssueDiscovery:
             )
         )
         assert eval_.total_solved_issues == 0
+
+    def test_merged_pr_missing_merged_at_does_not_inflate_solved(self):
+        # Regression: a corrupted record (MERGED + null merged_at) must bucket
+        # as closed-not-solved, never bumping the solved counters that gate
+        # MIN_VALID_SOLVED_ISSUES eligibility.
+        raw = _issue_dict()
+        raw['solving_pr']['merged_at'] = None
+
+        client = Mock()
+        client.get_miner_issues.return_value = _response([raw])
+        eval_ = _eval()
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        assert eval_.total_solved_issues == 0
+        assert eval_.total_valid_solved_issues == 0
+        assert eval_.total_closed_issues == 1
 
     def test_mirror_request_error_does_not_abort_other_miners(self):
         client = Mock()


### PR DESCRIPTION
## Summary

A solving PR with `state == 'MERGED'` but `merged_at is None` is structurally unscoreable (time decay needs `merged_at`). `_mirror_issue_for_scoring` already drops it, but only **after** `total_solved_issues` and `total_valid_solved_issues` have been incremented. One corrupted record could push a miner past `MIN_VALID_SOLVED_ISSUES`, flipping eligibility and producing a non-zero discovery score from the other valid issues.

This PR adds the missing gate in `_classify_issue` so the corrupted record buckets as `not-solved-closed` before the counters bump — matching the defensive gate already present on the OSS mirror scoring path.

## Changes

- `gittensor/validator/issue_discovery/mirror_scan.py`: reject `MERGED` solving PRs with `merged_at is None` in `_classify_issue`; document the gate in the module docstring.
- `tests/validator/issue_discovery/test_mirror_scan.py`: unit test on `_classify_issue` and a regression test verifying the counters stay at zero.

Close #919 

## Test plan

- [ ] `pytest tests/validator/issue_discovery/test_mirror_scan.py`
- [ ] Verify no behavior change for clean records (existing tests still green)
