### PR TITLE
perf: optimizing collect_node_signatures function

### DIFF
--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -82,8 +82,8 @@ def parse_code(content: str, language: str) -> Optional[Tree]:
 
 # Type alias for node signatures
 # Structural: ("structural", node_type)
-# Leaf: ("leaf", node_type, text)
-NodeSignature = Union[Tuple[str, str], Tuple[str, str, str]]
+# Leaf: ("leaf", node_type, text_bytes)
+NodeSignature = Union[Tuple[str, str], Tuple[str, str, bytes]]
 
 
 def collect_node_signatures(
@@ -95,7 +95,7 @@ def collect_node_signatures(
 
     Walks the tree and collects signatures for:
     - Structural nodes: ("structural", node_type) - captures structure without content
-    - Leaf nodes: ("leaf", node_type, text) - captures content for meaningful tokens
+    - Leaf nodes: ("leaf", node_type, text_bytes) - captures content for meaningful tokens
 
     Comments are skipped entirely (score 0).
 
@@ -107,33 +107,28 @@ def collect_node_signatures(
         Counter of node signatures (multiset for handling duplicates)
     """
     signatures: Counter[NodeSignature] = Counter()
+    cursor = tree.walk()
 
-    def walk_node(node: Node) -> None:
-        # Skip comments entirely
-        if node.type in COMMENT_NODE_TYPES:
-            return
-
+    while True:
+        node: Node = cursor.node  # type: ignore[assignment]
         node_type = node.type
 
-        # Check if this is a structural node (has structural bonus)
-        if weights.get_structural_weight(node_type) > 0:
-            # Structural signature: only type matters (not content)
-            signatures[('structural', node_type)] += 1
+        if node_type not in COMMENT_NODE_TYPES:
+            if weights.get_structural_weight(node_type) > 0:
+                signatures[('structural', node_type)] += 1
+            if node.child_count == 0:
+                signatures[('leaf', node_type, node.text or b'')] += 1
+            if cursor.goto_first_child():
+                continue
 
-        # Check if this is a leaf node
-        if node.child_count == 0:
-            # Skip comment types at leaf level too
-            if node_type not in COMMENT_NODE_TYPES:
-                # Leaf signature: type + text content
-                text = node.text.decode('utf-8') if node.text else ''
-                signatures[('leaf', node_type, text)] += 1
+        if cursor.goto_next_sibling():
+            continue
 
-        # Recurse into children
-        for child in node.children:
-            walk_node(child)
-
-    walk_node(tree.root_node)
-    return signatures
+        while cursor.goto_parent():
+            if cursor.goto_next_sibling():
+                break
+        else:
+            return signatures
 
 
 def has_inline_tests(content: str, extension: str) -> bool:

--- a/tests/validator/test_collect_node_signatures.py
+++ b/tests/validator/test_collect_node_signatures.py
@@ -1,0 +1,75 @@
+"""Unit tests for collect_node_signatures cursor-based AST traversal."""
+
+import pytest
+
+from gittensor.constants import COMMENT_NODE_TYPES
+from gittensor.validator.utils.load_weights import TokenConfig, load_token_config
+from gittensor.validator.utils.tree_sitter_scoring import (
+    collect_node_signatures,
+    parse_code,
+)
+
+
+@pytest.fixture
+def weights() -> TokenConfig:
+    return load_token_config()
+
+
+def _signatures(content: str, language: str, weights: TokenConfig):
+    tree = parse_code(content, language)
+    assert tree is not None, f'parser missing for {language}'
+    return collect_node_signatures(tree, weights)
+
+
+def test_comments_excluded_entirely(weights):
+    """Comment nodes and their children must not appear in the signature multiset."""
+    content = 'def foo():\n    # leaf token inside comment\n    return 1\n'
+    sigs = _signatures(content, 'python', weights)
+
+    for sig in sigs:
+        assert sig[1] not in COMMENT_NODE_TYPES, f'comment node leaked into signatures: {sig}'
+        if len(sig) == 3:
+            assert b'leaf token inside comment' not in sig[2]
+
+
+def test_structural_and_leaf_signatures_present(weights):
+    """A simple function should produce both structural and leaf signatures."""
+    content = 'def foo():\n    return 1\n'
+    sigs = _signatures(content, 'python', weights)
+
+    assert ('structural', 'function_definition') in sigs
+    assert ('leaf', 'identifier', b'foo') in sigs
+    assert ('leaf', 'integer', b'1') in sigs
+
+
+def test_duplicate_structures_counted(weights):
+    """Counter must track multiplicity for repeated structural nodes."""
+    content = 'def a():\n    return 1\n\ndef b():\n    return 2\n'
+    sigs = _signatures(content, 'python', weights)
+
+    assert sigs[('structural', 'function_definition')] == 2
+    assert sigs[('leaf', 'identifier', b'a')] == 1
+    assert sigs[('leaf', 'identifier', b'b')] == 1
+
+
+def test_rust_signatures(weights):
+    """Rust traversal collects structural nodes and identifiers, skips comments."""
+    content = 'fn run() {\n    // note\n    let x = 1;\n    let y = 2;\n}\n'
+    sigs = _signatures(content, 'rust', weights)
+
+    assert sigs[('structural', 'let_declaration')] == 2
+    assert ('leaf', 'identifier', b'x') in sigs
+    assert ('leaf', 'identifier', b'y') in sigs
+    for sig in sigs:
+        assert sig[1] not in COMMENT_NODE_TYPES
+
+
+def test_bash_signatures(weights):
+    """Bash traversal handles flat scripts without recursion-stack issues."""
+    content = '#!/bin/bash\n# greet\necho hello\necho world\n'
+    sigs = _signatures(content, 'bash', weights)
+
+    assert ('leaf', 'word', b'echo') in sigs
+    assert sigs[('leaf', 'word', b'echo')] == 2
+    for sig in sigs:
+        assert sig[1] not in COMMENT_NODE_TYPES

--- a/tests/validator/test_token_scoring_integration.py
+++ b/tests/validator/test_token_scoring_integration.py
@@ -231,6 +231,268 @@ const createUser = (id: number, name: string): User => ({
         assert breakdown.added_count == 0
         assert breakdown.deleted_count == 0
 
+    # ------------------------------------------------------------------
+    # Golden-value regression tests
+    #
+    # These pin the exact ScoreBreakdown produced for a small set of stable
+    # fixtures, so any change in tree-sitter grammar output, TokenConfig
+    # weights, the scoring algorithm, or comment-exclusion behavior is
+    # caught here. If one of these fails, identify which of the above
+    # changed and update the expected values intentionally.
+    # ------------------------------------------------------------------
+
+    def test_pinned_python_simple_function(self, weights):
+        breakdown = score_tree_diff(None, 'def foo():\n    return 1\n', 'py', weights)
+
+        assert breakdown.structural_added_count == 2
+        assert breakdown.leaf_added_count == 7
+        assert breakdown.structural_deleted_count == 0
+        assert breakdown.leaf_deleted_count == 0
+        assert breakdown.structural_score == pytest.approx(2.35, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(0.10, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(2.45, abs=1e-6)
+
+    def test_pinned_python_empty_file(self, weights):
+        breakdown = score_tree_diff(None, '', 'py', weights)
+
+        assert breakdown.structural_added_count == 0
+        assert breakdown.leaf_added_count == 0
+        assert breakdown.total_score == 0.0
+
+    def test_pinned_python_only_comments(self, weights):
+        """Comment-only content scores zero (the walker skips comment subtrees)."""
+        content = '# just a comment\n# and another\n'
+        breakdown = score_tree_diff(None, content, 'py', weights)
+
+        assert breakdown.structural_added_count == 0
+        assert breakdown.leaf_added_count == 0
+        assert breakdown.total_score == 0.0
+
+    def test_pinned_python_rename_identifier(self, weights):
+        """Renaming an identifier produces one leaf-add and one leaf-delete; structure unchanged."""
+        breakdown = score_tree_diff(
+            'def foo():\n    return 1\n',
+            'def bar():\n    return 1\n',
+            'py',
+            weights,
+        )
+
+        assert breakdown.structural_added_count == 0
+        assert breakdown.structural_deleted_count == 0
+        assert breakdown.leaf_added_count == 1
+        assert breakdown.leaf_deleted_count == 1
+        assert breakdown.structural_score == pytest.approx(0.0, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(0.14, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(0.14, abs=1e-6)
+
+    def test_pinned_python_add_statement(self, weights):
+        """Adding `x = 1` and changing the return introduces structural + leaf additions."""
+        breakdown = score_tree_diff(
+            'def foo():\n    return 1\n',
+            'def foo():\n    x = 1\n    return x\n',
+            'py',
+            weights,
+        )
+
+        assert breakdown.structural_added_count == 1
+        assert breakdown.structural_deleted_count == 0
+        assert breakdown.leaf_added_count == 3
+        assert breakdown.leaf_deleted_count == 0
+        assert breakdown.structural_score == pytest.approx(0.20, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(0.14, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(0.34, abs=1e-6)
+
+    def test_pinned_python_deleted_file_mirrors_new_file(self, weights):
+        """Deleting a file produces the same counts/score as adding it."""
+        src = 'def foo():\n    return 1\n'
+        added = score_tree_diff(None, src, 'py', weights)
+        deleted = score_tree_diff(src, None, 'py', weights)
+
+        assert deleted.structural_added_count == 0
+        assert deleted.leaf_added_count == 0
+        assert deleted.structural_deleted_count == added.structural_added_count
+        assert deleted.leaf_deleted_count == added.leaf_added_count
+        assert deleted.total_score == pytest.approx(added.total_score, abs=1e-6)
+
+    def test_pinned_python_identical_files_score_zero(self, weights):
+        src = 'def foo():\n    return 1\n'
+        breakdown = score_tree_diff(src, src, 'py', weights)
+
+        assert breakdown.structural_added_count == 0
+        assert breakdown.leaf_added_count == 0
+        assert breakdown.structural_deleted_count == 0
+        assert breakdown.leaf_deleted_count == 0
+        assert breakdown.total_score == 0.0
+
+    def test_pinned_rust_simple_function(self, weights):
+        """Rust function has no structural-bonus node type but produces leaf signatures."""
+        content = 'fn add(a: i32, b: i32) -> i32 { a + b }\n'
+        breakdown = score_tree_diff(None, content, 'rs', weights)
+
+        assert breakdown.structural_added_count == 0
+        assert breakdown.leaf_added_count == 18
+        assert breakdown.structural_score == pytest.approx(0.0, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(0.35, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(0.35, abs=1e-6)
+
+    def test_pinned_bash_unweighted_leaves(self, weights):
+        """Bash 'word' nodes produce leaf signatures but carry zero leaf weight - score zero."""
+        breakdown = score_tree_diff(None, 'echo hello\necho world\n', 'sh', weights)
+
+        assert breakdown.leaf_added_count == 4
+        assert breakdown.total_score == 0.0
+
+    def test_pinned_rust_struct_with_impl(self, weights):
+        """Rust struct + impl with multiple methods, match, let, generics."""
+        content = """//! Module-level doc.
+use std::collections::HashMap;
+
+pub struct Counter {
+    map: HashMap<String, u64>,
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Self { map: HashMap::new() }
+    }
+
+    pub fn add(&mut self, key: String) -> u64 {
+        let count = self.map.entry(key).or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    pub fn get(&self, key: &str) -> u64 {
+        match self.map.get(key) {
+            Some(&n) => n,
+            None => 0,
+        }
+    }
+}
+"""
+        breakdown = score_tree_diff(None, content, 'rs', weights)
+
+        assert breakdown.structural_added_count == 7
+        assert breakdown.leaf_added_count == 123
+        assert breakdown.structural_score == pytest.approx(4.45, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(3.56, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(8.01, abs=1e-6)
+
+    def test_pinned_rust_add_impl_method(self, weights):
+        """Adding a new impl block with one method produces incremental structural + leaf adds."""
+        old = """pub struct Counter {
+    map: std::collections::HashMap<String, u64>,
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Self { map: std::collections::HashMap::new() }
+    }
+}
+"""
+        new = (
+            old
+            + """
+impl Counter {
+    pub fn remove(&mut self, key: &str) -> Option<u64> {
+        self.map.remove(key)
+    }
+}
+"""
+        )
+        breakdown = score_tree_diff(old, new, 'rs', weights)
+
+        assert breakdown.structural_added_count == 2
+        assert breakdown.structural_deleted_count == 0
+        assert breakdown.leaf_added_count == 32
+        assert breakdown.leaf_deleted_count == 0
+        assert breakdown.total_score == pytest.approx(3.25, abs=1e-6)
+
+    def test_pinned_typescript_interface_class(self, weights):
+        """TypeScript interface + class with map field, methods, and conditional logic."""
+        content = """interface User {
+    id: number;
+    name: string;
+}
+
+class UserRegistry {
+    private users: Map<number, User> = new Map();
+
+    addUser(user: User): boolean {
+        if (this.users.has(user.id)) {
+            return false;
+        }
+        this.users.set(user.id, user);
+        return true;
+    }
+
+    findById(id: number): User | undefined {
+        return this.users.get(id);
+    }
+}
+"""
+        breakdown = score_tree_diff(None, content, 'ts', weights)
+
+        assert breakdown.structural_added_count == 12
+        assert breakdown.leaf_added_count == 97
+        assert breakdown.structural_score == pytest.approx(11.70, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(3.17, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(14.87, abs=1e-6)
+
+    def test_pinned_typescript_method_rename(self, weights):
+        """Renaming methods produces only leaf-level diffs (structure preserved)."""
+        old = """class Registry {
+    addUser(id: number): boolean { return true; }
+    findById(id: number): number { return id; }
+}
+"""
+        new = """class Registry {
+    register(id: number): boolean { return true; }
+    lookup(id: number): number { return id; }
+}
+"""
+        breakdown = score_tree_diff(old, new, 'ts', weights)
+
+        assert breakdown.structural_added_count == 0
+        assert breakdown.structural_deleted_count == 0
+        assert breakdown.leaf_added_count == 2
+        assert breakdown.leaf_deleted_count == 2
+        assert breakdown.structural_score == pytest.approx(0.0, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(0.28, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(0.28, abs=1e-6)
+
+    def test_pinned_python_control_flow(self, weights):
+        """Python with rich control flow (for / if / elif / else / try / except / with /
+        raise / return / augmented_assignment) exercises many structural-bonus node
+        types in a single fixture.
+        """
+        content = """def process(items):
+    results = []
+    for item in items:
+        if item < 0:
+            continue
+        elif item == 0:
+            results.append(None)
+        else:
+            try:
+                with open(f"item_{item}.txt") as f:
+                    results.append(f.read())
+            except FileNotFoundError:
+                results.append("missing")
+            except OSError as e:
+                raise RuntimeError(f"io error: {e}") from e
+    return results
+"""
+        breakdown = score_tree_diff(None, content, 'py', weights)
+
+        assert breakdown.structural_added_count == 22
+        assert breakdown.leaf_added_count == 90
+        assert breakdown.structural_deleted_count == 0
+        assert breakdown.leaf_deleted_count == 0
+        assert breakdown.structural_score == pytest.approx(8.00, abs=1e-6)
+        assert breakdown.leaf_score == pytest.approx(1.99, abs=1e-6)
+        assert breakdown.total_score == pytest.approx(9.99, abs=1e-6)
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Closes #966

## Summary

This PR introduces set of optimizations to the `collect_node_signatures`:

- Recursive `walk_node` approach is replaced with `TreeCursor` (`tree.walk()`) and a plain `while` loop.
- Leaf `("leaf", node_type, text)` replaced with `("leaf", node_type, bytes)` to strip unnecessary utf-8 decoding.
- Some micro-optimizations, like double `node.text` call, list allocations, and sticking to C calls.

## Benchmark

Benchmarking e2e scoring:

```
  | fixture     | before (HEAD~1)   | after (this PR)   | speedup |
  |-------------|-------------------|-------------------|---------|
  | py-tiny     |     9.61us        |     8.39us        | 1.15x   |
  | py-small    |    87.65us        |    67.23us        | 1.30x   |
  | py-medium   |     2626us        |     2030us        | 1.29x   |
  | py-large    |    10827us        |     8192us        | 1.32x   |
  | rs-tiny     |    22.35us        |    18.24us        | 1.23x   |
  | rs-small    |   122.10us        |    97.90us        | 1.25x   |
  | rs-medium   |     2193us        |     1700us        | 1.29x   |
  | rs-large    |     9024us        |     6527us        | 1.38x   |
  | sh-tiny     |     7.68us        |     6.32us        | 1.21x   |
  | sh-small    |    76.20us        |    63.66us        | 1.20x   |
  | sh-medium   |     1633us        |     1198us        | 1.36x   |
  | sh-large    |     6595us        |     4775us        | 1.38x   |
```

`python -m benchmarks.bench_collect_node_signatures` (run in the branch with actual changes)

[benchmarks/bench_collect_node_signatures.py](https://github.com/user-attachments/files/27351022/bench_collect_node_signatures.py)

## Test plan

Added `tests/validator/test_collect_node_signatures.py` which pins the exact function behavior, and also added more e2e tests to the `tests/validator/test_token_scoring_integration.py` to pin even more the existing scoring behavior (to not break anything in future).