### PR TITLE
feat(scoring): gate PR scoring by PAT first-registration date

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -75,6 +75,7 @@ MAX_LINES_SCORED_FOR_NON_CODE_EXT = 300
 # =============================================================================
 DEFAULT_REPO_WEIGHT = 0.01  # fallback weight for repos not in master_repositories.json
 PR_LOOKBACK_DAYS = 35  # rolling window for scoring
+REGISTRATION_GRACE_DAYS = 7
 MERGED_PR_BASE_SCORE = 25
 MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5  # PRs below this get 0 base score
 MAX_CONTRIBUTION_BONUS = 25

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -728,6 +728,7 @@ def try_add_open_or_closed_pr(
     pr_raw: Dict,
     pr_state: str,
     lookback_date_filter: datetime,
+    registration_cutoff: Optional[datetime] = None,
 ) -> None:
     """
     Attempts to add an OPEN or CLOSED PR to miner_eval if eligible.
@@ -737,6 +738,7 @@ def try_add_open_or_closed_pr(
         pr_raw: Raw PR data from GraphQL
         pr_state: GitHub PR state (OPEN, CLOSED, MERGED)
         lookback_date_filter: Date filter for lookback period
+        registration_cutoff: Skip closed PRs whose closed_at is earlier than this cutoff
     """
     # Ignore all maintainer contributions
     if not os.environ.get('DEV_MODE') and pr_raw.get('authorAssociation') in MAINTAINER_ASSOCIATIONS:
