### PR TITLE
refactor: bundle of small refactors

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Set
 import bittensor as bt
 import wandb
 
-from gittensor.__init__ import __version__
+from gittensor import __version__
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.validator import pat_storage
 from gittensor.validator.forward import forward


### PR DESCRIPTION
## Summary

Per @anderdc's review on this PR, consolidating the 8 small refactors from #942, #943, #948, #949, #952, #953, #954, #955 into one bundle. Each commit is preserved as-is so they can be reviewed individually if useful, or squash-merged together.

#864 and #873 are mid-review and remain separate as requested.

### Commits in this bundle (oldest → newest)

1. **#942** — `refactor: use GITHUB_HTTP_TIMEOUT_SECONDS at the three remaining timeout=15 sites`
2. **#943** — `refactor: remove unused REPO_SCAN_* constants`
3. **#948** — `refactor: inline single-use get_github_pat and is_comment_node helpers`
4. **#949** — `refactor: inline single-use _calculate_base_score adapter into score_mirror_pr`
5. **#952** — `refactor: centralize ink! issues-mapping selector as ISSUES_MAPPING_ROOT_KEY`
6. **#953** — `refactor: remove unused U32_MAX constant`
7. **#954** — `refactor: remove unused GITHUB_DOMAIN constant`
8. **#955** — `refactor: normalize __version__ import in neurons/validator.py`

### Aggregate change

- 10 files changed, **+22 / -46 lines** (net **-24 lines**).
- No behaviour change in any commit.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` on the merged bundle — all **726 tests pass**.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)