### PR TITLE
fix: recycle treasury emission share when treasury is disabled or unregistered

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -175,14 +175,16 @@ def blend_emission_pools(
     else:
         recycle_extra += ISSUE_DISCOVERY_EMISSION_SHARE
 
-    # Pool 3: Issue treasury (15% flat to UID 111)
-    if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
+    # Pool 3: Issue treasury (15% flat to ISSUES_TREASURY_UID, recycled if disabled/unregistered)
+    if ISSUES_TREASURY_UID != RECYCLE_UID and ISSUES_TREASURY_UID in miner_uids:
         treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
         rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
         bt.logging.info(
             f'Treasury allocation: UID {ISSUES_TREASURY_UID} receives '
             f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
         )
+    else:
+        recycle_extra += ISSUES_TREASURY_EMISSION_SHARE
 
     # Pool 4: Recycle (25% + unclaimed from empty pools)
     if RECYCLE_UID in miner_uids:


### PR DESCRIPTION
**Description:**

## Summary
- When `ISSUES_TREASURY_UID` is set to `RECYCLE_UID` (treasury disabled per [constants.py:215](gittensor/constants.py#L215)) or the treasury neuron is not registered on the metagraph, the 15% treasury share was silently dropped instead of being recycled.
- Pools 1 (OSS) and 2 (issue discovery) already fall through to `recycle_extra` when empty; pool 3 (treasury) now does the same so total emissions consistently sum to 100%.
- Also replaces the `ISSUES_TREASURY_UID > 0` guard with the more direct `ISSUES_TREASURY_UID != RECYCLE_UID` to match the intent stated in the constants comment.

## Test plan
- [ ] Validator with treasury UID registered: 15% still flows to treasury, recycle pool unchanged.
- [ ] Validator with `ISSUES_TREASURY_UID = RECYCLE_UID`: recycle UID receives 25% + 15% = 40% (plus any unclaimed OSS/issue-discovery share).
- [ ] Validator where treasury UID is not in metagraph: same as above — 15% flows to recycle.
- [ ] Sum of emitted weights equals 1.0 in all three cases.

Fixes #974 