### PR TITLE
fix: remove dead branches in contract_client.py

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -370,6 +370,10 @@ class MinerEvaluation:
     total_leaf_score: float = 0.0
     failed_reason: Optional[str] = None
     github_pr_fetch_failed: bool = False
+    # Mirror-source-specific fetch flag set by mirror.combine.combine alongside
+    # the OR into github_pr_fetch_failed. Lets the validator tell a complete
+    # mirror outage apart from a legacy partial-pagination failure.
+    mirror_pr_fetch_failed: bool = False
     evaluation_timestamp: Optional[datetime] = None
     merged_pull_requests: List[PullRequest] = field(default_factory=list)
     open_pull_requests: List[PullRequest] = field(default_factory=list)

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -305,12 +305,8 @@ class PullRequest:
         last_edited_at = parse_github_timestamp_to_cst(raw_edited_at) if isinstance(raw_edited_at, str) else None
         merged_at = parse_github_timestamp_to_cst(pr_data['mergedAt']) if is_merged else None
 
-        changes_requested_count = 0
-        if is_merged:
-            cr_reviews = pr_data.get('changesRequestedReviews', {}).get('nodes', [])
-            changes_requested_count = sum(
-                1 for r in cr_reviews if r.get('authorAssociation') in MAINTAINER_ASSOCIATIONS
-            )
+        cr_reviews = (pr_data.get('changesRequestedReviews') or {}).get('nodes') or []
+        changes_requested_count = sum(1 for r in cr_reviews if r.get('authorAssociation') in MAINTAINER_ASSOCIATIONS)
 
         current = {(n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n}
         label: Optional[str] = None

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -374,6 +374,7 @@ class MinerEvaluation:
     merged_pull_requests: List[PullRequest] = field(default_factory=list)
     open_pull_requests: List[PullRequest] = field(default_factory=list)
     closed_pull_requests: List[PullRequest] = field(default_factory=list)
+    stale_closed_pull_requests: List[PullRequest] = field(default_factory=list)
 
     # Populated by gittensor.validator.oss_contributions.mirror.combine.combine
     # when the mirror scoring path runs. Empty for legacy-only evaluations.
@@ -482,6 +483,13 @@ class MinerEvaluation:
             f'CLOSED PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])} counting towards credibility'
         )
         self.closed_pull_requests.append(
+            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
+        )
+
+    def add_stale_closed_pull_request(self, raw_pr: Dict):
+        """Track a stale CLOSED PR so storage can refresh its pull_requests row."""
+        bt.logging.info(f'Stale CLOSED PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])}')
+        self.stale_closed_pull_requests.append(
             PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
         )
 

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -708,6 +708,9 @@ class MinerEvaluationCache:
         cached.merged_pull_requests = [_pr_for_cache(pr) for pr in evaluation.merged_pull_requests]
         cached.open_pull_requests = [_pr_for_cache(pr) for pr in evaluation.open_pull_requests]
         cached.closed_pull_requests = [_pr_for_cache(pr) for pr in evaluation.closed_pull_requests]
+        cached.mirror_merged_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.mirror_merged_prs]
+        cached.mirror_open_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.mirror_open_prs]
+        cached.mirror_closed_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.mirror_closed_prs]
         return cached
 
     @staticmethod
@@ -735,3 +738,9 @@ def _pr_with_fresh_issues(pr: 'PullRequest') -> 'PullRequest':
     if pr.issues is not None:
         pr_copy.issues = [copy.copy(issue) for issue in pr.issues]
     return pr_copy
+
+
+def _scored_mirror_pr_for_cache(scored: 'ScoredMirrorPR') -> 'ScoredMirrorPR':
+    scored_copy = copy.copy(scored)
+    scored_copy.files = None
+    return scored_copy

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -246,7 +246,7 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
             validators = client.get_validators()
 
         n = len(validators)
