### PR TITLE
feat: Be able to run scoring pipeline locally

### DIFF
--- a/gittensor/cli/miner_commands/__init__.py
+++ b/gittensor/cli/miner_commands/__init__.py
@@ -7,12 +7,14 @@ Command structure:
     gitt miner (alias: m)     - Miner management commands
         post                     Broadcast GitHub PAT to validators
         check                    Check how many validators have your PAT
+        score                    Score GitHub entities through the production pipeline
 """
 
 import click
 
 from .check import miner_check
 from .post import miner_post
+from .score import score_command
 
 
 @click.group(name='miner')
@@ -23,12 +25,14 @@ def miner_group():
     Commands:
         post     Broadcast your GitHub PAT to validators
         check    Check how many validators have your PAT stored
+        score    Run the validator scoring pipeline end-to-end for a single miner
     """
     pass
 
 
 miner_group.add_command(miner_post, name='post')
 miner_group.add_command(miner_check, name='check')
+miner_group.add_command(score_command, name='score')
 
 
 def register_miner_commands(cli):

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -8,17 +8,21 @@ Stubs axon, wallet, subtensor and DB.
 from __future__ import annotations
 
 import dataclasses
+import json
+import os
 import sys
-from datetime import datetime
+from contextlib import contextmanager
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional, Set, Tuple, cast
-from unittest.mock import patch
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, Dict, Iterator, NoReturn, Optional, Set, Tuple, cast
 
 import click
 from rich.console import Console
 from rich.table import Table
 
-from gittensor.cli.issue_commands.helpers import emit_json, get_github_pat
+from gittensor.cli.issue_commands.helpers import emit_json
 from gittensor.cli.miner_commands.helpers import _error
 
 if TYPE_CHECKING:
@@ -36,7 +40,7 @@ def _die(msg: str, json_mode: bool) -> NoReturn:
 
 
 def _resolve_pat(cli_pat: Optional[str], json_mode: bool) -> str:
-    pat = cli_pat or get_github_pat()
+    pat = cli_pat or os.environ.get('GITTENSOR_MINER_PAT')
     if not pat:
         _die('--pat flag or GITTENSOR_MINER_PAT environment variable is required.', json_mode)
     return pat
@@ -46,33 +50,14 @@ def _round(x: float) -> float:
     return round(x, 4)
 
 
-class _SparseHotkeys:
-    def __init__(self, uid: int, hotkey: str):
-        self._data = {uid: hotkey}
-
-    def __getitem__(self, key: int) -> str:
-        return self._data.get(key, '__unused__')
-
-
-class _StubMetagraph:
-    def __init__(self, uid: int, hotkey: str):
-        self.hotkeys = _SparseHotkeys(uid, hotkey)
-
-
 class _StubValidator:
     """Stub `self` with no tensor, wallet, axon, wandb, and DB connection."""
 
     def __init__(self, uid: int, hotkey: str):
-        self.metagraph = _StubMetagraph(uid, hotkey)
+        self.metagraph = SimpleNamespace(hotkeys={uid: hotkey})
 
     def store_or_use_cached_evaluation(self, miner_evaluations: Dict) -> Set[int]:
         return set()
-
-    async def bulk_store_evaluation(self, miner_evaluations: Dict, skip_uids: Set[int]) -> None:
-        return
-
-    def update_scores(self, rewards, miner_uids, blacklisted_uids=None) -> None:
-        return
 
 
 _PR_SKIP: frozenset = frozenset({'file_changes', 'issues'})
@@ -96,20 +81,18 @@ _EVAL_SKIP: frozenset = frozenset(
 _EVAL_PROPERTIES: Tuple[str, ...] = ('total_merged_prs', 'total_open_prs', 'total_closed_prs', 'total_prs')
 
 
-def _jsonable(value: Any) -> Any:
-    if isinstance(value, Enum):
-        return value.value
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, (set, frozenset)):
-        return sorted(value)
-    return value
-
-
 def _project(obj: Any, skip: frozenset = frozenset(), extra_properties: Tuple[str, ...] = ()) -> Dict[str, Any]:
-    """Shallow-project a dataclass into a JSON-friendly dict."""
-    out = {f.name: _jsonable(getattr(obj, f.name)) for f in dataclasses.fields(obj) if f.name not in skip}
-    out.update({p: _jsonable(getattr(obj, p)) for p in extra_properties})
+    """Shallow-project a dataclass into a JSON-friendly dict.
+
+    Coerces Enum -> .value so DB-shape keys carry the underlying string;
+    datetime/set fall through to emit_json's default=str at serialize time.
+    """
+
+    def _coerce(v: Any) -> Any:
+        return v.value if isinstance(v, Enum) else v
+
+    out = {f.name: _coerce(getattr(obj, f.name)) for f in dataclasses.fields(obj) if f.name not in skip}
+    out.update({p: _coerce(getattr(obj, p)) for p in extra_properties})
     return out
 
 
