### PR TITLE
fix: use cache fallback on transient GitHub /user failures

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -6,6 +6,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from math import ceil
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
@@ -37,6 +38,19 @@ from gittensor.validator.utils.load_weights import RepositoryConfig
 
 # Beyond this many CHANGES_REQUESTED reviews the quality multiplier is already 0
 _MAX_CHANGES_REQUESTED_REVIEWS = ceil(1 / REVIEW_PENALTY_RATE)
+
+
+class GitHubIdentityStatus(Enum):
+    VALID = 'VALID'
+    INVALID_AUTH = 'INVALID_AUTH'
+    TRANSIENT_FAILURE = 'TRANSIENT_FAILURE'
+
+
+@dataclass(frozen=True)
+class GitHubIdentityResult:
+    github_id: Optional[str]
+    status: GitHubIdentityStatus
+
 
 # core github graphql query
 QUERY = """
@@ -222,17 +236,33 @@ def get_session(token: str) -> requests.Session:
     return _session_cache[key]
 
 
-def get_github_id(token: str) -> Optional[str]:
-    """Get GitHub numeric user id (as string) using a PAT.
+def _is_rate_limited_response(response: requests.Response) -> bool:
+    if response.status_code == 429:
+        return True
+    if response.status_code != 403:
+        return False
+    if response.headers.get('x-ratelimit-remaining') == '0':
+        return True
+    try:
+        message = str(response.json().get('message', '')).lower()
+    except Exception:
+        message = getattr(response, 'text', '').lower()
+    return 'rate limit' in message
+
+
+def get_github_identity(token: str) -> GitHubIdentityResult:
+    """Get GitHub numeric user id and whether lookup failure is cacheable.
 
     Args:
         token (str): GitHub personal access token.
 
     Returns:
-        Optional[str]: Numeric user id as a string, or None if it cannot be determined.
+        GitHubIdentityResult: Numeric user id on success, invalid auth for
+            permanent auth failures, or transient failure when GitHub/user JSON
+            could not be reached after retries.
     """
     if not token:
-        return None
+        return GitHubIdentityResult(None, GitHubIdentityStatus.INVALID_AUTH)
 
     session = get_session(token)
 
@@ -243,12 +273,35 @@ def get_github_id(token: str) -> Optional[str]:
             if response.status_code == 200:
                 try:
                     user_data: Dict[str, Any] = response.json()
-                except Exception as e:  # pragma: no cover
+                except Exception as e:
                     bt.logging.warning(f'Failed to parse GitHub /user JSON response: {e}')
-                    return None
+                    if attempt < 5:
+                        time.sleep(2)
+                        continue
+                    return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
                 user_id = user_data.get('id')
-                return str(user_id) if user_id is not None else None
+                if user_id is not None:
+                    return GitHubIdentityResult(str(user_id), GitHubIdentityStatus.VALID)
+
+                bt.logging.warning(f'GitHub /user response missing id (attempt {attempt + 1}/6)')
+                if attempt < 5:
+                    time.sleep(2)
+                    continue
+                return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+
+            if response.status_code == 408 or _is_rate_limited_response(response):
+                bt.logging.warning(
+                    f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
+                )
+                if attempt < 5:
+                    time.sleep(2)
+                    continue
+                return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+
+            if 400 <= response.status_code < 500:
+                bt.logging.warning(f'GitHub /user auth failed with status {response.status_code}')
+                return GitHubIdentityResult(None, GitHubIdentityStatus.INVALID_AUTH)
 
             bt.logging.warning(
                 f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
@@ -261,7 +314,12 @@ def get_github_id(token: str) -> Optional[str]:
             if attempt < 5:  # Don't sleep on last attempt
                 time.sleep(2)
 
-    return None
+    return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+
+
+def get_github_id(token: str) -> Optional[str]:
+    """Get GitHub numeric user id (as string) using a PAT."""
+    return get_github_identity(token).github_id
 
 
 def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str) -> Optional[str]:

--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -8,7 +8,7 @@ import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
 from gittensor.constants import RECYCLE_UID
-from gittensor.validator.utils.github_validation import validate_github_credentials
+from gittensor.validator.utils.github_validation import validate_github_credentials_result
 
 
 def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, MinerEvaluation]) -> Set[int]:
@@ -98,7 +98,11 @@ def _zero_for_duplicate_penalty(eval_: MinerEvaluation, reason: str) -> None:
 
 
 def validate_response_and_initialize_miner_evaluation(
-    uid: int, hotkey: str, pat: Optional[str], stale_hotkey: Optional[str] = None
+    uid: int,
+    hotkey: str,
+    pat: Optional[str],
+    stale_hotkey: Optional[str] = None,
+    stored_github_id: Optional[str] = None,
 ) -> MinerEvaluation:
     """
     Validate a miner's stored PAT and initialize their evaluation object.
@@ -108,6 +112,8 @@ def validate_response_and_initialize_miner_evaluation(
         hotkey: The miner's hotkey
         pat: The miner's GitHub PAT from local storage (may be None if not stored)
         stale_hotkey: If set, the UID has a stored PAT from this old hotkey (re-registration detected)
+        stored_github_id: GitHub id pinned when the PAT was accepted; used only
+            to allow cache fallback if GitHub /user is transiently unavailable.
 
     Returns:
         MinerEvaluation: Initialized evaluation object with failure reason if validation failed
@@ -131,11 +137,15 @@ def validate_response_and_initialize_miner_evaluation(
 
     miner_eval = MinerEvaluation(uid=uid, hotkey=hotkey)
 
-    github_id, error = validate_github_credentials(uid, pat)
-    if error:
-        miner_eval.failed_reason = error
+    validation = validate_github_credentials_result(uid, pat, stored_github_id=stored_github_id)
+    if validation.error:
+        miner_eval.failed_reason = validation.error
         return miner_eval
 
-    miner_eval.github_id = github_id
+    miner_eval.github_id = validation.github_id
+    if validation.transient_failure:
+        miner_eval.github_pr_fetch_failed = True
+        return miner_eval
+
     miner_eval.github_pat = pat
     return miner_eval

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -39,6 +39,7 @@ async def evaluate_miners_pull_requests(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     stale_hotkey: Optional[str] = None,
+    stored_github_id: Optional[str] = None,
 ) -> MinerEvaluation:
     """
     Entry point from taking a miners response -> Get PRs -> Score PRs
