### PR TITLE
fix: transient GitHub /user failures now trigger cache fallback instead of skipping evaluation

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from math import ceil
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 
 from gittensor.utils.utils import backoff_seconds, parse_repo_name
 
@@ -222,17 +222,20 @@ def get_session(token: str) -> requests.Session:
     return _session_cache[key]
 
 
-def get_github_id(token: str) -> Optional[str]:
+def get_github_id(token: str) -> Tuple[Optional[str], bool]:
     """Get GitHub numeric user id (as string) using a PAT.
 
     Args:
         token (str): GitHub personal access token.
 
     Returns:
-        Optional[str]: Numeric user id as a string, or None if it cannot be determined.
+        Tuple[Optional[str], bool]: (user_id, is_transient_failure).
+        user_id is the numeric GitHub user id as string, or None on failure.
+        is_transient_failure is True when the failure is due to network/5xx/parse
+        errors (not an invalid PAT), so callers can use cached data as fallback.
     """
     if not token:
-        return None
+        return None, False
 
     session = get_session(token)
 
@@ -245,10 +248,10 @@ def get_github_id(token: str) -> Optional[str]:
                     user_data: Dict[str, Any] = response.json()
                 except Exception as e:  # pragma: no cover
                     bt.logging.warning(f'Failed to parse GitHub /user JSON response: {e}')
-                    return None
+                    return None, True
 
                 user_id = user_data.get('id')
-                return str(user_id) if user_id is not None else None
+                return (str(user_id), False) if user_id is not None else (None, False)
 
             bt.logging.warning(
                 f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
@@ -261,7 +264,7 @@ def get_github_id(token: str) -> Optional[str]:
             if attempt < 5:  # Don't sleep on last attempt
                 time.sleep(2)
 
-    return None
+    return None, True
 
 
 def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str) -> Optional[str]:

--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -131,9 +131,15 @@ def validate_response_and_initialize_miner_evaluation(
 
     miner_eval = MinerEvaluation(uid=uid, hotkey=hotkey)
 
-    github_id, error = validate_github_credentials(uid, pat)
+    github_id, error, is_transient = validate_github_credentials(uid, pat)
     if error:
-        miner_eval.failed_reason = error
+        if is_transient:
+            # Transient GitHub API failure — don't set failed_reason so
+            # store_or_use_cached_evaluation can fall back to cached data.
+            miner_eval.github_pr_fetch_failed = True
+            miner_eval.should_use_cache_fallback = True
+        else:
+            miner_eval.failed_reason = error
         return miner_eval
 
     miner_eval.github_id = github_id

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -49,7 +49,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     uid = validator.metagraph.hotkeys.index(hotkey)
 
     # 2. Validate PAT (checks it works, extracts github_id, verifies account age)
-    github_id, error = validate_github_credentials(uid, synapse.github_access_token)
+    github_id, error, _ = validate_github_credentials(uid, synapse.github_access_token)
     if error:
         return _reject(error)
 
@@ -117,7 +117,7 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
     synapse.has_pat = True
 
     # Re-validate the stored PAT
-    _, error = validate_github_credentials(uid, entry['pat'])
+    _, error, _ = validate_github_credentials(uid, entry['pat'])
     if error:
         synapse.pat_valid = False
         synapse.rejection_reason = error

--- a/gittensor/validator/utils/github_validation.py
+++ b/gittensor/validator/utils/github_validation.py
@@ -8,13 +8,20 @@ from typing import Optional, Tuple
 from gittensor.utils.github_api_tools import get_github_id
 
 
-def validate_github_credentials(uid: int, pat: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
-    """Validate PAT and return (github_id, error_reason) tuple."""
+def validate_github_credentials(
+    uid: int, pat: Optional[str]
+) -> Tuple[Optional[str], Optional[str], bool]:
+    """Validate PAT and return (github_id, error_reason, is_transient) tuple.
+
+    is_transient is True when the failure is due to a transient GitHub API
+    error (timeout, 5xx, parse failure) rather than an invalid PAT, so that
+    callers can choose to fall back to cached evaluation data.
+    """
     if not pat:
-        return None, f'No Github PAT provided by miner {uid}'
+        return None, f'No Github PAT provided by miner {uid}', False
 
-    github_id = get_github_id(pat)
+    github_id, is_transient = get_github_id(pat)
     if not github_id:
-        return None, f"No Github id found for miner {uid}'s PAT"
+        return None, f"No Github id found for miner {uid}'s PAT", is_transient
 
-    return github_id, None
+    return github_id, None, False


### PR DESCRIPTION
## Summary

Fixes #931

## Problem

When GitHub `/user` times out, returns 5xx, or produces unparsable JSON, `get_github_id()` returned `None` — indistinguishable from an invalid PAT. `validate_github_credentials` then set `failed_reason`, which caused `store_or_use_cached_evaluation` to skip the miner entirely, even when a valid cached evaluation existed.

Result: a transient network hiccup wipes out a miner's evaluation for that round.

## Fix

1. `get_github_id()` returns `(user_id, is_transient)` tuple to distinguish network/5xx/parse failures from permanent auth failures
2. `validate_github_credentials()` propagates the `is_transient` flag
3. `inspect_miner()`: on transient failure, sets `github_pr_fetch_failed=True` and `should_use_cache_fallback=True` instead of `failed_reason`, activating the existing cache fallback path
4. `pat_handler.py`: adapts to new 3-tuple return (ignores `is_transient` — PAT registration should not use stale cache)

## Testing

All modified files pass syntax validation (`ast.parse`).