### PR TITLE
refactor: move MAX_ISSUE_ID to gittensor/constants.py and use it on the validator side

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -20,7 +20,7 @@ import requests
 from rich.console import Console
 
 from gittensor.cli.issue_commands.tables import build_pr_table
-from gittensor.constants import NETWORK_MAP
+from gittensor.constants import MAX_ISSUE_ID, NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
     compute_ink5_lazy_key,
     decode_issue_from_storage,
@@ -38,7 +38,6 @@ ALPHA_DECIMALS = 9
 ALPHA_RAW_UNIT = 10**ALPHA_DECIMALS
 MIN_BOUNTY_ALPHA = 10
 MAX_BOUNTY_ALPHA = 100_000_000
-MAX_ISSUE_ID = 1_000_000
 MAX_ISSUE_NUMBER = 2**32 - 1
 REPO_PATTERN = re.compile(r'^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$')
 GITHUB_API_TIMEOUT = 10

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -215,3 +215,4 @@ MAX_OPEN_PR_THRESHOLD = 30  # Maximum open PR threshold (base + bonus capped at 
 CONTRACT_ADDRESS = '5FWNdk8YNtNcHKrAx2krqenFrFAZG7vmsd2XN2isJSew3MrD'
 ISSUES_TREASURY_UID = 111  # UID of the smart contract neuron, if set to RECYCLE_UID then it's disabled
 ISSUES_TREASURY_EMISSION_SHARE = 0.15  # % of emissions allocated to funding issues treasury
+MAX_ISSUE_ID = 1_000_000  # sanity-check upper bound for any real deployment

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -15,6 +15,7 @@ import bittensor as bt
 from substrateinterface import Keypair
 from substrateinterface.exceptions import ExtrinsicNotFound
 
+from gittensor.constants import MAX_ISSUE_ID
 from gittensor.validator.issue_competitions.storage_utils import (
     compute_ink5_lazy_key,
     decode_issue_from_storage,
@@ -191,8 +192,7 @@ class IssueCompetitionContractClient:
             if next_issue_id <= 1:
                 return []
 
-            MAX_REASONABLE_ISSUE_ID = 1_000_000
-            if next_issue_id > MAX_REASONABLE_ISSUE_ID:
+            if next_issue_id > MAX_ISSUE_ID:
                 bt.logging.warning(f'next_issue_id ({next_issue_id}) unreasonably large')
                 return []
 


### PR DESCRIPTION
## Summary

Follow-up to the just-merged #873, which deduped the `1_000_000` issue-ID bound on the CLI side using the `helpers.py`-local `MAX_ISSUE_ID`. The validator-side path in `IssueCompetitionContractClient.get_issues_by_status` still carries its own local copy with the same value and same intent:

```python
# gittensor/validator/issue_competitions/contract_client.py:194-195
MAX_REASONABLE_ISSUE_ID = 1_000_000
if next_issue_id > MAX_REASONABLE_ISSUE_ID:
```

This PR hoists `MAX_ISSUE_ID` into [gittensor/constants.py](gittensor/constants.py) (alongside `CONTRACT_ADDRESS`, `ISSUES_TREASURY_UID`, etc.) so both consumers share a single definition. Validator code stays clean of any `cli/*` dependency, matching the import-direction precedent already set by #425 (`NETWORK_MAP`) and #460 (`get_contract_address`).

### Changes

- [gittensor/constants.py](gittensor/constants.py) — add `MAX_ISSUE_ID = 1_000_000` to the Issues Competition section.
- [gittensor/cli/issue_commands/helpers.py](gittensor/cli/issue_commands/helpers.py) — drop the local definition, import from `gittensor.constants`. Existing call sites (`validate_issue_id`, `_read_issues_from_child_storage`) are unaffected.
- [gittensor/validator/issue_competitions/contract_client.py](gittensor/validator/issue_competitions/contract_client.py) — drop local `MAX_REASONABLE_ISSUE_ID`, import `MAX_ISSUE_ID` from `gittensor.constants`.

Net: **+4 / -4 lines** across 3 files. No behaviour change — same `1_000_000` bound, same comparison.

(Happy to fold this into the #955 bundle if that's preferred — easy to cherry-pick.)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 754 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)