### PR TITLE
fix: increase closingIssuesReferences limit to 100 and warn on truncation in _PR_TIMELINE_QUERY

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -423,8 +423,9 @@ query($owner: String!, $name: String!, $issueNumber: Int!) {
                 createdAt
                 author { ... on User { databaseId login } }
                 baseRepository { nameWithOwner }
-                closingIssuesReferences(first: 20) {
+                closingIssuesReferences(first: 100) {
                   nodes { number }
+                  pageInfo { hasNextPage }
                 }
                 reviews(first: 1, states: APPROVED) { totalCount }
               }
@@ -501,8 +502,14 @@ def _search_issue_referencing_prs_graphql(
 
         author = pr.get('author') or {}
         reviews = pr.get('reviews') or {}
-        closing = pr.get('closingIssuesReferences', {}).get('nodes', [])
+        closing_ref = pr.get('closingIssuesReferences', {})
+        closing = closing_ref.get('nodes', [])
         closing_numbers = [n.get('number') for n in closing if n.get('number') is not None]
+        if closing_ref.get('pageInfo', {}).get('hasNextPage'):
+            bt.logging.warning(
+                f'PR #{pr_number} closes more than 100 issues — '
+                f'closingIssuesReferences truncated; solver lookup may miss issue references beyond position 100'
+            )
 
         pr_info: PRInfo = {
             'number': pr_number,


### PR DESCRIPTION
Fixes #885

## Problem
`_PR_TIMELINE_QUERY` requested `closingIssuesReferences(first: 20)`.
A PR closing more than 20 issues has its 21st-and-later closing
references silently truncated. `find_solver_from_cross_references`
filters merged PRs by `issue_number in p.get('closing_numbers', [])`,
so any issue at position 21+ returns no matches and the validator
records `solver_lookup_failed=True` — the miner loses credit for a
PR they legitimately merged.

## Fix
Two changes to `github_api_tools.py`:

1. **Increased the limit** from `first: 20` to `first: 100` (GitHub's
   per-field maximum for `closingIssuesReferences`). This eliminates
   the truncation for the overwhelming majority of real-world PRs.

2. **Added `pageInfo { hasNextPage }` to the query** and a
   `bt.logging.warning` when `hasNextPage` is `True`. PRs closing
   more than 100 issues are vanishingly rare, but operators can now
   correlate the warning with a missed solver attribution instead of
   debugging silently wrong results.

## Changes
- `gittensor/utils/github_api_tools.py` — `first: 20` → `first: 100`,
  added `pageInfo { hasNextPage }`, added truncation warning