### PR TITLE
refactor: inline single-use get_github_pat and is_comment_node helpers

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -268,18 +268,13 @@ def confirm_or_abort(prompt: str, yes: bool, default: bool = False) -> bool:
     return False
 
 
-def get_github_pat() -> Optional[str]:
-    """Return GITTENSOR_MINER_PAT from environment, or None."""
-    return os.environ.get('GITTENSOR_MINER_PAT') or None
-
-
 def fetch_open_issue_pull_requests(
     repository_full_name: str,
     issue_number: int,
     as_json: bool,
 ) -> list:
     """Fetch open PR submissions for a GitHub issue."""
-    token = get_github_pat() or ''
+    token = os.environ.get('GITTENSOR_MINER_PAT') or ''
     if not token and not as_json:
         print_warning('No GitHub token found; set GITTENSOR_MINER_PAT to fetch GitHub issue submissions')
 

--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -86,11 +86,6 @@ def parse_code(content: str, language: str) -> Optional[Tree]:
 NodeSignature = Union[Tuple[str, str], Tuple[str, str, str]]
 
 
-def is_comment_node(node: Node) -> bool:
-    """Check if a node is a comment."""
-    return node.type in COMMENT_NODE_TYPES
-
-
 def collect_node_signatures(
     tree: Tree,
     weights: TokenConfig,
@@ -115,7 +110,7 @@ def collect_node_signatures(
 
     def walk_node(node: Node) -> None:
         # Skip comments entirely
-        if is_comment_node(node):
+        if node.type in COMMENT_NODE_TYPES:
             return
 
         node_type = node.type


### PR DESCRIPTION
## Summary

Two private 3-line wrappers each have exactly one caller in their own module:

1. **`get_github_pat`** in [gittensor/cli/issue_commands/helpers.py](gittensor/cli/issue_commands/helpers.py) — wraps a single `os.environ.get('GITTENSOR_MINER_PAT')`. The only caller already does `... or ''`, so the wrapper's `or None` fallback collapses on inline.

2. **`is_comment_node`** in [gittensor/validator/utils/tree_sitter_scoring.py](gittensor/validator/utils/tree_sitter_scoring.py) — wraps a single `node.type in COMMENT_NODE_TYPES` membership check.

`grep -rn` confirms no other call sites or test references in `gittensor/`, `neurons/`, or `tests/`.

Net: **-12 / +2 lines**, two fewer module-level helpers.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 726 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)