@@ -210,6 +193,22 @@ def _render_table(payload: Dict[str, Any]) -> None:
         console.print(pr_table)
 
 
+@contextmanager
+def _override_pats_file(snapshot: list) -> Iterator[None]:
+    """Point pat_storage at a tempfile holding our injected PAT snapshot."""
+    from gittensor.validator import pat_storage
+
+    original = pat_storage.PATS_FILE
+    with TemporaryDirectory() as tmp:
+        fake = Path(tmp) / 'miner_pats.json'
+        fake.write_text(json.dumps(snapshot))
+        pat_storage.PATS_FILE = fake
+        try:
+            yield
+        finally:
+            pat_storage.PATS_FILE = original
+
+
 def _apply_log_level(level: str) -> None:
     """Configure bittensor's logger. The dev tool bypasses BaseNeuron, which is
     where production normally calls `bt.logging.set_config`, so the level stays
@@ -221,7 +220,13 @@ def _apply_log_level(level: str) -> None:
 
 
 def _drain_logs() -> None:
-    """Stop log production and wait for the async stderr writer to drain."""
+    """Stop log production and wait for the async stderr writer to drain.
+
+    bittensor logs through a queue consumed by a background worker thread.
+    `queue.empty()` only tells us nothing more is *enqueued*; the worker may
+    still be inside `write()` for the last record. The grace tick covers that
+    race so the final lines aren't truncated by a fast process exit.
+    """
     import time
 
     import bittensor as bt
@@ -232,7 +237,7 @@ def _drain_logs() -> None:
         deadline = time.monotonic() + 2.0
         while not queue.empty() and time.monotonic() < deadline:
             time.sleep(0.05)
-        time.sleep(0.1)  # grace tick: queue empty != worker finished writing
+        time.sleep(0.1)
     sys.stderr.flush()
     sys.stdout.flush()
 
@@ -292,10 +297,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
     pat_snapshot = [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': resolved_pat}]
 
     async def _run() -> Dict[str, Any]:
-        with patch(
-            'gittensor.validator.oss_contributions.reward.pat_storage.load_all_pats',
-            return_value=pat_snapshot,
-        ):
+        with _override_pats_file(pat_snapshot):
             oss_rewards, miner_evaluations, _, _ = await oss_contributions(
                 stub, miner_uids, master_repositories, programming_languages, token_config
             )

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -1,0 +1,326 @@
+# Entrius 2025
+
+"""gitt miner score - Run the validator scoring pipeline end-to-end against a single miner.
+
+Stubs axon, wallet, subtensor and DB.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional, Set, Tuple, cast
+from unittest.mock import patch
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from gittensor.cli.issue_commands.helpers import emit_json, get_github_pat
+from gittensor.cli.miner_commands.helpers import _error
+
+if TYPE_CHECKING:
+    from neurons.validator import Validator
+
+console = Console()
+
+_DEV_UID = 1
+_DEV_HOTKEY = 'dev'
+
+
+def _die(msg: str, json_mode: bool) -> NoReturn:
+    _error(msg, json_mode)
+    sys.exit(1)
+
+
+def _resolve_pat(cli_pat: Optional[str], json_mode: bool) -> str:
+    pat = cli_pat or get_github_pat()
+    if not pat:
+        _die('--pat flag or GITTENSOR_MINER_PAT environment variable is required.', json_mode)
+    return pat
+
+
+def _round(x: float) -> float:
+    return round(x, 4)
+
+
+class _SparseHotkeys:
+    def __init__(self, uid: int, hotkey: str):
+        self._data = {uid: hotkey}
+
+    def __getitem__(self, key: int) -> str:
+        return self._data.get(key, '__unused__')
+
+
+class _StubMetagraph:
+    def __init__(self, uid: int, hotkey: str):
+        self.hotkeys = _SparseHotkeys(uid, hotkey)
+
+
+class _StubValidator:
+    """Stub `self` with no tensor, wallet, axon, wandb, and DB connection."""
+
+    def __init__(self, uid: int, hotkey: str):
+        self.metagraph = _StubMetagraph(uid, hotkey)
+
+    def store_or_use_cached_evaluation(self, miner_evaluations: Dict) -> Set[int]:
+        return set()
+
+    async def bulk_store_evaluation(self, miner_evaluations: Dict, skip_uids: Set[int]) -> None:
+        return
+
+    def update_scores(self, rewards, miner_uids, blacklisted_uids=None) -> None:
+        return
+
+
+_PR_SKIP: frozenset = frozenset({'file_changes', 'issues'})
+
+_EVAL_SKIP: frozenset = frozenset(
+    {
+        'github_pat',  # secret - must never appear in serialized output
+        'evaluation_timestamp',
+        'merged_pull_requests',
+        'open_pull_requests',
+        'closed_pull_requests',
+        'mirror_merged_prs',
+        'mirror_open_prs',
+        'mirror_closed_prs',
+        'unique_repos_contributed_to',
+    }
+)
+
+# @property accessors stored as columns in BULK_UPSERT_MINER_EVALUATION; pulled
+# in alongside dataclass fields so JSON keys match DB schema.
+_EVAL_PROPERTIES: Tuple[str, ...] = ('total_merged_prs', 'total_open_prs', 'total_closed_prs', 'total_prs')
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (set, frozenset)):
+        return sorted(value)
+    return value
+
+
+def _project(obj: Any, skip: frozenset = frozenset(), extra_properties: Tuple[str, ...] = ()) -> Dict[str, Any]:
+    """Shallow-project a dataclass into a JSON-friendly dict."""
+    out = {f.name: _jsonable(getattr(obj, f.name)) for f in dataclasses.fields(obj) if f.name not in skip}
+    out.update({p: _jsonable(getattr(obj, p)) for p in extra_properties})
+    return out
+
+
+def _serialize_pr(pr, source: str) -> Dict[str, Any]:
+    payload = _project(pr, skip=_PR_SKIP)
+    payload['source'] = source  # synthetic, not in DB; flags legacy vs mirror scoring path
+    return payload
+
+
+def _serialize_evaluation(miner_eval) -> Dict[str, Any]:
+    from gittensor.validator.oss_contributions.mirror.adapters import (
+        mirror_scored_pr_to_legacy_pull_request,
+    )
+
+    def _legacy(prs):
+        return [_serialize_pr(pr, 'legacy') for pr in prs]
+
+    def _mirror(scored_list):
+        return [
+            _serialize_pr(
+                mirror_scored_pr_to_legacy_pull_request(s, miner_eval.uid, miner_eval.hotkey, miner_eval.github_id),
+                'mirror',
+            )
+            for s in scored_list
+        ]
+
+    payload = _project(miner_eval, skip=_EVAL_SKIP, extra_properties=_EVAL_PROPERTIES)
+    for key, legacy_list, mirror_list in (
+        ('merged_pull_requests', miner_eval.merged_pull_requests, miner_eval.mirror_merged_prs),
+        ('open_pull_requests', miner_eval.open_pull_requests, miner_eval.mirror_open_prs),
+        ('closed_pull_requests', miner_eval.closed_pull_requests, miner_eval.mirror_closed_prs),
+    ):
+        payload[key] = _legacy(legacy_list) + _mirror(mirror_list)
+    return payload
+
+
+def _render_table(payload: Dict[str, Any]) -> None:
+    miner = payload['miner_evaluation']
+    rewards = payload['rewards']
+
+    table = Table(title=f'Miner UID {miner["uid"]} ({miner["hotkey"]}) - github_id={miner["github_id"]}')
+    table.add_column('Field', style='cyan')
+    table.add_column('Value', style='green')
+
+    if miner['failed_reason']:
+        table.add_row('[red]failed_reason[/red]', miner['failed_reason'])
+        console.print(table)
+        return
+
+    table.add_row('Eligible (OSS)', str(miner['is_eligible']))
+    table.add_row('Credibility (OSS)', f'{miner["credibility"]:.4f}')
+    table.add_row('Eligible (issue discovery)', str(miner['is_issue_eligible']))
+    table.add_row('Credibility (issue)', f'{miner["issue_credibility"]:.4f}')
+    table.add_row(
+        'PRs merged / open / closed',
+        f'{miner["total_merged_prs"]} / {miner["total_open_prs"]} / {miner["total_closed_prs"]}',
+    )
+    table.add_row('Unique repos', str(miner['unique_repos_count']))
+    table.add_row('Total token score', f'{miner["total_token_score"]:.2f}')
+    table.add_row('Base total score', f'{miner["base_total_score"]:.2f}')
+    table.add_row('[bold]Total earned score[/bold]', f'[bold]{miner["total_score"]:.2f}[/bold]')
+    table.add_row('Total collateral', f'{miner["total_collateral_score"]:.2f}')
+    table.add_row('Issue discovery score', f'{miner["issue_discovery_score"]:.2f}')
+    table.add_row(
+        '  solved / valid / open',
+        f'{miner["total_solved_issues"]} / {miner["total_valid_solved_issues"]} / {miner["total_open_issues"]}',
+    )
+    table.add_row('OSS reward (normalized)', f'{rewards["oss_normalized"]:.6f}')
+    table.add_row('Issue disc. reward (normalized)', f'{rewards["issue_discovery_normalized"]:.6f}')
+    table.add_row(
+        '[bold green]Final blended reward[/bold green]', f'[bold green]{rewards["blended_final"]:.6f}[/bold green]'
+    )
+    console.print(table)
+
+    pr_table = Table(title='Per-PR breakdown', show_lines=False)
+    pr_table.add_column('Repo#PR', style='cyan')
+    pr_table.add_column('State', style='magenta')
+    pr_table.add_column('Source')
+    pr_table.add_column('Base', justify='right')
+    pr_table.add_column('Earned', justify='right')
+    pr_table.add_column('Token', justify='right')
+    pr_table.add_column('Label')
+
+    def _add(prs) -> None:
+        for pr in prs:
+            pr_table.add_row(
+                f'{pr["repository_full_name"]}#{pr["number"]}',
+                pr['pr_state'],
+                pr['source'],
+                f'{pr["base_score"]:.2f}',
+                f'{pr["earned_score"]:.2f}',
+                f'{pr["token_score"]:.2f}',
+                pr['label'] or '-',
+            )
+
+    _add(miner['merged_pull_requests'] + miner['open_pull_requests'] + miner['closed_pull_requests'])
+    if pr_table.row_count > 0:
+        console.print(pr_table)
+
+
+def _apply_log_level(level: str) -> None:
+    """Configure bittensor's logger. The dev tool bypasses BaseNeuron, which is
+    where production normally calls `bt.logging.set_config`, so the level stays
+    at the default (warning) unless we set it ourselves.
+    """
+    import bittensor as bt
+
+    getattr(bt.logging, f'set_{level}')()
+
+
+def _drain_logs() -> None:
+    """Stop log production and wait for the async stderr writer to drain."""
+    import time
+
+    import bittensor as bt
+
+    bt.logging.off()
+    queue = bt.logging.get_queue()
+    if not queue.empty():
+        deadline = time.monotonic() + 2.0
+        while not queue.empty() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        time.sleep(0.1)  # grace tick: queue empty != worker finished writing
+    sys.stderr.flush()
+    sys.stdout.flush()
+
+
+@click.command(name='score')
+@click.option('--pat', default=None, help='GitHub Personal Access Token. Uses GITTENSOR_MINER_PAT env if unset.')
+@click.option(
+    '--log-level',
+    type=click.Choice(['warning', 'info', 'debug', 'trace']),
+    default='info',
+    show_default=True,
+    help="Bittensor log verbosity. 'info' surfaces the validator pipeline's per-step progress on stderr.",
+)
+@click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Emit result as JSON on stdout.')
+def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
+    """Locally run the validator scoring pipeline end-to-end for the miner identified by --pat.
+
+    No subtensor, wallet, DB, axon, or wandb is touched.
+
+    Example:
+        gitt miner score --pat ghp_xxxxx
+        gitt miner score --pat ghp_xxxxx --log-level debug
+    """
+    import asyncio
+
+    resolved_pat = _resolve_pat(pat, json_mode)
+
+    # Deferred imports: keeps --help fast (these pull bittensor + the validator graph).
+    from gittensor.validator.forward import (
+        blend_emission_pools,
+        issue_discovery,
+        oss_contributions,
+    )
+    from gittensor.validator.utils.load_weights import (
+        load_master_repo_weights,
+        load_programming_language_weights,
+        load_token_config,
+    )
+
+    _apply_log_level(log_level)
+
+    # `oss_contributions` is typed as taking a real `Validator`; the stub fulfils
+    # the surface that function actually uses (metagraph.hotkeys, the cache hook).
+    stub = cast('Validator', _StubValidator(_DEV_UID, _DEV_HOTKEY))
+    miner_uids = {_DEV_UID}
+
+    if json_mode:
+        master_repositories = load_master_repo_weights()
+        programming_languages = load_programming_language_weights()
+        token_config = load_token_config()
+    else:
+        with console.status('[bold cyan]Loading weights', spinner='dots'):
+            master_repositories = load_master_repo_weights()
+            programming_languages = load_programming_language_weights()
+            token_config = load_token_config()
+
+    pat_snapshot = [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': resolved_pat}]
+
+    async def _run() -> Dict[str, Any]:
+        with patch(
+            'gittensor.validator.oss_contributions.reward.pat_storage.load_all_pats',
+            return_value=pat_snapshot,
+        ):
+            oss_rewards, miner_evaluations, _, _ = await oss_contributions(
+                stub, miner_uids, master_repositories, programming_languages, token_config
+            )
+            issue_rewards = await issue_discovery(
+                miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
+            )
+        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+
+        return {
+            'success': True,
+            'miner_evaluation': _serialize_evaluation(miner_evaluations[_DEV_UID]),
+            'rewards': {
+                'oss_normalized': _round(float(oss_rewards[0])),
+                'issue_discovery_normalized': _round(float(issue_rewards[0])),
+                'blended_final': _round(float(rewards[0])),
+            },
+        }
+
+    if not json_mode:
+        console.print('[bold cyan]Running validator pipeline...[/bold cyan]')
+    payload = asyncio.run(_run())
+
+    _drain_logs()
+
+    if json_mode:
+        emit_json(payload)
+    else:
+        _render_table(payload)

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -60,8 +60,6 @@ class _StubValidator:
         return set()
 
 
-_PR_SKIP: frozenset = frozenset({'file_changes', 'issues'})
-
 _EVAL_SKIP: frozenset = frozenset(
     {
         'github_pat',  # secret - must never appear in serialized output
@@ -96,36 +94,20 @@ def _project(obj: Any, skip: frozenset = frozenset(), extra_properties: Tuple[st
     return out
 
 
-def _serialize_pr(pr, source: str) -> Dict[str, Any]:
-    payload = _project(pr, skip=_PR_SKIP)
-    payload['source'] = source  # synthetic, not in DB; flags legacy vs mirror scoring path
+def _serialize_pr(scored) -> Dict[str, Any]:
+    """Flatten a ScoredMirrorPR into a JSON-friendly dict, lifting raw fields off .pr."""
+    payload = _project(scored, skip=frozenset({'pr', 'files'}))
+    payload['repository_full_name'] = scored.pr.repo_full_name
+    payload['number'] = scored.pr.pr_number
+    payload['pr_state'] = scored.pr.state
     return payload
 
 
 def _serialize_evaluation(miner_eval) -> Dict[str, Any]:
-    from gittensor.validator.oss_contributions.mirror.adapters import (
-        mirror_scored_pr_to_legacy_pull_request,
-    )
-
-    def _legacy(prs):
-        return [_serialize_pr(pr, 'legacy') for pr in prs]
-
-    def _mirror(scored_list):
-        return [
-            _serialize_pr(
-                mirror_scored_pr_to_legacy_pull_request(s, miner_eval.uid, miner_eval.hotkey, miner_eval.github_id),
-                'mirror',
-            )
-            for s in scored_list
-        ]
-
     payload = _project(miner_eval, skip=_EVAL_SKIP, extra_properties=_EVAL_PROPERTIES)
-    for key, legacy_list, mirror_list in (
-        ('merged_pull_requests', miner_eval.merged_pull_requests, miner_eval.mirror_merged_prs),
-        ('open_pull_requests', miner_eval.open_pull_requests, miner_eval.mirror_open_prs),
-        ('closed_pull_requests', miner_eval.closed_pull_requests, miner_eval.mirror_closed_prs),
-    ):
-        payload[key] = _legacy(legacy_list) + _mirror(mirror_list)
+    payload['merged_pull_requests'] = [_serialize_pr(s) for s in miner_eval.mirror_merged_prs]
+    payload['open_pull_requests'] = [_serialize_pr(s) for s in miner_eval.mirror_open_prs]
+    payload['closed_pull_requests'] = [_serialize_pr(s) for s in miner_eval.mirror_closed_prs]
     return payload
 
 
@@ -170,7 +152,6 @@ def _render_table(payload: Dict[str, Any]) -> None:
     pr_table = Table(title='Per-PR breakdown', show_lines=False)
     pr_table.add_column('Repo#PR', style='cyan')
     pr_table.add_column('State', style='magenta')
-    pr_table.add_column('Source')
     pr_table.add_column('Base', justify='right')
     pr_table.add_column('Earned', justify='right')
     pr_table.add_column('Token', justify='right')
@@ -181,7 +162,6 @@ def _render_table(payload: Dict[str, Any]) -> None:
             pr_table.add_row(
                 f'{pr["repository_full_name"]}#{pr["number"]}',
                 pr['pr_state'],
-                pr['source'],
                 f'{pr["base_score"]:.2f}',
                 f'{pr["earned_score"]:.2f}',
                 f'{pr["token_score"]:.2f}',
@@ -293,6 +273,9 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
             master_repositories = load_master_repo_weights()
             programming_languages = load_programming_language_weights()
             token_config = load_token_config()
+
+    # Drop non-mirror repos so reward.py never hits its legacy/PAT branch here.
+    master_repositories = {name: cfg for name, cfg in master_repositories.items() if cfg.mirror_enabled}
 
     pat_snapshot = [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': resolved_pat}]
 

--- a/tests/cli/test_miner_score.py
+++ b/tests/cli/test_miner_score.py
@@ -3,6 +3,8 @@
 """Tests for `gitt miner score` (validator-pipeline e2e for one miner)."""
 
 import json
+from datetime import datetime, timezone
+from typing import Dict, Optional
 from unittest.mock import AsyncMock, patch
 
 import numpy as np
@@ -40,13 +42,9 @@ def _patch_pipeline(
     issue_value: float = 0.1,
     blended: float = 0.3,
     oss_side_effect=None,
+    master_repos: Optional[Dict] = None,
 ):
-    """Mock the three forward entry points to return controlled values.
-
-    Pass `oss_side_effect=...` to inject a custom oss_contributions impl (used by
-    tests that want to capture call args); otherwise a default AsyncMock returns
-    the supplied `oss_value`/`miner_evaluation` tuple.
-    """
+    """Mock the three forward entry points; `oss_side_effect` captures call args, `master_repos` exercises the mirror_enabled filter."""
     miner_evaluations = {uid: miner_evaluation}
 
     oss_rewards = np.array([oss_value])
@@ -65,7 +63,7 @@ def _patch_pipeline(
         oss_patch,
         patch('gittensor.validator.forward.issue_discovery', new=AsyncMock(return_value=issue_rewards)),
         patch('gittensor.validator.forward.blend_emission_pools', return_value=final_rewards),
-        patch('gittensor.validator.utils.load_weights.load_master_repo_weights', return_value={}),
+        patch('gittensor.validator.utils.load_weights.load_master_repo_weights', return_value=master_repos or {}),
         patch('gittensor.validator.utils.load_weights.load_programming_language_weights', return_value={}),
         patch('gittensor.validator.utils.load_weights.load_token_config', return_value=_stub_token_config()),
     ]
@@ -75,6 +73,58 @@ def _stub_token_config():
     from gittensor.validator.utils.load_weights import TokenConfig
 
     return TokenConfig(structural_bonus={}, leaf_tokens={}, language_configs={})
+
+
+def _make_scored_mirror_pr(
+    repo_full_name: str = 'octo/repo',
+    pr_number: int = 42,
+    state: str = 'MERGED',
+    base_score: float = 12.5,
+    earned_score: float = 9.75,
+    token_score: float = 33.0,
+    label: str = 'feature',
+):
+    """Build a populated ScoredMirrorPR minimally sufficient for serialization."""
+    from gittensor.utils.mirror.models import MirrorPullRequest, MirrorReviewSummary
+    from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
+
+    now = datetime.now(timezone.utc)
+    pr = MirrorPullRequest(
+        repo_full_name=repo_full_name,
+        pr_number=pr_number,
+        title='add feature',
+        body=None,
+        state=state,
+        author_github_id='12345',
+        author_login='miner',
+        author_association='CONTRIBUTOR',
+        created_at=now,
+        closed_at=None,
+        merged_at=now if state == 'MERGED' else None,
+        last_edited_at=None,
+        edited_after_merge=False,
+        hours_since_merge=0.0,
+        merged_by_login='maintainer',
+        base_ref='main',
+        head_ref='feature',
+        head_repo_full_name=repo_full_name,
+        default_branch='main',
+        head_sha='abc',
+        base_sha='def',
+        merge_base_sha='def',
+        additions=10,
+        deletions=2,
+        commits_count=1,
+        scoring_data_stored=True,
+        review_summary=MirrorReviewSummary(),
+    )
+    return ScoredMirrorPR(
+        pr=pr,
+        base_score=base_score,
+        earned_score=earned_score,
+        token_score=token_score,
+        label=label,
+    )
 
 
 class TestScoreCommand:
@@ -190,6 +240,82 @@ class TestScoreCommand:
         assert result.exit_code == 0, result.output
         assert captured['hotkey_at_uid'] == _DEV_HOTKEY
         assert captured['miner_uids'] == {_DEV_UID}
+
+    def test_populated_mirror_prs_render_in_json(self, runner, miner_eval_factory):
+        """Populated mirror PRs must flatten into the JSON shape via _serialize_evaluation."""
+        evaluation = miner_eval_factory(
+            uid=_DEV_UID,
+            is_eligible=True,
+            credibility=0.9,
+            mirror_merged_prs=[_make_scored_mirror_pr()],
+        )
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score', '--json-output'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        merged = payload['miner_evaluation']['merged_pull_requests']
+        assert len(merged) == 1
+        row = merged[0]
+        assert row['repository_full_name'] == 'octo/repo'
+        assert row['number'] == 42
+        assert row['pr_state'] == 'MERGED'
+        assert row['base_score'] == 12.5
+        assert row['earned_score'] == 9.75
+        assert row['token_score'] == 33.0
+        assert row['label'] == 'feature'
+        # Raw nested payloads and the deprecated `source` tag must not leak.
+        assert 'pr' not in row
+        assert 'files' not in row
+        assert 'source' not in row
+
+    def test_populated_mirror_prs_render_in_table(self, runner, miner_eval_factory):
+        """The per-PR table must surface a row for each populated mirror PR."""
+        evaluation = miner_eval_factory(
+            uid=_DEV_UID,
+            is_eligible=True,
+            credibility=0.9,
+            mirror_merged_prs=[_make_scored_mirror_pr()],
+        )
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        assert 'octo/repo#42' in result.output
+        assert 'Per-PR breakdown' in result.output
+
+    def test_master_repos_filtered_to_mirror_enabled(self, runner, miner_eval_factory):
+        """Non-mirror repos must be filtered out before oss_contributions is called."""
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        evaluation = miner_eval_factory(uid=_DEV_UID)
+        captured = {}
+
+        async def _capture_oss(self, miner_uids, master_repositories, *args, **kwargs):
+            captured['repos'] = dict(master_repositories)
+            return np.array([0.0]), {_DEV_UID: evaluation}, set(), set()
+
+        unfiltered = {
+            'legacy/repo': RepositoryConfig(weight=1.0, mirror_enabled=False),
+            'mirror/repo': RepositoryConfig(weight=1.0, mirror_enabled=True),
+        }
+        with _multi_patch(
+            _patch_pipeline(
+                uid=_DEV_UID,
+                miner_evaluation=evaluation,
+                oss_side_effect=_capture_oss,
+                master_repos=unfiltered,
+            )
+        ):
+            result = runner.invoke(cli, ['miner', 'score'], env={'GITTENSOR_MINER_PAT': 'ghp_dummy'})
+        assert result.exit_code == 0, result.output
+        assert set(captured['repos'].keys()) == {'mirror/repo'}
 
     def test_pat_storage_load_all_pats_is_patched(self, runner, miner_eval_factory):
         """The injected PAT snapshot must override pat_storage.load_all_pats()."""

--- a/tests/cli/test_miner_score.py
+++ b/tests/cli/test_miner_score.py
@@ -1,0 +1,218 @@
+# Entrius 2025
+
+"""Tests for `gitt miner score` (validator-pipeline e2e for one miner)."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from gittensor.cli.main import cli
+from gittensor.cli.miner_commands.score import _DEV_HOTKEY, _DEV_UID
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def miner_eval_factory():
+    """Build a populated MinerEvaluation for a UID without running real scoring."""
+
+    def _make(uid: int = 5, hotkey: str = 'dev', github_id: str = '12345', failed_reason=None, **overrides):
+        from gittensor.classes import MinerEvaluation
+
+        evaluation = MinerEvaluation(uid=uid, hotkey=hotkey, github_id=github_id, failed_reason=failed_reason)
+        for key, value in overrides.items():
+            setattr(evaluation, key, value)
+        return evaluation
+
+    return _make
+
+
+def _patch_pipeline(
+    uid: int,
+    miner_evaluation,
+    oss_value: float = 0.4,
+    issue_value: float = 0.1,
+    blended: float = 0.3,
+    oss_side_effect=None,
+):
+    """Mock the three forward entry points to return controlled values.
+
+    Pass `oss_side_effect=...` to inject a custom oss_contributions impl (used by
+    tests that want to capture call args); otherwise a default AsyncMock returns
+    the supplied `oss_value`/`miner_evaluation` tuple.
+    """
+    miner_evaluations = {uid: miner_evaluation}
+
+    oss_rewards = np.array([oss_value])
+    issue_rewards = np.array([issue_value])
+    final_rewards = np.array([blended])
+
+    if oss_side_effect is not None:
+        oss_patch = patch('gittensor.validator.forward.oss_contributions', side_effect=oss_side_effect)
+    else:
+        oss_patch = patch(
+            'gittensor.validator.forward.oss_contributions',
+            new=AsyncMock(return_value=(oss_rewards, miner_evaluations, set(), set())),
+        )
+
+    return [
+        oss_patch,
+        patch('gittensor.validator.forward.issue_discovery', new=AsyncMock(return_value=issue_rewards)),
+        patch('gittensor.validator.forward.blend_emission_pools', return_value=final_rewards),
+        patch('gittensor.validator.utils.load_weights.load_master_repo_weights', return_value={}),
+        patch('gittensor.validator.utils.load_weights.load_programming_language_weights', return_value={}),
+        patch('gittensor.validator.utils.load_weights.load_token_config', return_value=_stub_token_config()),
+    ]
+
+
+def _stub_token_config():
+    from gittensor.validator.utils.load_weights import TokenConfig
+
+    return TokenConfig(structural_bonus={}, leaf_tokens={}, language_configs={})
+
+
+class TestScoreCommand:
+    def test_help_text(self, runner):
+        result = runner.invoke(cli, ['miner', 'score', '--help'])
+        assert result.exit_code == 0
+        assert 'validator scoring pipeline' in result.output
+
+    def test_missing_pat_exits(self, runner, monkeypatch):
+        monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+        result = runner.invoke(cli, ['miner', 'score'])
+        assert result.exit_code == 1
+        assert 'GITTENSOR_MINER_PAT' in result.output
+
+    def test_e2e_table_output(self, runner, miner_eval_factory):
+        evaluation = miner_eval_factory(
+            uid=_DEV_UID,
+            is_eligible=True,
+            credibility=0.9,
+            base_total_score=20.0,
+            total_score=18.0,
+            total_token_score=42.0,
+            unique_repos_count=2,
+        )
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        assert f'Miner UID {_DEV_UID}' in result.output
+        assert 'Total earned score' in result.output
+        assert 'Final blended reward' in result.output
+
+    def test_e2e_json_output(self, runner, miner_eval_factory):
+        evaluation = miner_eval_factory(
+            uid=_DEV_UID,
+            is_eligible=True,
+            credibility=0.85,
+            base_total_score=20.0,
+            total_score=18.0,
+        )
+        with _multi_patch(
+            _patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation, oss_value=0.4, issue_value=0.1, blended=0.3)
+        ):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score', '--json-output'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload['success'] is True
+        assert payload['miner_evaluation']['uid'] == _DEV_UID
+        assert payload['miner_evaluation']['is_eligible'] is True
+        assert payload['miner_evaluation']['credibility'] == 0.85
+        assert payload['rewards']['oss_normalized'] == 0.4
+        assert payload['rewards']['issue_discovery_normalized'] == 0.1
+        assert payload['rewards']['blended_final'] == 0.3
+
+    def test_pat_never_appears_in_json(self, runner, miner_eval_factory):
+        """The introspection-based serializer relies on _EVAL_SKIP to redact secrets;
+        guard against it accidentally leaking github_pat into JSON output."""
+        evaluation = miner_eval_factory(uid=_DEV_UID, github_pat='ghp_should_not_leak')
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score', '--pat', 'ghp_should_not_leak', '--json-output'],
+                env={},
+            )
+        assert result.exit_code == 0, result.output
+        assert 'ghp_should_not_leak' not in result.output
+        payload = json.loads(result.output)
+        assert 'github_pat' not in payload['miner_evaluation']
+
+    def test_failed_reason_renders_in_table(self, runner, miner_eval_factory):
+        evaluation = miner_eval_factory(uid=_DEV_UID, failed_reason=f'No stored PAT for miner {_DEV_UID}')
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        assert 'failed_reason' in result.output
+        assert 'No stored PAT' in result.output
+
+    def test_failed_reason_in_json(self, runner, miner_eval_factory):
+        evaluation = miner_eval_factory(uid=_DEV_UID, failed_reason='whatever')
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score', '--json-output'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload['miner_evaluation']['failed_reason'] == 'whatever'
+
+    def test_pipeline_called_with_stub_validator(self, runner, miner_eval_factory):
+        """The dev tool must wire stub `self.metagraph.hotkeys[uid]` for get_rewards."""
+        evaluation = miner_eval_factory(uid=_DEV_UID, hotkey=_DEV_HOTKEY, github_id='99')
+        captured = {}
+
+        async def _capture_oss(self, miner_uids, *args, **kwargs):
+            captured['hotkey_at_uid'] = self.metagraph.hotkeys[_DEV_UID]
+            captured['miner_uids'] = miner_uids
+            return np.array([0.0]), {_DEV_UID: evaluation}, set(), set()
+
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation, oss_side_effect=_capture_oss)):
+            result = runner.invoke(cli, ['miner', 'score'], env={'GITTENSOR_MINER_PAT': 'ghp_dummy'})
+        assert result.exit_code == 0, result.output
+        assert captured['hotkey_at_uid'] == _DEV_HOTKEY
+        assert captured['miner_uids'] == {_DEV_UID}
+
+    def test_pat_storage_load_all_pats_is_patched(self, runner, miner_eval_factory):
+        """The injected PAT snapshot must override pat_storage.load_all_pats()."""
+        evaluation = miner_eval_factory(uid=_DEV_UID)
+        captured = {}
+
+        async def _capture_oss(self, miner_uids, *args, **kwargs):
+            from gittensor.validator.oss_contributions.reward import pat_storage
+
+            captured['pats'] = pat_storage.load_all_pats()
+            return np.array([0.0]), {_DEV_UID: evaluation}, set(), set()
+
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation, oss_side_effect=_capture_oss)):
+            result = runner.invoke(cli, ['miner', 'score', '--pat', 'ghp_injected'], env={})
+        assert result.exit_code == 0, result.output
+        assert captured['pats'] == [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': 'ghp_injected'}]
+
+
+def _multi_patch(patches):
+    """contextlib.ExitStack-style stack for a flat list of patch context managers."""
+    import contextlib
+
+    stack = contextlib.ExitStack()
+    for p in patches:
+        stack.enter_context(p)
+    return stack


### PR DESCRIPTION
Closes #946

## Summary

This PR introduces a new sub-command, which allows to run scoring pipeline (like validator does) locally, but without subnet/db/etc harness. It's primarily intended for debugging purposes, as currently there is no easy way to ensure your changes work e2e. Unit testing is good, but having no ability to run something manually makes people actually skip this method of testing.

Now you can, for example, do changes to the scoring algorithm, and check "live" results right after.

```sh
# or without --pat, using GITTENSOR_MINER_PAT variable
gitt miner score --pat ... --json-output --log-level info
```

The implementation just runs what validator runs, but with subnet/db/wallet things stubbed.

I've placed this command under `gitt miner score`, but we can also move it somewhere or even hide.

https://github.com/user-attachments/assets/f3384824-9cad-4ed1-8bd0-c84266e9d0f9

On the video we also see how the very first request responds with 502 (and it's reproducible for my PAT), likely some constant should be tweaked or something. Nobody knows what else this feature can also uncover =)

## Test plan

Covered with some tests, but strictly there is no much really new testable code.