### PR TITLE
Fix: classify `gitt miner post` PAT `/user` failures with distinct error codes

### DIFF
--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -109,10 +109,13 @@ def _print(message: str, json_mode: bool) -> None:
         console.print(message)
 
 
-def _error(msg: str, json_mode: bool) -> None:
+def _error(msg: str, json_mode: bool, error_code: str | None = None) -> None:
     """Print an error message in the appropriate format."""
     if json_mode:
-        click.echo(json.dumps({'success': False, 'error': msg}))
+        payload = {'success': False, 'error': msg}
+        if error_code is not None:
+            payload['error_code'] = error_code
+        click.echo(json.dumps(payload))
     else:
         console.print(f'[red]Error: {msg}[/red]')
 

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -98,10 +98,16 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
 
     # 1b. Validate PAT locally
     with _status('[bold]Validating PAT...', json_mode):
-        pat_valid = _validate_pat_locally(pat)
+        pat_valid, pat_error_code, pat_error_message = _validate_pat_locally(pat)
 
     if not pat_valid:
-        _error('GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.', json_mode)
+        _error(
+            pat_error_message
+            if pat_error_message is not None
+            else 'GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.',
+            json_mode,
+            error_code=pat_error_code,
+        )
         sys.exit(1)
 
     _print('[green]PAT is valid.[/green]', json_mode)
@@ -193,29 +199,45 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         _render_skipped_validators(excluded, json_mode)
 
 
-def _validate_pat_locally(pat: str) -> bool:
+def _validate_pat_locally(pat: str) -> tuple[bool, str | None, str | None]:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
     try:
         # Check basic auth
         user_resp = requests.get(
             f'{BASE_GITHUB_API_URL}/user', headers=make_headers(pat), timeout=GITHUB_HTTP_TIMEOUT_SECONDS
         )
-        if user_resp.status_code != 200:
-            return False
+    except requests.RequestException as exc:
+        return False, 'github_network_error', f'Failed to reach GitHub API: {exc}. Check your network and retry.'
 
