### PR TITLE
fix(config): use bittensor logging for neuron full path in check_config

### DIFF
--- a/gittensor/utils/config.py
+++ b/gittensor/utils/config.py
@@ -36,7 +36,7 @@ def check_config(cls, config: Any):
             config.neuron.name,
         )
     )
-    print('full path:', full_path)
+    bt.logging.debug(f'Neuron full path: {full_path}')
     config.neuron.full_path = os.path.expanduser(full_path)
     if not os.path.exists(config.neuron.full_path):
         os.makedirs(config.neuron.full_path, exist_ok=True)


### PR DESCRIPTION
## Problem

`check_config` printed the resolved neuron directory with `print`, which bypasses `bt.logging` and can pollute stdout for validator/miner processes.

## Change

This PR replaces the raw `print` call with `bt.logging.debug`, using a clear `Neuron full path:` message while preserving the existing path setup behavior.

## Tests

Added focused tests covering:

- `check_config` no longer emits the legacy `full path:` message to stdout/stderr.
- `config.neuron.full_path` is set correctly.
- The expected neuron directory is created under the configured logging root.

## Testing

```bash
uv sync --extra dev
uv run ruff check gittensor/utils/config.py tests/test_config_paths.py
uv run pytest tests/test_config_paths.py -q
```
