### PR TITLE
fix(cli): route all human-facing output to stderr so --json emits clean stdout

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -52,7 +52,11 @@ STATUS_COLORS: Dict[str, str] = {
 }
 
 
-console = Console()
+# All human-facing output (warnings, tables, spinners, etc.) goes to stderr so
+# that JSON payloads emitted via ``emit_json`` (stdout) stay clean.
+# This follows the same convention as ``gh``, ``kubectl`` and similar CLIs.
+console = Console(stderr=True)
+stderr_console = Console(stderr=True)
 
 CommandFunc = TypeVar('CommandFunc', bound=Callable[..., Any])
 NETWORK_CHOICE = click.Choice(['finney', 'test', 'local'], case_sensitive=False)

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -41,7 +41,7 @@ from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR
 
-console = Console()
+console = Console(stderr=True)
 
 
 @click.group(cls=StyledAliasGroup)

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -27,7 +27,7 @@ from .helpers import (
     _status,
 )
 
-console = Console()
+console = Console(stderr=True)
 
 _PAT_CHECK_STATUS_MARKUP = {
     'valid': '[green]✓ valid[/green]',

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -17,7 +17,7 @@ from rich.table import Table
 
 from gittensor.constants import NETWORK_MAP
 
-console = Console()
+console = Console(stderr=True)
 
 NETUID_DEFAULT = 74
 DEFAULT_MIN_VALIDATOR_VTRUST = 0.25

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -33,7 +33,7 @@ from gittensor.cli.miner_commands.helpers import (
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
 
-console = Console()
+console = Console(stderr=True)
 
 _PAT_POST_STATUS_MARKUP = {
     'accepted': '[green]✓[/green]',


### PR DESCRIPTION
## Summary

When running commands with `--json` (e.g. `gitt issues list --json | jq`), any warning or log message printed via Rich Console to stdout would corrupt the JSON payload and cause parse errors in downstream tools.

## Problem

`Console()` defaults to `stdout`. Several code paths (contract read warnings, verbose debug output, missing dependency messages) print to `console` during command execution - even when `--json` is active.

## Fix

Changed every Console() instance across the CLI codebase to Console(stderr=True). Only emit_json() and emit_error_json() continue to write to stdout via click.echo(err=False). This follows the same convention as gh, kubectl, and similar CLIs.

## Testing

Before: non-fatal warning corrupts JSON parse
After: warnings go to stderr, JSON stays clean on stdout

Fixes #956