### PR TITLE
fix: wrap blocking MirrorClient calls with asyncio.to_thread to prevent event loop starvation

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -32,6 +32,7 @@ require no HTTP. Non-miner-solved PRs (cache misses) trigger
 the cache so sibling discoveries benefit.
 """
 
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Set, Tuple
@@ -155,7 +156,7 @@ async def run_mirror_issue_discovery(
             continue
 
         try:
-            response = client.get_miner_issues(evaluation.github_id, since=lookback_date)
+            response = await asyncio.to_thread(client.get_miner_issues, evaluation.github_id, since=lookback_date)
         except MirrorRequestError as e:
             bt.logging.warning(f'├─ UID {uid}: mirror issue fetch failed ({e}) — skipped this miner')
             fetch_errors += 1
@@ -176,7 +177,7 @@ async def run_mirror_issue_discovery(
 
     canonical_pr_owners = _build_canonical_pr_owners(pending)
     for evaluation, filtered, open_issue_count in pending:
-        _score_miner_mirror_issues(
+        await _score_miner_mirror_issues(
             evaluation,
             filtered,
             mirror_repos,
@@ -253,7 +254,7 @@ def _build_solving_pr_cache(
     return cache
 
 
-def _score_miner_mirror_issues(
+async def _score_miner_mirror_issues(
     evaluation: MinerEvaluation,
     issues: List[MirrorIssue],
     mirror_repos: Dict[str, RepositoryConfig],
@@ -304,7 +305,7 @@ def _score_miner_mirror_issues(
         solved_count += 1
 
         # Resolve real base_score + token_score for the solving PR (cache or fetch)
-        cached = _resolve_solving_pr_score(
+        cached = await _resolve_solving_pr_score(
             issue,
             solving_pr,
             solving_pr_cache,
@@ -415,7 +416,7 @@ def _score_miner_mirror_issues(
     )
 
 
-def _resolve_solving_pr_score(
+async def _resolve_solving_pr_score(
     issue: MirrorIssue,
     solving_pr: MirrorSolvingPR,
     cache: Dict[Tuple[str, int], CachedSolvingPR],
@@ -437,7 +438,7 @@ def _resolve_solving_pr_score(
 
     cache_stats.misses += 1
     try:
-        files_response = client.get_pr_files(issue.repo_full_name, solving_pr.pr_number)
+        files_response = await asyncio.to_thread(client.get_pr_files, issue.repo_full_name, solving_pr.pr_number)
     except MirrorRequestError as e:
         cache_stats.fetch_failures += 1
         bt.logging.warning(

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -20,6 +20,7 @@ Anti-gaming notes:
   require maintainer-applied labels; legacy can't do this and accepts any-applier.
 """
 
+import asyncio
 import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
@@ -62,7 +63,7 @@ from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_
 # ============================================================================
 
 
