### PR TITLE
fix: mask github_access_token in PatBroadcastSynapse repr/str

### DIFF
--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import bittensor as bt
+from pydantic import Field
 
 
 class PatBroadcastSynapse(bt.Synapse):
@@ -12,12 +13,24 @@ class PatBroadcastSynapse(bt.Synapse):
     and responds with accepted/rejection_reason.
     """
 
-    # Miner request
-    github_access_token: str
+    # Miner request. repr=False keeps pydantic's default repr from emitting the
+    # raw token; the explicit __repr__/__str__ below render a last-4-char tag so
+    # masked log lines remain correlatable with rotated tokens.
+    github_access_token: str = Field(repr=False)
 
     # Validator response
     accepted: Optional[bool] = None
     rejection_reason: Optional[str] = None
+
+    def __repr__(self) -> str:
+        token = self.github_access_token or ''
+        masked = f'***{token[-4:]}' if len(token) >= 4 else '***'
+        return (
+            f'PatBroadcastSynapse(github_access_token={masked}, '
+            f'accepted={self.accepted!r}, rejection_reason={self.rejection_reason!r})'
+        )
+
+    __str__ = __repr__
 
 
 class PatCheckSynapse(bt.Synapse):

--- a/tests/test_synapses.py
+++ b/tests/test_synapses.py
@@ -1,0 +1,46 @@
+from gittensor.synapses import PatBroadcastSynapse
+
+SECRET = 'ghp_SUPERSECRET12345'
+
+
+def test_repr_does_not_leak_full_token():
+    syn = PatBroadcastSynapse(github_access_token=SECRET)
+    assert SECRET not in repr(syn)
+
+
+def test_str_does_not_leak_full_token():
+    syn = PatBroadcastSynapse(github_access_token=SECRET)
+    assert SECRET not in str(syn)
+
+
+def test_repr_keeps_last_four_chars_for_log_correlation():
+    syn = PatBroadcastSynapse(github_access_token=SECRET)
+    assert '***2345' in repr(syn)
+
+
+def test_short_token_is_fully_masked():
+    syn = PatBroadcastSynapse(github_access_token='abc')
+    rep = repr(syn)
+    assert 'abc' not in rep
+    assert '***' in rep
+
+
+def test_empty_token_does_not_crash_repr():
+    syn = PatBroadcastSynapse(github_access_token='')
+    assert '***' in repr(syn)
+
+
+def test_response_fields_still_visible_in_repr():
+    syn = PatBroadcastSynapse(
+        github_access_token=SECRET,
+        accepted=True,
+        rejection_reason='nope',
+    )
+    rep = repr(syn)
+    assert 'accepted=True' in rep
+    assert "rejection_reason='nope'" in rep
+
+
+def test_model_dump_json_still_includes_full_token():
+    syn = PatBroadcastSynapse(github_access_token=SECRET)
+    assert SECRET in syn.model_dump_json()

--- a/tests/test_synapses.py
+++ b/tests/test_synapses.py
@@ -25,6 +25,14 @@ def test_short_token_is_fully_masked():
     assert '***' in rep
 
 
+def test_four_char_token_renders_at_boundary():
+    # Pins the >=4 boundary: a 4-char token renders as ***<all 4>. If the
+    # threshold ever flips to >4 this test catches the regression instead of
+    # the change silently slipping past.
+    syn = PatBroadcastSynapse(github_access_token='abcd')
+    assert '***abcd' in repr(syn)
+
+
 def test_empty_token_does_not_crash_repr():
     syn = PatBroadcastSynapse(github_access_token='')
     assert '***' in repr(syn)
@@ -44,3 +52,11 @@ def test_response_fields_still_visible_in_repr():
 def test_model_dump_json_still_includes_full_token():
     syn = PatBroadcastSynapse(github_access_token=SECRET)
     assert SECRET in syn.model_dump_json()
+
+
+def test_attribute_access_returns_full_token():
+    # Validator handlers (pat_handler.handle_pat_broadcast) read the field
+    # directly to call validate_github_credentials and save_pat. repr=False
+    # must redact only the *display* path, not the attribute path.
+    syn = PatBroadcastSynapse(github_access_token=SECRET)
+    assert syn.github_access_token == SECRET


### PR DESCRIPTION
## Summary

`PatBroadcastSynapse.github_access_token` is a vanilla pydantic field with no `repr=False` and no `__repr__` override, so `repr(synapse)` and `str(synapse)` emit the raw PAT in plaintext. A single `bt.logging.debug(synapse)`, an uncaught-exception traceback that includes the synapse, or any log shipper that captures stdout would leak every miner's PAT to disk and downstream log infrastructure. The defensive `synapse.github_access_token = ''` clears in `pat_handler.py:41,73` only protect the response path — anything raising before those clears, or any debug log of the request, exposes the token.

This PR marks the field with `Field(repr=False)` and overrides `__repr__`/`__str__` to render `***<last4>` instead. The last-4 tag is preserved so masked log lines remain correlatable with rotated tokens. Wire format (`model_dump_json`) is unchanged — the token still transmits over the axon channel.

## Related Issues

Closes #850

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
