### PR TITLE
refactor: remove unused REPO_SCAN_* constants

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -166,11 +166,6 @@ OPEN_ISSUE_SPAM_BASE_THRESHOLD = 5  # half the PR base of 10
 OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT = 300.0  # +1 allowed open issue per this much token score
 MAX_OPEN_ISSUE_THRESHOLD = 30
 
-# Repo-centric closed issue scan caps (validator PAT budget)
-REPO_SCAN_PER_REPO_CAP = 300  # max solver lookups per repo
-REPO_SCAN_GLOBAL_CAP = 1500  # max solver lookups per round
-REPO_SCAN_CONCURRENCY = 2  # concurrent solver lookup threads
-
 # =============================================================================
 # Collateral
 # =============================================================================


### PR DESCRIPTION
Three constants in `gittensor/constants.py` are unreferenced anywhere in the codebase:

- `REPO_SCAN_PER_REPO_CAP`
- `REPO_SCAN_GLOBAL_CAP`
- `REPO_SCAN_CONCURRENCY`

They were only used by `gittensor/validator/issue_discovery/repo_scan.py`, which was deleted in #796 when issue discovery moved to `das-github-mirror`. The constants were left orphaned.

Verified zero remaining references via `grep -rni "REPO_SCAN" .`.

Test suite: 726 passed.