@@ -764,6 +766,9 @@ def try_add_open_or_closed_pr(
         if created_dt < lookback_date_filter:
             return
 
+        if registration_cutoff is not None and closed_dt < registration_cutoff:
+            return
+
         if closed_dt >= lookback_date_filter:
             miner_eval.add_closed_pull_request(pr_raw)
 
@@ -773,6 +778,7 @@ def should_skip_merged_pr(
     repository_full_name: str,
     repo_config: RepositoryConfig,
     lookback_date_filter: datetime,
+    registration_cutoff: Optional[datetime] = None,
 ) -> tuple[bool, Optional[str]]:
     """
     Validate a merged PR against all eligibility criteria.
@@ -782,6 +788,7 @@ def should_skip_merged_pr(
         repository_full_name (str): Full repository name (owner/repo)
         repo_config (RepositoryConfig): Repository configuration
         lookback_date_filter (datetime): Date filter for lookback period
+        registration_cutoff (Optional[datetime]): Skip merged PRs whose merged_at is earlier than this cutoff
 
     Returns:
         tuple[bool, Optional[str]]: (should_skip, skip_reason) - True if PR should be skipped with reason
@@ -797,6 +804,12 @@ def should_skip_merged_pr(
         return (
             True,
             f'Skipping PR #{pr_raw["number"]} in {repository_full_name} - merged before {PR_LOOKBACK_DAYS}-day lookback window',
+        )
+
+    if registration_cutoff is not None and merged_dt < registration_cutoff:
+        return (
+            True,
+            f'Skipping PR #{pr_raw["number"]} in {repository_full_name} - merged before miner registration on this validator',
         )
 
     # Skip if PR author is a maintainer
@@ -854,7 +867,10 @@ def should_skip_merged_pr(
 
 
 def load_miners_prs(
-    miner_eval: MinerEvaluation, master_repositories: Dict[str, RepositoryConfig], max_prs: int = 1000
+    miner_eval: MinerEvaluation,
+    master_repositories: Dict[str, RepositoryConfig],
+    max_prs: int = 1000,
+    registration_cutoff: Optional[datetime] = None,
 ) -> None:
     """
     Fetches user PRs via GraphQL API and categorize them by state.
@@ -864,6 +880,7 @@ def load_miners_prs(
         miner_eval: The MinerEvaluation object containing github details + more
         master_repositories: Repository metadata (name -> RepositoryConfig)
         max_prs: Maximum merged PRs to fetch
+        registration_cutoff: Skip PRs (merged or closed) whose effective timestamp predates this cutoff
     """
     bt.logging.info('*****Fetching PRs*****')
     miner_eval.github_pr_fetch_failed = False
@@ -945,11 +962,17 @@ def load_miners_prs(
                             continue
 
                     if pr_state in (PRState.OPEN.value, PRState.CLOSED.value):
-                        try_add_open_or_closed_pr(miner_eval, pr_raw, pr_state, lookback_date_filter)
+                        try_add_open_or_closed_pr(
+                            miner_eval, pr_raw, pr_state, lookback_date_filter, registration_cutoff=registration_cutoff
+                        )
                         continue
 
                     should_skip, skip_reason = should_skip_merged_pr(
-                        pr_raw, repository_full_name, repo_config, lookback_date_filter
+                        pr_raw,
+                        repository_full_name,
+                        repo_config,
+                        lookback_date_filter,
+                        registration_cutoff=registration_cutoff,
                     )
 
                     if should_skip:

--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -34,6 +34,7 @@ def load_mirror_miner_prs(
     mirror_eval: MirrorMinerEvaluation,
     mirror_repos: Dict[str, RepositoryConfig],
     client: Optional[MirrorClient] = None,
+    registration_cutoff: Optional[datetime] = None,
 ) -> None:
     """Populate mirror_eval with PRs fetched from the mirror service.
 
@@ -41,6 +42,7 @@ def load_mirror_miner_prs(
         mirror_eval: container to populate; must already have github_id set
         mirror_repos: repo configs to filter against (only mirror_enabled entries)
         client: optional MirrorClient for dependency injection in tests
+        registration_cutoff: skip merged/closed PRs whose effective timestamp predates this cutoff
     """
 
     bt.logging.info('*****Fetching PRs from mirror*****')
@@ -65,7 +67,7 @@ def load_mirror_miner_prs(
 
     for pr in response.pull_requests:
         try:
-            _maybe_add_pr(mirror_eval, pr, mirror_repos, lookback_date)
+            _maybe_add_pr(mirror_eval, pr, mirror_repos, lookback_date, registration_cutoff=registration_cutoff)
         except Exception as e:
             bt.logging.warning(f'Error processing mirror PR #{pr.pr_number} ({pr.repo_full_name}): {e}')
 
@@ -80,6 +82,7 @@ def _maybe_add_pr(
     pr: MirrorPullRequest,
     mirror_repos: Dict[str, RepositoryConfig],
     lookback_date: datetime,
+    registration_cutoff: Optional[datetime] = None,
 ) -> None:
     """Apply load-time filters and bucket pr by state if it passes."""
 
@@ -112,12 +115,19 @@ def _maybe_add_pr(
         # closing an old PR shouldn't trigger a fresh credibility penalty).
         if pr.created_at < lookback_date:
             return
+        if registration_cutoff is not None and pr.closed_at is not None and pr.closed_at < registration_cutoff:
+            return
         mirror_eval.closed_prs.append(ScoredMirrorPR(pr=pr))
     elif pr.state == 'MERGED':
         # Apply the merge-eligibility gate at LOAD time (matches legacy parity —
         # should_skip_merged_pr runs inside load_miners_prs before adding). If we
         # deferred to scoring, rejected PRs would remain in mirror_merged_prs and
         # inflate the merged_count used in check_eligibility, distorting credibility.
+        if registration_cutoff is not None and pr.merged_at is not None and pr.merged_at < registration_cutoff:
+            bt.logging.debug(
+                f'Skipping mirror PR #{pr.pr_number} in {pr.repo_full_name} - merged before miner registration on this validator'
+            )
+            return
         candidate = ScoredMirrorPR(pr=pr)
         should_skip, reason = _should_skip_merged_mirror_pr(candidate, repo_config)
         if should_skip:

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -2,6 +2,7 @@
 # Copyright © 2025 Entrius
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
@@ -39,6 +40,7 @@ async def evaluate_miners_pull_requests(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     stale_hotkey: Optional[str] = None,
+    registration_cutoff: Optional[datetime] = None,
 ) -> MinerEvaluation:
     """
     Entry point from taking a miners response -> Get PRs -> Score PRs
@@ -51,6 +53,7 @@ async def evaluate_miners_pull_requests(
         programming_languages: The programming languages and their weights
         token_config: Token-based scoring weights configuration
         stale_hotkey: If set, the UID has a stored PAT from this old hotkey (re-registration detected)
+        registration_cutoff: If set, skip merged/closed PRs whose effective timestamp predates this cutoff
 
     Returns:
         MinerEvaluation: The object containing scores, valid_prs, etc.
@@ -75,7 +78,7 @@ async def evaluate_miners_pull_requests(
 
     if legacy_repos:
         with session_scope():
-            load_miners_prs(miner_eval, legacy_repos)
+            load_miners_prs(miner_eval, legacy_repos, registration_cutoff=registration_cutoff)
             score_miner_prs(miner_eval, legacy_repos, programming_languages, token_config)
 
     if mirror_repos:
@@ -85,7 +88,9 @@ async def evaluate_miners_pull_requests(
             github_id=miner_eval.github_id,
         )
         with MirrorClient() as mirror_client:
-            load_mirror_miner_prs(mirror_eval, mirror_repos, client=mirror_client)
+            load_mirror_miner_prs(
+                mirror_eval, mirror_repos, client=mirror_client, registration_cutoff=registration_cutoff
+            )
             score_mirror_miner_prs(mirror_eval, mirror_repos, programming_languages, token_config, client=mirror_client)
         combine(miner_eval, mirror_eval)
 
@@ -133,6 +138,8 @@ async def get_rewards(
             else:
                 stale_hotkey = pat_entry.get('hotkey')
 
+        registration_cutoff = pat_storage.get_registration_cutoff(uid, hotkey)
+
         # Calculate score
         miner_evaluation = await evaluate_miners_pull_requests(
             uid,
@@ -142,6 +149,7 @@ async def get_rewards(
             programming_languages,
             token_config,
             stale_hotkey=stale_hotkey,
+            registration_cutoff=registration_cutoff,
         )
         miner_evaluations[uid] = miner_evaluation
 

--- a/gittensor/validator/pat_storage.py
+++ b/gittensor/validator/pat_storage.py
@@ -11,9 +11,11 @@ import json
 import os
 import tempfile
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
+
+from gittensor.constants import REGISTRATION_GRACE_DAYS
 
 PATS_FILE = Path(__file__).resolve().parents[2] / 'data' / 'miner_pats.json'
 
@@ -37,14 +39,25 @@ def save_pat(uid: int, hotkey: str, pat: str, github_id: str) -> None:
     """Upsert a PAT entry by UID. Creates the file if needed."""
     with _lock:
         entries = _read_file()
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        prior = next((e for e in entries if e.get('uid') == uid), None)
+
+        first_registered_at: Optional[str]
+        if prior is not None and prior.get('hotkey') == hotkey:
+            first_registered_at = prior.get('first_registered_at') if 'first_registered_at' in prior else None
+        else:
+            first_registered_at = now_iso
 
         entry = {
             'uid': uid,
             'hotkey': hotkey,
             'pat': pat,
             'github_id': github_id,
-            'stored_at': datetime.now(timezone.utc).isoformat(),
+            'stored_at': now_iso,
         }
+        if first_registered_at is not None:
+            entry['first_registered_at'] = first_registered_at
 
         for i, existing in enumerate(entries):
             if existing.get('uid') == uid:
@@ -54,6 +67,21 @@ def save_pat(uid: int, hotkey: str, pat: str, github_id: str) -> None:
             entries.append(entry)
 
         _write_file(entries)
+
+
+def get_registration_cutoff(uid: int, hotkey: str) -> Optional[datetime]:
+    """Return the registration scoring cutoff for this miner, or None when no gate applies."""
+    entry = get_pat_by_uid(uid)
+    if entry is None or entry.get('hotkey') != hotkey:
+        return None
+    raw = entry.get('first_registered_at')
+    if not raw:
+        return None
+    try:
+        first_registered_at = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return first_registered_at - timedelta(days=REGISTRATION_GRACE_DAYS)
 
 
 def get_pat_by_uid(uid: int) -> Optional[dict]:

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1646,5 +1646,124 @@ class TestSessionScope:
         assert github_api_tools._session_cache is None
 
 
+class TestRegistrationCutoffMergedGate:
+    @staticmethod
+    def _merged_pr(merged_at: str = '2026-04-15T00:00:00Z') -> Dict:
+        return {
+            'number': 42,
+            'mergedAt': merged_at,
+            'authorAssociation': 'CONTRIBUTOR',
+            'mergedBy': {'login': 'maintainer'},
+            'author': {'login': 'contributor'},
+            'reviews': {'nodes': []},
+            'repository': {
+                'name': 'foo',
+                'owner': {'login': 'owner'},
+                'defaultBranchRef': {'name': 'main'},
+            },
+            'baseRefName': 'main',
+            'headRefName': 'feature/bar',
+            'headRepository': {'name': 'foo', 'owner': {'login': 'fork-user'}},
+        }
+
+    @staticmethod
+    def _repo_config():
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        return RepositoryConfig(weight=0.5)
+
+    def test_no_cutoff_does_not_skip(self):
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        pr = self._merged_pr(merged_at='2026-04-15T00:00:00Z')
+
+        should_skip, _ = github_api_tools.should_skip_merged_pr(pr, 'owner/foo', self._repo_config(), lookback)
+
+        assert should_skip is False
+
+    def test_merged_before_cutoff_skipped(self):
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        cutoff = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        pr = self._merged_pr(merged_at='2026-04-10T00:00:00Z')
+
+        should_skip, reason = github_api_tools.should_skip_merged_pr(
+            pr, 'owner/foo', self._repo_config(), lookback, registration_cutoff=cutoff
+        )
+
+        assert should_skip is True
+        assert 'registration' in (reason or '').lower()
+
+    def test_merged_at_cutoff_not_skipped(self):
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        cutoff = datetime(2026, 4, 10, tzinfo=timezone.utc)
+        pr = self._merged_pr(merged_at='2026-04-10T00:00:00Z')
+
+        should_skip, _ = github_api_tools.should_skip_merged_pr(
+            pr, 'owner/foo', self._repo_config(), lookback, registration_cutoff=cutoff
+        )
+
+        assert should_skip is False
+
+    def test_merged_after_cutoff_not_skipped(self):
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        cutoff = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        pr = self._merged_pr(merged_at='2026-04-15T00:00:00Z')
+
+        should_skip, _ = github_api_tools.should_skip_merged_pr(
+            pr, 'owner/foo', self._repo_config(), lookback, registration_cutoff=cutoff
+        )
+
+        assert should_skip is False
+
+
+class TestRegistrationCutoffClosedGate:
+    @staticmethod
+    def _closed_pr(closed_at: str, created_at: str) -> Dict:
+        return {
+            'number': 7,
+            'closedAt': closed_at,
+            'createdAt': created_at,
+            'authorAssociation': 'CONTRIBUTOR',
+        }
+
+    def test_no_cutoff_added(self):
+        miner_eval = Mock()
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        pr = self._closed_pr(closed_at='2026-04-10T00:00:00Z', created_at='2026-04-05T00:00:00Z')
+
+        github_api_tools.try_add_open_or_closed_pr(miner_eval, pr, 'CLOSED', lookback)
+
+        miner_eval.add_closed_pull_request.assert_called_once()
+
+    def test_closed_before_cutoff_skipped(self):
+        miner_eval = Mock()
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        cutoff = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        pr = self._closed_pr(closed_at='2026-04-10T00:00:00Z', created_at='2026-04-05T00:00:00Z')
+
+        github_api_tools.try_add_open_or_closed_pr(miner_eval, pr, 'CLOSED', lookback, registration_cutoff=cutoff)
+
+        miner_eval.add_closed_pull_request.assert_not_called()
+
+    def test_closed_at_cutoff_kept(self):
+        miner_eval = Mock()
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        cutoff = datetime(2026, 4, 10, tzinfo=timezone.utc)
+        pr = self._closed_pr(closed_at='2026-04-10T00:00:00Z', created_at='2026-04-05T00:00:00Z')
+
+        github_api_tools.try_add_open_or_closed_pr(miner_eval, pr, 'CLOSED', lookback, registration_cutoff=cutoff)
+
+        miner_eval.add_closed_pull_request.assert_called_once()
+
+    def test_open_pr_unaffected_by_cutoff(self):
+        miner_eval = Mock()
+        lookback = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        cutoff = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        pr = {'number': 9, 'authorAssociation': 'CONTRIBUTOR'}
+
+        github_api_tools.try_add_open_or_closed_pr(miner_eval, pr, 'OPEN', lookback, registration_cutoff=cutoff)
+
+        miner_eval.add_open_pull_request.assert_called_once()
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -332,11 +332,11 @@ class TestErrorPaths:
         call_count = {'n': 0}
         original = load_mod._maybe_add_pr
 
-        def flaky(eval_, pr, repos, lookback):
+        def flaky(eval_, pr, repos, lookback, registration_cutoff=None):
             call_count['n'] += 1
             if call_count['n'] == 1:
                 raise RuntimeError('synthetic failure on first PR')
-            original(eval_, pr, repos, lookback)
+            original(eval_, pr, repos, lookback, registration_cutoff=registration_cutoff)
 
         monkeypatch.setattr(load_mod, '_maybe_add_pr', flaky)
 
@@ -353,3 +353,70 @@ class TestErrorPaths:
         assert len(eval_.merged_prs) == 1
         assert eval_.merged_prs[0].pr.pr_number == 2
         assert eval_.fetch_failed is False  # per-PR errors don't poison the whole batch
+
+
+class TestRegistrationCutoffGate:
+    def test_merged_before_cutoff_skipped(self):
+        client = Mock()
+        client.get_miner_pulls.return_value = _build_response(
+            [
+                _pr_dict(1, state='MERGED', merged_at='2026-04-10T00:00:00Z'),
+                _pr_dict(2, state='MERGED', merged_at='2026-04-25T00:00:00Z'),
+            ]
+        )
+        cutoff = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        eval_ = _eval()
+        load_mirror_miner_prs(eval_, _mirror_repos('entrius/gittensor-ui'), client=client, registration_cutoff=cutoff)
+
+        assert len(eval_.merged_prs) == 1
+        assert eval_.merged_prs[0].pr.pr_number == 2
+
+    def test_merged_at_cutoff_kept(self):
+        client = Mock()
+        client.get_miner_pulls.return_value = _build_response(
+            [
+                _pr_dict(1, state='MERGED', merged_at='2026-04-10T00:00:00Z'),
+            ]
+        )
+        cutoff = datetime(2026, 4, 10, tzinfo=timezone.utc)
+        eval_ = _eval()
+        load_mirror_miner_prs(eval_, _mirror_repos('entrius/gittensor-ui'), client=client, registration_cutoff=cutoff)
+
+        assert len(eval_.merged_prs) == 1
+        assert eval_.merged_prs[0].pr.pr_number == 1
+
+    def test_closed_before_cutoff_skipped(self):
+        recent_create = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+        client = Mock()
+        client.get_miner_pulls.return_value = _build_response(
+            [
+                _pr_dict(
+                    1,
+                    state='CLOSED',
+                    merged_at=None,
+                    created_at=recent_create,
+                ),
+            ]
+        )
+        # Override closed_at to before cutoff (mirror dict sets closed_at=merged_at;
+        # for state=CLOSED with merged_at=None, closed_at is None — so set it explicitly)
+        prs = client.get_miner_pulls.return_value.pull_requests
+        prs[0].closed_at = datetime(2026, 4, 10, tzinfo=timezone.utc)
+
+        cutoff = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        eval_ = _eval()
+        load_mirror_miner_prs(eval_, _mirror_repos('entrius/gittensor-ui'), client=client, registration_cutoff=cutoff)
+
+        assert len(eval_.closed_prs) == 0
+
+    def test_no_cutoff_does_not_skip(self):
+        client = Mock()
+        client.get_miner_pulls.return_value = _build_response(
+            [
+                _pr_dict(1, state='MERGED', merged_at='2026-04-10T00:00:00Z'),
+            ]
+        )
+        eval_ = _eval()
+        load_mirror_miner_prs(eval_, _mirror_repos('entrius/gittensor-ui'), client=client)
+
+        assert len(eval_.merged_prs) == 1

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -185,6 +185,17 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_99'
         assert entry['hotkey'] == 'hotkey_1'
 
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    def test_first_broadcast_stamps_first_registered_at(self, mock_validate, mock_test_query, mock_validator):
+        synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_valid')
+        _run(handle_pat_broadcast(mock_validator, synapse))
+
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
+        assert 'first_registered_at' in entry
+        assert entry['first_registered_at'] == entry['stored_at']
+
 
 class TestHandlePatCheck:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)

--- a/tests/validator/test_pat_storage.py
+++ b/tests/validator/test_pat_storage.py
@@ -4,9 +4,11 @@
 
 import json
 import threading
+from datetime import datetime, timedelta
 
 import pytest
 
+from gittensor.constants import REGISTRATION_GRACE_DAYS
 from gittensor.validator import pat_storage
 
 
@@ -141,3 +143,124 @@ class TestConcurrency:
         assert not errors
         entries = pat_storage.load_all_pats()
         assert len(entries) == 20
+
+
+class TestFirstRegisteredAt:
+    def test_new_entry_stamps_first_registered_at(self):
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp', 'user_1')
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
+        assert 'first_registered_at' in entry
+        assert entry['first_registered_at'] == entry['stored_at']
+
+    def test_re_broadcast_preserves_first_registered_at(self, use_tmp_pats_file):
+        initial = [
+            {
+                'uid': 1,
+                'hotkey': 'hotkey_1',
+                'pat': 'ghp_old',
+                'github_id': 'user_1',
+                'stored_at': '2026-01-01T00:00:00+00:00',
+                'first_registered_at': '2026-01-01T00:00:00+00:00',
+            }
+        ]
+        use_tmp_pats_file.write_text(json.dumps(initial))
+
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_new', 'user_1')
+
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry['first_registered_at'] == '2026-01-01T00:00:00+00:00'
+        assert entry['pat'] == 'ghp_new'
+        assert entry['stored_at'] != '2026-01-01T00:00:00+00:00'
+
+    def test_legacy_entry_grandfathered_on_re_broadcast(self, use_tmp_pats_file):
+        legacy = [
+            {
+                'uid': 1,
+                'hotkey': 'hotkey_1',
+                'pat': 'ghp_old',
+                'github_id': 'user_1',
+                'stored_at': '2020-01-01T00:00:00+00:00',
+            }
+        ]
+        use_tmp_pats_file.write_text(json.dumps(legacy))
+
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_new', 'user_1')
+
+        entry = pat_storage.get_pat_by_uid(1)
+        assert 'first_registered_at' not in entry
+        assert entry['pat'] == 'ghp_new'
+
+    def test_hotkey_change_resets_first_registered_at(self, use_tmp_pats_file):
+        initial = [
+            {
+                'uid': 1,
+                'hotkey': 'old_hotkey',
+                'pat': 'ghp_old',
+                'github_id': 'user_old',
+                'stored_at': '2020-01-01T00:00:00+00:00',
+                'first_registered_at': '2020-01-01T00:00:00+00:00',
+            }
+        ]
+        use_tmp_pats_file.write_text(json.dumps(initial))
+
+        pat_storage.save_pat(1, 'new_hotkey', 'ghp_new', 'user_new')
+
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry['first_registered_at'] != '2020-01-01T00:00:00+00:00'
+        assert entry['first_registered_at'] == entry['stored_at']
+
+
+class TestGetRegistrationCutoff:
+    def test_no_entry(self):
+        assert pat_storage.get_registration_cutoff(1, 'hotkey_1') is None
+
+    def test_hotkey_mismatch(self):
+        pat_storage.save_pat(1, 'old_hotkey', 'ghp', 'user_1')
+        assert pat_storage.get_registration_cutoff(1, 'different_hotkey') is None
+
+    def test_legacy_entry_no_field(self, use_tmp_pats_file):
+        legacy = [
+            {
+                'uid': 1,
+                'hotkey': 'hotkey_1',
+                'pat': 'ghp',
+                'github_id': 'user_1',
+                'stored_at': '2020-01-01T00:00:00+00:00',
+            }
+        ]
+        use_tmp_pats_file.write_text(json.dumps(legacy))
+        assert pat_storage.get_registration_cutoff(1, 'hotkey_1') is None
+
+    def test_returns_first_registered_minus_grace(self, use_tmp_pats_file):
+        first_reg = '2026-04-01T00:00:00+00:00'
+        entry = [
+            {
+                'uid': 1,
+                'hotkey': 'hotkey_1',
+                'pat': 'ghp',
+                'github_id': 'user_1',
+                'stored_at': first_reg,
+                'first_registered_at': first_reg,
+            }
+        ]
+        use_tmp_pats_file.write_text(json.dumps(entry))
+
+        cutoff = pat_storage.get_registration_cutoff(1, 'hotkey_1')
+
+        assert cutoff is not None
+        expected = datetime.fromisoformat(first_reg) - timedelta(days=REGISTRATION_GRACE_DAYS)
+        assert cutoff == expected
+
+    def test_malformed_iso_returns_none(self, use_tmp_pats_file):
+        bad = [
+            {
+                'uid': 1,
+                'hotkey': 'hotkey_1',
+                'pat': 'ghp',
+                'github_id': 'user_1',
+                'first_registered_at': 'not-a-date',
+            }
+        ]
+        use_tmp_pats_file.write_text(json.dumps(bad))
+        assert pat_storage.get_registration_cutoff(1, 'hotkey_1') is None

--- a/tests/validator/test_pat_storage.py
+++ b/tests/validator/test_pat_storage.py
@@ -169,6 +169,7 @@ class TestFirstRegisteredAt:
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_new', 'user_1')
 
         entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['first_registered_at'] == '2026-01-01T00:00:00+00:00'
         assert entry['pat'] == 'ghp_new'
         assert entry['stored_at'] != '2026-01-01T00:00:00+00:00'
@@ -188,6 +189,7 @@ class TestFirstRegisteredAt:
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_new', 'user_1')
 
         entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert 'first_registered_at' not in entry
         assert entry['pat'] == 'ghp_new'
 
@@ -207,6 +209,7 @@ class TestFirstRegisteredAt:
         pat_storage.save_pat(1, 'new_hotkey', 'ghp_new', 'user_new')
 
         entry = pat_storage.get_pat_by_uid(1)
+        assert entry is not None
         assert entry['first_registered_at'] != '2020-01-01T00:00:00+00:00'
         assert entry['first_registered_at'] == entry['stored_at']
 


### PR DESCRIPTION
## Summary

Closes #1000

Skip merged/closed PRs that predate a miner's first PAT registration on this validator (minus a 7-day grace window). Closes the aged-account-purchase vector - registering a GitHub account that already has merged PRs to whitelisted repos no longer earns emissions for that pre-existing work.

## Changes

- `pat_storage`: stamp `first_registered_at` on first save; preserve it across re-broadcasts of the same hotkey; reset it on hotkey change. Legacy entries that lack the field stay grandfathered (no gate). New `get_registration_cutoff(uid, hotkey)` helper.
- `github_api_tools` (legacy path): `should_skip_merged_pr` and `try_add_open_or_closed_pr` accept `registration_cutoff` and skip when `merged_at` / `closed_at` falls before it.
- `mirror/load.py` (mirror path): same gate at load time on both `merged_at` and `closed_at`.
- `reward.py`: looks up the cutoff per UID and threads it into both load paths.
- `constants`: `REGISTRATION_GRACE_DAYS = 7`.

## Migration

Existing PAT entries without `first_registered_at` are grandfathered - the gate stays disabled for them indefinitely, even on re-broadcast. **No score regressions for current miners.**

## Test plan

- [x] `pytest` - 748 passed
- [x] `ruff check` + `ruff format --check` - clean
- [x] `pyright` on touched files - 0 errors
- [x] New tests cover: before / at / after cutoff (merged + closed), open PRs unaffected, legacy grandfather, hotkey-change reset, malformed ISO, smoke test for first-broadcast stamping
