### PR TITLE
refactor: remove unused GITHUB_DOMAIN constant

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -22,8 +22,6 @@ from gittensor.constants import (
 )
 from gittensor.utils.utils import parse_repo_name
 
-GITHUB_DOMAIN = 'https://github.com/'
-
 
 class PRState(Enum):
     """PR state for scoring"""


### PR DESCRIPTION
## Summary

`GITHUB_DOMAIN = 'https://github.com/'` is defined at module scope in [gittensor/classes.py](gittensor/classes.py) but has zero references anywhere in `gittensor/`, `neurons/`, or `tests/`. The sites that build GitHub URLs use inline f-strings (e.g. `f'https://github.com/{repo}/issues/{issue_number}'` in `cli/issue_commands/helpers.py`, `mutations.py`, and `submissions.py`) and don't import this constant.

Verified via `grep -rn GITHUB_DOMAIN` — only the definition line.

Net: **-2 lines**.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 726 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)