### PR TITLE
Fix mirror open issue count to ignore transferred issues

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -171,7 +171,7 @@ async def run_mirror_issue_discovery(
         # also written to evaluation.total_open_issues so the DB row reflects
         # mirror-scoped state (the legacy GraphQL global open-issue count was
         # never the right signal for the gate).
-        open_issue_count = sum(1 for i in filtered if i.state == 'OPEN')
+        open_issue_count = sum(1 for i in filtered if i.state == 'OPEN' and not i.is_transferred)
         pending.append((evaluation, filtered, open_issue_count))
 
     canonical_pr_owners = _build_canonical_pr_owners(pending)

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -702,6 +702,39 @@ class TestOpenIssueSpamSourceIsMirror:
         assert eval_.issue_discovery_score > 0
         assert eval_.total_open_issues == 2
 
+    def test_transferred_open_issues_do_not_count_for_spam_or_audit(self):
+        """Transferred issues are ignored by scoring and by the open-issue count."""
+        open_issues = [
+            _issue_dict(
+                issue_number=200 + i,
+                state='OPEN',
+                state_reason=None,
+                solved_by_pr=None,
+                is_transferred=(i >= 5),
+            )
+            for i in range(8)
+        ]
+        solved_issues = [_issue_dict(issue_number=300 + i, author_github_id=f'discoverer{i}') for i in range(8)]
+        client = Mock()
+        client.get_miner_issues.return_value = _response(open_issues + solved_issues)
+
+        eval_ = _eval()
+        eval_.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100, token_score=100.0)]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Only the 5 non-transferred open issues count, so spam stays below/at threshold.
+        assert eval_.issue_discovery_score > 0
+        assert eval_.total_open_issues == 5
+
 
 class TestCrossMinerOneIssuePerPr:
     """Regression tests for the cross-miner one-issue-per-PR rule.


### PR DESCRIPTION
## Summary
Closes  #1007

Exclude transferred OPEN mirror issues from `open_issue_count`. Transferred issues are already classified as `ignore`, so they should not affect the spam multiplier or `total_open_issues`.
- Exclude transferred OPEN issues from mirror issue-discovery `open_issue_count`
- Prevent transferred issues from inflating the open-issue spam multiplier
- Keep `evaluation.total_open_issues` aligned with mirror anti-gaming semantics
- Add regression coverage for transferred OPEN issues not affecting spam scoring or audit counts

## Changes
- Update `mirror_scan.py` to count only non-transferred OPEN issues.
- Add regression coverage for transferred OPEN issues.
- Verify transferred OPEN issues do not inflate `evaluation.total_open_issues` or trip spam scoring.

## Test plan
- `python3 -m pytest tests/validator/issue_discovery/test_mirror_scan.py`