-        # Check GraphQL access (same test the validator runs during PAT broadcast)
+    if user_resp.status_code == 200:
+        pass
+    elif user_resp.status_code == 401:
+        return False, 'pat_invalid', 'GitHub PAT is invalid or expired. Rotate your token at github.com/settings/tokens.'
+    elif user_resp.status_code == 429:
+        return False, 'github_rate_limited', 'GitHub API rate limit reached. Retry after the reset time.'
+    elif user_resp.status_code == 403:
+        if user_resp.headers.get('x-ratelimit-remaining') == '0' or 'rate limit' in user_resp.text.lower():
+            return False, 'github_rate_limited', 'GitHub API rate limit reached. Retry after the reset time.'
+        return False, 'pat_invalid', 'GitHub PAT is invalid or expired. Rotate your token at github.com/settings/tokens.'
+    elif user_resp.status_code == 408 or 500 <= user_resp.status_code < 600:
+        return False, 'github_unavailable', f'GitHub API is currently unavailable (HTTP {user_resp.status_code}). Retry in a few minutes.'
+    else:
+        return False, 'pat_invalid', 'GitHub PAT is invalid or expired. Rotate your token at github.com/settings/tokens.'
+
+    try:
         gql_resp = requests.post(
             f'{BASE_GITHUB_API_URL}/graphql',
             json={'query': GRAPHQL_VIEWER_QUERY},
             headers=make_graphql_headers(pat),
             timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
-        if gql_resp.status_code != 200:
-            console.print(
-                '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
-            )
-            return False
+    except requests.RequestException as exc:
+        return False, 'github_network_error', f'Failed to reach GitHub API: {exc}. Check your network and retry.'
 
-        return True
-    except requests.RequestException:
-        return False
+    if gql_resp.status_code != 200:
+        console.print(
+            '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
+        )
+        return False, 'pat_invalid', 'PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.'
+
+    return True, None, None

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import requests
 from click.testing import CliRunner
 
 from gittensor import __version__
@@ -48,7 +49,7 @@ class TestMinerPost:
         output = json.loads(result.output)
         assert output['success'] is False
 
-    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=(False, 'pat_invalid', 'GitHub PAT is invalid or expired. Rotate your token at github.com/settings/tokens.'))
     def test_pat_flag_used(self, mock_validate, runner, monkeypatch):
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
         result = runner.invoke(cli, ['miner', 'post', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'])
@@ -56,12 +57,70 @@ class TestMinerPost:
         assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
         mock_validate.assert_called_once_with('ghp_test123')
 
-    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=(False, 'pat_invalid', 'GitHub PAT is invalid or expired. Rotate your token at github.com/settings/tokens.'))
     def test_invalid_pat_exits(self, mock_validate, runner, monkeypatch):
         monkeypatch.setenv('GITTENSOR_MINER_PAT', 'ghp_invalid')
         result = runner.invoke(cli, ['miner', 'post', '--wallet', 'test', '--hotkey', 'test'])
         assert result.exit_code != 0
         assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
+
+    @patch('gittensor.cli.miner_commands.post.requests.post')
+    @patch('gittensor.cli.miner_commands.post.requests.get')
+    def test_user_endpoint_401_maps_to_pat_invalid(self, mock_get, mock_post, runner, monkeypatch):
+        mock_get.return_value = SimpleNamespace(status_code=401, headers={}, text='')
+        mock_post.return_value = SimpleNamespace(status_code=200)
+        result = runner.invoke(
+            cli,
+            ['miner', 'post', '--json-output', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'],
+        )
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output['error_code'] == 'pat_invalid'
+        assert 'invalid' in output['error'].lower() or 'expired' in output['error'].lower()
+        mock_post.assert_not_called()
+
+    @patch('gittensor.cli.miner_commands.post.requests.post')
+    @patch('gittensor.cli.miner_commands.post.requests.get')
+    def test_user_endpoint_500_maps_to_github_unavailable(self, mock_get, mock_post, runner, monkeypatch):
+        mock_get.return_value = SimpleNamespace(status_code=500, headers={}, text='')
+        mock_post.return_value = SimpleNamespace(status_code=200)
+        result = runner.invoke(
+            cli,
+            ['miner', 'post', '--json-output', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'],
+        )
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output['error_code'] == 'github_unavailable'
+        assert 'http 500' in output['error'].lower()
+        mock_post.assert_not_called()
+
+    @patch('gittensor.cli.miner_commands.post.requests.post')
+    @patch('gittensor.cli.miner_commands.post.requests.get')
+    def test_user_endpoint_403_rate_limit_maps_to_github_rate_limited(self, mock_get, mock_post, runner, monkeypatch):
+        mock_get.return_value = SimpleNamespace(status_code=403, headers={'x-ratelimit-remaining': '0'}, text='API rate limit exceeded')
+        mock_post.return_value = SimpleNamespace(status_code=200)
+        result = runner.invoke(
+            cli,
+            ['miner', 'post', '--json-output', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'],
+        )
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output['error_code'] == 'github_rate_limited'
+        assert 'rate limit' in output['error'].lower()
+        mock_post.assert_not_called()
+
+    @patch('gittensor.cli.miner_commands.post.requests.post')
+    @patch('gittensor.cli.miner_commands.post.requests.get', side_effect=requests.Timeout('timed out'))
+    def test_user_endpoint_timeout_maps_to_github_network_error(self, mock_get, mock_post, runner, monkeypatch):
+        result = runner.invoke(
+            cli,
+            ['miner', 'post', '--json-output', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'],
+        )
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output['error_code'] == 'github_network_error'
+        assert 'timed out' in output['error'].lower()
+        mock_post.assert_not_called()
 
     def test_help_text(self, runner):
         result = runner.invoke(cli, ['miner', 'post', '--help'])
@@ -96,7 +155,7 @@ class TestMinerPost:
                 return responses
 
         with (
-            patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=True),
+            patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=(True, None, None)),
             patch(
                 'gittensor.cli.miner_commands.post._connect_bittensor',
                 return_value=(wallet, object(), metagraph, FakeDendrite()),


### PR DESCRIPTION
## Summary

This change fixes `gitt miner post` local PAT validation by distinguishing GitHub `/user` failures into actionable error categories instead of treating all failures as an invalid or expired token.

Close: #1013 

## Problem

The current local PAT preflight only returns a bare boolean from `_validate_pat_locally()`. That means:

- `401 Unauthorized` is indistinguishable from
- `5xx`, `408`, or rate-limit-style `403`, and
- `requests.RequestException` network failures.

All of these were reported as:

> GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.

That is misleading when GitHub is unavailable, rate limited, or unreachable.

## Fix

### Behavior changes

`_validate_pat_locally()` now returns a tuple:
- `pat_valid: bool`
- `error_code: str | None`
- `error_message: str | None`

The `/user` preflight now distinguishes:

- `pat_invalid`: `401` or invalid `403`
- `github_rate_limited`: `429` or rate-limit-style `403`
- `github_unavailable`: `408` or `5xx`
- `github_network_error`: `requests.RequestException`

`_error()` now accepts an optional `error_code` and includes it in JSON output.

### Scope

This fix is intentionally narrow and only affects the local PAT `/user` preflight path in `gitt miner post`. The GraphQL permission check remains unchanged in behavior.

## Files changed

- `gittensor/cli/miner_commands/post.py`
  - Updated `_validate_pat_locally()` return shape and error classification
  - Updated CLI PAT validation flow to emit distinct error messages and `error_code` in JSON

- `gittensor/cli/miner_commands/helpers.py`
  - Extended `_error()` to include optional `error_code` in JSON responses

- `tests/cli/test_miner_commands.py`
  - Updated existing `_validate_pat_locally` patching to the new tuple contract
  - Added focused regression tests for `/user`:
    - `401` → `pat_invalid`
    - `500` → `github_unavailable`
    - `403` with rate-limit evidence → `github_rate_limited`
    - request timeout → `github_network_error`

## Testing

The modified files pass Python syntax checks:

```bash
python3 -m py_compile gittensor/cli/miner_commands/post.py \
    gittensor/cli/miner_commands/helpers.py \
    tests/cli/test_miner_commands.py
```

## Why this matters

Operators no longer get a misleading token-rotation message when GitHub is temporarily unavailable or rate limited. The CLI now provides actionable guidance and machine-readable error classification for automation.
