### PR TITLE
fix(cli): surface skipped validators in miner post/check error path

### DIFF
--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -136,7 +136,18 @@ def _require_validator_axons(
         metagraph, min_vtrust=min_vtrust, min_stake=min_stake
     )
     if not validator_axons:
-        _error('No reachable validator axons found on the network.', json_mode)
+        if excluded:
+            msg = (
+                f'No validators passed --min-vtrust={min_vtrust:g} / '
+                f'--min-stake={min_stake:,.0f} α; all {len(excluded)} candidate(s) excluded.'
+            )
+            if json_mode:
+                click.echo(json.dumps({'success': False, 'error': msg, 'skipped': excluded}))
+            else:
+                _render_skipped_validators(excluded, json_mode)
+                console.print(f'[red]Error: {msg}[/red]')
+        else:
+            _error('No reachable validator axons found on the network.', json_mode)
         sys.exit(1)
     return validator_axons, validator_uids, excluded
 

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -16,6 +16,7 @@ from gittensor.cli.miner_commands.helpers import (
     _pat_check_aggregate_counts,
     _pat_post_aggregate_counts,
     _pat_post_row_category,
+    _require_validator_axons,
 )
 
 
@@ -182,6 +183,67 @@ class TestValidatorAxonFilter:
         mg = _fake_metagraph([(0.99, False, 1_000.0)])
         _, _, excluded = _get_validator_axons(mg, min_vtrust=0.25, min_stake=15_000.0)
         assert len(excluded[0]['reasons']) == 2
+
+
+class TestRequireValidatorAxonsErrorPath:
+    """Regression: the error path must surface the same `excluded` payload the
+    success path renders, so operators see which threshold eliminated each UID."""
+
+    def test_filtered_json_envelope_includes_skipped_array(self, capsys):
+        mg = _fake_metagraph(
+            [
+                (0.99, True, 5_000.0),
+                (0.85, True, 3_000.0),
+                (0.72, True, 8_000.0),
+            ]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _require_validator_axons(mg, True, min_vtrust=0.25, min_stake=15_000.0)
+        assert exc_info.value.code == 1
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload['success'] is False
+        assert '--min-stake' in payload['error']
+        assert '--min-vtrust' in payload['error']
+        assert len(payload['skipped']) == 3
+        assert {entry['uid'] for entry in payload['skipped']} == {0, 1, 2}
+        assert all(entry['reasons'] for entry in payload['skipped'])
+
+    def test_filtered_tty_renders_skipped_table_and_error(self, capsys):
+        mg = _fake_metagraph(
+            [
+                (0.99, True, 5_000.0),
+                (0.85, False, 50_000.0),
+            ]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _require_validator_axons(mg, False, min_vtrust=0.25, min_stake=15_000.0)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert 'Skipped Validators' in out
+        assert 'No validators passed' in out
+        assert 'Error:' in out
+
+    def test_truly_empty_metagraph_keeps_generic_message(self, capsys):
+        mg = _fake_metagraph([])
+        with pytest.raises(SystemExit) as exc_info:
+            _require_validator_axons(mg, True, min_vtrust=0.25, min_stake=15_000.0)
+        assert exc_info.value.code == 1
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload == {
+            'success': False,
+            'error': 'No reachable validator axons found on the network.',
+        }
+
+    def test_subvtrust_only_metagraph_keeps_generic_message(self, capsys):
+        # Sub-vtrust UIDs are dropped silently and never enter `excluded`,
+        # so the message should remain the generic one — not the threshold one.
+        mg = _fake_metagraph([(0.10, True, 50_000.0), (0.05, True, 100_000.0)])
+        with pytest.raises(SystemExit) as exc_info:
+            _require_validator_axons(mg, True, min_vtrust=0.25, min_stake=15_000.0)
+        assert exc_info.value.code == 1
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload['error'] == 'No reachable validator axons found on the network.'
+        assert 'skipped' not in payload
 
 
 class TestPatCheckAggregateCounts:


### PR DESCRIPTION
## Summary
When `--min-stake` / `--min-vtrust` exclude every high-vtrust validator, both `gitt miner post` and `gitt miner check` printed only the generic `No reachable validator axons found on the network.` and discarded the `excluded` list that the success path already exposes. 
The fix branches on whether `excluded` is non-empty and surfaces the same payload — TTY renders the existing `Skipped Validators` table, JSON includes `skipped` on the error envelope.
The original generic message is preserved when the metagraph carries no candidates at all (n=0 or every UID below `min_vtrust`).

## Problem
- `gittensor/cli/miner_commands/helpers.py:138` (pre-fix) called  `_error('No reachable validator axons found on the network.', json_mode)` and  exited, regardless of why every candidate dropped out.
- Operators hitting this case are exactly the ones who need the diagnostic (their stake/vtrust thresholds eliminated everyone).
- #906 introduced `--min-stake` / `--min-vtrust` and the `excluded` list, wired  it into the success path, but the error path was missed.

## Out of scope
- Exit-code semantics for full-rejection (#841 territory) — different bug.
- `_error()` signature changes to accept extra fields — tangential, would touch  unrelated callers.

## Validation
- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors
- `uv run python -m pytest` — 745 passed (+4 new regression tests)

Closes #989 
