### PR TITLE
fix: persist refreshed issue discovery for cached fallback UIDs

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -67,7 +67,7 @@ async def forward(self: 'Validator') -> None:
         )
 
         # 2. Score issue discovery
-        issue_rewards = await issue_discovery(
+        issue_rewards, issue_refreshed_uids = await issue_discovery(
             miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
         )
 
@@ -75,7 +75,12 @@ async def forward(self: 'Validator') -> None:
         await issue_competitions(self, miner_evaluations)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
-        await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
+        evaluation_only_uids = issue_refreshed_cached_uids(cached_uids, issue_refreshed_uids)
+        await self.bulk_store_evaluation(
+            miner_evaluations,
+            skip_uids=cached_uids,
+            evaluation_only_uids=evaluation_only_uids,
+        )
 
         # 5. Blend 4 emission pools into final rewards
         rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
@@ -117,7 +122,7 @@ async def issue_discovery(
     programming_languages: Dict,
     token_config,
     miner_uids: set[int],
-) -> np.ndarray:
+) -> Tuple[np.ndarray, Set[int]]:
     """Score issue discovery and return normalized rewards array.
 
     Mirror-only path: uses ``MirrorClient.get_miner_issues`` with authoritative
@@ -127,14 +132,18 @@ async def issue_discovery(
     solver attribution on busy issues, and non-mirror repos are deliberately
     left out of issue discovery entirely until their mirror_enabled flag flips.
 
-    Returns numpy array of normalized issue discovery rewards (sorted by UID).
+    Returns normalized issue discovery rewards (sorted by UID) plus UIDs whose
+    issue-discovery fields were refreshed from a successful mirror fetch.
     """
     mirror_repos: Dict[str, RepositoryConfig] = {
         name: cfg for name, cfg in master_repositories.items() if cfg.mirror_enabled
     }
 
+    refreshed_uids: Set[int] = set()
     if mirror_repos:
-        await run_mirror_issue_discovery(miner_evaluations, mirror_repos, programming_languages, token_config)
+        refreshed_uids = await run_mirror_issue_discovery(
+            miner_evaluations, mirror_repos, programming_languages, token_config
+        )
     else:
         bt.logging.info('No mirror-enabled repos — issue discovery skipped for this round')
 
