### PR TITLE
refactor: centralize ink! issues-mapping selector as ISSUES_MAPPING_ROOT_KEY

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -22,6 +22,7 @@ from rich.console import Console
 from gittensor.cli.issue_commands.tables import build_pr_table
 from gittensor.constants import NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
+    ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
     decode_issue_from_storage,
     decode_packed_contract_storage,
@@ -807,7 +808,7 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
     for issue_id in range(1, next_issue_id):
         # SCALE encode u64 as little-endian 8 bytes
         encoded_id = struct.pack('<Q', issue_id)
-        lazy_key = compute_ink5_lazy_key('52789899', encoded_id)
+        lazy_key = compute_ink5_lazy_key(ISSUES_MAPPING_ROOT_KEY, encoded_id)
 
         val_result = substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
         if not val_result.get('result'):

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -16,6 +16,7 @@ from substrateinterface import Keypair
 from substrateinterface.exceptions import ExtrinsicNotFound
 
 from gittensor.validator.issue_competitions.storage_utils import (
+    ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
     decode_issue_from_storage,
     get_contract_child_storage_key,
@@ -154,7 +155,7 @@ class IssueCompetitionContractClient:
 
         try:
             encoded_id = struct.pack('<Q', issue_id)
-            lazy_key = compute_ink5_lazy_key('52789899', encoded_id)
+            lazy_key = compute_ink5_lazy_key(ISSUES_MAPPING_ROOT_KEY, encoded_id)
 
             val_result = self.subtensor.substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
             if not val_result.get('result'):

--- a/gittensor/validator/issue_competitions/storage_utils.py
+++ b/gittensor/validator/issue_competitions/storage_utils.py
@@ -8,6 +8,9 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# ink! mapping selector for the issues storage map (matches the contract's storage layout).
+ISSUES_MAPPING_ROOT_KEY = '52789899'
+
 
 @dataclass
 class PackedContractStorage:


### PR DESCRIPTION
## Summary

The ink! storage selector `'52789899'` for the issues mapping is duplicated at the two active call sites that compute lazy keys for child storage reads:

- [gittensor/validator/issue_competitions/contract_client.py](gittensor/validator/issue_competitions/contract_client.py) — `read_issue_from_child_storage`
- [gittensor/cli/issue_commands/helpers.py](gittensor/cli/issue_commands/helpers.py) — `_read_issues_from_child_storage`

Both files already import from `gittensor/validator/issue_competitions/storage_utils`, so this PR hoists the literal into a single named constant `ISSUES_MAPPING_ROOT_KEY` in `storage_utils.py` and updates both call sites to use it. If the contract storage layout ever changes, the selector lives in one place alongside the other storage-decoding helpers.

The existing test fixture in `tests/utils/test_issue_competitions_storage_utils.py` keeps the literal `'52789899'` (it asserts a specific lazy-key output for that exact selector input — fixture intent preserved).

Net: **+7 / -2 lines** across 3 files.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 726 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)