### PR TITLE
refactor: inline single-use _calculate_base_score adapter

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -144,7 +144,15 @@ def score_mirror_pr(
 
     file_changes, file_contents = mirror_files_to_legacy(pr.repo_full_name, pr.pr_number, files)
 
-    scored.base_score = _calculate_base_score(scored, file_changes, file_contents, programming_languages, token_config)
+    result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
+    scored.token_score = result.token_score
+    scored.structural_count = result.structural_count
+    scored.structural_score = result.structural_score
+    scored.leaf_count = result.leaf_count
+    scored.leaf_score = result.leaf_score
+    scored.total_nodes_scored = result.total_nodes_scored
+    scored.code_density = result.code_density
+    scored.base_score = result.base_score
 
     _calculate_pr_multipliers(scored, repo_config)
 
@@ -314,25 +322,6 @@ def calculate_base_score_for_pr_files(
         total_nodes_scored=total_nodes_scored,
         code_density=code_density,
     )
-
-
-def _calculate_base_score(
-    scored: ScoredMirrorPR,
-    file_changes: List[FileChange],
-    file_contents: Dict[str, FileContentPair],
-    programming_languages: Dict[str, LanguageConfig],
-    token_config: TokenConfig,
-) -> float:
-    """Thin wrapper: run the shared helper and copy fields onto ScoredMirrorPR."""
-    result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
-    scored.token_score = result.token_score
-    scored.structural_count = result.structural_count
-    scored.structural_score = result.structural_score
-    scored.leaf_count = result.leaf_count
-    scored.leaf_score = result.leaf_score
-    scored.total_nodes_scored = result.total_nodes_scored
-    scored.code_density = result.code_density
-    return result.base_score
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`_calculate_base_score` in [gittensor/validator/oss_contributions/mirror/scoring.py](gittensor/validator/oss_contributions/mirror/scoring.py) is described in its own docstring as a *"Thin wrapper: run the shared helper and copy fields onto ScoredMirrorPR"* and has exactly one caller (`score_mirror_pr`).

The wrapper mutates **seven** fields on `scored` while returning only `base_score`, hiding most of its side effects behind a misleading return signature — the only visible mutation at the call site is `scored.base_score = ...`. Inlining moves the field-copying out into the caller alongside that existing assignment, so all eight mutations land on one block in `score_mirror_pr`.

The shared helper `calculate_base_score_for_pr_files` (which actually performs the computation) is unaffected and still callable from any future non-mutating consumer.

`grep -rn _calculate_base_score` confirms no other call sites or test references in `gittensor/`, `neurons/`, or `tests/`.

Net: **-20 / +9 lines**, one fewer module-level helper.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 726 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)