@@ -142,7 +151,12 @@ async def issue_discovery(
     issue_rewards_dict = normalize_issue_discovery_rewards(miner_evaluations)
 
     sorted_uids = sorted(miner_uids)
-    return np.array([issue_rewards_dict.get(uid, 0.0) for uid in sorted_uids])
+    return np.array([issue_rewards_dict.get(uid, 0.0) for uid in sorted_uids]), refreshed_uids
+
+
+def issue_refreshed_cached_uids(cached_uids: Set[int], issue_refreshed_uids: Set[int]) -> Set[int]:
+    """Return cached fallback UIDs that need an evaluation-row refresh."""
+    return cached_uids & issue_refreshed_uids
 
 
 def blend_emission_pools(

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -106,7 +106,7 @@ async def run_mirror_issue_discovery(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     client: Optional[MirrorClient] = None,
-) -> None:
+) -> Set[int]:
     """Score issue discovery for mirror-enabled repos. Mutates miner_evaluations.
 
     For each miner, fetches their authored issues via the mirror and classifies
@@ -117,6 +117,10 @@ async def run_mirror_issue_discovery(
     Depends on OSS scoring (``score_mirror_miner_prs``) having already run for
     this cycle — the cross-miner solving-PR cache is built by walking every
     miner's populated ``mirror_merged_prs``.
+
+    Returns the UIDs whose mirror issue fetch completed successfully. These
+    evaluations contain current issue-discovery fields even when the miner has
+    zero qualifying issues, so cached OSS fallback must not skip their DB row.
     """
     bt.logging.info('')
     bt.logging.info('=' * 50)
@@ -125,7 +129,7 @@ async def run_mirror_issue_discovery(
 
     if not mirror_repos:
         bt.logging.info('No mirror-enabled repos — issue discovery skipped')
-        return
+        return set()
 
     client = client or MirrorClient()
     lookback_date = datetime.now(timezone.utc) - timedelta(days=PR_LOOKBACK_DAYS)
@@ -142,6 +146,7 @@ async def run_mirror_issue_discovery(
     skipped_failed = 0
     fetch_errors = 0
     no_issues = 0
+    refreshed_uids: Set[int] = set()
 
     # Phase 1: fetch each miner's issues.  The one-issue-per-PR rule is round-
     # global, so scoring is deferred until every miner's batch is in hand.
@@ -161,8 +166,10 @@ async def run_mirror_issue_discovery(
             fetch_errors += 1
             continue
 
+        refreshed_uids.add(uid)
         filtered = [i for i in response.issues if i.repo_full_name in enabled_names]
         if not filtered:
+            _clear_issue_discovery_fields(evaluation)
             no_issues += 1
             continue
 
@@ -199,6 +206,18 @@ async def run_mirror_issue_discovery(
         f'({cache_stats.misses - cache_stats.fetch_failures} fetched OK, '
         f'{cache_stats.fetch_failures} fetch failures)'
     )
+    return refreshed_uids
+
+
+def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
+    evaluation.total_solved_issues = 0
+    evaluation.total_valid_solved_issues = 0
+    evaluation.total_closed_issues = 0
+    evaluation.total_open_issues = 0
+    evaluation.issue_token_score = 0.0
+    evaluation.issue_credibility = 0.0
+    evaluation.is_issue_eligible = False
+    evaluation.issue_discovery_score = 0.0
 
 
 def _build_canonical_pr_owners(
@@ -274,6 +293,8 @@ def _score_miner_mirror_issues(
     ``canonical_pr_owners`` enforces the cross-miner one-issue-per-PR rule:
     only the marker-matching issue scores, siblings count for credibility.
     """
+    _clear_issue_discovery_fields(evaluation)
+
     solved_count = 0
     valid_solved_count = 0
     closed_count = 0

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -27,6 +27,44 @@ class DatabaseStorage:
     def is_enabled(self) -> bool:
         return self.db_connection is not None
 
+    def store_miner_evaluation(self, miner_eval: MinerEvaluation) -> StorageResult:
+        """
+        Store only the miner identity and aggregate evaluation row.
+
+        Used when cached OSS fallback supplied already-stored PR data, but a
+        later scoring phase refreshed top-level fields such as issue discovery.
+        """
+        if not self.is_enabled():
+            return StorageResult(success=False, errors=['Database storage not enabled'], stored_counts={})
+
+        result = StorageResult(success=True, errors=[], stored_counts={})
+
+        try:
+            assert self.db_connection is not None and self.repo is not None
+            self.db_connection.autocommit = False
+
+            miner_eval.evaluation_timestamp = datetime.now(timezone.utc)
+
+            miner = Miner(miner_eval.uid, miner_eval.hotkey, miner_eval.github_id or '')
+            result.stored_counts['miners'] = self.repo.set_miner(miner, commit=False)
+            self.repo.cleanup_stale_miner_data(miner_eval, commit=False)
+            result.stored_counts['evaluations'] = 1 if self.repo.set_miner_evaluation(miner_eval, commit=False) else 0
+
+            self.db_connection.commit()
+            self.db_connection.autocommit = True
+
+        except Exception as ex:
+            if self.db_connection is not None:
+                self.db_connection.rollback()
+                self.db_connection.autocommit = True
+
+            error_msg = f'Failed to store miner evaluation row for UID {miner_eval.uid}: {str(ex)}'
+            result.success = False
+            result.errors.append(error_msg)
+            self.logger.error(error_msg)
+
+        return result
+
     def store_evaluation(self, miner_eval: MinerEvaluation) -> StorageResult:
         """
         Store all evaluation data in an optimized manner with proper error handling.

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -98,30 +98,49 @@ class Validator(BaseValidatorNeuron):
         bt.logging.info('load_state()')
         self.load_state()
 
-    async def bulk_store_evaluation(self, miner_evals: Dict[int, MinerEvaluation], skip_uids: Set[int] = None):
+    async def bulk_store_evaluation(
+        self,
+        miner_evals: Dict[int, MinerEvaluation],
+        skip_uids: Set[int] = None,
+        evaluation_only_uids: Set[int] = None,
+    ):
         """Store all miner evaluations, log summary rather than per-UID.
 
         Args:
             miner_evals: Dict of UID -> MinerEvaluation to store.
             skip_uids: Set of UIDs to skip (e.g. cached evaluations that were already stored previously).
+            evaluation_only_uids: Cached UIDs whose aggregate evaluation row should be refreshed
+                without re-storing cached PR and file-change payloads.
         """
         if self.db_storage is None:
             return
 
         skip_uids = skip_uids or set()
+        evaluation_only_uids = evaluation_only_uids or set()
         successful_count = 0
+        evaluation_only_count = 0
         skipped_count = 0
         failed_uids: List[int] = []
 
         for uid, evaluation in miner_evals.items():
             if uid in skip_uids:
-                skipped_count += 1
-                continue
+                if uid not in evaluation_only_uids:
+                    skipped_count += 1
+                    continue
 
             try:
-                storage_result = self.db_storage.store_evaluation(evaluation)
+                if uid in skip_uids:
+                    storage_result = self.db_storage.store_miner_evaluation(evaluation)
+                    evaluation_only_store = True
+                else:
+                    storage_result = self.db_storage.store_evaluation(evaluation)
+                    evaluation_only_store = False
+
                 if storage_result.success:
-                    successful_count += 1
+                    if evaluation_only_store:
+                        evaluation_only_count += 1
+                    else:
+                        successful_count += 1
                 else:
                     failed_uids.append(uid)
                     bt.logging.warning(f'Storage partially failed for UID {uid}:')
@@ -134,6 +153,8 @@ class Validator(BaseValidatorNeuron):
         # Summary logging
         if successful_count > 0:
             bt.logging.success(f'Stored validation results for {successful_count} UIDs to DB')
+        if evaluation_only_count > 0:
+            bt.logging.success(f'Stored refreshed evaluation rows for {evaluation_only_count} cached UIDs to DB')
         if skipped_count > 0:
             bt.logging.info(f'Skipped {skipped_count} UIDs (cached evaluations)')
         if failed_uids:

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -244,8 +244,9 @@ class TestRunMirrorIssueDiscovery:
 
     def test_no_mirror_repos_short_circuits(self):
         client = Mock()
-        _run(run_mirror_issue_discovery({}, {}, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG, client=client))
+        refreshed = _run(run_mirror_issue_discovery({}, {}, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG, client=client))
         client.get_miner_issues.assert_not_called()
+        assert refreshed == set()
 
     def test_miner_without_github_id_skipped(self):
         client = Mock()
@@ -358,7 +359,16 @@ class TestRunMirrorIssueDiscovery:
             ]
         )
         eval_ = _eval()
-        _run(
+        eval_.issue_discovery_score = 99.0
+        eval_.issue_token_score = 88.0
+        eval_.issue_credibility = 0.5
+        eval_.is_issue_eligible = True
+        eval_.total_solved_issues = 7
+        eval_.total_valid_solved_issues = 7
+        eval_.total_closed_issues = 2
+        eval_.total_open_issues = 3
+
+        refreshed = _run(
             run_mirror_issue_discovery(
                 {1: eval_},
                 _mirror_repos('entrius/gittensor-ui'),
@@ -367,7 +377,32 @@ class TestRunMirrorIssueDiscovery:
                 client=client,
             )
         )
+        assert refreshed == {1}
         assert eval_.total_solved_issues == 0
+        assert eval_.total_valid_solved_issues == 0
+        assert eval_.total_closed_issues == 0
+        assert eval_.total_open_issues == 0
+        assert eval_.issue_discovery_score == 0.0
+        assert eval_.issue_token_score == 0.0
+        assert eval_.issue_credibility == 0.0
+        assert eval_.is_issue_eligible is False
+
+    def test_successful_empty_issue_fetch_marks_uid_refreshed(self):
+        client = Mock()
+        client.get_miner_issues.return_value = _response([])
+        eval_ = _eval()
+
+        refreshed = _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        assert refreshed == {1}
 
     def test_mirror_request_error_does_not_abort_other_miners(self):
         client = Mock()
@@ -384,7 +419,7 @@ class TestRunMirrorIssueDiscovery:
         # Seed cache so working miner's solving PR is scoreable
         working.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
 
-        _run(
+        refreshed = _run(
             run_mirror_issue_discovery(
                 {1: failing, 2: working},
                 _mirror_repos('entrius/gittensor-ui'),
@@ -393,6 +428,7 @@ class TestRunMirrorIssueDiscovery:
                 client=client,
             )
         )
+        assert refreshed == {2}
         assert failing.total_solved_issues == 0
         assert working.total_solved_issues == 1
 

--- a/tests/validator/test_cached_issue_discovery_storage.py
+++ b/tests/validator/test_cached_issue_discovery_storage.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+forward_module = pytest.importorskip('gittensor.validator.forward')
+storage_module = pytest.importorskip('gittensor.validator.utils.storage')
+classes = pytest.importorskip('gittensor.classes')
+load_weights = pytest.importorskip('gittensor.validator.utils.load_weights')
+validator_module = pytest.importorskip('neurons.validator')
+
+DatabaseStorage = storage_module.DatabaseStorage
+StorageResult = storage_module.StorageResult
+MinerEvaluation = classes.MinerEvaluation
+RepositoryConfig = load_weights.RepositoryConfig
+TokenConfig = load_weights.TokenConfig
+Validator = validator_module.Validator
+
+
+def test_issue_refreshed_cached_uids_are_evaluation_only_storage_uids():
+    evaluation_only_uids = forward_module.issue_refreshed_cached_uids(
+        cached_uids={1, 2, 3},
+        issue_refreshed_uids={2, 4},
+    )
+
+    assert evaluation_only_uids == {2}
+
+
+def test_issue_discovery_returns_refreshed_uids_from_mirror_scan(monkeypatch):
+    async def fake_run_mirror_issue_discovery(*args, **kwargs):
+        return {7}
+
+    monkeypatch.setattr(forward_module, 'run_mirror_issue_discovery', fake_run_mirror_issue_discovery)
+
+    evaluations = {7: MinerEvaluation(uid=7, hotkey='hk7', github_id='777')}
+    repos = {'entrius/gittensor': RepositoryConfig(weight=1.0, mirror_enabled=True)}
+
+    rewards, refreshed_uids = asyncio.run(
+        forward_module.issue_discovery(evaluations, repos, {}, TokenConfig(), miner_uids={7})
+    )
+
+    assert rewards.tolist() == [0.0]
+    assert refreshed_uids == {7}
+
+
+def test_bulk_store_refreshes_cached_uid_with_evaluation_only_storage():
+    validator = MagicMock()
+    validator.db_storage.store_evaluation.return_value = StorageResult(True, [], {})
+    validator.db_storage.store_miner_evaluation.return_value = StorageResult(True, [], {})
+
+    cached_eval = MinerEvaluation(uid=1, hotkey='hk1', github_id='111')
+    fresh_eval = MinerEvaluation(uid=2, hotkey='hk2', github_id='222')
+
+    asyncio.run(
+        Validator.bulk_store_evaluation(
+            cast(Validator, validator),
+            {1: cached_eval, 2: fresh_eval},
+            skip_uids={1},
+            evaluation_only_uids={1},
+        )
+    )
+
+    validator.db_storage.store_miner_evaluation.assert_called_once_with(cached_eval)
+    validator.db_storage.store_evaluation.assert_called_once_with(fresh_eval)
+
+
+def test_store_miner_evaluation_skips_pr_issue_and_file_payloads():
+    with patch.object(storage_module, 'create_database_connection', return_value=MagicMock()):
+        with patch.object(storage_module, 'Repository') as mock_repo_cls:
+            mock_repo = MagicMock()
+            mock_repo.set_miner.return_value = 1
+            mock_repo.set_miner_evaluation.return_value = True
+            mock_repo_cls.return_value = mock_repo
+
+            storage = DatabaseStorage()
+            evaluation = MinerEvaluation(uid=1, hotkey='hk1', github_id='111')
+
+            result = storage.store_miner_evaluation(evaluation)
+
+    assert result.success is True
+    mock_repo.set_miner.assert_called_once()
+    mock_repo.cleanup_stale_miner_data.assert_called_once_with(evaluation, commit=False)
+    mock_repo.set_miner_evaluation.assert_called_once_with(evaluation, commit=False)
+    mock_repo.store_pull_requests_bulk.assert_not_called()
+    mock_repo.store_issues_bulk.assert_not_called()
+    mock_repo.store_file_changes_bulk.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #922.

Cached OSS fallback UIDs were skipped entirely during DB storage, even when mirror issue discovery later refreshed their top-level issue-discovery fields in the same forward pass.

This change separates cached PR/file payload skipping from aggregate evaluation-row persistence:

- mirror issue discovery now returns UIDs whose issue fetch completed successfully
- successful empty/no-relevant issue responses clear stale issue-discovery fields
- cached UIDs with refreshed issue discovery are written through an evaluation-row-only storage path
- cached PR, issue, and file-change payloads remain skipped

## Why

A GitHub PR-fetch failure can restore a cached evaluation and mark the UID as cached. Mirror issue discovery can still succeed afterward and mutate fields such as:

- `issue_discovery_score`
- `issue_token_score`
- `issue_credibility`
- `is_issue_eligible`
- `total_solved_issues`
- `total_valid_solved_issues`
- `total_closed_issues`
- `total_open_issues`

Before this fix, `bulk_store_evaluation(..., skip_uids=cached_uids)` skipped the whole UID, so emissions could use fresh in-memory issue-discovery values while the DB/dashboard kept stale values.

## Fix

- Thread issue-discovery refreshed UIDs through `forward()`.
- Compute cached UIDs that need only an aggregate evaluation-row refresh.
- Add `DatabaseStorage.store_miner_evaluation()` to persist miner identity + `miner_evaluations` row without re-storing cached PR/file data.
- Extend `bulk_store_evaluation()` with `evaluation_only_uids`.

## Testing

- `uv run pytest tests/ -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pre-commit run --files gittensor/validator/forward.py gittensor/validator/issue_discovery/mirror_scan.py gittensor/validator/utils/storage.py neurons/validator.py tests/validator/issue_discovery/test_mirror_scan.py tests/validator/test_cached_issue_discovery_storage.py`
