### PR TITLE
fix: isolate per-miner exceptions in OSS scoring loop

### DIFF
--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -2,6 +2,7 @@
 # Copyright © 2025 Entrius
 from __future__ import annotations
 
+from traceback import print_exception
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
@@ -133,16 +134,27 @@ async def get_rewards(
             else:
                 stale_hotkey = pat_entry.get('hotkey')
 
-        # Calculate score
-        miner_evaluation = await evaluate_miners_pull_requests(
-            uid,
-            hotkey,
-            pat,
-            master_repositories,
-            programming_languages,
-            token_config,
-            stale_hotkey=stale_hotkey,
-        )
+        # Calculate score. Per-miner try/except so one miner's crash cannot
+        # abort the whole round — issue_discovery's mirror_scan loop already
+        # has the same isolation; this brings the OSS path to parity.
+        try:
+            miner_evaluation = await evaluate_miners_pull_requests(
+                uid,
+                hotkey,
+                pat,
+                master_repositories,
+                programming_languages,
+                token_config,
+                stale_hotkey=stale_hotkey,
+            )
+        except Exception as e:
+            bt.logging.error(f'UID {uid}: evaluation crashed — {type(e).__name__}: {e}')
+            bt.logging.debug(str(print_exception(type(e), e, e.__traceback__)))
+            miner_evaluation = MinerEvaluation(
+                uid=uid,
+                hotkey=hotkey,
+                failed_reason=f'Evaluation crashed: {type(e).__name__}: {e}',
+            )
         miner_evaluations[uid] = miner_evaluation
 
     # If evaluation of miner was successful, store to cache, if api failure, fallback to previous successful evaluation if any

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -153,15 +153,15 @@ async def get_rewards(
         # has the same isolation; this brings the OSS path to parity.
         try:
             miner_evaluation = await evaluate_miners_pull_requests(
-              uid,
-              hotkey,
-              pat,
-              master_repositories,
-              programming_languages,
-              token_config,
-              stale_hotkey=stale_hotkey,
-              stored_github_id=stored_github_id,
-          )
+                uid,
+                hotkey,
+                pat,
+                master_repositories,
+                programming_languages,
+                token_config,
+                stale_hotkey=stale_hotkey,
+                stored_github_id=stored_github_id,
+            )
         except Exception as e:
             bt.logging.error(f'UID {uid}: evaluation crashed — {type(e).__name__}: {e}')
             bt.logging.debug(str(print_exception(type(e), e, e.__traceback__)))

--- a/tests/validator/oss_contributions/test_reward.py
+++ b/tests/validator/oss_contributions/test_reward.py
@@ -13,6 +13,7 @@ existing isolation pattern in ``issue_discovery/mirror_scan.py``.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Dict, Set
 from unittest.mock import AsyncMock
@@ -39,8 +40,7 @@ class _StubValidator:
         return set()
 
 
-@pytest.mark.asyncio
-async def test_per_miner_exception_does_not_abort_round(monkeypatch):
+def test_per_miner_exception_does_not_abort_round(monkeypatch):
     """A single miner raising in evaluate_miners_pull_requests must not stop
     the loop; every other UID must still be evaluated and the round must
     return normally."""
@@ -65,12 +65,14 @@ async def test_per_miner_exception_does_not_abort_round(monkeypatch):
         lambda evals: {uid: 0.0 for uid in evals},
     )
 
