### PR TITLE
fix: surface decode failures in _read_issues_from_child_storage instead of silently returning empty list 

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -746,7 +746,9 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
         return None
 
 
-def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool = False) -> List[Dict[str, Any]]:
+def _read_issues_from_child_storage(
+    substrate, contract_addr: str, verbose: bool = False
+) -> Tuple[List[Dict[str, Any]], int]:
     """
     Read all issues from contract child storage.
 
@@ -770,14 +772,14 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
     if not child_key:
         if verbose:
             console.print(f'[dim]Debug: Cannot read issues - no child storage key for {contract_addr}[/dim]')
-        return []
+        return [], 0
 
     # First, read packed storage to get next_issue_id
     packed_storage = _read_contract_packed_storage(substrate, contract_addr, verbose)
     if not packed_storage:
         if verbose:
             console.print('[dim]Debug: Cannot read issues - packed storage read failed[/dim]')
-        return []
+        return [], 0
 
     next_issue_id = packed_storage.get('next_issue_id', 1)
     if verbose:
@@ -788,15 +790,16 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
     if next_issue_id > MAX_REASONABLE_ISSUE_ID:
         console.print(f'[yellow]Warning: next_issue_id ({next_issue_id}) is unreasonably large.[/yellow]')
         console.print('[yellow]This may indicate a storage format mismatch. Check contract version.[/yellow]')
-        return []
+        return [], 0
 
     # If next_issue_id is 1, no issues have been registered yet
     if next_issue_id <= 1:
         if verbose:
             console.print('[dim]Debug: No issues registered (next_issue_id <= 1)[/dim]')
-        return []
+        return [], 0
 
     issues = []
+    decode_errors = 0
     status_names = ['Registered', 'Active', 'Completed', 'Cancelled']
 
     # Iterate through all issue IDs (1 to next_issue_id - 1)
@@ -839,13 +842,14 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
                     f'{decoded.repository_full_name}#{decoded.issue_number}[/dim]'
                 )
         except Exception as e:
+            decode_errors += 1
             if verbose:
                 console.print(f'[dim]Debug: Failed to decode issue {issue_id}: {e}[/dim]')
             continue
 
     # Sort by ID
     issues.sort(key=lambda x: x['id'])
-    return issues
+    return issues, decode_errors
 
 
 def _make_contract_client(contract_addr: str, ws_endpoint: str, wallet_name: str, wallet_hotkey: str):
@@ -897,7 +901,12 @@ def read_issues_from_contract(ws_endpoint: str, contract_addr: str, verbose: boo
             console.print('[dim]Debug: Connected successfully[/dim]')
 
         # Read issues directly from child storage
-        return _read_issues_from_child_storage(substrate, contract_addr, verbose)
+        issues, decode_errors = _read_issues_from_child_storage(substrate, contract_addr, verbose)
+        if decode_errors > 0:
+            console.print(
+                f'[yellow]WARNING: storage decoder reported {decode_errors} failure(s); results may be incomplete[/yellow]'
+            )
+        return issues
 
     except ImportError as e:
         console.print(f'[yellow]Cannot read from contract: {e}[/yellow]')

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -196,7 +196,11 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
 
         with console.status('[bold cyan]Reading contract storage...', spinner='dots'):
             substrate = SubstrateInterface(url=ws_endpoint)
-            issues = _read_issues_from_child_storage(substrate, contract_addr, verbose)
+            issues, decode_errors = _read_issues_from_child_storage(substrate, contract_addr, verbose)
+            if decode_errors > 0:
+                console.print(
+                    f'[yellow]WARNING: storage decoder reported {decode_errors} failure(s); results may be incomplete[/yellow]'
+                )
 
         total_bounty_pool = sum(issue.get('bounty_amount', 0) for issue in issues)
 
@@ -252,7 +256,11 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
             treasury_stake = client.get_treasury_stake()
 
             substrate = SubstrateInterface(url=ws_endpoint)
-            issues = _read_issues_from_child_storage(substrate, contract_addr, verbose)
+            issues, decode_errors = _read_issues_from_child_storage(substrate, contract_addr, verbose)
+            if decode_errors > 0:
+                console.print(
+                    f'[yellow]WARNING: storage decoder reported {decode_errors} failure(s); results may be incomplete[/yellow]'
+                )
             total_bounty_pool = sum(issue.get('bounty_amount', 0) for issue in issues)
 
         pending_harvest = max(0, treasury_stake - total_bounty_pool)


### PR DESCRIPTION
Closes #872

## Problem

`_read_issues_from_child_storage` in `gittensor/cli/issue_commands/helpers.py` catches all decode exceptions per-item and silently continues. When every item fails to decode, the function returns `[]` with no indication of failure. All call sites in `view.py` and `helpers.py` then print "0 issues found" — identical output to a genuinely empty contract. Operators have no way to distinguish between:

- The contract having zero registered issues
- The decoder failing on every storage entry due to corruption or schema mismatch

This silent failure masks real on-chain data and can send operators down the wrong debugging path.

## Fix

### `gittensor/cli/issue_commands/helpers.py`

- Changed return type of `_read_issues_from_child_storage` from `List[Dict[str, Any]]` to `Tuple[List[Dict[str, Any]], int]` — the second element is the count of decode failures
- All early-exit return paths now return `([], 0)`
- Added `decode_errors` counter that increments on every caught decode exception
- Final return is now `(issues, decode_errors)`
- Updated the internal call site at line 900 to unpack the tuple and print a `WARNING` when `decode_errors > 0`

### `gittensor/cli/issue_commands/view.py`

- Updated both call sites (lines 199 and 255) to unpack `(issues, decode_errors)` and print:
- whenever `decode_errors > 0`

## Behavior After Fix

- Zero issues + zero decode errors → normal "0 issues found" output, no warning
- Zero issues + decode errors → warning printed, operator knows decoder failed
- Some issues + decode errors → issues displayed + warning that results are partial

## Files Changed

- `gittensor/cli/issue_commands/helpers.py` — return tuple, track decode_errors, warn at internal call site
- `gittensor/cli/issue_commands/view.py` — unpack tuple, surface warning at both call sites