### PR TITLE
feat: show GitHub username after PAT validation in gitt miner post

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -98,13 +98,13 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
 
     # 1b. Validate PAT locally
     with _status('[bold]Validating PAT...', json_mode):
-        pat_valid = _validate_pat_locally(pat)
+        github_login = _validate_pat_locally(pat)
 
-    if not pat_valid:
+    if github_login is None:
         _error('GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.', json_mode)
         sys.exit(1)
 
-    _print('[green]PAT is valid.[/green]', json_mode)
+    _print(f'[green]PAT is valid.[/green] GitHub account: [bold]@{github_login}[/bold]', json_mode)
 
     # 2. Resolve wallet and network
     wallet_name = wallet_name or _load_config_value('wallet') or 'default'
@@ -168,6 +168,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
             json.dumps(
                 {
                     'success': accepted_count > 0,
+                    'github_login': github_login,
                     'total_validators': len(results),
                     **counts,
                     'skipped': excluded,
@@ -193,15 +194,19 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         _render_skipped_validators(excluded, json_mode)
 
 
-def _validate_pat_locally(pat: str) -> bool:
-    """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
+def _validate_pat_locally(pat: str) -> Optional[str]:
+    """Validate PAT mirrors the validator-side checks: user identity + GraphQL access.
+
+    Returns the GitHub login on success, or None if the PAT is invalid.
+    """
     try:
-        # Check basic auth
+        # Check basic auth and extract login
         user_resp = requests.get(
             f'{BASE_GITHUB_API_URL}/user', headers=make_headers(pat), timeout=GITHUB_HTTP_TIMEOUT_SECONDS
         )
         if user_resp.status_code != 200:
-            return False
+            return None
+        login: Optional[str] = user_resp.json().get('login') or None
 
         # Check GraphQL access (same test the validator runs during PAT broadcast)
         gql_resp = requests.post(
@@ -214,8 +219,8 @@ def _validate_pat_locally(pat: str) -> bool:
             console.print(
                 '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
             )
-            return False
+            return None
 
-        return True
+        return login
     except requests.RequestException:
-        return False
+        return None

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -194,7 +194,7 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         _render_skipped_validators(excluded, json_mode)
 
 
-def _validate_pat_locally(pat: str) -> Optional[str]:
+def _validate_pat_locally(pat: str) -> str | None:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access.
 
     Returns the GitHub login on success, or None if the PAT is invalid.
@@ -206,7 +206,7 @@ def _validate_pat_locally(pat: str) -> Optional[str]:
         )
         if user_resp.status_code != 200:
             return None
-        login: Optional[str] = user_resp.json().get('login') or None
+        login: str | None = user_resp.json().get('login') or None
 
         # Check GraphQL access (same test the validator runs during PAT broadcast)
         gql_resp = requests.post(

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -96,14 +96,14 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         pat = click.prompt('Enter your GitHub Personal Access Token', hide_input=True)
 
     # 1b. Validate PAT locally
-    with _status('[bold]Validating PAT...', json_mode):
+    with _status('[bold]Validating PAT...'):
         github_login = _validate_pat_locally(pat)
 
     if github_login is None:
         _error('GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.', json_mode)
         sys.exit(1)
 
-    _print(f'[green]PAT is valid.[/green] GitHub account: [bold]@{github_login}[/bold]', json_mode)
+    _print(f'[green]PAT is valid.[/green] GitHub account: [bold]@{github_login}[/bold]')
 
     # 2. Resolve wallet and network
     wallet_name = wallet_name or _load_config_value('wallet') or 'default'

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -32,14 +32,16 @@ def _fake_metagraph(rows: list[tuple[float, bool, float]]):
 
 @pytest.fixture
 def runner():
-    return CliRunner()
+    return CliRunner(mix_stderr=False)
 
 
 class TestMinerPost:
-    def test_no_pat_prompts_interactively(self, runner, monkeypatch):
+    @patch('gittensor.cli.miner_commands.post.click.prompt', return_value='ghp_fake')
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=None)
+    def test_no_pat_prompts_interactively(self, mock_validate, mock_prompt, runner, monkeypatch):
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
-        result = runner.invoke(cli, ['miner', 'post', '--wallet', 'test', '--hotkey', 'test'], input='')
-        assert 'Enter your GitHub Personal Access Token' in result.output
+        runner.invoke(cli, ['miner', 'post', '--wallet', 'test', '--hotkey', 'test'])
+        mock_prompt.assert_called_once_with('Enter your GitHub Personal Access Token', hide_input=True)
 
     def test_no_pat_json_mode_exits(self, runner, monkeypatch):
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
@@ -53,7 +55,7 @@ class TestMinerPost:
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
         result = runner.invoke(cli, ['miner', 'post', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'])
         assert result.exit_code != 0
-        assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
+        assert 'invalid' in result.stderr.lower() or 'expired' in result.stderr.lower()
         mock_validate.assert_called_once_with('ghp_test123')
 
     @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=None)
@@ -61,7 +63,7 @@ class TestMinerPost:
         monkeypatch.setenv('GITTENSOR_MINER_PAT', 'ghp_invalid')
         result = runner.invoke(cli, ['miner', 'post', '--wallet', 'test', '--hotkey', 'test'])
         assert result.exit_code != 0
-        assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
+        assert 'invalid' in result.stderr.lower() or 'expired' in result.stderr.lower()
 
     def test_help_text(self, runner):
         result = runner.invoke(cli, ['miner', 'post', '--help'])
@@ -119,6 +121,7 @@ class TestMinerPost:
 
         assert result.exit_code == 0, result.output
         output = json.loads(result.stdout)
+        assert output['github_login'] == 'testuser'
         assert output['total_validators'] == 3
         assert output['accepted'] == 1
         assert output['rejected'] == 1

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -32,7 +32,7 @@ def _fake_metagraph(rows: list[tuple[float, bool, float]]):
 
 @pytest.fixture
 def runner():
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 class TestMinerPost:

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -48,7 +48,7 @@ class TestMinerPost:
         output = json.loads(result.output)
         assert output['success'] is False
 
-    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=None)
     def test_pat_flag_used(self, mock_validate, runner, monkeypatch):
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
         result = runner.invoke(cli, ['miner', 'post', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'])
@@ -56,7 +56,7 @@ class TestMinerPost:
         assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
         mock_validate.assert_called_once_with('ghp_test123')
 
-    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=None)
     def test_invalid_pat_exits(self, mock_validate, runner, monkeypatch):
         monkeypatch.setenv('GITTENSOR_MINER_PAT', 'ghp_invalid')
         result = runner.invoke(cli, ['miner', 'post', '--wallet', 'test', '--hotkey', 'test'])
@@ -96,7 +96,7 @@ class TestMinerPost:
                 return responses
 
         with (
-            patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=True),
+            patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value='testuser'),
             patch(
                 'gittensor.cli.miner_commands.post._connect_bittensor',
                 return_value=(wallet, object(), metagraph, FakeDendrite()),


### PR DESCRIPTION
## Summary

- `_validate_pat_locally` already calls `GET /user` to verify the PAT —  the response includes a `login` field that was being discarded
- Return the login instead of a bare `bool`, and surface it in the  confirmation line: `PAT is valid. GitHub account: @your-username`
- Add `github_login` to the `--json-output` result object
- No additional API call — zero performance impact

Closes #1004 

## Test plan
- [ ] `gitt miner post` with a valid PAT shows the correct GitHub username
- [ ] `gitt miner post` with an invalid PAT still exits with the error message
- [ ] `gitt miner post --json-output` includes `github_login` in the response

<img width="902" height="72" alt="image" src="https://github.com/user-attachments/assets/142a8efe-c4ca-4b69-af08-cf00764c725f" />
