### PR TITLE
fix: don't cache fabricated zero when mirror scoring_data_stored=False

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -446,6 +446,15 @@ def _resolve_solving_pr_score(
         )
         return None
 
+    if not files_response.scoring_data_stored:
+        cache_stats.fetch_failures += 1
+        bt.logging.warning(
+            f'Mirror scoring data unavailable for solving PR #{solving_pr.pr_number} '
+            f'({issue.repo_full_name}): scoring_data_stored=False — '
+            f'issue #{issue.issue_number} not scored'
+        )
+        return None
+
     file_changes, file_contents = mirror_files_to_legacy(
         issue.repo_full_name, solving_pr.pr_number, files_response.files
     )

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -656,8 +656,8 @@ class TestCacheStats:
         stats = _CacheStats()
 
         issue = MirrorIssue.from_dict(_issue_dict())
-        result = _resolve_solving_pr_score(
-            issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        result = asyncio.run(
+            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
         )
 
         assert result is None
@@ -695,11 +695,15 @@ class TestCacheStats:
         issue_a = MirrorIssue.from_dict(_issue_dict(issue_number=50))
         issue_b = MirrorIssue.from_dict(_issue_dict(issue_number=51))
 
-        result_a = _resolve_solving_pr_score(
-            issue_a, issue_a.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        result_a = asyncio.run(
+            _resolve_solving_pr_score(
+                issue_a, issue_a.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+            )
         )
-        result_b = _resolve_solving_pr_score(
-            issue_b, issue_b.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        result_b = asyncio.run(
+            _resolve_solving_pr_score(
+                issue_b, issue_b.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+            )
         )
 
         assert result_a is None

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -628,6 +628,86 @@ class TestCacheStats:
         # Failed lookups are NOT cached (so a retry is possible)
         assert cache == {}
 
+    def test_resolve_treats_unavailable_scoring_data_as_failure(self):
+        # scoring_data_stored=False is data-availability noise, not a real
+        # zero score. Same handling as MirrorRequestError: increment
+        # fetch_failures, return None, leave cache empty so a sibling miner's
+        # later lookup can retry within the cycle.
+        from gittensor.validator.issue_discovery.mirror_scan import (
+            _CacheStats,
+            _resolve_solving_pr_score,
+        )
+
+        client = Mock()
+        client.get_pr_files.return_value = MirrorPullRequestFilesResponse.from_dict(
+            {
+                'repo_full_name': 'entrius/gittensor-ui',
+                'pr_number': 100,
+                'head_sha': 'h',
+                'base_sha': 'b',
+                'merge_base_sha': 'mb',
+                'scoring_data_stored': False,
+                'files': [],
+            }
+        )
+        cache = {}
+        stats = _CacheStats()
+
+        issue = MirrorIssue.from_dict(_issue_dict())
+        result = _resolve_solving_pr_score(
+            issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        )
+
+        assert result is None
+        assert stats.misses == 1
+        assert stats.fetch_failures == 1
+        assert cache == {}
+
+    def test_unavailable_scoring_data_is_not_cached_across_sibling_lookups(self):
+        # Acceptance for issue #836: a single scoring_data_stored=False response
+        # feeding two issues that share the same solving PR (i.e. across two
+        # miners discovering the same PR) results in two misses, two fetch
+        # failures, and an empty cache. Without the fix, the first call would
+        # cache base_score=0 / token_score=0, the second would be a "hit" on
+        # that fabricated zero, and fetch_failures would never increment.
+        from gittensor.validator.issue_discovery.mirror_scan import (
+            _CacheStats,
+            _resolve_solving_pr_score,
+        )
+
+        client = Mock()
+        client.get_pr_files.return_value = MirrorPullRequestFilesResponse.from_dict(
+            {
+                'repo_full_name': 'entrius/gittensor-ui',
+                'pr_number': 100,
+                'head_sha': 'h',
+                'base_sha': 'b',
+                'merge_base_sha': 'mb',
+                'scoring_data_stored': False,
+                'files': [],
+            }
+        )
+        cache = {}
+        stats = _CacheStats()
+
+        issue_a = MirrorIssue.from_dict(_issue_dict(issue_number=50))
+        issue_b = MirrorIssue.from_dict(_issue_dict(issue_number=51))
+
+        result_a = _resolve_solving_pr_score(
+            issue_a, issue_a.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        )
+        result_b = _resolve_solving_pr_score(
+            issue_b, issue_b.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+        )
+
+        assert result_a is None
+        assert result_b is None
+        assert stats.hits == 0
+        assert stats.misses == 2
+        assert stats.fetch_failures == 2
+        assert cache == {}
+        assert client.get_pr_files.call_count == 2
+
 
 class TestOpenIssueSpamSourceIsMirror:
     """The open-issue spam multiplier sources its count from mirror's response,


### PR DESCRIPTION
## Summary

In `_resolve_solving_pr_score` (`gittensor/validator/issue_discovery/mirror_scan.py`), a mirror response with `scoring_data_stored=False` was treated as a successful fetch of an empty diff — `mirror_files_to_legacy()` returned no file changes, `calculate_base_score_for_pr_files()` returned `base_score=0 / token_score=0`, and that fabricated zero was committed to the cross-miner solving-PR cache. Sibling miners' lookups against the same `(repo, pr_number)` then served the cached zero with no in-cycle retry, even after the mirror finished its backfill mid-cycle.

This PR adds an explicit guard immediately after the `MirrorRequestError` branch: when `files_response.scoring_data_stored is False`, increment `cache_stats.fetch_failures`, log a warning that mentions data unavailability (not "below threshold"), and return `None` without writing to `cache`. Parity with the existing `MirrorRequestError` handling — same three actions, same callsite-visible semantics.

Scope: only `gittensor/validator/issue_discovery/mirror_scan.py` and its sibling test file. No change to `mirror/scoring.py` and no change to credibility/eligibility behavior

## Related Issues

Closes #836

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] `tests/validator/issue_discovery/test_mirror_scan.py::TestCacheStats` — 2 new cases:
  - `test_resolve_treats_unavailable_scoring_data_as_failure` — single call: asserts `result is None`, `fetch_failures == 1`, empty cache.
  - `test_unavailable_scoring_data_is_not_cached_across_sibling_lookups` — the literal acceptance criterion from #836: two issues sharing one solving PR, `scoring_data_stored=False` returned both times → `misses == 2`, `fetch_failures == 2`, `cache == {}`, `client.get_pr_files.call_count == 2`.
- [x] Full validator test suite passes locally (728/728).
- [x] Ruff lint + format clean (`uv run pre-commit run --all-files`).
- [x] Pyright: 0 errors / 0 warnings (`uv run pre-commit run --all-files --hook-stage pre-push`).

## Checklist

- [x] Code follows project style guidelines.
- [x] Self-review completed.
- [x] No change to mirror OSS scoring (`oss_contributions/mirror/scoring.py`).
- [x] No change to credibility/eligibility behavior; legacy parity preserved.
- [x] Cache mutation is gated: `cache` stays empty on availability failure, leaving the slot open for sibling miners' in-cycle retries.
