### PR TITLE
fix: deduplicate legacy+mirror PRs in pioneer scoring to prevent double-counting

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -247,11 +247,16 @@ def calculate_pioneer_dividends(
     repo_contributions: Dict[str, Dict[int, Tuple[datetime, int, float]]] = {}
 
     for uid, evaluation in miner_evaluations.items():
+        seen_prs: set = set()  # (repo, pr_number) — guard against legacy+mirror double-count
         for pr in evaluation.merged_pull_requests + evaluation.mirror_merged_prs:
             if not pr.is_pioneer_eligible():
                 continue
             assert pr.merged_at is not None
             repo = pr.repository_full_name
+            pr_key = (repo, pr.number)
+            if pr_key in seen_prs:
+                continue
+            seen_prs.add(pr_key)
             pr_index.setdefault(repo, {}).setdefault(uid, []).append(pr)
 
             current = repo_contributions.setdefault(repo, {}).get(uid)


### PR DESCRIPTION
Fixes #887

## Problem
`calculate_pioneer_dividends` iterates
`merged_pull_requests + mirror_merged_prs` without deduplication.
A PR that exists in both lists (migrated repos temporarily tracked
on both paths, or a mirror backfill that overlaps with a legacy fetch)
is counted twice: once in `pr_index` (inflating the pioneer rank list)
and once in `repo_contributions` (inflating `earned_score` totals and
misplacing the earliest-merge anchor).

The rank inflation causes downstream validators to assign different
pioneer ranks to the same miner depending on whether their cache
includes the legacy PR, the mirror PR, or both — breaking consensus
on dividend amounts.

## Fix
Added a `seen_prs: set` per-miner loop that tracks `(repo, pr_number)`
pairs. Any PR whose key is already in `seen_prs` is skipped before it
can touch `pr_index` or `repo_contributions`.

## Changes
- `gittensor/validator/oss_contributions/scoring.py` — added `seen_prs`
  deduplication guard in `calculate_pioneer_dividends`