### PR TITLE
fix: remove duplicate github_id entries from eligible_miners instead of silently overwriting 

### DIFF
--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -62,11 +62,19 @@ async def issue_competitions(
             bt.logging.success(f'Harvested emissions! Extrinsic: {harvest_result.get("tx_hash", "")}')
 
         # Build mapping of github_id->hotkey for eligible miners only
-        eligible_miners = {
-            eval.github_id: eval.hotkey
-            for eval in miner_evaluations.values()
-            if eval.github_id and eval.github_id != '0' and eval.is_eligible
-        }
+        eligible_miners: dict[str, str] = {}
+        for eval_ in miner_evaluations.values():
+            if not eval_.github_id or eval_.github_id == '0' or not eval_.is_eligible:
+                continue
+            if eval_.github_id in eligible_miners:
+                bt.logging.error(
+                    f'Duplicate github_id={eval_.github_id} across hotkeys: '
+                    f'{eligible_miners[eval_.github_id][:12]}... vs {eval_.hotkey[:12]}... '
+                    f'— removing from eligible_miners to prevent ambiguous bounty vote'
+                )
+                eligible_miners.pop(eval_.github_id, None)
+                continue
+            eligible_miners[eval_.github_id] = eval_.hotkey
         bt.logging.info(f'Issue bounties: {len(eligible_miners)} eligible miners out of {len(miner_evaluations)} total')
         for github_id, hotkey in eligible_miners.items():
             bt.logging.info(f'  Eligible miner: github_id={github_id}, hotkey={hotkey[:12]}...')


### PR DESCRIPTION
Fixes #895

## Problem
`eligible_miners` in `issue_competitions/forward.py` was built via a
dict comprehension keyed by `github_id`. When two eligible
`MinerEvaluation` entries share the same `github_id`, the second
silently overwrites the first with a non-deterministic winner (Python
dict iteration order over `.values()`).

The surviving hotkey is then used at line 137 to vote-pay the bounty
solver. If the surviving hotkey is not the actual PR author, validators
vote for the wrong miner — or if `get_miner_coldkey()` fails on the
surviving hotkey, the validator skips voting and the bounty becomes
stuck `Active` indefinitely.

This is a defense-in-depth fix: the upstream
`detect_and_penalize_miners_sharing_github` prevents most duplicates,
but race conditions between PAT broadcast and the penalty pass, plus
historical state-divergence bugs (#533, #596), mean duplicates can
still reach this code path in production.

## Fix
Replaced the silent dict comprehension with an explicit loop that:
1. Logs an `error`-level message identifying both hotkeys when a
   duplicate `github_id` is detected
2. Removes the colliding entry from `eligible_miners` entirely, so
   the validator skips voting on that bounty rather than mis-paying

## Changes
- `gittensor/validator/issue_competitions/forward.py` — replaced
  dict comprehension with duplicate-detecting loop