### PR TITLE
fix: prevent scoring data loss and fix fragile test in stale PR refresh 

### DIFF
--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -100,6 +100,16 @@ DO UPDATE SET
     updated_at = NOW()
 """
 
+# Targeted state-only refresh for stale-closed PRs (avoids overwriting scored columns)
+REFRESH_STALE_PR_STATES = """
+UPDATE pull_requests
+   SET pr_state   = 'CLOSED',
+       updated_at = NOW()
+ WHERE number               = %s
+   AND repository_full_name = %s
+   AND pr_state            != 'CLOSED'
+"""
+
 # Issue Queries
 BULK_UPSERT_ISSUES = """
 INSERT INTO issues (

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -23,6 +23,7 @@ from .queries import (
     CLEANUP_STALE_MINER_EVALUATIONS_BY_HOTKEY,
     CLEANUP_STALE_MINERS,
     CLEANUP_STALE_MINERS_BY_HOTKEY,
+    REFRESH_STALE_PR_STATES,
     SET_MINER,
 )
 
@@ -215,6 +216,28 @@ class Repository(BaseRepository):
             if commit:
                 self.db.rollback()
             self.logger.error(f'Error in bulk pull request storage: {e}')
+            return 0
+
+    def refresh_stale_pr_states(self, pull_requests: List[PullRequest], commit: bool = True) -> int:
+        """Update pr_state to CLOSED for stale PRs without touching scoring columns.
+
+        Uses a targeted UPDATE so previously-computed scores (earned_score, base_score,
+        credibility_multiplier, etc.) are preserved on rows that were already scored.
+        Only rows currently stored as non-CLOSED are affected.
+        """
+        if not pull_requests:
+            return 0
+        values = [(pr.number, pr.repository_full_name) for pr in pull_requests]
+        try:
+            with self.get_cursor() as cursor:
+                cursor.executemany(REFRESH_STALE_PR_STATES, values)
+                if commit:
+                    self.db.commit()
+                return len(values)
+        except Exception as e:
+            if commit:
+                self.db.rollback()
+            self.logger.error(f'Error refreshing stale PR states: {e}')
             return 0
 
     def store_issues_bulk(self, issues: List[Issue], commit: bool = True) -> int:

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -71,7 +71,7 @@ class DatabaseStorage:
                 result.stored_counts['closed_pull_requests'] = self.repo.store_pull_requests_bulk(
                     miner_eval.closed_pull_requests + _adapt_mirror(miner_eval.mirror_closed_prs), commit=False
                 )
-                result.stored_counts['stale_closed_pull_requests'] = self.repo.store_pull_requests_bulk(
+                result.stored_counts['stale_closed_pull_requests'] = self.repo.refresh_stale_pr_states(
                     miner_eval.stale_closed_pull_requests, commit=False
                 )
                 result.stored_counts['issues'] = self.repo.store_issues_bulk(miner_eval.get_all_issues(), commit=False)

--- a/tests/validator/utils/test_storage_mirror.py
+++ b/tests/validator/utils/test_storage_mirror.py
@@ -86,6 +86,7 @@ def _make_storage_with_mock_repo():
             mock_repo = MagicMock()
             mock_repo.set_miner.return_value = 1
             mock_repo.store_pull_requests_bulk.return_value = 0  # actual count irrelevant
+            mock_repo.refresh_stale_pr_states.return_value = 0
             mock_repo.store_issues_bulk.return_value = 0
             mock_repo.store_file_changes_bulk.return_value = 0
             mock_repo.set_miner_evaluation.return_value = True
@@ -173,12 +174,17 @@ class TestStoreEvaluationCombinesBothLists:
 
         storage.store_evaluation(eval_)
 
-        stale_call = mock_repo.store_pull_requests_bulk.call_args_list[3]
-        stale_arg = stale_call.args[0]
+        # Stale PRs must go through refresh_stale_pr_states (targeted UPDATE), not the
+        # full-column UPSERT, so previously-scored rows are not overwritten with defaults.
+        mock_repo.refresh_stale_pr_states.assert_called_once()
+        stale_arg = mock_repo.refresh_stale_pr_states.call_args.args[0]
         assert len(stale_arg) == 1
         assert stale_arg[0].number == 7
         assert stale_arg[0].pr_state == PRState.CLOSED
         assert eval_.total_closed_prs == 0
+        # Verify the stale PR did not leak into store_pull_requests_bulk
+        for call in mock_repo.store_pull_requests_bulk.call_args_list:
+            assert not any(pr.number == 7 for pr in call.args[0])
 
 
 def test_cleanup_stale_called_with_commit_false():


### PR DESCRIPTION
## Description

Two gaps left unaddressed by #769.

**Gap 1 — Stale UPSERT silently zeroes previously-scored rows**

`store_pull_requests_bulk` in `gittensor/validator/utils/storage.py:74-76` routes stale PRs through `BULK_UPSERT_PULL_REQUESTS`, which uses `ON CONFLICT DO UPDATE SET` with `EXCLUDED.*` — overwriting every column on conflict. `PullRequest.from_graphql_response()` leaves all scoring fields at dataclass defaults (`base_score = 0.0`, `earned_score = 0.0`, `credibility_multiplier = 1.0`, etc.). Any PR that was previously scored — for example, one that was OPEN with collateral before the window shifted — has those computed values silently replaced with zeros on every subsequent scan.

**Gap 2 — Fragile positional assertion in `test_stale_closed_prs_are_stored_separately`**

`tests/validator/utils/test_storage_mirror.py:176` asserts stale storage correctness via `call_args_list[3]`. If the call order inside `store_evaluation` ever changes, the assertion silently targets the wrong call and the test continues to pass.

## Changes

- Add `REFRESH_STALE_PR_STATES` to `queries.py` — a targeted `UPDATE` that touches only `pr_state` and `updated_at`, leaving all scoring columns on existing rows untouched
- Add `Repository.refresh_stale_pr_states()` backed by the new query
- Wire `store_evaluation` to call `refresh_stale_pr_states` instead of `store_pull_requests_bulk` for the stale bucket
- Replace `call_args_list[3]` with `refresh_stale_pr_states.assert_called_once()` and add a leak guard asserting stale PRs do not reach `store_pull_requests_bulk`

No schema changes required.

Closes #991
