### PR TITLE
refactor: remove unused U32_MAX constant

### DIFF
--- a/neurons/base/utils/weight_utils.py
+++ b/neurons/base/utils/weight_utils.py
@@ -4,7 +4,6 @@ import bittensor
 import numpy as np
 from numpy import complexfloating, dtype, floating, ndarray
 
-U32_MAX = 4294967295
 U16_MAX = 65535
 
 


### PR DESCRIPTION
## Summary

`U32_MAX = 4294967295` is defined at the top of [neurons/base/utils/weight_utils.py](neurons/base/utils/weight_utils.py) but has zero references anywhere in the codebase. The sibling `U16_MAX` constant is actively used by `convert_weights_and_uids_for_emit` and `process_weights_for_netuid`.

Verified via:
- `grep -rn U32_MAX` — only the definition line.
- `grep -rn 4294967295` — only the definition line.

Net: **-1 line**.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 726 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)