### PR TITLE
fix: gate MERGED-without-merged_at solving PRs in mirror issue discovery (#926)

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -12,6 +12,8 @@ emission blending / normalization doesn't change.
 Anti-gaming gates (all applied):
 - solved_by_pr must be populated
 - solving_pr.state == 'MERGED'
+- solving_pr.merged_at is not None (anti-corruption — matches the OSS
+  mirror path's defensive gate)
 - not solving_pr.edited_after_merge
 - issue.last_edited_at <= solving_pr.merged_at (anti-spec-rewrite)
 - issue.state_reason == 'COMPLETED' (not NOT_PLANNED, not null)
@@ -456,6 +458,19 @@ def _classify_issue(issue: MirrorIssue) -> str:
         bt.logging.debug(
             f'  issue #{issue.issue_number} ({issue.repo_full_name}): closed-not-solved '
             f'(solving PR #{sp.pr_number} state={sp.state}, not MERGED)'
+        )
+        return 'not-solved-closed'
+
+    # Data corruption: state==MERGED but merged_at missing. Mirror's OSS path
+    # treats this same shape as a hard skip (oss_contributions/mirror/scoring.py
+    # rejects with "MERGED but missing merged_at"); apply the same gate here so
+    # an unscoreable record can't inflate total_valid_solved_issues past the
+    # eligibility floor — _mirror_issue_for_scoring would later drop it for the
+    # same reason, but only after the counter was already incremented.
+    if sp.merged_at is None:
+        bt.logging.debug(
+            f'  issue #{issue.issue_number} ({issue.repo_full_name}): closed-not-solved '
+            f'(solving PR #{sp.pr_number} MERGED but missing merged_at — data corruption)'
         )
         return 'not-solved-closed'
 

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -204,6 +204,16 @@ class TestClassifyIssue:
         issue = MirrorIssue.from_dict(_issue_dict(solving_pr_state='OPEN'))
         assert _classify_issue(issue) == 'not-solved-closed'
 
+    def test_solving_pr_merged_with_null_merged_at_counts_as_closed(self):
+        # Data corruption: state==MERGED but merged_at missing. Without this
+        # gate, _mirror_issue_for_scoring drops the record but the counter has
+        # already incremented, letting one corrupted row carry a miner past
+        # MIN_VALID_SOLVED_ISSUES. Mirrors the OSS mirror scoring gate.
+        raw = _issue_dict()
+        raw['solving_pr']['merged_at'] = None
+        issue = MirrorIssue.from_dict(raw)
+        assert _classify_issue(issue) == 'not-solved-closed'
+
     def test_solving_pr_edited_after_merge_counts_as_closed(self):
         issue = MirrorIssue.from_dict(_issue_dict(solving_pr_edited_after_merge=True))
         assert _classify_issue(issue) == 'not-solved-closed'
@@ -367,6 +377,67 @@ class TestRunMirrorIssueDiscovery:
             )
         )
         assert eval_.total_solved_issues == 0
+
+    def test_merged_pr_missing_merged_at_does_not_inflate_valid_solved(self):
+        """Regression for the eligibility-gate inflation bug.
+
+        A solving PR reported as MERGED but with merged_at=null is structurally
+        unscoreable (time decay needs merged_at). Before the gate fix, such an
+        issue still bumped solved_count and valid_solved_count before being
+        dropped by _mirror_issue_for_scoring — letting one corrupted record
+        flip a miner from 6 valid solveds (ineligible) to 7 (eligible) and
+        produce a non-zero discovery score from the other six.
+        """
+        from gittensor.constants import MIN_VALID_SOLVED_ISSUES
+
+        # Build (MIN_VALID_SOLVED_ISSUES - 1) clean solveds so the miner is
+        # exactly one short of the gate.
+        valid_count = MIN_VALID_SOLVED_ISSUES - 1
+        valid_issues = [
+            _issue_dict(
+                issue_number=300 + i,
+                solved_by_pr=400 + i,
+                author_github_id=f'discoverer{i}',
+            )
+            for i in range(valid_count)
+        ]
+        # One MERGED-but-missing-merged_at corrupted record. Without the gate
+        # this would push valid_solved_count to MIN_VALID_SOLVED_ISSUES and
+        # flip eligibility.
+        corrupted = _issue_dict(
+            issue_number=500,
+            solved_by_pr=600,
+            author_github_id='discovererC',
+        )
+        corrupted['solving_pr']['merged_at'] = None
+
+        client = Mock()
+        client.get_miner_issues.return_value = _response(valid_issues + [corrupted])
+
+        eval_ = _eval()
+        # Pre-seed every solving PR (including the corrupted one's) so the
+        # cache hits and valid_solved gating depends purely on classification.
+        eval_.mirror_merged_prs = [
+            _scored_mirror_pr('entrius/gittensor-ui', 400 + i, token_score=100.0) for i in range(valid_count)
+        ] + [_scored_mirror_pr('entrius/gittensor-ui', 600, token_score=100.0)]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Corrupted record bucketed as closed-not-solved, not solved.
+        assert eval_.total_solved_issues == valid_count
+        assert eval_.total_valid_solved_issues == valid_count
+        assert eval_.total_closed_issues == 1
+        # Stays one short of the eligibility floor.
+        assert eval_.is_issue_eligible is False
+        assert eval_.issue_discovery_score == 0
 
     def test_mirror_request_error_does_not_abort_other_miners(self):
         client = Mock()


