### PR TITLE
fix: avoid recursion limit in tree-sitter signature collection

### DIFF
--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -113,10 +113,15 @@ def collect_node_signatures(
     """
     signatures: Counter[NodeSignature] = Counter()
 
-    def walk_node(node: Node) -> None:
-        # Skip comments entirely
+    # Iterative DFS to avoid Python's recursion limit on deeply nested ASTs
+    # (e.g. long chained method calls, deeply nested data literals).
+    stack: List[Node] = [tree.root_node]
+    while stack:
+        node = stack.pop()
+
+        # Skip comments entirely (and their subtrees)
         if is_comment_node(node):
-            return
+            continue
 
         node_type = node.type
 
@@ -127,17 +132,12 @@ def collect_node_signatures(
 
         # Check if this is a leaf node
         if node.child_count == 0:
-            # Skip comment types at leaf level too
-            if node_type not in COMMENT_NODE_TYPES:
-                # Leaf signature: type + text content
-                text = node.text.decode('utf-8') if node.text else ''
-                signatures[('leaf', node_type, text)] += 1
+            # Leaf signature: type + text content
+            text = node.text.decode('utf-8') if node.text else ''
+            signatures[('leaf', node_type, text)] += 1
+        else:
+            stack.extend(node.children)
 
-        # Recurse into children
-        for child in node.children:
-            walk_node(child)
-
-    walk_node(tree.root_node)
     return signatures
 
 


### PR DESCRIPTION
**Description:**

## Summary
- `collect_node_signatures()` in [gittensor/validator/utils/tree_sitter_scoring.py:116-138](gittensor/validator/utils/tree_sitter_scoring.py#L116-L138) walked the AST via a recursive inner function. Deeply nested ASTs (long chained method calls, deeply nested data literals, generated/minified code) could exceed Python's default recursion limit (~1000) and raise `RecursionError` mid-scoring.
- Replaced with an iterative DFS using an explicit stack — same semantics, depth bounded only by available memory.
- Drops the unreachable inner `COMMENT_NODE_TYPES` check at [line 131](gittensor/validator/utils/tree_sitter_scoring.py#L131); the top-of-loop comment guard already covers it.

## Test plan
- [ ] Existing tree-sitter scoring tests pass unchanged.
- [ ] Spot-check a real PR's scoring output before/after — totals identical.
- [ ] Synthetic input with >1000-deep nesting (e.g. `a.b.c...` chain) no longer raises `RecursionError` and produces a non-zero breakdown.
- [ ] Comment-only files still score 0.

Fixes #978 