### PR TITLE
fix: remove disappeared repos from master_repositories.json

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -249,9 +249,6 @@
   "flowsurface-rs/flowsurface": {
     "weight": 0.051
   },
-  "fx-integral/metahash": {
-    "weight": 0.0431
-  },
   "General-Tao-Ventures/cartha-cli": {
     "weight": 0.0476
   },
@@ -696,9 +693,6 @@
   },
   "thenervelab/thebrain": {
     "weight": 0.039
-  },
-  "threetau/kinitro": {
-    "weight": 0.0368
   },
   "tinygrad/tinygrad": {
     "weight": 0.0677


### PR DESCRIPTION
## Summary
- Removes `fx-integral/metahash` and `threetau/kinitro` from `gittensor/validator/weights/master_repositories.json` — both repositories return 404 on GitHub and can no longer be cloned, fetched, or evaluated.

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`)
- [x] No remaining references to either repo slug in the codebase

Fixes: #964 