### PR TITLE
fix: recycle unavailable issue discovery rewards on per-miner fetch failure

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -132,14 +132,16 @@ async def issue_discovery(
     mirror_repos: Dict[str, RepositoryConfig] = {
         name: cfg for name, cfg in master_repositories.items() if cfg.mirror_enabled
     }
+    reward_coverage = 1.0
 
     if mirror_repos:
-        await run_mirror_issue_discovery(miner_evaluations, mirror_repos, programming_languages, token_config)
+        result = await run_mirror_issue_discovery(miner_evaluations, mirror_repos, programming_languages, token_config)
+        reward_coverage = result.reward_coverage
     else:
         bt.logging.info('No mirror-enabled repos — issue discovery skipped for this round')
 
     # Normalize into independent pool
-    issue_rewards_dict = normalize_issue_discovery_rewards(miner_evaluations)
+    issue_rewards_dict = normalize_issue_discovery_rewards(miner_evaluations, reward_coverage=reward_coverage)
 
     sorted_uids = sorted(miner_uids)
     return np.array([issue_rewards_dict.get(uid, 0.0) for uid in sorted_uids])
@@ -172,6 +174,10 @@ def blend_emission_pools(
     issue_total = float(issue_rewards.sum())
     if issue_total > 0:
         rewards += issue_rewards * ISSUE_DISCOVERY_EMISSION_SHARE
+        recycled_issue_share = max(0.0, 1.0 - min(issue_total, 1.0)) * ISSUE_DISCOVERY_EMISSION_SHARE
+        if recycled_issue_share > 1e-12:
+            recycle_extra += recycled_issue_share
+            bt.logging.info(f'Recycling {recycled_issue_share * 100:.1f}% unavailable issue-discovery emissions')
     else:
         recycle_extra += ISSUE_DISCOVERY_EMISSION_SHARE
 

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -97,6 +97,21 @@ class _CacheStats:
     fetch_failures: int = 0
 
 
+@dataclass
+class MirrorIssueDiscoveryResult:
+    """Fetch coverage for the mirror issue-discovery phase."""
+
+    attempted_fetches: int = 0
+    successful_fetches: int = 0
+    fetch_errors: int = 0
+
+    @property
+    def reward_coverage(self) -> float:
+        if self.attempted_fetches == 0:
+            return 1.0
+        return self.successful_fetches / self.attempted_fetches
+
+
 _FAR_FUTURE = datetime.max.replace(tzinfo=timezone.utc)
 
 
@@ -106,7 +121,7 @@ async def run_mirror_issue_discovery(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     client: Optional[MirrorClient] = None,
-) -> None:
+) -> MirrorIssueDiscoveryResult:
     """Score issue discovery for mirror-enabled repos. Mutates miner_evaluations.
 
     For each miner, fetches their authored issues via the mirror and classifies
@@ -125,7 +140,7 @@ async def run_mirror_issue_discovery(
 
     if not mirror_repos:
         bt.logging.info('No mirror-enabled repos — issue discovery skipped')
-        return
+        return MirrorIssueDiscoveryResult()
 
     client = client or MirrorClient()
     lookback_date = datetime.now(timezone.utc) - timedelta(days=PR_LOOKBACK_DAYS)
@@ -140,8 +155,8 @@ async def run_mirror_issue_discovery(
 
     skipped_no_gh = 0
     skipped_failed = 0
-    fetch_errors = 0
     no_issues = 0
+    result = MirrorIssueDiscoveryResult()
 
     # Phase 1: fetch each miner's issues.  The one-issue-per-PR rule is round-
     # global, so scoring is deferred until every miner's batch is in hand.
@@ -154,13 +169,15 @@ async def run_mirror_issue_discovery(
             skipped_failed += 1
             continue
 
+        result.attempted_fetches += 1
         try:
             response = client.get_miner_issues(evaluation.github_id, since=lookback_date)
         except MirrorRequestError as e:
             bt.logging.warning(f'├─ UID {uid}: mirror issue fetch failed ({e}) — skipped this miner')
-            fetch_errors += 1
+            result.fetch_errors += 1
             continue
 
+        result.successful_fetches += 1
         filtered = [i for i in response.issues if i.repo_full_name in enabled_names]
         if not filtered:
             no_issues += 1
@@ -192,13 +209,14 @@ async def run_mirror_issue_discovery(
     bt.logging.info('')
     bt.logging.info(
         f'Issue discovery complete | {len(pending)} processed | {no_issues} no mirror issues | '
-        f'{fetch_errors} fetch errors | {skipped_no_gh} no github_id | {skipped_failed} prior OSS failure'
+        f'{result.fetch_errors} fetch errors | {skipped_no_gh} no github_id | {skipped_failed} prior OSS failure'
     )
     bt.logging.info(
         f'Solving-PR cache: {cache_stats.hits} hits | {cache_stats.misses} misses '
         f'({cache_stats.misses - cache_stats.fetch_failures} fetched OK, '
         f'{cache_stats.fetch_failures} fetch failures)'
     )
+    return result
 
 
 def _build_canonical_pr_owners(

--- a/gittensor/validator/issue_discovery/normalize.py
+++ b/gittensor/validator/issue_discovery/normalize.py
@@ -8,8 +8,16 @@ import bittensor as bt
 from gittensor.classes import MinerEvaluation
 
 
-def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluation]) -> Dict[int, float]:
-    """Normalize issue discovery scores to sum to 1.0, preserving ratios."""
+def normalize_issue_discovery_rewards(
+    miner_evaluations: Dict[int, MinerEvaluation],
+    reward_coverage: float = 1.0,
+) -> Dict[int, float]:
+    """Normalize issue discovery scores while preserving unavailable fetch share.
+
+    ``reward_coverage`` is the fraction of attempted mirror issue fetches that
+    succeeded this round. When it is below 1.0, only that fraction of the issue
+    pool is allocated to scored miners; the remainder is recycled by the caller.
+    """
 
     if not miner_evaluations:
         return {}
@@ -27,8 +35,11 @@ def normalize_issue_discovery_rewards(miner_evaluations: Dict[int, MinerEvaluati
         bt.logging.info('Issue discovery: all scores are zero, returning empty rewards')
         return rewards
 
-    normalized = {uid: score / total for uid, score in rewards.items()}
+    coverage = max(0.0, min(1.0, reward_coverage))
+    normalized = {uid: (score / total) * coverage for uid, score in rewards.items()}
 
     bt.logging.info(f'Issue discovery: normalized {nonzero_count} miners with scores > 0')
+    if coverage < 1.0:
+        bt.logging.warning(f'Issue discovery: withholding {(1.0 - coverage) * 100:.1f}% due to mirror fetch errors')
 
     return normalized

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -384,7 +384,7 @@ class TestRunMirrorIssueDiscovery:
         # Seed cache so working miner's solving PR is scoreable
         working.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
 
-        _run(
+        result = _run(
             run_mirror_issue_discovery(
                 {1: failing, 2: working},
                 _mirror_repos('entrius/gittensor-ui'),
@@ -395,6 +395,10 @@ class TestRunMirrorIssueDiscovery:
         )
         assert failing.total_solved_issues == 0
         assert working.total_solved_issues == 1
+        assert result.attempted_fetches == 2
+        assert result.successful_fetches == 1
+        assert result.fetch_errors == 1
+        assert result.reward_coverage == 0.5
 
 
 # ============================================================================

--- a/tests/validator/issue_discovery/test_normalize.py
+++ b/tests/validator/issue_discovery/test_normalize.py
@@ -1,0 +1,23 @@
+from gittensor.classes import MinerEvaluation
+from gittensor.validator.issue_discovery.normalize import normalize_issue_discovery_rewards
+
+
+def test_normalize_scales_by_fetch_coverage():
+    miner_a = MinerEvaluation(uid=1, hotkey='hk1', github_id='gh1')
+    miner_b = MinerEvaluation(uid=2, hotkey='hk2', github_id='gh2')
+    miner_a.issue_discovery_score = 10.0
+    miner_b.issue_discovery_score = 30.0
+
+    rewards = normalize_issue_discovery_rewards({1: miner_a, 2: miner_b}, reward_coverage=0.5)
+
+    assert rewards == {1: 0.125, 2: 0.375}
+    assert sum(rewards.values()) == 0.5
+
+
+def test_normalize_defaults_to_full_coverage():
+    miner = MinerEvaluation(uid=1, hotkey='hk1', github_id='gh1')
+    miner.issue_discovery_score = 10.0
+
+    rewards = normalize_issue_discovery_rewards({1: miner})
+
+    assert rewards == {1: 1.0}

--- a/tests/validator/test_forward.py
+++ b/tests/validator/test_forward.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+from gittensor.constants import ISSUE_DISCOVERY_EMISSION_SHARE, OSS_EMISSION_SHARE, RECYCLE_EMISSION_SHARE, RECYCLE_UID
+from gittensor.validator.forward import blend_emission_pools
+
+
+def test_blend_recycles_unavailable_issue_discovery_share():
+    miner_uids = {RECYCLE_UID, 1}
+    oss_rewards = np.array([0.0, 0.0])
+    issue_rewards = np.array([0.0, 0.5])
+
+    rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+
+    unavailable_issue_share = ISSUE_DISCOVERY_EMISSION_SHARE * 0.5
+    assert rewards[0] == pytest.approx(RECYCLE_EMISSION_SHARE + OSS_EMISSION_SHARE + unavailable_issue_share)
+    assert rewards[1] == pytest.approx(ISSUE_DISCOVERY_EMISSION_SHARE * 0.5)


### PR DESCRIPTION
## Summary

Fixes #940. Per-miner DAS fetch failures during issue discovery no longer inflate surviving miners' shares of the 30% issue-discovery emissions pool. Instead, the unverifiable share is recycled/withheld so transient data-availability failures don't masquerade as a performance signal.

- Track per-miner fetch failures in `mirror_scan.py` so callers can distinguish "no issues" from "fetch failed".
- Adjust `normalize.py` to exclude unavailable miners from the redistribution base.
- In `forward.py`, recycle the unverifiable portion of the issue-discovery pool rather than spreading it across the remaining miners.

## Test plan

- [x] `tests/validator/issue_discovery/test_normalize.py` — covers the failed-miner exclusion case.
- [x] `tests/validator/test_forward.py` — covers pool recycling when fetches fail.
- [x] `tests/validator/issue_discovery/test_mirror_scan.py` — surfaces the new failure-tracking signal.