### PR TITLE
fix(config): use bt.logging.debug instead of raw print in check_config

### DIFF
--- a/gittensor/utils/config.py
+++ b/gittensor/utils/config.py
@@ -36,7 +36,7 @@ def check_config(cls, config: Any):
             config.neuron.name,
         )
     )
-    print('full path:', full_path)
+    bt.logging.debug(f'Neuron full path: {full_path}')
     config.neuron.full_path = os.path.expanduser(full_path)
     if not os.path.exists(config.neuron.full_path):
         os.makedirs(config.neuron.full_path, exist_ok=True)


### PR DESCRIPTION
## Summary

`check_config` printed the resolved neuron directory with `print()`, which bypasses `bt.logging` and can pollute stdout for validator/miner processes.

## Fix

Replace the raw `print` call with `bt.logging.debug`, using a clear `Neuron full path:` message while preserving the existing path setup behavior.

Fixes #935