-    rewards, evaluations, cached_uids, penalized_uids = await reward_module.get_rewards(
-        validator,
-        uids,
-        master_repositories={},
-        programming_languages={},
-        token_config=SimpleNamespace(),
+    rewards, evaluations, cached_uids, penalized_uids = asyncio.run(
+        reward_module.get_rewards(
+            validator,
+            uids,
+            master_repositories={},
+            programming_languages={},
+            token_config=SimpleNamespace(),
+        )
     )
 
     assert set(evaluations.keys()) == uids, 'every UID must be present after the round'
@@ -85,8 +87,7 @@ async def test_per_miner_exception_does_not_abort_round(monkeypatch):
     assert penalized_uids == set()
 
 
-@pytest.mark.asyncio
-async def test_failed_reason_records_exception_class_and_message(monkeypatch):
+def test_failed_reason_records_exception_class_and_message(monkeypatch):
     """The substituted MinerEvaluation must capture both the exception class
     name and its message so post-hoc DB inspection can identify the vector."""
 
@@ -100,12 +101,14 @@ async def test_failed_reason_records_exception_class_and_message(monkeypatch):
     monkeypatch.setattr(reward_module, 'finalize_miner_scores', lambda evals: None)
     monkeypatch.setattr(reward_module, 'normalize_rewards_linear', lambda evals: {7: 0.0})
 
-    _, evaluations, _, _ = await reward_module.get_rewards(
-        validator,
-        {7},
-        master_repositories={},
-        programming_languages={},
-        token_config=SimpleNamespace(),
+    _, evaluations, _, _ = asyncio.run(
+        reward_module.get_rewards(
+            validator,
+            {7},
+            master_repositories={},
+            programming_languages={},
+            token_config=SimpleNamespace(),
+        )
     )
 
     failed = evaluations[7]

--- a/tests/validator/oss_contributions/test_reward.py
+++ b/tests/validator/oss_contributions/test_reward.py
@@ -1,0 +1,115 @@
+"""Per-miner exception isolation in the OSS scoring loop.
+
+Regression for the failure mode where a single miner's uncaught exception in
+``evaluate_miners_pull_requests`` aborted the whole scoring round, causing the
+validator's daemon scoring thread to die at ``base/validator.py``'s
+``except Exception`` and leaving the main thread to log "Validator running"
+indefinitely with no further forward passes.
+
+The fix wraps the per-miner call in ``try/except Exception`` and substitutes a
+``MinerEvaluation(failed_reason=...)`` so the loop continues. This matches the
+existing isolation pattern in ``issue_discovery/mirror_scan.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict, Set
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+reward_module = pytest.importorskip(
+    'gittensor.validator.oss_contributions.reward',
+    reason='Requires gittensor validator subpackage',
+)
+classes_module = pytest.importorskip('gittensor.classes', reason='Requires gittensor classes')
+
+MinerEvaluation = classes_module.MinerEvaluation
+
+
+class _StubValidator:
+    """Minimal stand-in for the parts of Validator that get_rewards reads."""
+
+    def __init__(self, hotkeys: Dict[int, str]):
+        self.metagraph = SimpleNamespace(hotkeys=hotkeys)
+
+    def store_or_use_cached_evaluation(self, miner_evaluations: Dict[int, MinerEvaluation]) -> Set[int]:
+        return set()
+
+
+@pytest.mark.asyncio
+async def test_per_miner_exception_does_not_abort_round(monkeypatch):
+    """A single miner raising in evaluate_miners_pull_requests must not stop
+    the loop; every other UID must still be evaluated and the round must
+    return normally."""
+
+    uids = {1, 2, 3, 4, 5}
+    boom_uid = 3
+    hotkeys = {uid: f'hot{uid}' for uid in uids}
+    validator = _StubValidator(hotkeys=hotkeys)
+
+    async def fake_evaluate(uid, hotkey, *args, **kwargs):
+        if uid == boom_uid:
+            raise RecursionError('simulated tree-sitter blow-up')
+        return MinerEvaluation(uid=uid, hotkey=hotkey)
+
+    monkeypatch.setattr(reward_module, 'evaluate_miners_pull_requests', fake_evaluate)
+    monkeypatch.setattr(reward_module.pat_storage, 'load_all_pats', lambda: [])
+    monkeypatch.setattr(reward_module, 'detect_and_penalize_miners_sharing_github', lambda evals: set())
+    monkeypatch.setattr(reward_module, 'finalize_miner_scores', lambda evals: None)
+    monkeypatch.setattr(
+        reward_module,
+        'normalize_rewards_linear',
+        lambda evals: {uid: 0.0 for uid in evals},
+    )
+
+    rewards, evaluations, cached_uids, penalized_uids = await reward_module.get_rewards(
+        validator,
+        uids,
+        master_repositories={},
+        programming_languages={},
+        token_config=SimpleNamespace(),
+    )
+
+    assert set(evaluations.keys()) == uids, 'every UID must be present after the round'
+    crashed = evaluations[boom_uid]
+    assert crashed.failed_reason is not None, 'crashed miner must carry a failed_reason'
+    assert 'RecursionError' in crashed.failed_reason
+    for uid in uids - {boom_uid}:
+        assert evaluations[uid].failed_reason is None, f'UID {uid} should not be marked failed'
+    assert isinstance(rewards, np.ndarray)
+    assert rewards.shape == (len(uids),)
+    assert cached_uids == set()
+    assert penalized_uids == set()
+
+
+@pytest.mark.asyncio
+async def test_failed_reason_records_exception_class_and_message(monkeypatch):
+    """The substituted MinerEvaluation must capture both the exception class
+    name and its message so post-hoc DB inspection can identify the vector."""
+
+    hotkeys = {7: 'hot7'}
+    validator = _StubValidator(hotkeys=hotkeys)
+
+    raise_call = AsyncMock(side_effect=ValueError('malformed mirror json'))
+    monkeypatch.setattr(reward_module, 'evaluate_miners_pull_requests', raise_call)
+    monkeypatch.setattr(reward_module.pat_storage, 'load_all_pats', lambda: [])
+    monkeypatch.setattr(reward_module, 'detect_and_penalize_miners_sharing_github', lambda evals: set())
+    monkeypatch.setattr(reward_module, 'finalize_miner_scores', lambda evals: None)
+    monkeypatch.setattr(reward_module, 'normalize_rewards_linear', lambda evals: {7: 0.0})
+
+    _, evaluations, _, _ = await reward_module.get_rewards(
+        validator,
+        {7},
+        master_repositories={},
+        programming_languages={},
+        token_config=SimpleNamespace(),
+    )
+
+    failed = evaluations[7]
+    assert failed.uid == 7
+    assert failed.hotkey == 'hot7'
+    assert 'ValueError' in failed.failed_reason
+    assert 'malformed mirror json' in failed.failed_reason


### PR DESCRIPTION
## Summary

Wrap the per-miner `evaluate_miners_pull_requests` call in `gittensor/validator/oss_contributions/reward.py` in `try/except Exception` so a single miner's uncaught exception cannot abort the whole scoring round.

Without this, any unhandled exception (e.g. `RecursionError` from #978, `ValueError` from #893, future schema-drift `KeyError` / `AttributeError`) propagates through `oss_contributions` → `forward` → `concurrent_forward` → the `while True` at `neurons/base/validator.py:144-169`. The `except Exception` there logs once and `run()` returns. Because `run()` is the target of a daemon thread (`base/validator.py:179`), the **scoring thread dies silently** while the main thread keeps printing `Validator running | uid X | ...` every 30s — no further forward passes, no weight updates, until manual restart. After restart the validator re-fetches the same data and re-crashes on the same miner.

The crashed miner now gets a `MinerEvaluation(uid=uid, hotkey=hotkey, failed_reason=...)`, so downstream skip-on-failure paths (`MinerEvaluationCache.store_or_use_cached_evaluation`, `mirror_scan`, `repository.upsert_miner_evaluation`) already treat the miner as non-scoring this round without any new per-site awareness.

This is a **safety net**, not a substitute for fixing each specific exception class at source. It brings the OSS path to parity with `issue_discovery/mirror_scan.py:157-162`, which already isolates per-miner failures.

## Related Issues

Closes #995 

Related (independent vectors that fire this chain):
- #978 — `RecursionError` from `tree_sitter_utils.walk_node` on AST depth >1000
- #893 — raw `ValueError` from `MirrorClient._get` `response.json()` not classified as `MirrorRequestError`

## Type of Change

- [x] Bug fix (defense-in-depth)

## Testing

- [x] Tests added
- [x] Manually verified loop continues past a forced exception

New `tests/validator/oss_contributions/test_reward.py`:

- `test_per_miner_exception_does_not_abort_round` — boom on UID 3 (raises `RecursionError`); asserts UIDs 1/2/4/5 are still scored, UID 3 carries `failed_reason`, `get_rewards` returns a normal `(rewards, evaluations, cached_uids, penalized_uids)` tuple.
- `test_failed_reason_records_exception_class_and_message` — asserts the substituted `MinerEvaluation.failed_reason` includes both the exception class name and message, so post-hoc DB inspection can identify the vector that crashed a miner.

Local verification:

```
pytest tests/validator/oss_contributions/  # 124 passed
ruff check gittensor/validator/oss_contributions/reward.py tests/validator/oss_contributions/test_reward.py  # clean
ruff format --check gittensor/validator/oss_contributions/reward.py tests/validator/oss_contributions/test_reward.py  # clean
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added
- [x] `ruff check` / `ruff format --check` clean
- [x] Catches `Exception` (not `BaseException`) so `KeyboardInterrupt` / `SystemExit` still propagate
- [x] No behavior change on the happy path — the wrap only adds a fallback
