### PR TITLE
fix: gate issue bounty solver lookup on completed closures

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -1052,6 +1052,18 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
         if data.get('state') != 'closed':
             return {'is_closed': False}
 
+        state_reason = data.get('state_reason')
+        if not isinstance(state_reason, str) or state_reason.strip().lower() != 'completed':
+            bt.logging.info(
+                f'Issue closed on GitHub but not completed: {repo}#{issue_number} state_reason={state_reason}'
+            )
+            return {
+                'is_closed': True,
+                'solver_github_id': None,
+                'pr_number': None,
+                'solver_lookup_failed': False,
+            }
+
         bt.logging.debug(f'Finding solver for {repo}#{issue_number}')
         solver_lookup = find_solver_from_cross_references(repo, issue_number, token)
         if solver_lookup is None:

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1004,7 +1004,7 @@ class TestCheckGithubIssueClosed:
     def test_graphql_failure_sets_solver_lookup_failed(self, mock_logging, mock_get, mock_graphql):
         issue_response = Mock()
         issue_response.status_code = 200
-        issue_response.json.return_value = {'state': 'closed'}
+        issue_response.json.return_value = {'state': 'closed', 'state_reason': 'completed'}
         mock_get.return_value = issue_response
         mock_graphql.return_value = None
 
@@ -1023,7 +1023,7 @@ class TestCheckGithubIssueClosed:
     def test_closed_issue_with_no_solver_keeps_lookup_failed_false(self, mock_logging, mock_get, mock_graphql):
         issue_response = Mock()
         issue_response.status_code = 200
-        issue_response.json.return_value = {'state': 'closed'}
+        issue_response.json.return_value = {'state': 'closed', 'state_reason': 'completed'}
         mock_get.return_value = issue_response
         mock_graphql.return_value = _graphql_response([])
 
@@ -1035,6 +1035,35 @@ class TestCheckGithubIssueClosed:
             'pr_number': None,
             'solver_lookup_failed': False,
         }
+
+    @pytest.mark.parametrize(
+        'issue_payload',
+        [
+            {'state': 'closed', 'state_reason': 'not_planned'},
+            {'state': 'closed', 'state_reason': 'duplicate'},
+            {'state': 'closed', 'state_reason': 'transferred'},
+            {'state': 'closed', 'state_reason': None},
+            {'state': 'closed'},
+        ],
+    )
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_non_completed_closed_issue_skips_solver_lookup(self, mock_logging, mock_get, mock_graphql, issue_payload):
+        issue_response = Mock()
+        issue_response.status_code = 200
+        issue_response.json.return_value = issue_payload
+        mock_get.return_value = issue_response
+
+        result = check_github_issue_closed('owner/repo', 12, 'fake_token')
+
+        assert result == {
+            'is_closed': True,
+            'solver_github_id': None,
+            'pr_number': None,
+            'solver_lookup_failed': False,
+        }
+        mock_graphql.assert_not_called()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Gate issue-bounty solver lookup on GitHub's completed closure reason.

`check_github_issue_closed()` previously treated any REST issue with `state == "closed"` as eligible for solver lookup. That allowed issues closed as `not_planned`, `duplicate`, or with missing/null `state_reason` to still return a merged PR solver, which `issue_competitions()` could turn into `vote_solution()` for an eligible miner.

This change requires closed issues to have `state_reason == "completed"` before `find_solver_from_cross_references()` runs. Non-completed or missing closure reasons now return a closed/no-solver result, preserving the existing response shape while preventing solution votes for non-completed closures.

## Related Issues

Closes #979

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

- `./.venv/bin/pytest tests/utils/test_github_api_tools.py::TestCheckGithubIssueClosed -q`
- `./.venv/bin/pytest tests/utils/test_github_api_tools.py -q`
- `./.venv/bin/pytest tests/validator/test_issue_competitions_forward.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pyright`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
