### PR TITLE
refactor: use GITHUB_HTTP_TIMEOUT_SECONDS at the three remaining timeout=15 sites

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -287,7 +287,7 @@ def get_merge_base_sha(repository: str, base_sha: str, head_sha: str, token: str
         try:
             response = session.get(
                 f'{BASE_GITHUB_API_URL}/repos/{repository}/compare/{base_sha}...{head_sha}',
-                timeout=15,
+                timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
             )
 
             if response.status_code == 200:
@@ -349,7 +349,7 @@ def get_pull_request_file_changes(repository: str, pr_number: int, token: str) -
             response = session.get(
                 f'{BASE_GITHUB_API_URL}/repos/{repository}/pulls/{pr_number}/files',
                 params={'per_page': per_page, 'page': page},
-                timeout=15,
+                timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
             )
 
             if response.status_code == 200:
@@ -1040,7 +1040,7 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
     try:
         response = session.get(
             f'{BASE_GITHUB_API_URL}/repos/{repo}/issues/{issue_number}',
-            timeout=15,
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
 
         if response.status_code != 200:


### PR DESCRIPTION
[\`gittensor/utils/github_api_tools.py\`](gittensor/utils/github_api_tools.py) already imports \`GITHUB_HTTP_TIMEOUT_SECONDS\` from \`gittensor.constants\` and uses it for the \`/user\` request (line 242). Three other GitHub HTTP calls in the same file (\`get_merge_base_sha\`, \`get_pull_request_file_changes\`, \`check_github_issue_closed\`) still passed the literal \`15\`. Switch them to the constant so a future timeout tweak doesn't need to be applied in four places.

Same shape as the merged #455 (use shared constant). 3-line diff, no behaviour change, no new imports.