### PR TITLE
fix: bound old_content size in tree-sitter scoring

### DIFF
--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -309,12 +309,9 @@ def calculate_token_score_from_file_changes(
                     is_test_file=is_test_file,
                     scoring_method='skipped-binary',
                 )
-            elif (
-                len(content_pair.new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES
-                or (
-                    content_pair.old_content is not None
-                    and len(content_pair.old_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES
-                )
+            elif len(content_pair.new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES or (
+                content_pair.old_content is not None
+                and len(content_pair.old_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES
             ):
                 bt.logging.debug(f'  │   {file.short_name}: skipped (file too large, >{MAX_FILE_SIZE_BYTES} bytes)')
                 file_result = FileScoreResult(

--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -309,7 +309,13 @@ def calculate_token_score_from_file_changes(
                     is_test_file=is_test_file,
                     scoring_method='skipped-binary',
                 )
-            elif len(content_pair.new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES:
+            elif (
+                len(content_pair.new_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES
+                or (
+                    content_pair.old_content is not None
+                    and len(content_pair.old_content.encode('utf-8')) > MAX_FILE_SIZE_BYTES
+                )
+            ):
                 bt.logging.debug(f'  │   {file.short_name}: skipped (file too large, >{MAX_FILE_SIZE_BYTES} bytes)')
                 file_result = FileScoreResult(
                     filename=file.short_name,


### PR DESCRIPTION
**Description:**

## Summary
- The `MAX_FILE_SIZE_BYTES` guard in `calculate_token_score_from_file_changes()` ([gittensor/validator/utils/tree_sitter_scoring.py:312](gittensor/validator/utils/tree_sitter_scoring.py#L312)) only checked `new_content`. A PR that shrinks or rewrites a previously large file would pass the new-side check, then `score_tree_diff` would still parse an arbitrarily large old AST to score deletions ([line 190-193](gittensor/validator/utils/tree_sitter_scoring.py#L190-L193)).
- Now skipped (`scoring_method='skipped-large'`) when either side exceeds the limit, restoring the guard's stated intent.

## Test plan
- [ ] PR adding a large file (>`MAX_FILE_SIZE_BYTES`): still skipped as before.
- [ ] PR shrinking a large file (old large, new small): now skipped instead of silently parsing the old AST.
- [ ] PR replacing a small file with a small file: scored normally.
- [ ] PR deleting a large file (`status == 'removed'`): still hits the existing `'removed'` branch and isn't affected.

Fixes #976 