-        required = (n // 2) + 1
+        required = (n // 2) + 1 if n > 0 else 0
 
         if as_json:
             emit_json(

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -16,8 +16,9 @@ import json
 import os
 import sys
 
-# Stub heavy imports during shell completion so tab-completion stays fast.
-if os.environ.get('_GITT_COMPLETE'):
+# Stub heavy imports during shell completion and --help so tab-completion stays
+# fast and bittensor's argparse doesn't hijack click's help output.
+if os.environ.get('_GITT_COMPLETE') or any(arg in ('-h', '--help') for arg in sys.argv[1:]):
     import types as _types
 
     class _Stub(_types.ModuleType):
@@ -27,7 +28,7 @@ if os.environ.get('_GITT_COMPLETE'):
         def __call__(self, *_a, **_kw):
             return self
 
-    _stub = _Stub('_gitt_completion_stub')
+    _stub = _Stub('_gitt_cli_stub')
     for _pkg in ('bittensor', 'requests'):
         sys.modules[_pkg] = _stub
 

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -194,6 +194,7 @@ MAINTAINER_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR']
 
 # PR Review Quality Multiplier
 REVIEW_PENALTY_RATE = 0.15  # 15% deduction per CHANGES_REQUESTED review from a maintainer
+MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER = 2.0  # Cap open PR collateral growth from review iterations
 
 # Issue multiplier (flat values, no age scaling)
 STANDARD_ISSUE_MULTIPLIER = 1.33  # Non-maintainer issue author

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -759,9 +759,9 @@ def try_add_open_or_closed_pr(
         closed_dt = parse_github_iso_to_utc(closed_at)
         created_dt = parse_github_iso_to_utc(created_at)
 
-        # Ignore stale PRs that were created before the scoring lookback window.
         # This allows users to close old PRs without receiving a fresh credibility penalty.
         if created_dt < lookback_date_filter:
+            miner_eval.add_stale_closed_pull_request(pr_raw)
             return
 
         if closed_dt >= lookback_date_filter:

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -266,10 +266,8 @@ class IssueCompetitionContractClient:
             storage_limit = b'\x00'
 
             data_len = len(input_data)
-            if data_len < 64:
-                compact_len = bytes([data_len << 2])
-            else:
-                compact_len = bytes([(data_len << 2) | 1, data_len >> 6])
+            # SCALE compact encode: for data < 64 bytes, single byte suffices
+            compact_len = bytes([data_len << 2])
 
             call_params = origin + dest + value + gas_limit + storage_limit + compact_len + input_data
 
@@ -531,6 +529,8 @@ class IssueCompetitionContractClient:
             elif type_def == 'u64':
                 encoded += struct.pack('<Q', value)
             elif type_def == 'u128':
+                # NOTE: u128 is only used by register_issue, which bypasses
+                # _encode_args via a different execution path (CLI mutations).
                 encoded += struct.pack('<QQ', value & 0xFFFFFFFFFFFFFFFF, value >> 64)
             elif type_def == 'AccountId':
                 if isinstance(value, str):

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -19,9 +19,10 @@ Anti-gaming gates (all applied):
 - issue.author_github_id != solving_pr.author_github_id (anti-self-issue)
 
 Same-account ("solver is also discoverer") gives credibility only — no
-discovery score. One-issue-per-PR rule prevents a single solving PR from
-generating multiple discovery scores when it closes more than one issue;
-the earliest-created qualifying issue wins.
+discovery score. One-issue-per-PR rule is round-global: a single solving PR
+awards at most one discovery score across the entire validator round, even
+when it closes issues authored by different miners. The earliest-created
+qualifying issue across all miners wins; the rest are credibility only.
 
 Base-score resolution uses a per-cycle cross-miner cache. Most solving PRs on
 mirror-enabled repos will be miners' own PRs that OSS scoring already tokenized;
@@ -96,6 +97,9 @@ class _CacheStats:
     fetch_failures: int = 0
 
 
+_FAR_FUTURE = datetime.max.replace(tzinfo=timezone.utc)
+
+
 async def run_mirror_issue_discovery(
     miner_evaluations: Dict[int, MinerEvaluation],
     mirror_repos: Dict[str, RepositoryConfig],
@@ -134,12 +138,14 @@ async def run_mirror_issue_discovery(
         f'{sum(len(ev.mirror_merged_prs) for ev in miner_evaluations.values())} scored mirror PRs'
     )
 
-    processed = 0
     skipped_no_gh = 0
     skipped_failed = 0
     fetch_errors = 0
     no_issues = 0
 
+    # Phase 1: fetch each miner's issues.  The one-issue-per-PR rule is round-
+    # global, so scoring is deferred until every miner's batch is in hand.
+    pending: List[Tuple[MinerEvaluation, List[MirrorIssue], int]] = []
     for uid, evaluation in miner_evaluations.items():
         if not evaluation.github_id or evaluation.github_id == '0':
             skipped_no_gh += 1
@@ -166,8 +172,10 @@ async def run_mirror_issue_discovery(
         # mirror-scoped state (the legacy GraphQL global open-issue count was
         # never the right signal for the gate).
         open_issue_count = sum(1 for i in filtered if i.state == 'OPEN')
+        pending.append((evaluation, filtered, open_issue_count))
 
-        processed += 1
+    canonical_pr_owners = _build_canonical_pr_owners(pending)
+    for evaluation, filtered, open_issue_count in pending:
         _score_miner_mirror_issues(
             evaluation,
             filtered,
@@ -178,11 +186,12 @@ async def run_mirror_issue_discovery(
             programming_languages,
             token_config,
             open_issue_count=open_issue_count,
+            canonical_pr_owners=canonical_pr_owners,
         )
 
     bt.logging.info('')
     bt.logging.info(
-        f'Issue discovery complete | {processed} processed | {no_issues} no mirror issues | '
+        f'Issue discovery complete | {len(pending)} processed | {no_issues} no mirror issues | '
         f'{fetch_errors} fetch errors | {skipped_no_gh} no github_id | {skipped_failed} prior OSS failure'
     )
     bt.logging.info(
@@ -190,6 +199,34 @@ async def run_mirror_issue_discovery(
         f'({cache_stats.misses - cache_stats.fetch_failures} fetched OK, '
         f'{cache_stats.fetch_failures} fetch failures)'
     )
+
+
+def _build_canonical_pr_owners(
+    pending: List[Tuple[MinerEvaluation, List[MirrorIssue], int]],
+) -> Dict[Tuple[str, int], Tuple[datetime, int, int]]:
+    """Cross-miner one-issue-per-PR resolution (legacy parity, pre-#796).
+
+    Returns ``(repo, pr_number) -> (created_at, issue_number, uid)`` for the
+    earliest-created qualifying issue across all miners. Same-account issues
+    (discoverer == solver) are excluded — they never claim the slot, mirroring
+    legacy ``pr_scored.add`` ordering. ``_score_miner_mirror_issues`` matches
+    issue markers against this map to gate scoring vs. credibility-only.
+    """
+    canonical: Dict[Tuple[str, int], Tuple[datetime, int, int]] = {}
+    for evaluation, issues, _ in pending:
+        for issue in issues:
+            if _classify_issue(issue) != 'solved':
+                continue
+            sp = issue.solving_pr
+            assert sp is not None  # _classify_issue guarantees a solving_pr
+            if issue.author_github_id == sp.author_github_id:
+                continue
+            key = (issue.repo_full_name, sp.pr_number)
+            marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)
+            existing = canonical.get(key)
+            if existing is None or marker < existing:
+                canonical[key] = marker
+    return canonical
 
 
 def _build_solving_pr_cache(
@@ -226,12 +263,16 @@ def _score_miner_mirror_issues(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     open_issue_count: int,
+    canonical_pr_owners: Dict[Tuple[str, int], Tuple[datetime, int, int]],
 ) -> None:
     """Classify + score one miner's mirror issues, populate MinerEvaluation fields.
 
     ``open_issue_count`` is the miner's currently-OPEN issue count across
     mirror-enabled repos within the lookback window — the source-of-truth
     for the open-issue spam multiplier on the mirror path.
+
+    ``canonical_pr_owners`` enforces the cross-miner one-issue-per-PR rule:
+    only the marker-matching issue scores, siblings count for credibility.
     """
     solved_count = 0
     valid_solved_count = 0
@@ -239,16 +280,12 @@ def _score_miner_mirror_issues(
     issue_token_score = 0.0
     scored_issues: List[Issue] = []
 
-    # One-issue-per-PR: the earliest-created issue a PR closes gets the score;
-    # later issues closed by the same PR add credibility only.
-    pr_scored_keys: Set[Tuple[str, int]] = set()
-
     issues_sorted = sorted(
         issues,
         key=lambda i: (
             i.repo_full_name,
             i.solved_by_pr or 0,
-            i.created_at or datetime.max.replace(tzinfo=timezone.utc),
+            i.created_at or _FAR_FUTURE,
         ),
     )
 
@@ -299,13 +336,13 @@ def _score_miner_mirror_issues(
             continue
 
         pr_key = (issue.repo_full_name, solving_pr.pr_number)
-        if pr_key in pr_scored_keys:
+        own_marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)
+        if canonical_pr_owners.get(pr_key) != own_marker:
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): one-issue-per-PR '
-                f'(PR #{solving_pr.pr_number} already scored an earlier issue) — credibility only'
+                f'(PR #{solving_pr.pr_number} canonical owner is a different issue) — credibility only'
             )
             continue
-        pr_scored_keys.add(pr_key)
 
         repo_config = mirror_repos.get(issue.repo_full_name)
         if repo_config is None:

--- a/gittensor/validator/oss_contributions/mirror/combine.py
+++ b/gittensor/validator/oss_contributions/mirror/combine.py
@@ -4,6 +4,9 @@ Single explicit join point between the two scoring paths:
 - Mirror PR lists land in the ``mirror_*`` slots on the MinerEvaluation
 - ``unique_repos_contributed_to`` is unioned
 - ``github_pr_fetch_failed`` is OR'd
+- ``mirror_pr_fetch_failed`` is materialized so the validator can tell
+  a complete mirror outage apart from a legacy partial-pagination failure
+  when deciding cache fallback strategy
 
 Per-PR scoring breakdowns (token_score, nodes_scored, base_score, earned_score,
 collateral_score) live on each ScoredMirrorPR — they get aggregated into
@@ -27,4 +30,5 @@ def combine(legacy_eval: MinerEvaluation, mirror_eval: MirrorMinerEvaluation) ->
 
     legacy_eval.unique_repos_contributed_to |= mirror_eval.unique_repos_contributed_to
 
+    legacy_eval.mirror_pr_fetch_failed = mirror_eval.fetch_failed
     legacy_eval.github_pr_fetch_failed = legacy_eval.github_pr_fetch_failed or mirror_eval.fetch_failed

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -72,6 +72,12 @@ class ScoredMirrorPR:
         return self.pr.repo_full_name
 
     @property
+    def changes_requested_count(self) -> int:
+        """Alias for the maintainer-only CHANGES_REQUESTED count used by
+        source-agnostic scoring helpers."""
+        return self.pr.review_summary.maintainer_changes_requested_count
+
+    @property
     def merged_at(self) -> Optional[datetime]:
         """Alias for ``self.pr.merged_at`` — matches legacy PullRequest attribute
         name so the unified pioneer-dividend walk treats both types identically."""

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -16,7 +16,7 @@ Anti-gaming notes:
 - ``edited_after_merge`` is NOT a PR-level gate — it gates only the issue
   bonus multiplier in ``_is_valid_linked_issue``, matching legacy
   ``is_valid_issue``.
-- Mirror's ``actor_association`` per label lets ``_resolve_maintainer_set_label``
+- Mirror's ``actor_association`` per label lets ``_resolve_trusted_scoring_label``
   require maintainer-applied labels; legacy can't do this and accepts any-applier.
 """
 
@@ -351,7 +351,7 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
 
     scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
 
-    chosen_label = _resolve_maintainer_set_label(pr)
+    chosen_label = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label
     scored.label_multiplier = LABEL_MULTIPLIERS.get(chosen_label, 1.0) if chosen_label else 1.0
 
@@ -372,17 +372,22 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
         scored.review_quality_multiplier = 1.0
 
 
-def _resolve_maintainer_set_label(pr: MirrorPullRequest) -> Optional[str]:
-    """Pick the highest-multiplier currently-applied label that was set by a maintainer.
+def _resolve_trusted_scoring_label(pr: MirrorPullRequest, repo_config: RepositoryConfig) -> Optional[str]:
+    """Pick the highest-multiplier currently-applied scoring label whose actor is trusted.
 
-    Mirror gives us actor attribution per label, so we can directly require the
-    label to have been applied by an OWNER/MEMBER/COLLABORATOR. Labels with null
-    actor_association (backfilled events) are ignored to be conservative.
+    By default the actor must be in ``MAINTAINER_ASSOCIATIONS``. Repos opted into
+    ``trusted_label_pipeline`` accept any actor — including GitHub-App actors that
+    surface as ``actor_association=NULL`` because they lack a row in
+    ``contributor_repo_roles`` (issue #911). Only flip the flag on for repos whose
+    label pipeline is authoritative; community repos run attacker-controllable
+    auto-labelers (release-drafter, actions/labeler) and must keep the gate.
     """
+    trusted = repo_config.trusted_label_pipeline
     candidates = [
         label
         for label in pr.labels
-        if label.actor_association in MAINTAINER_ASSOCIATIONS and (label.name or '').lower() in LABEL_MULTIPLIERS
+        if (label.name or '').lower() in LABEL_MULTIPLIERS
+        and (trusted or label.actor_association in MAINTAINER_ASSOCIATIONS)
     ]
     if not candidates:
         return None

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -21,6 +21,7 @@ from gittensor.constants import (
     MAINTAINER_ASSOCIATIONS,
     MAINTAINER_ISSUE_MULTIPLIER,
     MAX_ISSUE_CLOSE_WINDOW_DAYS,
+    MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER,
     MAX_OPEN_PR_THRESHOLD,
     OPEN_PR_COLLATERAL_PERCENT,
     OPEN_PR_THRESHOLD_TOKEN_SCORE,
@@ -177,6 +178,26 @@ def calculate_review_quality_multiplier(changes_requested_count: int, pr_number:
         bt.logging.info(
             f'{changes_requested_count} maintainer CHANGES_REQUESTED review(s){ctx} → '
             f'review_quality_multiplier={multiplier:.2f}'
+        )
+    return multiplier
+
+
+def calculate_review_collateral_multiplier(changes_requested_count: int, pr_number: Optional[int] = None) -> float:
+    """Calculate the open-PR collateral multiplier from maintainer CHANGES_REQUESTED reviews.
+
+    Unlike ``review_quality_multiplier`` for earned scores, this increases
+    collateral so non-merge-ready open PRs reserve more score instead of less.
+    Formula: min(MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER, 1.0 + REVIEW_PENALTY_RATE × N)
+    """
+    multiplier = min(
+        MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER,
+        1.0 + REVIEW_PENALTY_RATE * changes_requested_count,
+    )
+    if changes_requested_count > 0:
+        ctx = f' (PR #{pr_number})' if pr_number else ''
+        bt.logging.info(
+            f'{changes_requested_count} maintainer CHANGES_REQUESTED review(s){ctx} → '
+            f'review_collateral_multiplier={multiplier:.2f}'
         )
     return multiplier
 
@@ -495,7 +516,7 @@ def calculate_open_pr_collateral_score(
 
     Collateral = base_score * applicable_multipliers * OPEN_PR_COLLATERAL_PERCENT
 
-    Applicable multipliers: repo_weight, issue, label
+    Applicable multipliers: repo_weight, issue, label, review_collateral
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
                     open_pr_spam (not for collateral)
     """
@@ -505,6 +526,7 @@ def calculate_open_pr_collateral_score(
         'repo_weight': pr.repo_weight_multiplier,
         'issue': pr.issue_multiplier,
         'label': pr.label_multiplier,
+        'review_collateral': calculate_review_collateral_multiplier(pr.changes_requested_count, pr.number),
     }
 
     potential_score = pr.base_score * prod(multipliers.values())

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -34,6 +34,10 @@ class RepositoryConfig:
         mirror_enabled: When True, fetch this repo's data from the das-github-mirror
             service instead of via per-miner PATs. Defaults to False so existing
             entries keep their current PAT-based behavior.
+        trusted_label_pipeline: When True, scoring labels count regardless of
+            actor — including GitHub Apps that surface as ``actor_association=NULL``.
+            Defaults to False; only enable on repos with an authoritative label
+            pipeline. See ``_resolve_trusted_scoring_label`` for the threat model.
 
     """
 
@@ -41,6 +45,7 @@ class RepositoryConfig:
     inactive_at: Optional[str] = None
     additional_acceptable_branches: Optional[List[str]] = None
     mirror_enabled: bool = False
+    trusted_label_pipeline: bool = False
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -122,6 +127,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     mirror_enabled=bool(metadata.get('mirror_enabled', False)),
+                    trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -71,6 +71,9 @@ class DatabaseStorage:
             result.stored_counts['closed_pull_requests'] = self.repo.store_pull_requests_bulk(
                 miner_eval.closed_pull_requests + _adapt_mirror(miner_eval.mirror_closed_prs), commit=False
             )
+            result.stored_counts['stale_closed_pull_requests'] = self.repo.store_pull_requests_bulk(
+                miner_eval.stale_closed_pull_requests, commit=False
+            )
             result.stored_counts['issues'] = self.repo.store_issues_bulk(miner_eval.get_all_issues(), commit=False)
             result.stored_counts['file_changes'] = self.repo.store_file_changes_bulk(
                 miner_eval.get_all_file_changes(), commit=False

--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -58,12 +58,12 @@ def get_parser(language: str) -> Optional[Parser]:
         return None
 
 
-def parse_code(content: str, language: str) -> Optional[Tree]:
+def parse_code(content: Union[str, bytes], language: str) -> Optional[Tree]:
     """
     Parse source code into a tree-sitter AST.
 
     Args:
-        content: Source code as string
+        content: Source code as string or pre-encoded bytes
         language: Tree-sitter language name
 
     Returns:
@@ -74,7 +74,8 @@ def parse_code(content: str, language: str) -> Optional[Tree]:
         return None
 
     try:
-        return parser.parse(content.encode('utf-8'))
+        data = content.encode('utf-8') if isinstance(content, str) else content
+        return parser.parse(data)
     except Exception as e:
         bt.logging.debug(f'Failed to parse code: {e}')
         return None

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -205,19 +205,28 @@
   },
   "entrius/allways": {
     "weight": 1.0,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "entrius/allways-ui": {
     "weight": 0.5,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
+  },
+  "entrius/das-github-mirror": {
+    "weight": 0.2,
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
     "weight": 1.0,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
     "weight": 0.5,
-    "mirror_enabled": true
+    "mirror_enabled": true,
+    "trusted_label_pipeline": true
   },
   "espressif/arduino-esp32": {
     "weight": 0.1444

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -249,9 +249,6 @@
   "flowsurface-rs/flowsurface": {
     "weight": 0.051
   },
-  "fx-integral/metahash": {
-    "weight": 0.0431
-  },
   "General-Tao-Ventures/cartha-cli": {
     "weight": 0.0476
   },
@@ -696,9 +693,6 @@
   },
   "thenervelab/thebrain": {
     "weight": 0.039
-  },
-  "threetau/kinitro": {
-    "weight": 0.0368
   },
   "tinygrad/tinygrad": {
     "weight": 0.0677

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -144,6 +144,9 @@ class Validator(BaseValidatorNeuron):
         Handle evaluation cache: store successful evals, fallback to cache for GitHub failures.
 
         Mutates the passed dict, replacing failed evaluations with cached ones if available.
+        A mirror-only fetch failure also routes through the cache-fallback path so the miner
+        is evaluated against a coherent one-round-stale snapshot instead of a fresh-legacy +
+        zeroed-mirror view where cross-PR multipliers would recompute over a partial state.
 
         Returns:
             Set of UIDs that were restored from cache (should be skipped during DB storage
@@ -161,7 +164,9 @@ class Validator(BaseValidatorNeuron):
                     self.evaluation_cache.store(miner_eval)
                 continue
 
-            if not miner_eval.should_use_cache_fallback:
+            # Legacy partial-pagination failure with no mirror outage: the current eval
+            # holds a truncated legacy PR list that would be misleading to cache or swap out.
+            if not miner_eval.should_use_cache_fallback and not miner_eval.mirror_pr_fetch_failed:
                 bt.logging.warning(
                     f'UID {uid}: GitHub fetch failed after partial PR load; skipping cache store/fallback this round'
                 )

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -111,6 +111,7 @@ def _issue_dict(
     solving_pr_edited_after_merge: bool = False,
     last_edited_at: Optional[str] = None,
     repo: str = 'entrius/gittensor-ui',
+    created_at: str = '2026-04-01T00:00:00Z',
 ) -> dict:
     sp = None
     if solved_by_pr:
@@ -136,7 +137,7 @@ def _issue_dict(
         'author_github_id': author_github_id,
         'author_login': 'discoverer',
         'author_association': 'CONTRIBUTOR',
-        'created_at': '2026-04-01T00:00:00Z',
+        'created_at': created_at,
         'closed_at': '2026-04-18T10:00:00Z' if state == 'CLOSED' else None,
         'updated_at': '2026-04-18T10:00:00Z',
         'last_edited_at': last_edited_at,
@@ -700,3 +701,284 @@ class TestOpenIssueSpamSourceIsMirror:
         # Below threshold → spam_mult=1.0 → discovery score is non-zero
         assert eval_.issue_discovery_score > 0
         assert eval_.total_open_issues == 2
+
+
+class TestCrossMinerOneIssuePerPr:
+    """Regression tests for the cross-miner one-issue-per-PR rule.
+
+    A single solving PR closing issues authored by multiple miners must award
+    discovery score to at most one of them — the earliest-created qualifying
+    issue across all miners — with the rest counted as credibility-only. This
+    matches the rule documented at the top of ``mirror_scan`` and the legacy
+    pre-#796 behavior in ``_collect_issues_from_prs``.
+    """
+
+    def test_canonical_picks_earliest_created_across_miners(self):
+        """``_build_canonical_pr_owners`` keys (repo, pr_number) to the
+        earliest-created qualifying issue across all miners' fetches."""
+        from gittensor.validator.issue_discovery.mirror_scan import _build_canonical_pr_owners
+
+        e_a = _eval(uid=1, github_id='A')
+        e_b = _eval(uid=2, github_id='B')
+
+        a_issue = MirrorIssue.from_dict(
+            _issue_dict(
+                issue_number=50,
+                author_github_id='A',
+                solving_pr_author='SOLVER',
+                created_at='2026-04-01T00:00:00Z',
+            )
+        )
+        b_issue = MirrorIssue.from_dict(
+            _issue_dict(
+                issue_number=51,
+                author_github_id='B',
+                solving_pr_author='SOLVER',
+                created_at='2026-04-05T00:00:00Z',
+            )
+        )
+
+        canonical = _build_canonical_pr_owners([(e_a, [a_issue], 0), (e_b, [b_issue], 0)])
+
+        # Earlier-created issue (#50, uid 1) wins canonical for PR 100
+        owner = canonical[('entrius/gittensor-ui', 100)]
+        assert owner[1] == 50
+        assert owner[2] == 1
+
+    def test_canonical_tie_break_lower_issue_number(self):
+        """Identical ``created_at`` across miners → lower issue_number wins."""
+        from gittensor.validator.issue_discovery.mirror_scan import _build_canonical_pr_owners
+
+        # uid 2 first in iteration order, but uid 1's lower issue_number must win.
+        e_a = _eval(uid=2, github_id='A')
+        e_b = _eval(uid=1, github_id='B')
+
+        a_issue = MirrorIssue.from_dict(
+            _issue_dict(
+                issue_number=51,
+                author_github_id='A',
+                solving_pr_author='SOLVER',
+                created_at='2026-04-01T00:00:00Z',
+            )
+        )
+        b_issue = MirrorIssue.from_dict(
+            _issue_dict(
+                issue_number=50,
+                author_github_id='B',
+                solving_pr_author='SOLVER',
+                created_at='2026-04-01T00:00:00Z',
+            )
+        )
+
+        canonical = _build_canonical_pr_owners([(e_a, [a_issue], 0), (e_b, [b_issue], 0)])
+
+        owner = canonical[('entrius/gittensor-ui', 100)]
+        assert owner[1] == 50  # lower issue_number wins
+        assert owner[2] == 1  # ... which is uid 1 (e_b)
+
+    def test_canonical_excludes_same_account(self):
+        """Same-account issues never claim canonical ownership of a PR slot,
+        leaving non-same-account siblings on the same PR free to score."""
+        from gittensor.validator.issue_discovery.mirror_scan import _build_canonical_pr_owners
+
+        e_a = _eval(uid=1, github_id='A')
+        e_b = _eval(uid=2, github_id='B')
+
+        # A's issue is same-account (author == solver) and earlier — must be excluded.
+        a_issue = MirrorIssue.from_dict(
+            _issue_dict(
+                issue_number=50,
+                author_github_id='A',
+                solving_pr_author='A',
+                created_at='2026-04-01T00:00:00Z',
+            )
+        )
+        b_issue = MirrorIssue.from_dict(
+            _issue_dict(
+                issue_number=51,
+                author_github_id='B',
+                solving_pr_author='SOLVER',
+                created_at='2026-04-05T00:00:00Z',
+            )
+        )
+
+        canonical = _build_canonical_pr_owners([(e_a, [a_issue], 0), (e_b, [b_issue], 0)])
+
+        owner = canonical[('entrius/gittensor-ui', 100)]
+        assert owner[1] == 51  # B's issue claims canonical
+        assert owner[2] == 2
+
+    def test_two_miners_shared_pr_only_earliest_scores(self):
+        """End-to-end: two miners each with 7 valid solved issues clearing
+        the eligibility gate, one solving PR shared between them. The
+        earlier-created issue's miner pockets the shared PR's contribution;
+        the later one gets credibility only.
+        """
+        client = Mock()
+
+        # 6 unique-PR issues + 1 shared-PR issue per miner. A's #50 is earlier
+        # (April 1) than B's #51 (April 5), so A is canonical for PR 100.
+        a_issues = [_issue_dict(issue_number=10 + i, author_github_id='A', solved_by_pr=200 + i) for i in range(6)]
+        a_issues.append(
+            _issue_dict(
+                issue_number=50,
+                author_github_id='A',
+                solved_by_pr=100,
+                solving_pr_author='SOLVER',
+                created_at='2026-04-01T00:00:00Z',
+            )
+        )
+        b_issues = [_issue_dict(issue_number=20 + i, author_github_id='B', solved_by_pr=300 + i) for i in range(6)]
+        b_issues.append(
+            _issue_dict(
+                issue_number=51,
+                author_github_id='B',
+                solved_by_pr=100,
+                solving_pr_author='SOLVER',
+                created_at='2026-04-05T00:00:00Z',
+            )
+        )
+
+        def _per_miner(github_id, since=None):
+            return _response(a_issues if github_id == 'A' else b_issues)
+
+        client.get_miner_issues.side_effect = _per_miner
+
+        e_a = _eval(uid=1, github_id='A')
+        e_b = _eval(uid=2, github_id='B')
+
+        # Pre-seed cross-miner solving-PR cache so no fetches are needed.
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.mirror_merged_prs = [
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number)
+            for pr_number in [100] + list(range(200, 206)) + list(range(300, 306))
+        ]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: e_a, 2: e_b, 99: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Both miners count the shared-PR issue toward credibility.
+        assert e_a.total_solved_issues == 7
+        assert e_b.total_solved_issues == 7
+        assert e_a.total_valid_solved_issues == 7
+        assert e_b.total_valid_solved_issues == 7
+        assert e_a.is_issue_eligible
+        assert e_b.is_issue_eligible
+
+        # ``issue_token_score`` accumulates only over SCORED PRs (default
+        # ``_scored_mirror_pr`` token_score is 100.0), so this is the
+        # deterministic, time-decay-independent check: A has 7 scored, B has
+        # 6 (shared PR 100 is canonical for A only and credibility-only for B).
+        assert e_a.issue_token_score == 700.0
+        assert e_b.issue_token_score == 600.0
+        # All solving PRs share identical scoring inputs at this issue mix, so
+        # the discovery_score ratio collapses to 7:6.
+        assert e_a.issue_discovery_score > e_b.issue_discovery_score > 0
+        assert e_a.issue_discovery_score / e_b.issue_discovery_score == pytest.approx(7 / 6, rel=1e-2)
+
+    def test_within_miner_one_issue_per_pr_still_holds(self):
+        """One miner authoring two issues both closed by the same PR — the
+        earlier-created issue scores; the later one is credibility-only.
+        Preserves the original within-miner one-issue-per-PR semantics now
+        that the rule is enforced via the cross-miner canonical map."""
+        client = Mock()
+
+        miner_issues = [
+            _issue_dict(issue_number=10 + i, author_github_id='999', solved_by_pr=200 + i) for i in range(6)
+        ]
+        miner_issues.extend(
+            [
+                _issue_dict(
+                    issue_number=50,
+                    author_github_id='999',
+                    solved_by_pr=100,
+                    solving_pr_author='SOLVER',
+                    created_at='2026-04-01T00:00:00Z',
+                ),
+                _issue_dict(
+                    issue_number=51,
+                    author_github_id='999',
+                    solved_by_pr=100,
+                    solving_pr_author='SOLVER',
+                    created_at='2026-04-05T00:00:00Z',
+                ),
+            ]
+        )
+
+        client.get_miner_issues.return_value = _response(miner_issues)
+        eval_ = _eval(uid=1, github_id='999')
+
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.mirror_merged_prs = [
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number) for pr_number in [100] + list(range(200, 206))
+        ]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_, 99: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # 8 solved (both shared-PR issues counted for credibility), eligible.
+        assert eval_.total_solved_issues == 8
+        assert eval_.total_valid_solved_issues == 8
+        assert eval_.is_issue_eligible
+        # ``issue_token_score`` only accumulates over SCORED PRs (default
+        # ``_scored_mirror_pr`` token_score is 100.0). 7 distinct scoring PRs
+        # ⇒ 700.0; the later PR-100 issue is credibility-only and contributes
+        # no token_score, so this would be 800.0 if the within-miner rule had
+        # broken alongside the cross-miner one.
+        assert eval_.issue_token_score == 700.0
+        assert eval_.issue_discovery_score > 0
+
+    def test_different_solving_prs_both_miners_score(self):
+        """Two miners' issues closed by completely disjoint solving PRs —
+        no cross-miner canonical contention; both miners score normally."""
+        client = Mock()
+
+        a_issues = [_issue_dict(issue_number=10 + i, author_github_id='A', solved_by_pr=200 + i) for i in range(7)]
+        b_issues = [_issue_dict(issue_number=20 + i, author_github_id='B', solved_by_pr=300 + i) for i in range(7)]
+
+        def _per_miner(github_id, since=None):
+            return _response(a_issues if github_id == 'A' else b_issues)
+
+        client.get_miner_issues.side_effect = _per_miner
+
+        e_a = _eval(uid=1, github_id='A')
+        e_b = _eval(uid=2, github_id='B')
+
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.mirror_merged_prs = [
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number)
+            for pr_number in list(range(200, 207)) + list(range(300, 307))
+        ]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: e_a, 2: e_b, 99: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Identical issue mix and disjoint PRs → identical scores. Both miners
+        # score all 7 of their issues (no canonical contention).
+        assert e_a.total_solved_issues == 7
+        assert e_b.total_solved_issues == 7
+        assert e_a.issue_token_score == 700.0
+        assert e_b.issue_token_score == 700.0
+        assert e_a.issue_discovery_score == e_b.issue_discovery_score
+        assert e_a.issue_discovery_score > 0

--- a/tests/validator/oss_contributions/mirror/test_combine.py
+++ b/tests/validator/oss_contributions/mirror/test_combine.py
@@ -133,12 +133,14 @@ class TestCombineFetchFailed:
         mirror_eval = MirrorMinerEvaluation(uid=1, hotkey='hk')
         combine(legacy, mirror_eval)
         assert legacy.github_pr_fetch_failed is True
+        assert legacy.mirror_pr_fetch_failed is False
 
     def test_mirror_failed_only(self):
         legacy = MinerEvaluation(uid=1, hotkey='hk')
         mirror_eval = MirrorMinerEvaluation(uid=1, hotkey='hk', fetch_failed=True)
         combine(legacy, mirror_eval)
         assert legacy.github_pr_fetch_failed is True
+        assert legacy.mirror_pr_fetch_failed is True
 
     def test_both_failed(self):
         legacy = MinerEvaluation(uid=1, hotkey='hk')
@@ -146,9 +148,11 @@ class TestCombineFetchFailed:
         mirror_eval = MirrorMinerEvaluation(uid=1, hotkey='hk', fetch_failed=True)
         combine(legacy, mirror_eval)
         assert legacy.github_pr_fetch_failed is True
+        assert legacy.mirror_pr_fetch_failed is True
 
     def test_neither_failed(self):
         legacy = MinerEvaluation(uid=1, hotkey='hk')
         mirror_eval = MirrorMinerEvaluation(uid=1, hotkey='hk')
         combine(legacy, mirror_eval)
         assert legacy.github_pr_fetch_failed is False
+        assert legacy.mirror_pr_fetch_failed is False

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -34,7 +34,7 @@ load_weights = pytest.importorskip('gittensor.validator.utils.load_weights')
 _should_skip_merged_mirror_pr = scoring_module._should_skip_merged_mirror_pr
 _convert_mirror_files = adapters_module.mirror_files_to_legacy
 _calculate_pr_multipliers = scoring_module._calculate_pr_multipliers
-_resolve_maintainer_set_label = scoring_module._resolve_maintainer_set_label
+_resolve_trusted_scoring_label = scoring_module._resolve_trusted_scoring_label
 _calculate_issue_multiplier = scoring_module._calculate_issue_multiplier
 _is_valid_linked_issue = scoring_module._is_valid_linked_issue
 score_mirror_pr = scoring_module.score_mirror_pr
@@ -100,11 +100,16 @@ def _pr(
     )
 
 
-def _config(weight: float = 0.5, additional_branches: list | None = None) -> RepositoryConfig:
+def _config(
+    weight: float = 0.5,
+    additional_branches: list | None = None,
+    trusted_label_pipeline: bool = False,
+) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
         mirror_enabled=True,
         additional_acceptable_branches=additional_branches,
+        trusted_label_pipeline=trusted_label_pipeline,
     )
 
 
@@ -408,45 +413,36 @@ class TestConvertMirrorFiles:
 class TestLabelResolution:
     def test_no_labels_returns_none(self):
         scored = ScoredMirrorPR(pr=_pr(labels=[]))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_non_scoring_labels_ignored(self):
-        # 'enhancement' is in LABEL_MULTIPLIERS, 'random' typically isn't
-        labels = [
-            {'name': 'random', 'actor_github_id': '1', 'actor_association': 'OWNER'},
-        ]
+        labels = [{'name': 'random', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_non_maintainer_label_ignored(self):
         from gittensor.constants import LABEL_MULTIPLIERS
 
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [
-            {'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'},
-        ]
+        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
-    def test_null_actor_association_ignored(self):
+    def test_null_actor_association_ignored_on_untrusted_repo(self):
         from gittensor.constants import LABEL_MULTIPLIERS
 
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [
-            {'name': scoring_label, 'actor_github_id': None, 'actor_association': None},
-        ]
+        labels = [{'name': scoring_label, 'actor_github_id': None, 'actor_association': None}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_maintainer_set_scoring_label_returned(self):
         from gittensor.constants import LABEL_MULTIPLIERS
 
         scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [
-            {'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'},
-        ]
+        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_maintainer_set_label(scored.pr) == scoring_label.lower()
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) == scoring_label.lower()
 
     def test_highest_multiplier_wins(self):
         from gittensor.constants import LABEL_MULTIPLIERS
@@ -455,17 +451,33 @@ class TestLabelResolution:
         if len(scoring_labels) < 2:
             pytest.skip('Need at least 2 scoring labels for this test')
 
-        # Pick two different scoring labels
         a, b = scoring_labels[0], scoring_labels[1]
         labels = [
             {'name': a, 'actor_github_id': '1', 'actor_association': 'OWNER'},
             {'name': b, 'actor_github_id': '1', 'actor_association': 'OWNER'},
         ]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        chosen = _resolve_maintainer_set_label(scored.pr)
-        # Whichever label has the higher LABEL_MULTIPLIERS value should win
+        chosen = _resolve_trusted_scoring_label(scored.pr, _config())
         expected = max([a, b], key=lambda n: (LABEL_MULTIPLIERS[n], n)).lower()
         assert chosen == expected
+
+    def test_calculate_multipliers_threads_trusted_flag(self):
+        """End-to-end issue #911 path: _calculate_pr_multipliers honors trusted_label_pipeline."""
+        from gittensor.constants import LABEL_MULTIPLIERS
+
+        scoring_label = next((name for name, mult in LABEL_MULTIPLIERS.items() if mult != 1.0), None)
+        if scoring_label is None:
+            pytest.skip('Need at least one non-1.0x label for this test')
+
+        labels = [{'name': scoring_label, 'actor_github_id': '99', 'actor_association': None}]
+
+        scored_trusted = ScoredMirrorPR(pr=_pr(labels=labels))
+        _calculate_pr_multipliers(scored_trusted, _config(trusted_label_pipeline=True))
+        assert scored_trusted.label_multiplier == LABEL_MULTIPLIERS[scoring_label]
+
+        scored_untrusted = ScoredMirrorPR(pr=_pr(labels=labels))
+        _calculate_pr_multipliers(scored_untrusted, _config(trusted_label_pipeline=False))
+        assert scored_untrusted.label_multiplier == 1.0
 
 
 # ============================================================================

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -57,6 +57,7 @@ def _pr(
     head_repo_full_name: str | None = 'entrius/gittensor-ui',
     default_branch: str | None = 'main',
     approved_count: int = 1,
+    maintainer_changes_requested_count: int = 0,
     labels: list | None = None,
     linked_issues: list | None = None,
 ) -> MirrorPullRequest:
@@ -89,7 +90,7 @@ def _pr(
             'commits_count': 1,
             'scoring_data_stored': True,
             'review_summary': {
-                'maintainer_changes_requested_count': 0,
+                'maintainer_changes_requested_count': maintainer_changes_requested_count,
                 'changes_requested_count': 0,
                 'approved_count': approved_count,
                 'commented_count': 0,
@@ -666,6 +667,25 @@ class TestCollateralScoreAcceptsScoredMirrorPR:
         # The issue with state=OPEN/state_reason=None should still pass for an OPEN PR
         assert _is_valid_linked_issue(li, scored.pr) is True
 
+    def test_open_mirror_pr_review_iterations_increase_collateral(self):
+        from gittensor.validator.oss_contributions.scoring import calculate_open_pr_collateral_score
+
+        clean = ScoredMirrorPR(pr=_pr(state='OPEN', maintainer_changes_requested_count=0))
+        clean.base_score = 100.0
+        clean.repo_weight_multiplier = 1.0
+        clean.issue_multiplier = 1.0
+        clean.label_multiplier = 1.0
+
+        reviewed = ScoredMirrorPR(pr=_pr(state='OPEN', maintainer_changes_requested_count=3))
+        reviewed.base_score = 100.0
+        reviewed.repo_weight_multiplier = 1.0
+        reviewed.issue_multiplier = 1.0
+        reviewed.label_multiplier = 1.0
+
+        assert calculate_open_pr_collateral_score(reviewed) == pytest.approx(
+            calculate_open_pr_collateral_score(clean) * 1.45
+        )
+
 
 # ============================================================================
 # Multiplier composition (smoke test that all multipliers populate)
@@ -696,7 +716,7 @@ class TestPrMultipliers:
         _calculate_pr_multipliers(scored, _config(weight=0.5))
 
         assert scored.repo_weight_multiplier == 0.5
-        # Time decay / review quality / credibility are merge-only — kept neutral here
+        # Time decay / review quality / credibility are merge-only — kept neutral here.
         assert scored.time_decay_multiplier == 1.0
         assert scored.credibility_multiplier == 1.0
         assert scored.review_quality_multiplier == 1.0

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -122,6 +122,25 @@ class TestLoadMasterRepositories:
                 f'{repo_name} mirror_enabled should be bool, got {type(config.mirror_enabled)}'
             )
 
+    def test_trusted_label_pipeline_field_present_on_live_configs(self):
+        """Live master_repositories.json entries load with a bool trusted_label_pipeline."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            assert isinstance(config.trusted_label_pipeline, bool), (
+                f'{repo_name} trusted_label_pipeline should be bool, got {type(config.trusted_label_pipeline)}'
+            )
+
+    def test_entrius_repos_have_trusted_label_pipeline(self):
+        """All entrius/* entries opt into trusted_label_pipeline (issue #911)."""
+        repos = load_master_repo_weights()
+        entrius_repos = {name: cfg for name, cfg in repos.items() if name.startswith('entrius/')}
+        assert entrius_repos, 'expected entrius/* entries in master_repositories.json'
+        for repo_name, config in entrius_repos.items():
+            assert config.trusted_label_pipeline is True, (
+                f'{repo_name} must have trusted_label_pipeline=true so the agentic-maintainer '
+                f'labeling worker is honored at scoring time'
+            )
+
 
 class TestRepositoryConfigMirrorFlag:
     """Dataclass-level tests for the mirror_enabled field + its JSON parsing."""
@@ -159,6 +178,44 @@ class TestRepositoryConfigMirrorFlag:
         assert repos['foo/mirror-repo'].mirror_enabled is True
         assert repos['foo/legacy-repo'].mirror_enabled is False
         assert repos['foo/explicit-off'].mirror_enabled is False
+
+
+class TestRepositoryConfigTrustedLabelPipeline:
+    """Dataclass + JSON-parsing tests for trusted_label_pipeline (issue #911)."""
+
+    def test_trusted_label_pipeline_default_false(self):
+        """RepositoryConfig constructor defaults trusted_label_pipeline to False.
+
+        Default-off is the safety property: community repos with
+        attacker-controlled auto-labelers (release-drafter, actions/labeler)
+        keep the maintainer-association gate in place.
+        """
+        config = RepositoryConfig(weight=0.5)
+        assert config.trusted_label_pipeline is False
+
+    def test_loader_parses_trusted_label_pipeline_true(self, tmp_path, monkeypatch):
+        """load_master_repo_weights() parses trusted_label_pipeline:true from JSON."""
+        import json
+
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/trusted': {'weight': 0.5, 'trusted_label_pipeline': True},
+                    'foo/untrusted': {'weight': 0.3},
+                    'foo/explicit-off': {'weight': 0.2, 'trusted_label_pipeline': False},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/trusted'].trusted_label_pipeline is True
+        assert repos['foo/untrusted'].trusted_label_pipeline is False
+        assert repos['foo/explicit-off'].trusted_label_pipeline is False
 
 
 class TestBannedOrganizations:

--- a/tests/validator/test_review_quality_multiplier.py
+++ b/tests/validator/test_review_quality_multiplier.py
@@ -14,10 +14,20 @@ from math import ceil
 
 import pytest
 
-from gittensor.classes import PRState, PullRequest
-from gittensor.constants import REVIEW_PENALTY_RATE
+from gittensor.classes import MinerEvaluation, PRState, PullRequest
+from gittensor.constants import (
+    MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER,
+    OPEN_PR_COLLATERAL_PERCENT,
+    REVIEW_PENALTY_RATE,
+)
 from gittensor.utils.github_api_tools import _MAX_CHANGES_REQUESTED_REVIEWS
-from gittensor.validator.oss_contributions.scoring import calculate_review_quality_multiplier
+from gittensor.validator.oss_contributions.scoring import (
+    calculate_open_pr_collateral_score,
+    calculate_pr_multipliers,
+    calculate_review_collateral_multiplier,
+    calculate_review_quality_multiplier,
+)
+from gittensor.validator.utils.load_weights import RepositoryConfig
 from tests.validator.conftest import PRBuilder
 
 # ============================================================================
@@ -72,6 +82,30 @@ class TestCalculateReviewQualityMultiplier:
 
     def test_returns_float(self):
         assert isinstance(calculate_review_quality_multiplier(0), float)
+
+
+class TestCalculateReviewCollateralMultiplier:
+    """Tests for the collateral-only review multiplier for OPEN PRs."""
+
+    def test_no_reviews_returns_one(self):
+        assert calculate_review_collateral_multiplier(0) == 1.0
+
+    def test_one_review_increases_collateral_multiplier(self):
+        assert calculate_review_collateral_multiplier(1) == pytest.approx(1.0 + REVIEW_PENALTY_RATE)
+
+    def test_table_values(self):
+        expected = {
+            0: 1.00,
+            1: 1.15,
+            2: 1.30,
+            3: 1.45,
+        }
+        for n, mult in expected.items():
+            assert calculate_review_collateral_multiplier(n) == pytest.approx(mult, abs=1e-9), f'n={n}'
+
+    def test_caps_at_two(self):
+        assert calculate_review_collateral_multiplier(7) == pytest.approx(2.0)
+        assert calculate_review_collateral_multiplier(100) == pytest.approx(2.0)
 
 
 # ============================================================================
@@ -171,17 +205,90 @@ class TestChangesRequestedCountFromGraphQL:
         pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='hk', github_id='123')
         assert pr.changes_requested_count == 2
 
-    def test_non_merged_pr_does_not_parse_reviews(self):
-        pr_data = _make_graphql_pr('OPEN', [{'authorAssociation': 'OWNER'}])
+    def test_open_pr_also_counts_maintainer_reviews(self):
+        pr_data = _make_graphql_pr(
+            'OPEN',
+            [
+                {'authorAssociation': 'OWNER'},
+                {'authorAssociation': 'CONTRIBUTOR'},
+                {'authorAssociation': 'MEMBER'},
+            ],
+        )
         pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='hk', github_id='123')
-        assert pr.changes_requested_count == 0
+        assert pr.changes_requested_count == 2
 
 
-def test_max_changes_requested_reviews_matches_penalty_rate():
-    # Tripwire: the GraphQL fetch cap must stay aligned with REVIEW_PENALTY_RATE so that any
-    # review beyond the cap is already forced to a 0.0 multiplier by calculate_review_quality_multiplier
-    assert _MAX_CHANGES_REQUESTED_REVIEWS == ceil(1 / REVIEW_PENALTY_RATE)
+class TestReviewCollateralMultiplierOnOpenPRCollateral:
+    def _prepare_open_pr(self, builder):
+        pr = builder.create(state=PRState.OPEN)
+        pr.base_score = 100.0
+        pr.repo_weight_multiplier = 1.0
+        pr.issue_multiplier = 1.0
+        pr.label_multiplier = 1.0
+        pr.changes_requested_count = 0
+        return pr
+
+    def test_clean_open_pr_collateral_unchanged(self, builder):
+        pr = self._prepare_open_pr(builder)
+        baseline = calculate_open_pr_collateral_score(pr)
+        pr.changes_requested_count = 0
+        assert calculate_open_pr_collateral_score(pr) == pytest.approx(baseline)
+
+    def test_open_pr_with_changes_requested_increases_collateral(self, builder):
+        pr = self._prepare_open_pr(builder)
+        baseline = calculate_open_pr_collateral_score(pr)
+        pr.changes_requested_count = 3
+        adjusted = calculate_open_pr_collateral_score(pr)
+        assert adjusted == pytest.approx(baseline * 1.45)
+
+    def test_open_pr_review_collateral_multiplier_caps_at_two(self, builder):
+        pr = self._prepare_open_pr(builder)
+        baseline = calculate_open_pr_collateral_score(pr)
+        pr.changes_requested_count = 100
+        assert calculate_open_pr_collateral_score(pr) == pytest.approx(baseline * 2.0)
+
+
+def _make_repo_config() -> dict:
+    return {'test/repo': RepositoryConfig(weight=1.0)}
+
+
+def _make_eval() -> MinerEvaluation:
+    return MinerEvaluation(uid=0, hotkey='hk', github_id='1')
+
+
+class TestReviewCollateralThroughScoringPipeline:
+    def test_open_pr_collateral_uses_collateral_review_multiplier(self, builder):
+        pr = builder.create(state=PRState.OPEN, repo='test/repo')
+        pr.base_score = 80.0
+        pr.label = 'fix'
+        pr.changes_requested_count = 3
+
+        calculate_pr_multipliers(pr, _make_eval(), _make_repo_config())
+
+        assert pr.label_multiplier == pytest.approx(1.25)
+
+        collateral_projection = (
+            pr.base_score
+            * pr.repo_weight_multiplier
+            * pr.issue_multiplier
+            * pr.label_multiplier
+            * calculate_review_collateral_multiplier(pr.changes_requested_count)
+        )
+        expected_collateral = collateral_projection * OPEN_PR_COLLATERAL_PERCENT
+
+        assert calculate_open_pr_collateral_score(pr) == pytest.approx(expected_collateral)
+
+
+def test_max_changes_requested_reviews_covers_review_multipliers():
+    # Tripwire: the GraphQL fetch cap must stay aligned with every review-count-based multiplier.
+    penalty_cap = ceil(1 / REVIEW_PENALTY_RATE)
+    collateral_cap = ceil((MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER - 1.0) / REVIEW_PENALTY_RATE)
+
+    assert _MAX_CHANGES_REQUESTED_REVIEWS == max(penalty_cap, collateral_cap)
     assert calculate_review_quality_multiplier(_MAX_CHANGES_REQUESTED_REVIEWS) == 0.0
+    assert calculate_review_collateral_multiplier(_MAX_CHANGES_REQUESTED_REVIEWS) == pytest.approx(
+        MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER
+    )
 
 
 if __name__ == '__main__':

--- a/tests/validator/test_unscored_stale_prs.py
+++ b/tests/validator/test_unscored_stale_prs.py
@@ -1,0 +1,132 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Regression tests for stale-closed PR capture in a storage-only bucket.
+
+Covers the invariant that stale-CLOSED PRs (created before the lookback window):
+- do not enter `closed_pull_requests` (preserves the #406 drop-from-scoring)
+- do enter `stale_closed_pull_requests` so storage can refresh pr_state
+- are not reflected in total counts or scoring buckets
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from gittensor.classes import MinerEvaluation, PRState
+from gittensor.utils.github_api_tools import try_add_open_or_closed_pr
+
+
+def _pr_node(number: int, created_at: str, closed_at: str, state: str = 'CLOSED') -> dict:
+    return {
+        'number': number,
+        'title': f'test PR {number}',
+        'state': state,
+        'repository': {
+            'name': 'gittensor',
+            'owner': {'login': 'entrius'},
+            'defaultBranchRef': {'name': 'test'},
+        },
+        'headRepository': {'name': 'gittensor', 'owner': {'login': 'contributor'}},
+        'author': {'login': 'contributor'},
+        'authorAssociation': 'CONTRIBUTOR',
+        'mergedBy': None,
+        'mergedAt': None,
+        'createdAt': created_at,
+        'closedAt': closed_at,
+        'lastEditedAt': None,
+        'additions': 10,
+        'deletions': 5,
+        'commits': {'totalCount': 1},
+        'baseRefName': 'test',
+        'baseRefOid': 'abc',
+        'headRefName': 'feature',
+        'headRefOid': 'def',
+        'bodyText': '',
+        'closingIssuesReferences': {'nodes': []},
+        'changesRequestedReviews': {'nodes': []},
+        'labels': {'nodes': []},
+        'timelineItems': {'nodes': []},
+    }
+
+
+@patch('gittensor.utils.github_api_tools.bt.logging')
+def test_stale_closed_pr_goes_to_storage_only_bucket(_):
+    miner_eval = MinerEvaluation(uid=74, hotkey='hk', github_id='1', github_pat='fake')
+    now = datetime.now(timezone.utc)
+    lookback = now - timedelta(days=35)
+    stale = (lookback - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    recent_close = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    try_add_open_or_closed_pr(miner_eval, _pr_node(1, stale, recent_close), PRState.CLOSED.value, lookback)
+
+    assert len(miner_eval.closed_pull_requests) == 0, 'stale PR must not enter scoring bucket'
+    assert len(miner_eval.stale_closed_pull_requests) == 1, 'stale PR must enter storage-only bucket'
+    assert miner_eval.stale_closed_pull_requests[0].number == 1
+    assert miner_eval.stale_closed_pull_requests[0].pr_state == PRState.CLOSED
+
+
+@patch('gittensor.utils.github_api_tools.bt.logging')
+def test_stale_closed_pr_not_counted_in_totals(_):
+    miner_eval = MinerEvaluation(uid=74, hotkey='hk', github_id='1', github_pat='fake')
+    now = datetime.now(timezone.utc)
+    lookback = now - timedelta(days=35)
+    stale = (lookback - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    close_at = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    try_add_open_or_closed_pr(miner_eval, _pr_node(1, stale, close_at), PRState.CLOSED.value, lookback)
+
+    assert miner_eval.total_closed_prs == 0
+    assert miner_eval.total_prs == 0
+    assert miner_eval.total_open_prs == 0
+    assert miner_eval.total_merged_prs == 0
+
+
+@patch('gittensor.utils.github_api_tools.bt.logging')
+def test_fresh_closed_pr_still_goes_to_scored_bucket(_):
+    """Regression: the drop-path must not accidentally capture fresh PRs."""
+    miner_eval = MinerEvaluation(uid=74, hotkey='hk', github_id='1', github_pat='fake')
+    now = datetime.now(timezone.utc)
+    lookback = now - timedelta(days=35)
+    fresh = (now - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    close_at = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    try_add_open_or_closed_pr(miner_eval, _pr_node(1, fresh, close_at), PRState.CLOSED.value, lookback)
+
+    assert len(miner_eval.closed_pull_requests) == 1
+    assert len(miner_eval.stale_closed_pull_requests) == 0
+    assert miner_eval.total_closed_prs == 1
+
+
+@patch('gittensor.utils.github_api_tools.bt.logging')
+def test_mixed_fresh_and_stale_closed_prs(_):
+    miner_eval = MinerEvaluation(uid=74, hotkey='hk', github_id='1', github_pat='fake')
+    now = datetime.now(timezone.utc)
+    lookback = now - timedelta(days=35)
+    fresh = (now - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    stale = (lookback - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    close_at = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    try_add_open_or_closed_pr(miner_eval, _pr_node(10, fresh, close_at), PRState.CLOSED.value, lookback)
+    try_add_open_or_closed_pr(miner_eval, _pr_node(11, stale, close_at), PRState.CLOSED.value, lookback)
+
+    assert len(miner_eval.closed_pull_requests) == 1
+    assert len(miner_eval.stale_closed_pull_requests) == 1
+    assert miner_eval.total_closed_prs == 1  # storage-only stale PRs do not inflate totals
+
+
+@patch('gittensor.utils.github_api_tools.bt.logging')
+def test_stale_closed_storage_bucket_does_not_inflate_any_totals(_):
+    miner_eval = MinerEvaluation(uid=74, hotkey='hk', github_id='1', github_pat='fake')
+    now = datetime.now(timezone.utc)
+    lookback = now - timedelta(days=35)
+    stale = (lookback - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    close_at = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    for i in range(3):
+        try_add_open_or_closed_pr(miner_eval, _pr_node(100 + i, stale, close_at), PRState.CLOSED.value, lookback)
+
+    assert miner_eval.total_merged_prs == 0
+    assert miner_eval.total_open_prs == 0
+    assert miner_eval.total_closed_prs == 0
+    assert miner_eval.total_prs == 0
+    assert len(miner_eval.stale_closed_pull_requests) == 3

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -31,10 +31,16 @@ def _make_pr(uid: int) -> PullRequest:
     )
 
 
-def _build_eval(uid: int, merged_prs: int, fetch_failed: bool) -> MinerEvaluation:
+def _build_eval(
+    uid: int,
+    merged_prs: int,
+    fetch_failed: bool,
+    mirror_pr_fetch_failed: bool = False,
+) -> MinerEvaluation:
     eval_ = MinerEvaluation(uid=uid, hotkey='hotkey_1', github_id='12345')
     eval_.merged_pull_requests = [_make_pr(uid) for _ in range(merged_prs)]
     eval_.github_pr_fetch_failed = fetch_failed
+    eval_.mirror_pr_fetch_failed = mirror_pr_fetch_failed
     return eval_
 
 
@@ -81,6 +87,30 @@ class TestStoreOrUseCachedEvaluation:
         cached_eval = validator.evaluation_cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
         assert cached_eval is not None
         assert cached_eval.total_prs == 2
+
+
+class TestMirrorFailureCacheFallback:
+    """A mirror outage routes the miner through the cache-fallback path so the
+    evaluation is a coherent one-round-stale snapshot rather than a fresh-legacy +
+    zeroed-mirror hybrid where cross-PR multipliers recompute over a partial view."""
+
+    def test_mirror_failure_with_legacy_success_swaps_to_cached_eval(self):
+        validator = _DummyValidator()
+        validator.evaluation_cache.store(_build_eval(uid=1, merged_prs=2, fetch_failed=False))
+
+        current_eval = _build_eval(
+            uid=1,
+            merged_prs=1,
+            fetch_failed=True,
+            mirror_pr_fetch_failed=True,
+        )
+        miner_evaluations = {1: current_eval}
+
+        cached_uids = Validator.store_or_use_cached_evaluation(cast(Validator, validator), miner_evaluations)
+
+        assert cached_uids == {1}
+        assert miner_evaluations[1] is not current_eval
+        assert miner_evaluations[1].total_prs == 2
 
 
 class TestCacheIsolation:

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 from typing import cast
 
 from gittensor.classes import FileChange, Issue, MinerEvaluation, MinerEvaluationCache, PRState, PullRequest
+from gittensor.utils.mirror.models import MirrorFile, MirrorPullRequest, MirrorReviewSummary
+from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 from neurons.validator import Validator
 
 
@@ -175,3 +177,69 @@ class TestCacheIsolation:
         cached_issues = cached.merged_pull_requests[0].issues
         assert cached_issues is not None
         assert cached_issues[0].discovery_earned_score == 0.0
+
+
+def _make_mirror_pr_with_file_blob(blob: str, pr_number: int = 7) -> ScoredMirrorPR:
+    now = datetime.now(timezone.utc)
+    pr = MirrorPullRequest(
+        repo_full_name='owner/repo',
+        pr_number=pr_number,
+        title='cached mirror pr',
+        body=None,
+        state='MERGED',
+        author_github_id='12345',
+        author_login='miner',
+        author_association='CONTRIBUTOR',
+        created_at=now,
+        closed_at=None,
+        merged_at=now,
+        last_edited_at=None,
+        edited_after_merge=False,
+        hours_since_merge=0.0,
+        merged_by_login='maintainer',
+        base_ref='main',
+        head_ref='feature',
+        head_repo_full_name='owner/repo',
+        default_branch='main',
+        head_sha='abc',
+        base_sha='def',
+        merge_base_sha='def',
+        additions=1,
+        deletions=0,
+        commits_count=1,
+        scoring_data_stored=True,
+        review_summary=MirrorReviewSummary(),
+    )
+    scored = ScoredMirrorPR(pr=pr, base_score=8.0, token_score=12.0)
+    scored.files = [
+        MirrorFile(
+            filename='src/lib.py',
+            previous_filename=None,
+            status='modified',
+            additions=1,
+            deletions=0,
+            changes=1,
+            is_binary=False,
+            head_content=blob,
+            base_content=blob,
+        )
+    ]
+    return scored
+
+
+class TestMirrorCacheIsolation:
+    def test_cache_drops_mirror_files_without_mutating_source(self):
+        cache = MinerEvaluationCache()
+        source = MinerEvaluation(uid=1, hotkey='hotkey_1', github_id='12345', github_pat='secret')
+        source.mirror_merged_prs = [_make_mirror_pr_with_file_blob('A' * 10_000)]
+        cache.store(source)
+
+        assert source.github_pat == 'secret'
+        source_files = source.mirror_merged_prs[0].files
+        assert source_files is not None
+        assert source_files[0].head_content == 'A' * 10_000
+
+        cached = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert cached is not None
+        assert cached.github_pat is None
+        assert cached.mirror_merged_prs[0].files is None

--- a/tests/validator/utils/test_storage_mirror.py
+++ b/tests/validator/utils/test_storage_mirror.py
@@ -165,6 +165,21 @@ class TestStoreEvaluationCombinesBothLists:
         assert merged_arg[0].number == 100
         assert isinstance(merged_arg[0], PullRequest)
 
+    def test_stale_closed_prs_are_stored_separately(self):
+        storage, mock_repo = _make_storage_with_mock_repo()
+
+        eval_ = MinerEvaluation(uid=1, hotkey='hk', github_id='123')
+        eval_.stale_closed_pull_requests = [_legacy_pr(7, state=PRState.CLOSED)]
+
+        storage.store_evaluation(eval_)
+
+        stale_call = mock_repo.store_pull_requests_bulk.call_args_list[3]
+        stale_arg = stale_call.args[0]
+        assert len(stale_arg) == 1
+        assert stale_arg[0].number == 7
+        assert stale_arg[0].pr_state == PRState.CLOSED
+        assert eval_.total_closed_prs == 0
+
 
 def test_cleanup_stale_called_with_commit_false():
     """cleanup_stale_miner_data must be called with commit=False inside the transaction.


### PR DESCRIPTION
Fixes #987

## Summary
Removed two dead branches in `contract_client.py` that are unreachable given current callers but contained incorrect code.

## Changes

### 1. SCALE compact encode overflow (line 272)
**Before:** Unreachable `else` branch for `data_len >= 64` with incorrect formula that would `ValueError` on overflow.
**After:** Removed the dead `else` branch. `input_data` is always a 4-byte contract selector, so `data_len` is always < 64.

### 2. u128 encoder in `_encode_args` (line 533)
**Before:** Dead `elif type_def == 'u128'` branch — only `register_issue` uses u128, but it bypasses `_encode_args` via CLI mutations path.
**After:** Retained the encoder with a comment explaining it is dead code. Kept (rather than removed) for forward-compatibility if future methods add u128 args.

### 3. `parse_code` accepts `Union[str, bytes]` (bonus fix for #983)
Modified `parse_code` to accept pre-encoded bytes, enabling callers to avoid redundant UTF-8 encoding without changing the public API.