### PR DESCRIPTION
## Summary

`_classify_issue` in `gittensor/validator/issue_discovery/mirror_scan.py` accepts a solving PR as `solved` whenever `solving_pr.state == 'MERGED'`, without checking that `solving_pr.merged_at` is populated. When the inline `solving_pr` comes back with `state == 'MERGED'` but `merged_at == null` (data corruption), the issue passes the gate, increments `total_solved_issues` and `total_valid_solved_issues`, and is then dropped later by `_mirror_issue_for_scoring` (which requires `merged_at` for time decay).

The downstream skip means no discovery score is produced for that issue, but the eligibility counters have already been bumped. One such corrupted record can carry a miner from one short of the issue-discovery eligibility floor (`MIN_VALID_SOLVED_ISSUES = 7`) into eligibility, letting the miner's other valid solveds produce a non-zero `issue_discovery_score`.

### Fix

Tighten `_classify_issue` to bucket `state == 'MERGED' and merged_at is None` as `not-solved-closed`, mirroring the defensive gate already enforced on the OSS mirror path at `gittensor/validator/oss_contributions/mirror/scoring.py:192-193` ("PR #N is MERGED but missing merged_at"). The downstream `merged_at is None` guard in `_mirror_issue_for_scoring` becomes belt-and-suspenders defense once the upstream gate is in place.

### Changes

**Source**

- `gittensor/validator/issue_discovery/mirror_scan.py`
  - Added a defensive gate in `_classify_issue` between the existing `state != 'MERGED'` check and the `edited_after_merge` check: returns `not-solved-closed` and emits a debug log when a `MERGED` solving PR has `merged_at == None`.
  - Updated the module-level header docstring's anti-gaming-gates list to include the new gate.

**Tests**

- `tests/validator/issue_discovery/test_mirror_scan.py`
  - `TestClassifyIssue.test_solving_pr_merged_with_null_merged_at_counts_as_closed` — unit test pinning the classifier disposition.
  - `TestRunMirrorIssueDiscovery.test_merged_pr_missing_merged_at_does_not_inflate_valid_solved` — end-to-end regression that builds `MIN_VALID_SOLVED_ISSUES - 1` clean solveds plus one corrupted record (the exact reproduction from the issue) and asserts `valid_solved_count` does NOT cross the eligibility floor and `issue_discovery_score == 0`.

A stash-revert sanity check (fix removed, tests kept) confirms both new tests fail with the exact issue symptom (`total_valid_solved_issues=7, is_issue_eligible=True`) and pass once the fix is restored.

## Related Issues

Closes #926

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Local results on the head commit:

- `uv run pytest tests/` — **715 passed, 0 failed** (2 unrelated pydantic warnings)
- `uv run pre-commit run --all-files` — All hooks pass (trailing-ws, EOF, yaml, json, line-ending, large-files, ruff lint, ruff format)
- `SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push` — pyright pass
- Stash-revert experiment: both new tests fail without the fix with `AssertionError: assert 7 == 6` (`total_valid_solved_issues=7, is_issue_eligible=True`), proving regression coverage maps to the reported behavior.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
