### PR TITLE
fix: skip cross-repo closes refs in PR linked issues

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -258,6 +258,16 @@ class PullRequest:
         for issue in raw_issues:
             if is_merged and not (issue.get('closedAt') and issue.get('state') == 'CLOSED'):
                 continue
+            # Reject cross-repo `closes ownerB/repoB#N` references: GitHub computes
+            # authorAssociation against the issue's repo, so a maintainer of repo B
+            # would otherwise grant the maintainer multiplier on a PR in repo A.
+            issue_repo = (issue.get('repository') or {}).get('nameWithOwner', '').lower()
+            if issue_repo and issue_repo != repository_full_name:
+                bt.logging.warning(
+                    f'Skipping issue #{issue.get("number")} - cross-repo link '
+                    f'(issue in {issue_repo}, PR in {repository_full_name})'
+                )
+                continue
             issue_author = issue.get('author') or {}
             author_db_id = issue_author.get('databaseId')
 

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -97,6 +97,7 @@ QUERY = """
                   createdAt
                   closedAt
                   updatedAt
+                  repository { nameWithOwner }
                   author {
                     login
                     ... on User { databaseId }

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -96,6 +96,72 @@ def test_is_test_file_detects_conftest_at_any_depth(filename):
     assert _file_change(filename).is_test_file() is True
 
 
+def _issue_node(number: int, name_with_owner: str | None) -> dict:
+    node = {
+        'number': number,
+        'title': f'Issue #{number}',
+        'state': 'CLOSED',
+        'stateReason': 'COMPLETED',
+        'createdAt': '2026-04-01T00:00:00Z',
+        'closedAt': '2026-04-15T00:00:00Z',
+        'updatedAt': '2026-04-15T00:00:00Z',
+        'author': {'login': 'maintainer_b', 'databaseId': 999},
+        'authorAssociation': 'OWNER',
+        'userContentEdits': {'nodes': []},
+        'timelineItems': {'nodes': []},
+    }
+    if name_with_owner is not None:
+        node['repository'] = {'nameWithOwner': name_with_owner}
+    return node
+
+
+def _pr_data_with_issues(issue_nodes: list[dict]) -> dict:
+    return {
+        'number': 42,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'state': 'MERGED',
+        'closingIssuesReferences': {'nodes': issue_nodes},
+        'bodyText': 'fixes things',
+        'lastEditedAt': None,
+        'mergedAt': '2026-04-16T00:00:00Z',
+        'timelineItems': {'nodes': []},
+        'title': 'fix: things',
+        'author': {'login': 'miner'},
+        'authorAssociation': 'CONTRIBUTOR',
+        'createdAt': '2026-04-15T00:00:00Z',
+        'additions': 3,
+        'deletions': 1,
+        'commits': {'totalCount': 1},
+        'headRefOid': 'abc123',
+        'baseRefOid': 'def456',
+    }
+
+
+def test_pull_request_skips_cross_repo_closing_issue_references():
+    pr_data = _pr_data_with_issues(
+        [
+            _issue_node(1, 'entrius/gittensor'),
+            _issue_node(2, 'entrius/other-repo'),
+            _issue_node(3, 'ENTRIUS/Gittensor'),  # case-insensitive match
+        ]
+    )
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.issues is not None
+    assert sorted(i.number for i in pr.issues) == [1, 3]
+
+
+def test_pull_request_keeps_issue_when_repository_field_missing():
+    """Backwards-compat: pre-fix cached payloads have no `repository` block — don't drop them."""
+    pr_data = _pr_data_with_issues([_issue_node(7, None)])
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.issues is not None
+    assert [i.number for i in pr.issues] == [7]
+
+
 def test_pull_request_handles_deleted_label_event():
     pr_data = {
         'number': 42,


### PR DESCRIPTION
## Summary
- GitHub computes `authorAssociation` against the *issue's* repo, so a `closes ownerB/repoB#N` link from a cross-repo issue could grant the 1.66× `MAINTAINER_ISSUE_MULTIPLIER` to a PR in repo A.
- Add `repository { nameWithOwner }` to the `closingIssuesReferences` GraphQL fragment and drop nodes whose repo doesn't match the PR's repo at construction time.
- Cached payloads without `repository` are passed through unchanged (backwards compat until refetch).

## Test plan
- [x] `pytest tests/test_classes.py` — new tests for cross-repo skip (case-insensitive) and missing-repo backwards compat
- [x] Full suite (`pytest tests/`) — 764 passed

Fixes #1019 