### PR TITLE
fix: reject mirror solving PRs with null merged_at in _classify_issue

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -459,6 +459,13 @@ def _classify_issue(issue: MirrorIssue) -> str:
         )
         return 'not-solved-closed'
 
+    if not sp.merged_at:
+        bt.logging.debug(
+            f'  issue #{issue.issue_number} ({issue.repo_full_name}): closed-not-solved '
+            f'(solving PR #{sp.pr_number} state=MERGED but merged_at is null — data corruption)'
+        )
+        return 'not-solved-closed'
+
     if sp.edited_after_merge:
         bt.logging.debug(
             f'  issue #{issue.issue_number} ({issue.repo_full_name}): closed-not-solved '


### PR DESCRIPTION
## Summary

Fixes #926

## Problem

In `_classify_issue`, a solving PR with `state=MERGED` passes the merged gate even when `merged_at` is null (data corruption from the mirror). This causes the issue to be counted as solved, incrementing `total_solved_issues` and eligibility counters, only to be silently dropped later by `_mirror_issue_for_scoring` which requires `merged_at` for time decay calculation.

Result: wasted eligibility budget, inconsistent solved counts.

## Fix

Add a `merged_at` null check immediately after the `state=MERGED` gate. If `merged_at` is null, classify as `'not-solved-closed'` with a debug log explaining the data corruption, matching the same defensive pattern used for `edited_after_merge` and other integrity checks in this function.