### PR TITLE
fix(validator): vote cancel when coldkey lookup fails instead of skipping

### DIFF
--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -139,8 +139,19 @@ async def issue_competitions(
                 miner_coldkey = get_miner_coldkey(miner_hotkey, self.subtensor, self.config.netuid)  # type: ignore[attr-defined]
                 if not miner_coldkey:
                     bt.logging.warning(
-                        f'Could not get coldkey for hotkey {miner_hotkey} (solver {solver_github_id}): {issue_label}'
+                        f'Could not get coldkey for hotkey {miner_hotkey} (solver {solver_github_id}): '
+                        f'voting cancel to avoid stuck ACTIVE state — {issue_label}'
                     )
+                    success = contract_client.vote_cancel_issue(
+                        issue_id=issue.id,
+                        reason=f'Coldkey resolution failed for eligible solver {solver_github_id} (hotkey {miner_hotkey[:16]}...)',
+                        wallet=self.wallet,
+                    )
+                    if success:
+                        cancels_cast += 1
+                        bt.logging.info(f'Voted cancel (coldkey lookup failed): {issue_label}')
+                    else:
+                        errors.append(f'Cancel vote failed after coldkey lookup failure for {issue_label}')
                     continue
 
                 bt.logging.info(


### PR DESCRIPTION
## Summary

When an eligible solver is found but `get_miner_coldkey()` returns None (RPC/metagraph lag, registration edge case), the handler previously logged a warning and continued without any on-chain vote. This left the contract issue stuck in ACTIVE state while off-chain state showed it was closed with a valid solver.

## Fix

The coldkey-failure branch now calls `vote_cancel_issue()` with a descriptive reason before continuing, ensuring the contract always advances to a defined terminal state. This matches the behavior of every other "solver not actionable" branch (no solver, solver not eligible, etc.), which all explicitly vote cancel.

Fixes #960