### PR TITLE
fix(cli): route warnings, errors, logs to stderr

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -22,7 +22,7 @@ from .helpers import (
     _make_contract_client,
     _resolve_contract_and_network,
     confirm_or_abort,
-    console,
+    err_console,
     format_alpha,
     print_error,
     print_network_header,
@@ -72,7 +72,7 @@ def admin_cancel(
     print_network_header(network_name, contract_addr)
 
     try:
-        with console.status('[bold cyan]Connecting and reading issue...', spinner='dots'):
+        with err_console.status('[bold cyan]Connecting and reading issue...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             issue = client.get_issue(issue_id)
 
@@ -80,7 +80,7 @@ def admin_cancel(
             print_error(f'Issue {issue_id} not found on contract.')
             raise SystemExit(1)
 
-        console.print(
+        err_console.print(
             Panel(
                 f'[cyan]Issue:[/cyan] {issue.repository_full_name}#{issue.issue_number}\n'
                 f'[cyan]Status:[/cyan] {issue.status.name}\n'
@@ -93,7 +93,7 @@ def admin_cancel(
         if not confirm_or_abort(f'Cancel issue {issue_id}? This returns the bounty to the alpha pool.', yes):
             return
 
-        with console.status('[bold cyan]Submitting cancellation...', spinner='dots'):
+        with err_console.status('[bold cyan]Submitting cancellation...', spinner='dots'):
             result = client.cancel_issue(issue_id, wallet)
 
         if result:
@@ -134,7 +134,7 @@ def admin_payout(
     print_network_header(network_name, contract_addr)
 
     try:
-        with console.status('[bold cyan]Connecting and reading issue...', spinner='dots'):
+        with err_console.status('[bold cyan]Connecting and reading issue...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             issue = client.get_issue(issue_id)
 
@@ -142,7 +142,7 @@ def admin_payout(
             print_error(f'Issue {issue_id} not found on contract.')
             raise SystemExit(1)
 
-        console.print(
+        err_console.print(
             Panel(
                 f'[cyan]Issue:[/cyan] {issue.repository_full_name}#{issue.issue_number}\n'
                 f'[cyan]Status:[/cyan] {issue.status.name}\n'
@@ -155,7 +155,7 @@ def admin_payout(
         if not confirm_or_abort(f'Pay out issue {issue_id}?', yes):
             return
 
-        with console.status('[bold cyan]Submitting payout...', spinner='dots'):
+        with err_console.status('[bold cyan]Submitting payout...', spinner='dots'):
             result = client.payout_bounty(issue_id, wallet)
 
         if result:
@@ -191,7 +191,7 @@ def admin_set_owner(
 
     print_network_header(network_name, contract_addr)
 
-    console.print(
+    err_console.print(
         Panel(
             f'[cyan]New Owner:[/cyan] {new_owner}\n'
             '[bold red]This transfer is IRREVERSIBLE. A mistyped address makes the contract unrecoverable.[/bold red]',
@@ -204,7 +204,7 @@ def admin_set_owner(
         return
 
     try:
-        with console.status('[bold cyan]Transferring ownership...', spinner='dots'):
+        with err_console.status('[bold cyan]Transferring ownership...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             result = client.set_owner(new_owner, wallet)
 
@@ -244,7 +244,7 @@ def admin_set_treasury(
 
     print_network_header(network_name, contract_addr)
 
-    console.print(
+    err_console.print(
         Panel(
             f'[cyan]New Treasury:[/cyan] {new_treasury}',
             title='Change Treasury Hotkey',
@@ -258,13 +258,13 @@ def admin_set_treasury(
         return
 
     try:
-        with console.status('[bold cyan]Updating treasury hotkey...', spinner='dots'):
+        with err_console.status('[bold cyan]Updating treasury hotkey...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             result = client.set_treasury_hotkey(new_treasury, wallet)
 
         if result:
             print_success(f'Treasury hotkey updated to {new_treasury}!')
-            console.print(
+            err_console.print(
                 '[dim]Note: Issue bounty amounts have been reset. Run harvest to re-fund from new treasury.[/dim]'
             )
         else:
@@ -301,7 +301,7 @@ def admin_add_validator(
 
     print_network_header(network_name, contract_addr)
 
-    console.print(
+    err_console.print(
         Panel(
             f'[cyan]Validator Hotkey:[/cyan] {hotkey}',
             title='Add Validator',
@@ -313,7 +313,7 @@ def admin_add_validator(
         return
 
     try:
-        with console.status('[bold cyan]Adding validator...', spinner='dots'):
+        with err_console.status('[bold cyan]Adding validator...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             result = client.add_validator(hotkey, wallet)
 
@@ -321,9 +321,9 @@ def admin_add_validator(
             print_success(f'Validator {hotkey} added to whitelist!')
         else:
             print_error('Failed to add validator.')
-            console.print('[yellow]Possible reasons:[/yellow]')
-            console.print('  \u2022 Caller is not the contract owner')
-            console.print('  \u2022 Validator is already whitelisted')
+            err_console.print('[yellow]Possible reasons:[/yellow]')
+            err_console.print('  \u2022 Caller is not the contract owner')
+            err_console.print('  \u2022 Validator is already whitelisted')
             raise SystemExit(1)
     except Exception as e:
         _handle_command_error(e)
@@ -355,7 +355,7 @@ def admin_remove_validator(
 
     print_network_header(network_name, contract_addr)
 
-    console.print(
+    err_console.print(
         Panel(
             f'[cyan]Validator Hotkey:[/cyan] {hotkey}',
             title='Remove Validator',
@@ -367,7 +367,7 @@ def admin_remove_validator(
         return
 
     try:
-        with console.status('[bold cyan]Removing validator...', spinner='dots'):
+        with err_console.status('[bold cyan]Removing validator...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             result = client.remove_validator(hotkey, wallet)
 
@@ -375,9 +375,9 @@ def admin_remove_validator(
             print_success(f'Validator {hotkey} removed from whitelist!')
         else:
             print_error('Failed to remove validator.')
-            console.print('[yellow]Possible reasons:[/yellow]')
-            console.print('  \u2022 Caller is not the contract owner')
-            console.print('  \u2022 Validator is not in the whitelist')
+            err_console.print('[yellow]Possible reasons:[/yellow]')
+            err_console.print('  \u2022 Caller is not the contract owner')
+            err_console.print('  \u2022 Validator is not in the whitelist')
             raise SystemExit(1)
     except Exception as e:
         _handle_command_error(e)

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -53,6 +53,7 @@ STATUS_COLORS: Dict[str, str] = {
 
 
 console = Console()
+err_console = Console(stderr=True)
 
 CommandFunc = TypeVar('CommandFunc', bound=Callable[..., Any])
 NETWORK_CHOICE = click.Choice(['finney', 'test', 'local'], case_sensitive=False)
@@ -179,18 +180,18 @@ def colorize_status(status: str) -> str:
 
 
 def print_success(message: str) -> None:
-    """Print a standardized success message."""
-    console.print(f'\n[green]\u2713 {message}[/green]\n', highlight=True)
+    """Print a success status message to stderr."""
+    err_console.print(f'\n[green]\u2713 {message}[/green]\n', highlight=True)
 
 
 def print_error(message: str) -> None:
     """Print a standardized error message."""
-    console.print(f'\n[red]\u2717 {message}[/red]\n', highlight=True)
+    err_console.print(f'\n[red]\u2717 {message}[/red]\n', highlight=True)
 
 
 def print_warning(message: str) -> None:
     """Print a warning message."""
-    console.print(f'\n[yellow]{message}[/yellow]\n', highlight=True)
+    err_console.print(f'\n[yellow]{message}[/yellow]\n', highlight=True)
 
 
 def emit_error_json(message: str, error_type: str = 'cli_error') -> None:
@@ -238,14 +239,14 @@ def loading_context(message: str, as_json: bool, spinner: str = 'dots', color='c
     return (
         nullcontext()
         if as_json
-        else console.status(f'[{color}]{message}[/{color}]', spinner=spinner, spinner_style=color)
+        else err_console.status(f'[{color}]{message}[/{color}]', spinner=spinner, spinner_style=color)
     )
 
 
 def print_network_header(network_name: str, contract_addr: str) -> None:
-    """Print a one-line network and contract context header."""
+    """Print a one-line network and contract context header to stderr."""
     short = f'{contract_addr[:12]}...{contract_addr[-6:]}' if len(contract_addr) > 20 else contract_addr
-    console.print(f'Network: {network_name} \u2022 Contract: {short}')
+    err_console.print(f'Network: {network_name} \u2022 Contract: {short}')
 
 
 def _is_interactive() -> bool:
@@ -264,7 +265,7 @@ def confirm_or_abort(prompt: str, yes: bool, default: bool = False) -> bool:
         return True
     if click.confirm(f'\n{prompt}', default=default):
         return True
-    console.print('[yellow]Cancelled.[/yellow]')
+    err_console.print('[yellow]Cancelled.[/yellow]')
     return False
 
 
@@ -420,7 +421,7 @@ def validate_repository(
                         f'status {resp.status_code}',
                         param_hint='--repo',
                     )
-                console.print(
+                err_console.print(
                     f'[yellow]Warning: GitHub API returned {resp.status_code} — skipping existence check[/yellow]'
                 )
         except requests.RequestException as exc:
@@ -431,7 +432,7 @@ def validate_repository(
                     detail,
                     param_hint='--repo',
                 )
-            console.print('[yellow]Warning: Could not reach GitHub API — skipping existence check[/yellow]')
+            err_console.print('[yellow]Warning: Could not reach GitHub API — skipping existence check[/yellow]')
 
     return owner, repo_name
 
@@ -464,7 +465,7 @@ def validate_github_issue(
                 detail,
                 param_hint='--issue',
             )
-        console.print('[yellow]Warning: Could not reach GitHub API — skipping issue check[/yellow]')
+        err_console.print('[yellow]Warning: Could not reach GitHub API — skipping issue check[/yellow]')
         return None
 
     if resp.status_code == 404:
@@ -479,7 +480,7 @@ def validate_github_issue(
                 f'status {resp.status_code}',
                 param_hint='--issue',
             )
-        console.print(f'[yellow]Warning: GitHub API returned {resp.status_code} — skipping issue check[/yellow]')
+        err_console.print(f'[yellow]Warning: GitHub API returned {resp.status_code} — skipping issue check[/yellow]')
         return None
 
     data = resp.json()
@@ -493,9 +494,9 @@ def validate_github_issue(
     state = data.get('state', 'unknown')
     if state != 'open':
         if state == 'closed':
-            console.print(f'[yellow]Warning: Issue #{issue_number} is already closed.[/yellow]')
+            err_console.print(f'[yellow]Warning: Issue #{issue_number} is already closed.[/yellow]')
         else:
-            console.print(f'[yellow]Warning: Issue #{issue_number} is {state}.[/yellow]')
+            err_console.print(f'[yellow]Warning: Issue #{issue_number} is {state}.[/yellow]')
 
     return data
 
@@ -714,22 +715,22 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
         child_key = get_contract_child_storage_key(substrate, contract_addr)
         if not child_key:
             if verbose:
-                console.print('[dim]Debug: Failed to get contract child storage key[/dim]')
+                err_console.print('[dim]Debug: Failed to get contract child storage key[/dim]')
             return None
 
         packed_bytes = read_contract_packed_storage_bytes(substrate, child_key)
         if not packed_bytes:
             if verbose:
-                console.print('[dim]Debug: No packed storage bytes returned[/dim]')
+                err_console.print('[dim]Debug: No packed storage bytes returned[/dim]')
             return None
 
         if verbose:
-            console.print(f'[dim]Debug: Packed storage data length = {len(packed_bytes)} bytes[/dim]')
+            err_console.print(f'[dim]Debug: Packed storage data length = {len(packed_bytes)} bytes[/dim]')
 
         packed = decode_packed_contract_storage(packed_bytes)
         if not packed:
             if verbose:
-                console.print(f'[dim]Debug: Packed storage too small ({len(packed_bytes)} < 74 bytes)[/dim]')
+                err_console.print(f'[dim]Debug: Packed storage too small ({len(packed_bytes)} < 74 bytes)[/dim]')
             return None
 
         return {
@@ -741,7 +742,7 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
         }
     except Exception as e:
         if verbose:
-            console.print(f'[dim]Debug: Failed to read packed storage: {e}[/dim]')
+            err_console.print(f'[dim]Debug: Failed to read packed storage: {e}[/dim]')
         return None
 
 
@@ -763,35 +764,35 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
         child_key = get_contract_child_storage_key(substrate, contract_addr)
     except Exception as e:
         if verbose:
-            console.print(f'[dim]Debug: Contract info query failed: {e}[/dim]')
+            err_console.print(f'[dim]Debug: Contract info query failed: {e}[/dim]')
         child_key = None
 
     if not child_key:
         if verbose:
-            console.print(f'[dim]Debug: Cannot read issues - no child storage key for {contract_addr}[/dim]')
+            err_console.print(f'[dim]Debug: Cannot read issues - no child storage key for {contract_addr}[/dim]')
         return []
 
     # First, read packed storage to get next_issue_id
     packed_storage = _read_contract_packed_storage(substrate, contract_addr, verbose)
     if not packed_storage:
         if verbose:
-            console.print('[dim]Debug: Cannot read issues - packed storage read failed[/dim]')
+            err_console.print('[dim]Debug: Cannot read issues - packed storage read failed[/dim]')
         return []
 
     next_issue_id = packed_storage.get('next_issue_id', 1)
     if verbose:
-        console.print(f'[dim]Debug: next_issue_id from contract = {next_issue_id}[/dim]')
+        err_console.print(f'[dim]Debug: next_issue_id from contract = {next_issue_id}[/dim]')
 
     # Sanity check: next_issue_id should be reasonable (< 1 million for any real deployment)
     if next_issue_id > MAX_ISSUE_ID:
-        console.print(f'[yellow]Warning: next_issue_id ({next_issue_id}) is unreasonably large.[/yellow]')
-        console.print('[yellow]This may indicate a storage format mismatch. Check contract version.[/yellow]')
+        err_console.print(f'[yellow]Warning: next_issue_id ({next_issue_id}) is unreasonably large.[/yellow]')
+        err_console.print('[yellow]This may indicate a storage format mismatch. Check contract version.[/yellow]')
         return []
 
     # If next_issue_id is 1, no issues have been registered yet
     if next_issue_id <= 1:
         if verbose:
-            console.print('[dim]Debug: No issues registered (next_issue_id <= 1)[/dim]')
+            err_console.print('[dim]Debug: No issues registered (next_issue_id <= 1)[/dim]')
         return []
 
     issues = []
@@ -800,7 +801,7 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
     # Iterate through all issue IDs (1 to next_issue_id - 1)
     # Issues mapping root key is '52789899'
     if verbose:
-        console.print(f'[dim]Debug: Reading issues 1 to {next_issue_id - 1} using mapping key 52789899[/dim]')
+        err_console.print(f'[dim]Debug: Reading issues 1 to {next_issue_id - 1} using mapping key 52789899[/dim]')
 
     for issue_id in range(1, next_issue_id):
         # SCALE encode u64 as little-endian 8 bytes
@@ -810,7 +811,9 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
         val_result = substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
         if not val_result.get('result'):
             if verbose:
-                console.print(f'[dim]Debug: No storage found for issue_id={issue_id} (key={lazy_key[:20]}...)[/dim]')
+                err_console.print(
+                    f'[dim]Debug: No storage found for issue_id={issue_id} (key={lazy_key[:20]}...)[/dim]'
+                )
             continue
 
         data = bytes.fromhex(val_result['result'].replace('0x', ''))
@@ -832,13 +835,13 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
                 }
             )
             if verbose:
-                console.print(
+                err_console.print(
                     f'[dim]Debug: Decoded issue {decoded.id}: '
                     f'{decoded.repository_full_name}#{decoded.issue_number}[/dim]'
                 )
         except Exception as e:
             if verbose:
-                console.print(f'[dim]Debug: Failed to decode issue {issue_id}: {e}[/dim]')
+                err_console.print(f'[dim]Debug: Failed to decode issue {issue_id}: {e}[/dim]')
             continue
 
     # Sort by ID
@@ -886,25 +889,25 @@ def read_issues_from_contract(ws_endpoint: str, contract_addr: str, verbose: boo
         from substrateinterface import SubstrateInterface
 
         if verbose:
-            console.print(f'[dim]Debug: Connecting to {ws_endpoint}...[/dim]')
+            err_console.print(f'[dim]Debug: Connecting to {ws_endpoint}...[/dim]')
 
         # Connect to subtensor
         substrate = SubstrateInterface(url=ws_endpoint)
 
         if verbose:
-            console.print('[dim]Debug: Connected successfully[/dim]')
+            err_console.print('[dim]Debug: Connected successfully[/dim]')
 
         # Read issues directly from child storage
         return _read_issues_from_child_storage(substrate, contract_addr, verbose)
 
     except ImportError as e:
-        console.print(f'[yellow]Cannot read from contract: {e}[/yellow]')
-        console.print('[dim]Install with: uv sync[/dim]')
+        err_console.print(f'[yellow]Cannot read from contract: {e}[/yellow]')
+        err_console.print('[dim]Install with: uv sync[/dim]')
         return []
     except Exception as e:
         if verbose:
-            console.print(f'[dim]Debug: Connection/read error: {e}[/dim]')
-        console.print(f'[yellow]Error reading from contract: {e}[/yellow]')
+            err_console.print(f'[dim]Debug: Connection/read error: {e}[/dim]')
+        err_console.print(f'[yellow]Error reading from contract: {e}[/yellow]')
         return []
 
 

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -21,6 +21,7 @@ from .helpers import (
     _is_interactive,
     _resolve_contract_and_network,
     console,
+    err_console,
     format_alpha,
     load_config,
     print_error,
@@ -30,6 +31,14 @@ from .helpers import (
     validate_github_issue,
     validate_repository,
 )
+
+
+def _print_register_revert_hints() -> None:
+    print_error('Contract rejected the request')
+    err_console.print('[yellow]Possible reasons:[/yellow]')
+    err_console.print('  • Issue already registered (same repo + issue number)')
+    err_console.print('  • Bounty too low (minimum 10 ALPHA)')
+    err_console.print('  • Caller is not the contract owner')
 
 
 @click.command('register', cls=StyledCommand)
@@ -117,7 +126,7 @@ def issue_register(
         $ gitt i reg --repo owner/repo --issue 1 --bounty 10 -y
     [/dim]
     """
-    console.print('\n[bold cyan]Register Issue for Bounty[/bold cyan]\n')
+    err_console.print('\n[bold cyan]Register Issue for Bounty[/bold cyan]\n')
 
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(
         contract,
@@ -146,7 +155,7 @@ def issue_register(
 
     github_url = f'https://github.com/{repo}/issues/{issue_number}'
 
-    console.print(
+    err_console.print(
         Panel(
             f'[cyan]Repository:[/cyan] {repo}\n'
             f'[cyan]Issue Number:[/cyan] #{issue_number}\n'
@@ -162,7 +171,7 @@ def issue_register(
 
     skip_confirm = yes or not _is_interactive()
     if not skip_confirm and not click.confirm('\nProceed with registration?', default=True):
-        console.print('[yellow]Registration cancelled.[/yellow]')
+        err_console.print('[yellow]Registration cancelled.[/yellow]')
         return
 
     try:
@@ -170,7 +179,7 @@ def issue_register(
         from substrateinterface import Keypair, SubstrateInterface
         from substrateinterface.contracts import ContractInstance
 
-        with console.status('[bold cyan]Connecting to network...', spinner='dots'):
+        with err_console.status('[bold cyan]Connecting to network...', spinner='dots'):
             substrate = SubstrateInterface(url=ws_endpoint)
 
         # CLI flags override config; fall back to config if not explicitly supplied
@@ -179,11 +188,11 @@ def issue_register(
 
         # For local development, check config first, then fall back to //Alice
         if network_name.lower() == 'local' and effective_wallet == 'default' and effective_hotkey == 'default':
-            console.print('[dim]Using //Alice for local development (no config set)...[/dim]')
+            err_console.print('[dim]Using //Alice for local development (no config set)...[/dim]')
             keypair = Keypair.create_from_uri('//Alice')
         else:
             # Load wallet from config or CLI args
-            console.print(f'[dim]Loading wallet {effective_wallet}/{effective_hotkey}...[/dim]')
+            err_console.print(f'[dim]Loading wallet {effective_wallet}/{effective_hotkey}...[/dim]')
             wallet = bt.Wallet(name=effective_wallet, hotkey=effective_hotkey)
             # Use COLDKEY for owner-only operations (register_issue requires owner)
             # Contract owner is set to deployer's coldkey during contract instantiation
@@ -209,7 +218,7 @@ def issue_register(
             substrate=substrate,
         )
 
-        console.print('[dim]Submitting transaction...[/dim]')
+        err_console.print('[dim]Submitting transaction...[/dim]')
 
         result = contract_instance.exec(
             keypair,  # type: ignore[arg-type]
@@ -229,11 +238,7 @@ def issue_register(
             is_revert = error_info and isinstance(error_info, dict) and error_info.get('name') == 'ContractReverted'
 
             if is_revert:
-                print_error('Contract rejected the request')
-                console.print('[yellow]Possible reasons:[/yellow]')
-                console.print('  \u2022 Issue already registered (same repo + issue number)')
-                console.print('  \u2022 Bounty too low (minimum 10 ALPHA)')
-                console.print('  \u2022 Caller is not the contract owner')
+                _print_register_revert_hints()
             elif error_info:
                 print_error(str(error_info))
 
@@ -242,20 +247,16 @@ def issue_register(
 
         print_success('Issue registered successfully!')
         console.print(f'[cyan]Transaction Hash:[/cyan] {result.extrinsic_hash}')
-        console.print('[dim]Issue will be visible once bounty is funded via harvest_emissions()[/dim]')
+        err_console.print('[dim]Issue will be visible once bounty is funded via harvest_emissions()[/dim]')
 
     except ImportError as e:
         print_error(f'Missing dependency - {e}')
-        console.print('[dim]Install with: uv sync[/dim]')
+        err_console.print('[dim]Install with: uv sync[/dim]')
         raise SystemExit(1)
     except Exception as e:
         error_msg = str(e)
         if 'ContractReverted' in error_msg:
-            print_error('Contract rejected the request')
-            console.print('[yellow]Possible reasons:[/yellow]')
-            console.print('  \u2022 Issue already registered (same repo + issue number)')
-            console.print('  \u2022 Bounty too low (minimum 10 ALPHA)')
-            console.print('  \u2022 Caller is not the contract owner')
+            _print_register_revert_hints()
         else:
             print_error(f'Error registering issue: {e}')
         raise SystemExit(1)
@@ -307,7 +308,7 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
         $ gitt harvest --wallet-name mywallet --wallet-hotkey mykey
     [/dim]
     """
-    console.print('\n[bold cyan]Manual Emission Harvest[/bold cyan]\n')
+    err_console.print('\n[bold cyan]Manual Emission Harvest[/bold cyan]\n')
 
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(
         contract,
@@ -317,7 +318,7 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
     )
 
     print_network_header(network_name, contract_addr)
-    console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey}[/dim]\n')
+    err_console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey}[/dim]\n')
 
     try:
         import bittensor as bt
@@ -326,23 +327,23 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
             IssueCompetitionContractClient,
         )
 
-        with console.status('[bold cyan]Loading wallet...', spinner='dots'):
+        with err_console.status('[bold cyan]Loading wallet...', spinner='dots'):
             wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
             hotkey_addr = wallet.hotkey.ss58_address
-        console.print(f'[green]Hotkey address:[/green] {hotkey_addr}')
+        err_console.print(f'[green]Hotkey address:[/green] {hotkey_addr}')
 
-        with console.status('[bold cyan]Connecting to network...', spinner='dots'):
+        with err_console.status('[bold cyan]Connecting to network...', spinner='dots'):
             subtensor = bt.Subtensor(network=ws_endpoint)
 
         # Show wallet balance (informational only)
         if verbose:
             try:
                 balance = subtensor.get_balance(hotkey_addr)
-                console.print(f'[dim]Wallet balance: {balance}[/dim]')
+                err_console.print(f'[dim]Wallet balance: {balance}[/dim]')
             except Exception as e:
-                console.print(f'[dim]Could not fetch balance: {e}[/dim]')
+                err_console.print(f'[dim]Could not fetch balance: {e}[/dim]')
 
-        with console.status('[bold cyan]Initializing contract client...', spinner='dots'):
+        with err_console.status('[bold cyan]Initializing contract client...', spinner='dots'):
             client = IssueCompetitionContractClient(
                 contract_address=contract_addr,
                 subtensor=subtensor,
@@ -350,57 +351,57 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
 
         if verbose:
             # Show contract state
-            console.print('[dim]Reading contract state...[/dim]')
+            err_console.print('[dim]Reading contract state...[/dim]')
             try:
                 alpha_pool = client.get_alpha_pool()
                 pending = client.get_treasury_stake()
                 last_harvest = client.get_last_harvest_block()
                 current_block = subtensor.get_current_block()
 
-                console.print(f'[dim]Alpha pool: {format_alpha(alpha_pool, 4)} ALPHA[/dim]')
-                console.print(f'[dim]Treasury stake: {format_alpha(pending, 4)} ALPHA[/dim]')
-                console.print(f'[dim]Last harvest block: {last_harvest}[/dim]')
-                console.print(f'[dim]Current block: {current_block}[/dim]')
+                err_console.print(f'[dim]Alpha pool: {format_alpha(alpha_pool, 4)} ALPHA[/dim]')
+                err_console.print(f'[dim]Treasury stake: {format_alpha(pending, 4)} ALPHA[/dim]')
+                err_console.print(f'[dim]Last harvest block: {last_harvest}[/dim]')
+                err_console.print(f'[dim]Current block: {current_block}[/dim]')
                 if last_harvest > 0:
-                    console.print(f'[dim]Blocks since harvest: {current_block - last_harvest}[/dim]')
+                    err_console.print(f'[dim]Blocks since harvest: {current_block - last_harvest}[/dim]')
             except Exception as e:
-                console.print(f'[yellow]Warning: Could not read contract state: {e}[/yellow]')
+                err_console.print(f'[yellow]Warning: Could not read contract state: {e}[/yellow]')
 
-        with console.status('[bold cyan]Calling harvest_emissions()...', spinner='dots'):
+        with err_console.status('[bold cyan]Calling harvest_emissions()...', spinner='dots'):
             result = client.harvest_emissions(wallet)
 
         if result:
             if result.get('status') == 'success':
                 print_success('Harvest succeeded!')
                 console.print(f'[cyan]Transaction hash:[/cyan] {result.get("tx_hash", "N/A")}')
-                console.print('[dim]Treasury stake processed. Excess emissions recycled if any.[/dim]')
+                err_console.print('[dim]Treasury stake processed. Excess emissions recycled if any.[/dim]')
             elif result.get('status') == 'partial':
-                console.print('\n[yellow]Harvest completed but recycling failed[/yellow]')
+                err_console.print('\n[yellow]Harvest completed but recycling failed[/yellow]')
                 console.print(f'[cyan]Transaction hash:[/cyan] {result.get("tx_hash", "N/A")}')
                 print_error(result.get('error', 'Unknown'))
-                console.print('[dim]Check proxy permissions: contract needs NonCritical proxy.[/dim]')
+                err_console.print('[dim]Check proxy permissions: contract needs NonCritical proxy.[/dim]')
                 raise SystemExit(1)
             elif result.get('status') in {'failed', 'error'}:
                 print_error(f'Harvest failed: {result.get("error", "Unknown error")}')
                 raise SystemExit(1)
             else:
-                console.print(f'\n[yellow]Harvest result: {result}[/yellow]')
+                err_console.print(f'\n[yellow]Harvest result: {result}[/yellow]')
                 raise SystemExit(1)
         else:
             print_error('Harvest returned None — check logs for details.')
-            console.print('[dim]Run with --verbose for more information.[/dim]')
+            err_console.print('[dim]Run with --verbose for more information.[/dim]')
             raise SystemExit(1)
 
     except ImportError as e:
         print_error(f'Missing dependency — {e}')
-        console.print('[dim]Install with: uv sync[/dim]')
+        err_console.print('[dim]Install with: uv sync[/dim]')
         raise SystemExit(1)
     except Exception as e:
         import traceback
 
         print_error(f'{type(e).__name__}: {e}')
         if verbose:
-            console.print(f'[dim]Full traceback:\n{traceback.format_exc()}[/dim]')
+            err_console.print(f'[dim]Full traceback:\n{traceback.format_exc()}[/dim]')
         else:
-            console.print('[dim]Run with --verbose for full traceback.[/dim]')
+            err_console.print('[dim]Run with --verbose for full traceback.[/dim]')
         raise SystemExit(1)

--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -65,8 +65,7 @@ def issues_submissions(
     if not contract_addr:
         handle_exception(as_json, 'Contract address not configured.', 'config_error')
 
-    if not as_json:
-        print_network_header(network_name, contract_addr)
+    print_network_header(network_name, contract_addr)
 
     try:
         with loading_context('Fetching issue from contract...', as_json):

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -25,8 +25,10 @@ from .helpers import (
     colorize_status,
     console,
     emit_json,
+    err_console,
     format_alpha,
     handle_exception,
+    loading_context,
     print_network_header,
     read_issues_from_contract,
     validate_issue_id,
@@ -93,10 +95,9 @@ def issues_list(
         missing_contract_message='Contract address not configured. Set via: gitt config set contract_address <ADDR>.',
     )
 
-    if not as_json:
-        print_network_header(network_name, contract_addr)
+    print_network_header(network_name, contract_addr)
 
-    with console.status('[bold cyan]Reading issues from contract...', spinner='dots'):
+    with loading_context('Reading issues from contract...', as_json):
         issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
 
     if as_json:
@@ -148,7 +149,7 @@ def issues_list(
         issues = [i for i in issues if i.get('repository_full_name', '').lower() == repo_filter.lower()]
 
     # Table view of all issues
-    console.print('[bold cyan]Available Issues[/bold cyan]\n')
+    err_console.print('[bold cyan]Available Issues[/bold cyan]\n')
 
     table = Table(show_header=True, header_style='bold magenta')
     table.add_column('ID', style='cyan', justify='right')
@@ -205,11 +206,11 @@ def issues_list(
                 colorize_status(status),
             )
         console.print(table)
-        console.print(f'\n[dim]Showing {len(issues)} issue(s)[/dim]')
-        console.print('[dim]Bounty Pool shows: filled/target (percentage)[/dim]')
+        err_console.print(f'\n[dim]Showing {len(issues)} issue(s)[/dim]')
+        err_console.print('[dim]Bounty Pool shows: filled/target (percentage)[/dim]')
     else:
-        console.print('[yellow]No issues found.[/yellow]')
-        console.print('[dim]Register an issue: gitt issues register --repo owner/repo --issue 1 --bounty 100[/dim]')
+        err_console.print('[yellow]No issues found.[/yellow]')
+        err_console.print('[dim]Register an issue: gitt issues register --repo owner/repo --issue 1 --bounty 100[/dim]')
 
 
 @click.command('bounty-pool', cls=StyledCommand)
@@ -225,13 +226,12 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    if not as_json:
-        print_network_header(network_name, contract_addr)
+    print_network_header(network_name, contract_addr)
 
     try:
         from substrateinterface import SubstrateInterface
 
-        with console.status('[bold cyan]Reading contract storage...', spinner='dots'):
+        with loading_context('Reading contract storage...', as_json):
             substrate = SubstrateInterface(url=ws_endpoint)
             issues = _read_issues_from_child_storage(substrate, contract_addr, verbose)
 
@@ -251,7 +251,7 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         console.print(
             f'[green]Issue Bounty Pool:[/green] {format_alpha(total_bounty_pool, 4)} ALPHA ({total_bounty_pool} raw)'
         )
-        console.print(f'[dim]Sum of bounty amounts from {len(issues)} issue(s)[/dim]')
+        err_console.print(f'[dim]Sum of bounty amounts from {len(issues)} issue(s)[/dim]')
     except Exception as e:
         handle_exception(as_json=as_json, message=str(e))
 
@@ -269,8 +269,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    if not as_json:
-        print_network_header(network_name, contract_addr)
+    print_network_header(network_name, contract_addr)
 
     try:
         import bittensor as bt
@@ -280,7 +279,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
             IssueCompetitionContractClient,
         )
 
-        with console.status('[bold cyan]Reading treasury and contract data...', spinner='dots'):
+        with loading_context('Reading treasury and contract data...', as_json):
             subtensor = bt.Subtensor(network=ws_endpoint)
             client = IssueCompetitionContractClient(
                 contract_address=contract_addr,
@@ -328,13 +327,12 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    if not as_json:
-        print_network_header(network_name, contract_addr)
+    print_network_header(network_name, contract_addr)
 
     try:
         from substrateinterface import SubstrateInterface
 
-        with console.status('[bold cyan]Reading contract configuration...', spinner='dots'):
+        with loading_context('Reading contract configuration...', as_json):
             substrate = SubstrateInterface(url=ws_endpoint)
             packed = _read_contract_packed_storage(substrate, contract_addr, verbose)
 
@@ -357,8 +355,8 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
             msg = 'Could not read contract configuration.'
             if as_json:
                 handle_exception(as_json=as_json, message=msg, error_type='read_failed')
-            console.print(f'[yellow]{msg}[/yellow]')
-            console.print('[dim]Try running with --verbose to see debug details.[/dim]')
+            err_console.print(f'[yellow]{msg}[/yellow]')
+            err_console.print('[dim]Try running with --verbose to see debug details.[/dim]')
             raise SystemExit(1)
     except Exception as e:
         handle_exception(as_json=as_json, message=str(e))

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -24,7 +24,9 @@ from .helpers import (
     confirm_or_abort,
     console,
     emit_json,
+    err_console,
     handle_exception,
+    loading_context,
     print_error,
     print_network_header,
     print_success,
@@ -126,7 +128,7 @@ def val_vote_solution(
 
     print_network_header(network_name, contract_addr)
 
-    console.print(
+    err_console.print(
         Panel(
             f'[cyan]Issue ID:[/cyan] {issue_id}\n'
             f'[cyan]Solver Hotkey:[/cyan] {solver_hotkey}\n'
@@ -141,7 +143,7 @@ def val_vote_solution(
         return
 
     try:
-        with console.status('[bold cyan]Submitting vote...', spinner='dots'):
+        with err_console.status('[bold cyan]Submitting vote...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             result = client.vote_solution(issue_id, solver_hotkey, solver_coldkey, pr_number, wallet)
 
@@ -188,7 +190,7 @@ def val_vote_cancel_issue(
 
     print_network_header(network_name, contract_addr)
 
-    console.print(
+    err_console.print(
         Panel(
             f'[cyan]Issue ID:[/cyan] {issue_id}\n[cyan]Reason:[/cyan] {reason}',
             title='Vote Cancel Issue',
@@ -200,7 +202,7 @@ def val_vote_cancel_issue(
         return
 
     try:
-        with console.status('[bold cyan]Submitting cancel vote...', spinner='dots'):
+        with err_console.status('[bold cyan]Submitting cancel vote...', spinner='dots'):
             wallet, client = _make_contract_client(contract_addr, ws_endpoint, wallet_name, wallet_hotkey)
             result = client.vote_cancel_issue(issue_id, reason, wallet)
 
@@ -227,8 +229,7 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    if not as_json:
-        print_network_header(network_name, contract_addr)
+    print_network_header(network_name, contract_addr)
 
     try:
         import bittensor as bt
@@ -237,7 +238,7 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
             IssueCompetitionContractClient,
         )
 
-        with console.status('[bold cyan]Reading validator whitelist...', spinner='dots'):
+        with loading_context('Reading validator whitelist...', as_json):
             subtensor = bt.Subtensor(network=ws_endpoint)
             client = IssueCompetitionContractClient(
                 contract_address=contract_addr,
@@ -271,8 +272,8 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
             console.print(f'\n[green]Validators:[/green] {n}')
             console.print(f'[green]Consensus threshold:[/green] {required} of {n} votes required')
         else:
-            console.print('[yellow]No validators whitelisted.[/yellow]')
-            console.print('[dim]Add validators with: gitt admin add-vali <HOTKEY>[/dim]')
+            err_console.print('[yellow]No validators whitelisted.[/yellow]')
+            err_console.print('[dim]Add validators with: gitt admin add-vali <HOTKEY>[/dim]')
 
     except Exception as e:
         handle_exception(as_json=as_json, message=str(e))

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -34,15 +34,12 @@ if os.environ.get('_GITT_COMPLETE') or any(arg in ('-h', '--help') for arg in sy
 
 import click
 from click.shell_completion import get_completion_class
-from rich.console import Console
 from rich.table import Table
 
 from gittensor import __version__
 from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
-from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR
-
-console = Console()
+from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR, console, err_console
 
 
 @click.group(cls=StyledAliasGroup)
@@ -63,11 +60,11 @@ def config_group(ctx):
 
 def show_config():
     """Show current CLI configuration"""
-    console.print('\n[bold]Gittensor CLI Configuration[/bold]\n')
+    err_console.print('\n[bold]Gittensor CLI Configuration[/bold]\n')
 
     if not CONFIG_FILE.exists():
-        console.print('[yellow]No config file found at ~/.gittensor/config.json[/yellow]')
-        console.print('[dim]Run ./up.sh --issues to create config[/dim]')
+        err_console.print('[yellow]No config file found at ~/.gittensor/config.json[/yellow]')
+        err_console.print('[dim]Run ./up.sh --issues to create config[/dim]')
         return
 
     try:
@@ -85,12 +82,12 @@ def show_config():
             table.add_row(key, str_val)
 
         console.print(table)
-        console.print(f'\n[dim]Config file: {CONFIG_FILE}[/dim]\n')
+        err_console.print(f'\n[dim]Config file: {CONFIG_FILE}[/dim]\n')
 
     except json.JSONDecodeError:
-        console.print('[red]Error: Invalid JSON in config file[/red]')
+        err_console.print('[red]Error: Invalid JSON in config file[/red]')
     except Exception as e:
-        console.print(f'[red]Error reading config: {e}[/red]')
+        err_console.print(f'[red]Error reading config: {e}[/red]')
 
 
 CONFIG_KEYS = ('wallet', 'hotkey', 'network', 'contract_address', 'ws_endpoint')
@@ -131,7 +128,7 @@ def config_set(key: str, value: str):
         try:
             config = json.loads(CONFIG_FILE.read_text())
         except json.JSONDecodeError:
-            console.print('[yellow]Warning: Existing config was invalid, starting fresh[/yellow]')
+            err_console.print('[yellow]Warning: Existing config was invalid, starting fresh[/yellow]')
 
     # Set the value
     old_value = config.get(key)
@@ -141,9 +138,9 @@ def config_set(key: str, value: str):
     CONFIG_FILE.write_text(json.dumps(config, indent=2))
 
     if old_value is not None:
-        console.print(f'[green]Updated {key}:[/green] {old_value} → {value}')
+        err_console.print(f'[green]Updated {key}:[/green] {old_value} → {value}')
     else:
-        console.print(f'[green]Set {key}:[/green] {value}')
+        err_console.print(f'[green]Set {key}:[/green] {value}')
 
 
 def _detect_shell():

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -7,7 +7,6 @@ import json
 import sys
 
 import click
-from rich.console import Console
 from rich.table import Table
 
 from .helpers import (
@@ -25,9 +24,8 @@ from .helpers import (
     _require_validator_axons,
     _resolve_endpoint,
     _status,
+    console,
 )
-
-console = Console()
 
 _PAT_CHECK_STATUS_MARKUP = {
     'valid': '[green]✓ valid[/green]',
@@ -75,10 +73,10 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, min_vtrust
     wallet_hotkey = wallet_hotkey or _load_config_value('hotkey') or 'default'
     ws_endpoint = _resolve_endpoint(network, rpc_url)
 
-    _print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]', json_mode)
+    _print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 2. Set up bittensor objects
-    with _status('[bold]Connecting to network...', json_mode):
+    with _status('[bold]Connecting to network...'):
         try:
             wallet, subtensor, metagraph, dendrite = _connect_bittensor(wallet_name, wallet_hotkey, ws_endpoint, netuid)
         except Exception as e:
@@ -104,7 +102,7 @@ def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, min_vtrust
             timeout=15.0,
         )
 
-    with _status(f'[bold]Checking {len(validator_axons)} validators...', json_mode):
+    with _status(f'[bold]Checking {len(validator_axons)} validators...'):
         responses = asyncio.run(_check())
 
     # 5. Collect results

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 import sys
 from collections import Counter
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +17,7 @@ from rich.table import Table
 from gittensor.constants import NETWORK_MAP
 
 console = Console()
+err_console = Console(stderr=True)
 
 NETUID_DEFAULT = 74
 DEFAULT_MIN_VALIDATOR_VTRUST = 0.25
@@ -98,15 +98,14 @@ def _connect_bittensor(wallet_name: str, wallet_hotkey: str, ws_endpoint: str, n
     return w, st, mg, dd
 
 
-def _status(message: str, json_mode: bool):
-    """Rich spinner in TTY mode, no-op in JSON mode."""
-    return nullcontext() if json_mode else console.status(message)
+def _status(message: str):
+    """Rich spinner bound to stderr so it never pollutes JSON stdout."""
+    return err_console.status(message)
 
 
-def _print(message: str, json_mode: bool) -> None:
-    """Print a message in TTY mode; no-op in JSON mode."""
-    if not json_mode:
-        console.print(message)
+def _print(message: str) -> None:
+    """Print a status/info message to stderr (safe under --json-output)."""
+    err_console.print(message)
 
 
 def _error(msg: str, json_mode: bool) -> None:
@@ -114,7 +113,7 @@ def _error(msg: str, json_mode: bool) -> None:
     if json_mode:
         click.echo(json.dumps({'success': False, 'error': msg}))
     else:
-        console.print(f'[red]Error: {msg}[/red]')
+        err_console.print(f'[red]Error: {msg}[/red]')
 
 
 def _require_registered(wallet, metagraph, netuid: int, json_mode: bool) -> None:

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -11,7 +11,6 @@ import sys
 
 import click
 import requests
-from rich.console import Console
 from rich.table import Table
 
 from gittensor.cli.miner_commands.helpers import (
@@ -29,11 +28,11 @@ from gittensor.cli.miner_commands.helpers import (
     _require_validator_axons,
     _resolve_endpoint,
     _status,
+    console,
+    err_console,
 )
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
-
-console = Console()
 
 _PAT_POST_STATUS_MARKUP = {
     'accepted': '[green]✓[/green]',
@@ -97,24 +96,24 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         pat = click.prompt('Enter your GitHub Personal Access Token', hide_input=True)
 
     # 1b. Validate PAT locally
-    with _status('[bold]Validating PAT...', json_mode):
+    with _status('[bold]Validating PAT...'):
         pat_valid = _validate_pat_locally(pat)
 
     if not pat_valid:
         _error('GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.', json_mode)
         sys.exit(1)
 
-    _print('[green]PAT is valid.[/green]', json_mode)
+    _print('[green]PAT is valid.[/green]')
 
     # 2. Resolve wallet and network
     wallet_name = wallet_name or _load_config_value('wallet') or 'default'
     wallet_hotkey = wallet_hotkey or _load_config_value('hotkey') or 'default'
     ws_endpoint = _resolve_endpoint(network, rpc_url)
 
-    _print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]', json_mode)
+    _print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
 
     # 3. Set up bittensor objects
-    with _status('[bold]Connecting to network...', json_mode):
+    with _status('[bold]Connecting to network...'):
         try:
             wallet, subtensor, metagraph, dendrite = _connect_bittensor(wallet_name, wallet_hotkey, ws_endpoint, netuid)
         except Exception as e:
@@ -140,7 +139,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
             timeout=30.0,
         )
 
-    with _status(f'[bold]Broadcasting to {len(validator_axons)} validators...', json_mode):
+    with _status(f'[bold]Broadcasting to {len(validator_axons)} validators...'):
         responses = asyncio.run(_broadcast())
 
     # 6. Collect results
@@ -211,7 +210,7 @@ def _validate_pat_locally(pat: str) -> bool:
             timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
         if gql_resp.status_code != 200:
-            console.print(
+            err_console.print(
                 '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
             )
             return False

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -264,7 +264,7 @@ class TestValidateGitHubIssue:
             },
         )()
         with patch('gittensor.cli.issue_commands.helpers.requests.get', return_value=mock_resp):
-            with patch('gittensor.cli.issue_commands.helpers.console.print') as mock_print:
+            with patch('gittensor.cli.issue_commands.helpers.err_console.print') as mock_print:
                 result = validate_github_issue('owner', 'repo', 42)
         assert result == issue_data
         mock_print.assert_called_once()
@@ -340,7 +340,7 @@ class TestRequireVerifiedExistsGitHubIssue:
             'gittensor.cli.issue_commands.helpers.requests.get',
             return_value=_fake_response(503),
         ):
-            with patch('gittensor.cli.issue_commands.helpers.console.print'):
+            with patch('gittensor.cli.issue_commands.helpers.err_console.print'):
                 result = validate_github_issue('owner', 'repo', 42)
         assert result is None
 
@@ -400,7 +400,7 @@ class TestRequireVerifiedExistsRepository:
             'gittensor.cli.issue_commands.helpers.requests.get',
             return_value=_fake_response(503),
         ):
-            with patch('gittensor.cli.issue_commands.helpers.console.print') as mock_print:
+            with patch('gittensor.cli.issue_commands.helpers.err_console.print') as mock_print:
                 owner, name = validate_repository('owner/repo')
         assert owner == 'owner'
         assert name == 'repo'

--- a/tests/cli/test_cli_json_error_output.py
+++ b/tests/cli/test_cli_json_error_output.py
@@ -45,7 +45,7 @@ def test_cli_commands_emit_json_on_exception(cli_root, runner, argv):
         result = runner.invoke(cli_root, argv, catch_exceptions=False)
 
     assert result.exit_code == 1
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload['success'] is False
     assert FORCED_MESSAGE in payload['error']['message']
 
@@ -63,7 +63,7 @@ def test_admin_info_emits_json_on_soft_read_failure(cli_root, runner):
         result = runner.invoke(cli_root, ['admin', 'info', '--json'], catch_exceptions=False)
 
     assert result.exit_code == 1
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload['success'] is False
     assert payload['error']['type'] == 'read_failed'
 

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -21,9 +21,9 @@ def test_submissions_json_schema_is_stable(cli_root, runner, sample_issue, sampl
         )
 
     assert result.exit_code == 0
-    assert '\x1b[' not in result.output
+    assert '\x1b[' not in result.stdout
 
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert set(payload.keys()) == {
         'success',
         'issue_id',
@@ -73,7 +73,7 @@ def test_submissions_json_handles_missing_closing_numbers(cli_root, runner, samp
         )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload['submission_count'] == 1
     assert payload['submissions'][0]['closes_issue'] is False
 
@@ -87,7 +87,7 @@ def test_submissions_json_missing_contract_returns_config_error(cli_root, runner
         )
 
     assert result.exit_code != 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload['success'] is False
     assert payload['error']['type'] == 'config_error'
     assert 'Contract address not configured' in payload['error']['message']
@@ -101,7 +101,7 @@ def test_submissions_json_invalid_issue_id_returns_bad_parameter(cli_root, runne
             catch_exceptions=False,
         )
         assert result.exit_code != 0
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert payload['success'] is False
         assert payload['error']['type'] == 'bad_parameter'
 

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -33,7 +33,7 @@ def test_issues_list_json_missing_issue_returns_structured_error(cli_root, runne
 
     assert result.exit_code != 0
 
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload['success'] is False
     assert payload['error']['type'] == 'not_found'
     assert '999' in payload['error']['message']

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -45,7 +45,7 @@ class TestMinerPost:
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
         result = runner.invoke(cli, ['miner', 'post', '--json-output', '--wallet', 'test', '--hotkey', 'test'])
         assert result.exit_code != 0
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         assert output['success'] is False
 
     @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
@@ -118,7 +118,7 @@ class TestMinerPost:
             )
 
         assert result.exit_code == 0, result.output
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         assert output['total_validators'] == 3
         assert output['accepted'] == 1
         assert output['rejected'] == 1


### PR DESCRIPTION
Closes #956

## Summary

This PR standardizes the output logic: **stdout** only for valuable data, **stderr** for logs/warnings/errors etc. Currently existing inconsistency breaks piping flows, like `gitt issues list --json | jq`, as stdout may be polluted with info which isn't relates to the calculated result.

It's a very common pattern of working with stdout/stderr (see https://clig.dev): 

> **Send output to stdout.** The primary output for your command should go to stdout. Anything that is machine readable should also go to stdout—this is where piping sends things by default.
> **Send messaging to stderr.** Log messages, errors, and so on should all be sent to stderr. This means that when commands are piped together, these messages are displayed to the user and not fed into the next command.

And used in a wide amount of existing tools (`curl`, `gh`, `kubectl` etc).

## Before

- `gitt issues list --json | jq` fails because of polluted stdout

## After

- `gitt issues list --json | jq` succeeds because stdout contains only JSON output, the rest is in stderr

## Test Plan

I can figure something out if necessary, but I'm really unsure whether it should be tested. Tell me if I need to cover this somehow.