@@ -51,6 +52,7 @@ async def evaluate_miners_pull_requests(
         programming_languages: The programming languages and their weights
         token_config: Token-based scoring weights configuration
         stale_hotkey: If set, the UID has a stored PAT from this old hotkey (re-registration detected)
+        stored_github_id: GitHub id recorded when the stored PAT was accepted
 
     Returns:
         MinerEvaluation: The object containing scores, valid_prs, etc.
@@ -58,9 +60,19 @@ async def evaluate_miners_pull_requests(
 
     bt.logging.info(f'******* Reward function called for UID: {uid} *******')
 
-    miner_eval = validate_response_and_initialize_miner_evaluation(uid, hotkey, pat, stale_hotkey=stale_hotkey)
+    miner_eval = validate_response_and_initialize_miner_evaluation(
+        uid,
+        hotkey,
+        pat,
+        stale_hotkey=stale_hotkey,
+        stored_github_id=stored_github_id,
+    )
     if miner_eval.failed_reason is not None:
         bt.logging.info(f'UID {uid} not being evaluated: {miner_eval.failed_reason}')
+        return miner_eval
+
+    if miner_eval.github_pr_fetch_failed:
+        bt.logging.warning(f'UID {uid}: GitHub identity lookup failed transiently; deferring to cache fallback')
         return miner_eval
 
     # Partition repos by source: legacy (PAT) vs mirror (das-github-mirror).
@@ -127,9 +139,11 @@ async def get_rewards(
         pat_entry = pat_by_uid.get(uid)
         pat = None
         stale_hotkey = None
+        stored_github_id = None
         if pat_entry:
             if pat_entry.get('hotkey') == hotkey:
                 pat = pat_entry['pat']
+                stored_github_id = pat_entry.get('github_id')
             else:
                 stale_hotkey = pat_entry.get('hotkey')
 
@@ -142,6 +156,7 @@ async def get_rewards(
             programming_languages,
             token_config,
             stale_hotkey=stale_hotkey,
+            stored_github_id=stored_github_id,
         )
         miner_evaluations[uid] = miner_evaluation
 

--- a/gittensor/validator/utils/github_validation.py
+++ b/gittensor/validator/utils/github_validation.py
@@ -3,18 +3,45 @@
 
 """Shared GitHub credential validation used by multiple validator subsystems."""
 
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from gittensor.utils.github_api_tools import get_github_id
+from gittensor.utils.github_api_tools import GitHubIdentityStatus, get_github_identity
+
+
+@dataclass(frozen=True)
+class GitHubCredentialValidation:
+    github_id: Optional[str]
+    error: Optional[str]
+    transient_failure: bool = False
 
 
 def validate_github_credentials(uid: int, pat: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
     """Validate PAT and return (github_id, error_reason) tuple."""
+    validation = validate_github_credentials_result(uid, pat)
+    return validation.github_id, validation.error
+
+
+def validate_github_credentials_result(
+    uid: int,
+    pat: Optional[str],
+    stored_github_id: Optional[str] = None,
+) -> GitHubCredentialValidation:
+    """Validate PAT and expose transient /user lookup failures to scoring."""
     if not pat:
-        return None, f'No Github PAT provided by miner {uid}'
+        return GitHubCredentialValidation(None, f'No Github PAT provided by miner {uid}')
 
-    github_id = get_github_id(pat)
-    if not github_id:
-        return None, f"No Github id found for miner {uid}'s PAT"
+    identity = get_github_identity(pat)
+    if identity.status is GitHubIdentityStatus.VALID:
+        return GitHubCredentialValidation(identity.github_id, None)
 
-    return github_id, None
+    if identity.status is GitHubIdentityStatus.TRANSIENT_FAILURE:
+        if stored_github_id and stored_github_id != '0':
+            return GitHubCredentialValidation(stored_github_id, None, transient_failure=True)
+        return GitHubCredentialValidation(
+            None,
+            f'Could not validate Github id for miner {uid}: GitHub /user lookup failed transiently',
+            transient_failure=True,
+        )
+
+    return GitHubCredentialValidation(None, f"No Github id found for miner {uid}'s PAT")

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -27,6 +27,7 @@ github_api_tools = pytest.importorskip(
 )
 
 get_github_graphql_query = github_api_tools.get_github_graphql_query
+get_github_identity = github_api_tools.get_github_identity
 get_github_id = github_api_tools.get_github_id
 get_pull_request_file_changes = github_api_tools.get_pull_request_file_changes
 get_merge_base_sha = github_api_tools.get_merge_base_sha
@@ -376,6 +377,76 @@ class TestOtherGitHubAPIFunctions:
 
         assert result == '12345'
         assert mock_get.call_count == 3
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_get_github_identity_marks_5xx_as_transient(self, mock_logging, mock_sleep, mock_get):
+        mock_response = Mock(status_code=500)
+        mock_get.return_value = mock_response
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id is None
+        assert result.status is github_api_tools.GitHubIdentityStatus.TRANSIENT_FAILURE
+        assert mock_get.call_count == 6
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_get_github_identity_marks_rate_limit_as_transient(self, mock_logging, mock_sleep, mock_get):
+        mock_response = Mock(status_code=429)
+        mock_get.return_value = mock_response
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id is None
+        assert result.status is github_api_tools.GitHubIdentityStatus.TRANSIENT_FAILURE
+        assert mock_get.call_count == 6
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_get_github_identity_marks_403_rate_limit_as_transient(self, mock_logging, mock_sleep, mock_get):
+        mock_response = Mock(status_code=403)
+        mock_response.headers = {'x-ratelimit-remaining': '0'}
+        mock_get.return_value = mock_response
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id is None
+        assert result.status is github_api_tools.GitHubIdentityStatus.TRANSIENT_FAILURE
+        assert mock_get.call_count == 6
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_get_github_identity_fails_closed_on_auth_status(self, mock_logging, mock_sleep, mock_get):
+        mock_response = Mock(status_code=403)
+        mock_response.headers = {}
+        mock_response.json.return_value = {'message': 'Resource not accessible by personal access token'}
+        mock_get.return_value = mock_response
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id is None
+        assert result.status is github_api_tools.GitHubIdentityStatus.INVALID_AUTH
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_get_github_identity_marks_bad_json_as_transient(self, mock_logging, mock_sleep, mock_get):
+        mock_response = Mock(status_code=200)
+        mock_response.json.side_effect = ValueError('bad json')
+        mock_get.return_value = mock_response
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id is None
+        assert result.status is github_api_tools.GitHubIdentityStatus.TRANSIENT_FAILURE
+        assert mock_get.call_count == 6
 
 
 # ============================================================================

--- a/tests/validator/oss_contributions/mirror/test_routing.py
+++ b/tests/validator/oss_contributions/mirror/test_routing.py
@@ -171,3 +171,30 @@ def test_failed_init_short_circuits():
         assert result is me
         mock_legacy_load.assert_not_called()
         mock_mirror_load.assert_not_called()
+
+
+def test_identity_fetch_failure_short_circuits_to_cache_fallback():
+    """Transient /user failure should not fetch legacy or mirror PRs."""
+    me = _make_miner_eval(github_id='12345')
+    me.github_pr_fetch_failed = True
+
+    with (
+        patch.object(reward_module, 'validate_response_and_initialize_miner_evaluation', return_value=me),
+        patch.object(reward_module, 'load_miners_prs') as mock_legacy_load,
+        patch.object(reward_module, 'load_mirror_miner_prs') as mock_mirror_load,
+    ):
+        result = _run(
+            evaluate_miners_pull_requests(
+                uid=1,
+                hotkey='hk',
+                pat='fake-pat',
+                master_repositories=_configs(),
+                programming_languages={},
+                token_config=TokenConfig(),
+            )
+        )
+
+        assert result is me
+        assert result.should_use_cache_fallback is True
+        mock_legacy_load.assert_not_called()
+        mock_mirror_load.assert_not_called()

--- a/tests/validator/test_github_identity_fallback.py
+++ b/tests/validator/test_github_identity_fallback.py
@@ -1,0 +1,45 @@
+from typing import Optional
+from unittest.mock import patch
+
+from gittensor.utils.github_api_tools import GitHubIdentityResult, GitHubIdentityStatus
+from gittensor.validator.oss_contributions.inspections import validate_response_and_initialize_miner_evaluation
+
+
+def _identity_result(status: GitHubIdentityStatus, github_id: Optional[str] = None) -> GitHubIdentityResult:
+    return GitHubIdentityResult(github_id=github_id, status=status)
+
+
+def test_transient_identity_lookup_uses_stored_id_for_cache_fallback():
+    with patch(
+        'gittensor.validator.utils.github_validation.get_github_identity',
+        return_value=_identity_result(GitHubIdentityStatus.TRANSIENT_FAILURE),
+    ):
+        evaluation = validate_response_and_initialize_miner_evaluation(
+            uid=7,
+            hotkey='hk',
+            pat='ghp_stored',
+            stored_github_id='12345',
+        )
+
+    assert evaluation.failed_reason is None
+    assert evaluation.github_id == '12345'
+    assert evaluation.github_pr_fetch_failed is True
+    assert evaluation.should_use_cache_fallback is True
+    assert evaluation.github_pat is None
+
+
+def test_auth_identity_failure_does_not_use_stored_id_for_cache_fallback():
+    with patch(
+        'gittensor.validator.utils.github_validation.get_github_identity',
+        return_value=_identity_result(GitHubIdentityStatus.INVALID_AUTH),
+    ):
+        evaluation = validate_response_and_initialize_miner_evaluation(
+            uid=7,
+            hotkey='hk',
+            pat='ghp_revoked',
+            stored_github_id='12345',
+        )
+
+    assert evaluation.failed_reason == "No Github id found for miner 7's PAT"
+    assert evaluation.github_id == '0'
+    assert evaluation.github_pr_fetch_failed is False


### PR DESCRIPTION
## Summary

Transient GitHub `/user` failures during scoring were indistinguishable from permanent PAT auth errors: `get_github_id()` returned `None` for both 5xx/timeouts/bad JSON and 401/403-invalid, so `validate_github_credentials()` set `failed_reason = "No Github id found for miner {uid}'s PAT"`. `store_or_use_cached_evaluation()` then skips any miner with `failed_reason` (`if miner_eval.failed_reason is not None: continue`), bypassing the cache fallback and zeroing a miner with a valid stored PAT and a prior cached evaluation.

Split `/user` lookup into `GitHubIdentityStatus {VALID, INVALID_AUTH, TRANSIENT_FAILURE}`:

- 5xx, 408, 429, 403 with `x-ratelimit-remaining: 0` / `rate limit` message, bad JSON, network errors → `TRANSIENT_FAILURE` (after 6 retries)
- 4xx non-rate-limited (401, 403, 404) → `INVALID_AUTH`, fail closed immediately
- 200 with id → `VALID`

On `TRANSIENT_FAILURE`, `validate_github_credentials_result()` reuses the `github_id` recorded at PAT-broadcast time from `pat_storage` and marks the evaluation `github_pr_fetch_failed=True` without setting `failed_reason`. `evaluate_miners_pull_requests` short-circuits before any legacy or mirror PR fetch, so `should_use_cache_fallback` becomes True (fetch-failed + `total_prs == 0`) and `store_or_use_cached_evaluation` looks up the cache by `(uid, hotkey, github_id)` — matching the id recorded by a prior successful round — and restores it.

Because the short-circuit happens before any PR is fetched, no partially-scored current-cycle work is discarded. Permanent auth failures still set `failed_reason` and skip cache fallback.

Scope:

- New identity result types in `gittensor/utils/github_api_tools.py`: `GitHubIdentityStatus`, `GitHubIdentityResult`, `get_github_identity`, `_is_rate_limited_response`. `get_github_id` is kept as a thin wrapper for backward compatibility (`pat_handler.py`).
- `GitHubCredentialValidation` in `gittensor/validator/utils/github_validation.py` plus a new `validate_github_credentials_result()` that accepts `stored_github_id` and exposes a `transient_failure` flag. The original 2-tuple `validate_github_credentials()` is retained unchanged for `pat_handler.py`.
- `validate_response_and_initialize_miner_evaluation()` now threads `stored_github_id` through and maps transient failure to `github_pr_fetch_failed=True` with `miner_eval.github_id = stored_github_id` so the cache lookup matches.
- `evaluate_miners_pull_requests()` short-circuits on `github_pr_fetch_failed` before legacy and mirror loading.
- `get_rewards()` reads `github_id` out of the `pat_storage` entry alongside the PAT.

Not related to:

- **#904 / #905**: that bug is GraphQL PR-list auth/scope errors wrongly *enabling* cache fallback via `load_miners_prs`. This PR is about REST `/user` transient errors wrongly *blocking* cache fallback via `get_github_id`. Different function, complementary semantics.
- **#879 / #880**: per-PR REST file-content fetch; downstream of scoring. This PR fires before any PR is loaded.

Behavior note for reviewers: permanent 4xx (401, non-rate-limited 403, 404) on `/user` now rejects in one round-trip instead of retrying 6× (~10s). This makes invalid-PAT rejection in `handle_pat_broadcast` / `handle_pat_check` snappier. Transient paths retain the existing 6-retry budget.

## Related Issues

Closes #931

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

New tests:

- `tests/utils/test_github_api_tools.py` — 5 cases for `get_github_identity`: 5xx → transient, 429 → transient, 403 with `x-ratelimit-remaining: 0` → transient, 403 without rate-limit markers → `INVALID_AUTH` (fails closed, no sleep), bad JSON → transient.
- `tests/validator/test_github_identity_fallback.py` — end-to-end at the `inspections` layer: transient + stored id sets `github_pr_fetch_failed=True` with no `failed_reason`; `INVALID_AUTH` sets `failed_reason` regardless of stored id.
- `tests/validator/oss_contributions/mirror/test_routing.py` — `evaluate_miners_pull_requests` skips both `load_miners_prs` and `load_mirror_miner_prs` on transient identity failure and yields `should_use_cache_fallback=True`.

Commands run:

```bash
uv run pytest tests/utils/test_github_api_tools.py tests/validator/test_github_identity_fallback.py tests/validator/oss_contributions/mirror/test_routing.py tests/validator/test_pat_handler.py tests/validator/test_validator_cache_fallback.py -q
uv run pytest tests/validator/oss_contributions -q
uv run ruff check gittensor/ tests/
uv run ruff format --check gittensor/ tests/
```

All green (116 target tests + 129 oss_contributions tests pass, ruff clean, formatter clean).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
