### PR TITLE
fix: increase closingIssuesReferences limit to 100 and warn on truncation

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -423,8 +423,9 @@ query($owner: String!, $name: String!, $issueNumber: Int!) {
                 createdAt
                 author { ... on User { databaseId login } }
                 baseRepository { nameWithOwner }
-                closingIssuesReferences(first: 20) {
+                closingIssuesReferences(first: 100) {
                   nodes { number }
+                  pageInfo { hasNextPage }
                 }
                 reviews(first: 1, states: APPROVED) { totalCount }
               }
@@ -501,8 +502,14 @@ def _search_issue_referencing_prs_graphql(
 
         author = pr.get('author') or {}
         reviews = pr.get('reviews') or {}
-        closing = pr.get('closingIssuesReferences', {}).get('nodes', [])
-        closing_numbers = [n.get('number') for n in closing if n.get('number') is not None]
+        closing = pr.get('closingIssuesReferences', {})
+        closing_numbers = [n.get('number') for n in closing.get('nodes', []) if n.get('number') is not None]
+        if closing.get('pageInfo', {}).get('hasNextPage'):
+            import bittensor as bt
+            bt.logging.warning(
+                f'PR #{pr_number} closingIssuesReferences exceeds 100 — '
+                f'some closing references were truncated and may cause solver lookup to fail'
+            )
 
         pr_info: PRInfo = {
             'number': pr_number,


### PR DESCRIPTION
## Summary

`_PR_TIMELINE_QUERY` requested `closingIssuesReferences(first: 20)`. A PR closing more than 20 issues had its 21st+ references silently truncated, causing `solver_lookup_failed` for the affected miner.

## Fix

1. Increased the limit from `first: 20` to `first: 100` (GitHub per-field maximum)
2. Added `pageInfo { hasNextPage }` with a `bt.logging.warning` when truncation still occurs, so operators can correlate missed solver attribution with the warning

Fixes #934