### PR TITLE
fix(mirror): fall back to main and gate head_ref on acceptable set

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -203,6 +203,12 @@ def _should_skip_merged_mirror_pr(scored: ScoredMirrorPR, repo_config: Repositor
     additional = repo_config.additional_acceptable_branches or []
     acceptable = ([pr.default_branch] if pr.default_branch else []) + additional
 
+    # Fall back to 'main' when both default_branch and additional are missing
+    # to match legacy behaviour (should_skip_merged_pr falls back to 'main'
+    # when GraphQL omits defaultBranchRef).
+    if not acceptable:
+        acceptable = ['main']
+
     # base_ref check — only enforce when we have an acceptable set to compare against.
     if acceptable and not branch_matches_pattern(pr.base_ref or '', acceptable):
         return True, (f'PR #{pr.pr_number} merged to {pr.base_ref!r} not in acceptable branches={acceptable}')
@@ -211,7 +217,7 @@ def _should_skip_merged_mirror_pr(scored: ScoredMirrorPR, repo_config: Repositor
     # branch. Only applies to same-repo PRs: fork branch names are arbitrary.
     # Falls through when head_ref or head_repo_full_name is missing (older data).
     is_same_repo = pr.head_repo_full_name is not None and pr.head_repo_full_name == pr.repo_full_name
-    if additional and pr.head_ref and is_same_repo and branch_matches_pattern(pr.head_ref, acceptable):
+    if acceptable and pr.head_ref and is_same_repo and branch_matches_pattern(pr.head_ref, acceptable):
         return True, (
             f'PR #{pr.pr_number} source branch {pr.head_ref!r} is itself in '
             f'acceptable branches — merging between acceptable branches not allowed'


### PR DESCRIPTION
## Summary

Two fixes to restore parity between mirror and legacy branch-gate logic in `_should_skip_merged_mirror_pr`:

### Fix 1 — base_ref fallback (#958)

When both `default_branch` and `additional_acceptable_branches` are empty, the `acceptable` set was empty and the `base_ref` gate was skipped entirely. Now falls back to `["main"]`, matching legacy `should_skip_merged_pr` which always has a usable default branch name (falls back to `"main"` when GraphQL omits `defaultBranchRef`).

### Fix 2 — head_ref guard condition (#959)

The head-ref (self-merge between acceptable branches) gate was guarded by `additional` (only `additional_acceptable_branches`), so repos with no extra branches never evaluated it. Changed the guard to `acceptable`, which always includes `default_branch`, matching legacy behaviour that applies the check whenever there is a non-empty acceptable branch set.

Fixes #958
Fixes #959