### PR TITLE
fix: score extensionless configured files

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -23,6 +23,7 @@ from gittensor.constants import (
 from gittensor.utils.utils import parse_repo_name
 
 GITHUB_DOMAIN = 'https://github.com/'
+_EXTENSIONLESS_FILE_EXTENSIONS = {'dockerfile', 'makefile'}
 
 
 class PRState(Enum):
@@ -71,7 +72,10 @@ class FileChange:
 
     def _calculate_file_extension(self) -> str:
         basename = self.filename.split('/')[-1]
-        return basename.split('.')[-1].lower() if '.' in basename else ''
+        if '.' in basename:
+            return basename.split('.')[-1].lower()
+        basename_lower = basename.lower()
+        return basename_lower if basename_lower in _EXTENSIONLESS_FILE_EXTENSIONS else ''
 
     def is_test_file(self) -> bool:
         filename_lower = self.filename.lower()

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -15,13 +15,12 @@ if TYPE_CHECKING:
     from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 
 from gittensor.constants import (
+    EXTENSIONLESS_FILE_EXTENSIONS,
     MAINTAINER_ASSOCIATIONS,
     MAX_CODE_DENSITY_MULTIPLIER,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
 )
 from gittensor.utils.utils import parse_repo_name
-
-_EXTENSIONLESS_FILE_EXTENSIONS = {'dockerfile', 'makefile'}
 
 
 def _apply_score_multipliers(base_score: float, multipliers: Dict[str, float], pr_label: str) -> float:
@@ -82,7 +81,7 @@ class FileChange:
         if '.' in basename:
             return basename.split('.')[-1].lower()
         basename_lower = basename.lower()
-        return basename_lower if basename_lower in _EXTENSIONLESS_FILE_EXTENSIONS else ''
+        return basename_lower if basename_lower in EXTENSIONLESS_FILE_EXTENSIONS else ''
 
     def is_test_file(self) -> bool:
         filename_lower = self.filename.lower()

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -69,6 +69,7 @@ NON_CODE_EXTENSIONS = [
     'erb',
 ]
 MAX_LINES_SCORED_FOR_NON_CODE_EXT = 300
+EXTENSIONLESS_FILE_EXTENSIONS = {'dockerfile', 'makefile'}
 
 # =============================================================================
 # Repository & PR Scoring

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -72,6 +72,22 @@ def test_is_test_file_preserves_existing_test_conventions():
     assert _file_change('src/foo/bar.py').is_test_file() is False
 
 
+@pytest.mark.parametrize(
+    'filename,expected',
+    [
+        ('Dockerfile', 'dockerfile'),
+        ('dockerfile', 'dockerfile'),
+        ('ops/Dockerfile', 'dockerfile'),
+        ('Makefile', 'makefile'),
+        ('makefile', 'makefile'),
+        ('build.mk', 'mk'),
+        ('README', ''),
+    ],
+)
+def test_file_extension_handles_configured_extensionless_filenames(filename, expected):
+    assert _file_change(filename).file_extension == expected
+
+
 def test_pull_request_handles_deleted_label_event():
     pr_data = {
         'number': 42,

--- a/tests/validator/test_token_scoring_integration.py
+++ b/tests/validator/test_token_scoring_integration.py
@@ -14,8 +14,10 @@ Run tests:
 
 import pytest
 
-from gittensor.validator.utils.load_weights import TokenConfig, load_token_config
-from gittensor.validator.utils.tree_sitter_scoring import score_tree_diff
+from gittensor.classes import FileChange
+from gittensor.utils.github_api_tools import FileContentPair
+from gittensor.validator.utils.load_weights import TokenConfig, load_programming_language_weights, load_token_config
+from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes, score_tree_diff
 
 
 class TestTreeDiffScoring:
@@ -24,6 +26,43 @@ class TestTreeDiffScoring:
     @pytest.fixture
     def weights(self) -> TokenConfig:
         return load_token_config()
+
+    @pytest.mark.parametrize(
+        'filename,old_content,new_content',
+        [
+            (
+                'Dockerfile',
+                'FROM python:3.12-slim\n',
+                'FROM python:3.12-slim\nRUN pip install uv\nCOPY . /app\n',
+            ),
+            (
+                'Makefile',
+                'test:\n\tpytest\n',
+                'test:\n\tpytest\n\nlint:\n\truff check\n',
+            ),
+        ],
+    )
+    def test_configured_extensionless_files_reach_tree_diff(self, weights, filename, old_content, new_content):
+        file_change = FileChange(
+            pr_number=1,
+            repository_full_name='test/repo',
+            filename=filename,
+            changes=3,
+            additions=2,
+            deletions=1,
+            status='modified',
+        )
+        result = calculate_token_score_from_file_changes(
+            [file_change],
+            {filename: FileContentPair(old_content=old_content, new_content=new_content)},
+            weights,
+            load_programming_language_weights(),
+        )
+
+        file_result = result.file_results[0]
+        assert file_change.file_extension == filename.lower()
+        assert file_result.scoring_method == 'tree-diff'
+        assert file_result.nodes_scored > 0
 
     def test_new_file_scores_all_nodes(self, weights):
         """


### PR DESCRIPTION
# Summary

Score configured extensionless files like `Dockerfile` and `Makefile`.

`FileChange._calculate_file_extension()` previously returned an empty string for basenames without a dot. As a result, files such as `Dockerfile`, `dockerfile`, `Makefile`, and `makefile` could not reach the configured tree-sitter scoring path, even though `programming_languages.json` defines `dockerfile` and `makefile`.

This PR normalizes those configured extensionless basenames to their language config keys, while preserving existing behavior for normal dotted files and unrelated extensionless files.

## Related Issues

Closes #985

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

- `./.venv/bin/pytest tests/test_classes.py::test_file_extension_handles_configured_extensionless_filenames tests/validator/test_token_scoring_integration.py::TestTreeDiffScoring::test_configured_extensionless_files_reach_tree_diff -q`
- `./.venv/bin/pytest tests/test_classes.py tests/validator/test_token_scoring_integration.py tests/validator/test_base_score.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pyright`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