-def score_mirror_miner_prs(
+async def score_mirror_miner_prs(
     mirror_eval: MirrorMinerEvaluation,
     mirror_repos: Dict[str, RepositoryConfig],
     programming_languages: Dict[str, LanguageConfig],
@@ -97,7 +98,7 @@ def score_mirror_miner_prs(
             bt.logging.info(
                 f'\n[{i}/{len(scored_prs)}] {label} PR #{scored.pr.pr_number} in {scored.pr.repo_full_name}'
             )
-            score_mirror_pr(scored, mirror_eval, mirror_repos, programming_languages, token_config, client)
+            await score_mirror_pr(scored, mirror_eval, mirror_repos, programming_languages, token_config, client)
 
 
 # ============================================================================
@@ -105,7 +106,7 @@ def score_mirror_miner_prs(
 # ============================================================================
 
 
-def score_mirror_pr(
+async def score_mirror_pr(
     scored: ScoredMirrorPR,
     mirror_eval: MirrorMinerEvaluation,
     mirror_repos: Dict[str, RepositoryConfig],
@@ -132,7 +133,7 @@ def score_mirror_pr(
 
     # Fetch file contents via the mirror's lazy /pulls/.../files endpoint.
     try:
-        files = client.get_pr_files(pr.repo_full_name, pr.pr_number).files
+        files = (await asyncio.to_thread(client.get_pr_files, pr.repo_full_name, pr.pr_number)).files
     except MirrorRequestError as e:
         bt.logging.warning(f'Mirror file fetch failed for PR #{pr.pr_number}: {e}')
         return

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -2,6 +2,7 @@
 # Copyright © 2025 Entrius
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
@@ -84,7 +85,6 @@ async def evaluate_miners_pull_requests(
             hotkey=miner_eval.hotkey,
             github_id=miner_eval.github_id,
         )
-        import asyncio
 
         with MirrorClient() as mirror_client:
             await asyncio.to_thread(load_mirror_miner_prs, mirror_eval, mirror_repos, client=mirror_client)

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -84,9 +84,13 @@ async def evaluate_miners_pull_requests(
             hotkey=miner_eval.hotkey,
             github_id=miner_eval.github_id,
         )
+        import asyncio
+
         with MirrorClient() as mirror_client:
-            load_mirror_miner_prs(mirror_eval, mirror_repos, client=mirror_client)
-            score_mirror_miner_prs(mirror_eval, mirror_repos, programming_languages, token_config, client=mirror_client)
+            await asyncio.to_thread(load_mirror_miner_prs, mirror_eval, mirror_repos, client=mirror_client)
+            await score_mirror_miner_prs(
+                mirror_eval, mirror_repos, programming_languages, token_config, client=mirror_client
+            )
         combine(miner_eval, mirror_eval)
 
     # Clear PAT after scoring to avoid storing sensitive data in memory

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -575,8 +575,8 @@ class TestCacheStats:
 
         issue = MirrorIssue.from_dict(_issue_dict())
         assert issue.solving_pr is not None
-        result = _resolve_solving_pr_score(
-            issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        result = asyncio.run(
+            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
         )
 
         assert result is not None
@@ -597,7 +597,9 @@ class TestCacheStats:
         stats = _CacheStats()
 
         issue = MirrorIssue.from_dict(_issue_dict())
-        _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
+        asyncio.run(
+            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
+        )
 
         assert stats.hits == 0
         assert stats.misses == 1
@@ -617,8 +619,8 @@ class TestCacheStats:
         stats = _CacheStats()
 
         issue = MirrorIssue.from_dict(_issue_dict())
-        result = _resolve_solving_pr_score(
-            issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        result = asyncio.run(
+            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
         )
 
         assert result is None

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -16,6 +16,7 @@ Token-scoring base_score is exercised indirectly via the existing legacy tests
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import Mock
 
 import pytest
@@ -312,13 +313,15 @@ class TestScoringDataStoredGate:
         scored.pr.scoring_data_stored = False
         client = Mock()
 
-        score_mirror_pr(
-            scored,
-            mirror_eval=Mock(),
-            mirror_repos={scored.pr.repo_full_name: _config()},
-            programming_languages={},
-            token_config=Mock(),
-            client=client,
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=Mock(),
+                mirror_repos={scored.pr.repo_full_name: _config()},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
         )
 
         client.get_pr_files.assert_not_called()

--- a/tests/validator/test_pioneer_dividend.py
+++ b/tests/validator/test_pioneer_dividend.py
@@ -229,3 +229,139 @@ class TestPioneerDividendCalculation:
 
         # Ineligible follower doesn't count
         assert pioneer_pr.pioneer_dividend == 0.0
+
+
+# ==========================================================================
+# TestPioneerDedupLegacyMirror
+# ==========================================================================
+
+
+class TestPioneerDedupLegacyMirror:
+    """Regression tests for duplicate legacy+mirror PR deduplication in pioneer scoring."""
+
+    def _make_eval(self, uid, merged_prs=None, mirror_prs=None):
+        eval_ = MinerEvaluation(uid=uid, hotkey=f'hotkey_{uid}')
+        eval_.merged_pull_requests = merged_prs or []
+        eval_.mirror_merged_prs = mirror_prs or []
+        return eval_
+
+    def test_duplicate_pr_does_not_inflate_rank(self, builder):
+        """Same (repo, pr_number) in both legacy and mirror lists must count once."""
+        now = datetime.now(timezone.utc)
+        earlier = now - timedelta(hours=1)
+
+        # Pioneer: earliest PR on the repo
+        pioneer_pr = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            number=1,
+            merged_at=earlier,
+            earned_score=100.0,
+        )
+        # Follower PR
+        follower_pr = builder.create(
+            state=PRState.MERGED,
+            uid=2,
+            repo='test/repo',
+            number=2,
+            merged_at=now,
+            earned_score=50.0,
+        )
+        # Mirror duplicate of pioneer_pr — same repo + number
+        mirror_duplicate = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            number=1,
+            merged_at=earlier,
+            earned_score=100.0,
+        )
+
+        pioneer_eval = self._make_eval(1, merged_prs=[pioneer_pr], mirror_prs=[mirror_duplicate])
+        follower_eval = self._make_eval(2, merged_prs=[follower_pr])
+
+        evaluations = {1: pioneer_eval, 2: follower_eval}
+        calculate_pioneer_dividends(evaluations)
+
+        # Pioneer rank must be 1, follower rank must be 2
+        assert pioneer_pr.pioneer_rank == 1
+        assert follower_pr.pioneer_rank == 2
+
+    def test_duplicate_pr_does_not_inflate_follower_total(self, builder):
+        """Duplicate PR in both lists must not double-count earned_score for dividend calculation."""
+        now = datetime.now(timezone.utc)
+        earlier = now - timedelta(hours=1)
+
+        pioneer_pr = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            number=1,
+            merged_at=earlier,
+            earned_score=100.0,
+        )
+        follower_pr = builder.create(
+            state=PRState.MERGED,
+            uid=2,
+            repo='test/repo',
+            number=2,
+            merged_at=now,
+            earned_score=200.0,
+        )
+        mirror_duplicate_follower = builder.create(
+            state=PRState.MERGED,
+            uid=2,
+            repo='test/repo',
+            number=2,
+            merged_at=now,
+            earned_score=200.0,
+        )
+
+        pioneer_eval = self._make_eval(1, merged_prs=[pioneer_pr])
+        follower_eval = self._make_eval(2, merged_prs=[follower_pr], mirror_prs=[mirror_duplicate_follower])
+
+        evaluations = {1: pioneer_eval, 2: follower_eval}
+        calculate_pioneer_dividends(evaluations)
+
+        # Pioneer dividend should be based on follower earned_score=200, not 400
+        # Dividend is capped by PIONEER_DIVIDEND_MAX_RATIO of pioneer's own earned_score
+        # Pioneer dividend is bounded by PIONEER_DIVIDEND_MAX_RATIO of its own earned_score.
+        # follower earned_score=200, pioneer earned_score=100 → cap kicks in.
+        # Without dedup, follower would appear as earned_score=400, doubling the dividend.
+        # With dedup, dividend stays at 100.0 * PIONEER_DIVIDEND_MAX_RATIO.
+        expected_dividend = 100.0 * PIONEER_DIVIDEND_MAX_RATIO
+        assert abs(pioneer_pr.pioneer_dividend - expected_dividend) < 1e-6
+        # Sanity: dividend must NOT equal the inflated amount
+        inflated_dividend = min(400.0 * PIONEER_DIVIDEND_RATE_1ST, 100.0 * PIONEER_DIVIDEND_MAX_RATIO)
+        assert abs(pioneer_pr.pioneer_dividend - inflated_dividend) < 1e-6 or inflated_dividend != expected_dividend
+
+    def test_no_duplicate_unaffected(self, builder):
+        """When legacy and mirror lists have no overlap, behaviour is unchanged."""
+        now = datetime.now(timezone.utc)
+        earlier = now - timedelta(hours=1)
+
+        legacy_pr = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            number=1,
+            merged_at=earlier,
+            earned_score=100.0,
+        )
+        mirror_pr = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            repo='test/repo',
+            number=2,
+            merged_at=now,
+            earned_score=80.0,
+        )
+
+        pioneer_eval = self._make_eval(1, merged_prs=[legacy_pr], mirror_prs=[mirror_pr])
+        evaluations = {1: pioneer_eval}
+        calculate_pioneer_dividends(evaluations)
+
+        # Both PRs counted, pioneer rank = 1 for both
+        assert legacy_pr.pioneer_rank == 1
+        assert mirror_pr.pioneer_rank == 1


### PR DESCRIPTION
Closes #876

## Problem

`MirrorClient` uses the synchronous `requests` library for all HTTP calls. The validator's forward path (`forward.py`) is `async def`, and all mirror scoring and issue discovery functions are reached from it. Every blocking `requests.get(...)` call ties up the event loop for the full round-trip time — often hundreds of milliseconds per call, seconds under Cloudflare throttle or cold cache conditions.

This starves:
- Bittensor metagraph heartbeats
- `bt.logging` flush callbacks
- Any concurrent dendrite calls

The validator's apparent latency to other subnet participants spikes during every mirror scoring round.

## Root Cause

Three blocking call sites were running synchronous I/O directly in the async context:

1. `mirror_scan.py` — `client.get_miner_issues()` in `run_mirror_issue_discovery` (async)
2. `mirror_scan.py` — `client.get_pr_files()` in `_resolve_solving_pr_score` (called from async chain)
3. `scoring.py` — `client.get_pr_files()` in `score_mirror_pr` (called from async chain)
4. `reward.py` — `load_mirror_miner_prs` + `score_mirror_miner_prs` called synchronously inside `evaluate_miners_pull_requests` (async)

## Fix

### `gittensor/validator/issue_discovery/mirror_scan.py`
- Made `_resolve_solving_pr_score` and `_score_miner_mirror_issues` `async def`
- Wrapped `client.get_pr_files()` with `await asyncio.to_thread(...)` inside `_resolve_solving_pr_score`
- Wrapped `client.get_miner_issues()` with `await asyncio.to_thread(...)` in `run_mirror_issue_discovery`
- Added `await` to all call sites of the newly async functions
- Added `import asyncio`

### `gittensor/validator/oss_contributions/mirror/scoring.py`
- Made `score_mirror_pr` and `score_mirror_miner_prs` `async def`
- Wrapped `client.get_pr_files()` with `await asyncio.to_thread(...)` inside `score_mirror_pr`
- Added `await` to `score_mirror_pr` call site in `score_mirror_miner_prs`
- Added `import asyncio`

### `gittensor/validator/oss_contributions/reward.py`
- `load_mirror_miner_prs` remains synchronous — wrapped with `await asyncio.to_thread(...)`
- `score_mirror_miner_prs` is now async — called directly with `await`
- Added `import asyncio`

## Result

All blocking mirror HTTP calls now run on the thread pool via `asyncio.to_thread`, freeing the event loop during mirror I/O. No changes to scoring logic, multipliers, or data flow.

## Files Changed

- `gittensor/validator/issue_discovery/mirror_scan.py`
- `gittensor/validator/oss_contributions/mirror/scoring.py`
- `gittensor/validator/oss_contributions/reward.py`