### PR TITLE
refactor: deduplicate calculate_final_earned_score between PullRequest and ScoredMirrorPR

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -22,6 +22,15 @@ from gittensor.constants import (
 from gittensor.utils.utils import parse_repo_name
 
 
+def _apply_score_multipliers(base_score: float, multipliers: Dict[str, float], pr_label: str) -> float:
+    """Compute earned score and emit the standard scoring log lines."""
+    earned = base_score * prod(multipliers.values())
+    mult_str = ' × '.join(f'{k}={v:.2f}' for k, v in multipliers.items())
+    bt.logging.info(f'├─ {pr_label} → {earned:.2f}')
+    bt.logging.info(f'│  └─ {base_score:.2f} × {mult_str}')
+    return earned
+
+
 class PRState(Enum):
     """PR state for scoring"""
 
@@ -231,15 +240,8 @@ class PullRequest:
             'cred': self.credibility_multiplier,
             'review': self.review_quality_multiplier,
         }
-
-        self.earned_score = self.base_score * prod(multipliers.values())
-
-        mult_str = ' × '.join(f'{k}={v:.2f}' for k, v in multipliers.items())
-        bt.logging.info(
-            f'├─ {self.pr_state.value} PR #{self.number} ({self.repository_full_name}) → {self.earned_score:.2f}'
-        )
-        bt.logging.info(f'│  └─ {self.base_score:.2f} × {mult_str}')
-
+        label = f'{self.pr_state.value} PR #{self.number} ({self.repository_full_name})'
+        self.earned_score = _apply_score_multipliers(self.base_score, multipliers, label)
         return self.earned_score
 
     @classmethod

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -12,11 +12,9 @@ dataclass so downstream math (``calculate_final_earned_score``,
 
 from dataclasses import dataclass
 from datetime import datetime
-from math import prod
 from typing import List, Optional
 
-import bittensor as bt
-
+from gittensor.classes import _apply_score_multipliers
 from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE
 from gittensor.utils.mirror.models import MirrorFile, MirrorPullRequest
 
@@ -102,13 +100,6 @@ class ScoredMirrorPR:
             'cred': self.credibility_multiplier,
             'review': self.review_quality_multiplier,
         }
-
-        self.earned_score = self.base_score * prod(multipliers.values())
-
-        mult_str = ' × '.join(f'{k}={v:.2f}' for k, v in multipliers.items())
-        bt.logging.info(
-            f'├─ {self.pr.state} PR #{self.pr.pr_number} ({self.pr.repo_full_name}) → {self.earned_score:.2f}'
-        )
-        bt.logging.info(f'│  └─ {self.base_score:.2f} × {mult_str}')
-
+        label = f'{self.pr.state} PR #{self.pr.pr_number} ({self.pr.repo_full_name})'
+        self.earned_score = _apply_score_multipliers(self.base_score, multipliers, label)
         return self.earned_score


### PR DESCRIPTION
## Summary

Closes #950

Extract `_apply_score_multipliers(base_score, multipliers, pr_label)` into `classes.py` so `PullRequest` and `ScoredMirrorPR` share one implementation of the multiplier computation and log lines.

## Changes

- Add `_apply_score_multipliers` as a module-level function in `classes.py`
- Update `PullRequest.calculate_final_earned_score` to delegate to it
- Update `ScoredMirrorPR.calculate_final_earned_score` to import and delegate to it
- Drop now-unused `from math import prod` and `import bittensor as bt` from `scored_pr.py`

## Behaviour

No behaviour change — multiplier keys, order, earned-score assignment, and log output are identical to before.

## Test plan

- [ ] Existing scoring tests pass unchanged
- [ ] Log output format is identical to before
