### PR TITLE
feat: per-repo label multipliers with fnmatch wildcard support (closes #1016)

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -185,6 +185,10 @@ class PullRequest:
     label_multiplier: float = 1.0  # Multiplier resolved from per-repo label_multipliers config
     label: Optional[str] = None  # Resolved scoring label (set during scoring, stored in DB)
     current_labels: frozenset = field(default_factory=frozenset)  # All currently-applied labels (lowercased)
+    # Current labels ordered by last application (most recent first) from timeline scan.
+    # Subset of current_labels that appeared in timelineItems; labels absent from the timeline
+    # (truncated) are not included here and fall back to highest-multiplier selection.
+    label_timeline_order: tuple = field(default_factory=tuple)
     changes_requested_count: int = 0  # Number of maintainer CHANGES_REQUESTED reviews
     earned_score: float = 0.0
     collateral_score: float = 0.0  # For OPEN PRs: potential_score * collateral_percent
@@ -313,15 +317,18 @@ class PullRequest:
         current: frozenset = frozenset(
             (n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n
         )
-        # Scan timeline in reverse to find the most recently applied label that is still on the PR.
+        # Collect all currently-applied labels in reverse-timeline order (most recently applied first).
         # Per-repo multiplier resolution happens later in calculate_pr_multipliers which has repo config.
         label: Optional[str] = None
+        timeline_ordered: list = []
         if current:
+            seen: set = set()
             for event in reversed((pr_data.get('timelineItems') or {}).get('nodes') or []):
                 name = ((event or {}).get('label') or {}).get('name', '').lower()
-                if name and name in current:
-                    label = name
-                    break
+                if name and name in current and name not in seen:
+                    seen.add(name)
+                    timeline_ordered.append(name)
+            label = timeline_ordered[0] if timeline_ordered else None
 
         return cls(
             number=pr_data['number'],
@@ -345,6 +352,7 @@ class PullRequest:
             base_ref_oid=pr_data.get('baseRefOid'),
             label=label,
             current_labels=current,
+            label_timeline_order=tuple(timeline_ordered),
             changes_requested_count=changes_requested_count,
         )
 

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 
 from gittensor.constants import (
-    LABEL_MULTIPLIERS,
     MAINTAINER_ASSOCIATIONS,
     MAX_CODE_DENSITY_MULTIPLIER,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
@@ -183,8 +182,9 @@ class PullRequest:
     time_decay_multiplier: float = 1.0
     credibility_multiplier: float = 1.0
     review_quality_multiplier: float = 1.0  # Penalty for CHANGES_REQUESTED reviews from maintainers
-    label_multiplier: float = 1.0  # Multiplier based on PR label (exact match against known labels)
-    label: Optional[str] = None  # Last label set on the PR
+    label_multiplier: float = 1.0  # Multiplier resolved from per-repo label_multipliers config
+    label: Optional[str] = None  # Resolved scoring label (set during scoring, stored in DB)
+    current_labels: frozenset = field(default_factory=frozenset)  # All currently-applied labels (lowercased)
     changes_requested_count: int = 0  # Number of maintainer CHANGES_REQUESTED reviews
     earned_score: float = 0.0
     collateral_score: float = 0.0  # For OPEN PRs: potential_score * collateral_percent
@@ -310,18 +310,18 @@ class PullRequest:
         cr_reviews = (pr_data.get('changesRequestedReviews') or {}).get('nodes') or []
         changes_requested_count = sum(1 for r in cr_reviews if r.get('authorAssociation') in MAINTAINER_ASSOCIATIONS)
 
-        current = {(n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n}
+        current: frozenset = frozenset(
+            (n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n
+        )
+        # Scan timeline in reverse to find the most recently applied label that is still on the PR.
+        # Per-repo multiplier resolution happens later in calculate_pr_multipliers which has repo config.
         label: Optional[str] = None
-        scoring_labels = current & LABEL_MULTIPLIERS.keys()
-        if scoring_labels:
+        if current:
             for event in reversed((pr_data.get('timelineItems') or {}).get('nodes') or []):
                 name = ((event or {}).get('label') or {}).get('name', '').lower()
-                if name in scoring_labels:
+                if name and name in current:
                     label = name
                     break
-            if label is None:
-                # Timeline truncated — fall back to highest-multiplier currently-applied label
-                label = max(scoring_labels, key=lambda n: (LABEL_MULTIPLIERS[n], n))
 
         return cls(
             number=pr_data['number'],
@@ -344,6 +344,7 @@ class PullRequest:
             head_ref_oid=pr_data.get('headRefOid'),
             base_ref_oid=pr_data.get('baseRefOid'),
             label=label,
+            current_labels=current,
             changes_requested_count=changes_requested_count,
         )
 

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -184,11 +184,11 @@ class PullRequest:
     review_quality_multiplier: float = 1.0  # Penalty for CHANGES_REQUESTED reviews from maintainers
     label_multiplier: float = 1.0  # Multiplier resolved from per-repo label_multipliers config
     label: Optional[str] = None  # Resolved scoring label (set during scoring, stored in DB)
-    current_labels: frozenset = field(default_factory=frozenset)  # All currently-applied labels (lowercased)
+    current_labels: frozenset[str] = field(default_factory=frozenset)  # All currently-applied labels (lowercased)
     # Current labels ordered by last application (most recent first) from timeline scan.
     # Subset of current_labels that appeared in timelineItems; labels absent from the timeline
     # (truncated) are not included here and fall back to highest-multiplier selection.
-    label_timeline_order: tuple = field(default_factory=tuple)
+    label_timeline_order: tuple[str, ...] = field(default_factory=tuple)
     changes_requested_count: int = 0  # Number of maintainer CHANGES_REQUESTED reviews
     earned_score: float = 0.0
     collateral_score: float = 0.0  # For OPEN PRs: potential_score * collateral_percent
@@ -319,7 +319,6 @@ class PullRequest:
         )
         # Collect all currently-applied labels in reverse-timeline order (most recently applied first).
         # Per-repo multiplier resolution happens later in calculate_pr_multipliers which has repo config.
-        label: Optional[str] = None
         timeline_ordered: list = []
         if current:
             seen: set = set()
@@ -328,7 +327,6 @@ class PullRequest:
                 if name and name in current and name not in seen:
                     seen.add(name)
                     timeline_ordered.append(name)
-            label = timeline_ordered[0] if timeline_ordered else None
 
         return cls(
             number=pr_data['number'],
@@ -350,7 +348,6 @@ class PullRequest:
             last_edited_at=last_edited_at,
             head_ref_oid=pr_data.get('headRefOid'),
             base_ref_oid=pr_data.get('baseRefOid'),
-            label=label,
             current_labels=current,
             label_timeline_order=tuple(timeline_ordered),
             changes_requested_count=changes_requested_count,

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -83,29 +83,6 @@ CONTRIBUTION_SCORE_FOR_FULL_BONUS = 1500
 # Boosts
 MAX_CODE_DENSITY_MULTIPLIER = 1.15
 
-# Label multipliers - applied based on the last label set on the PR (requires triage+ access)
-LABEL_MULTIPLIERS: dict[str, float] = {
-    # features
-    'feature': 1.50,
-    'feat': 1.50,
-    # bug fixes
-    'bug': 1.25,
-    'fix': 1.25,
-    'crash': 1.25,
-    'regression': 1.25,
-    'security': 1.25,
-    # enhancements
-    'enhancement': 1.10,
-    'improve': 1.10,
-    'perf': 1.10,
-    # refactors
-    'refactor': 0.5,
-    'cleanup': 0.5,
-    'polish': 0.5,
-    'debt': 0.5,
-    'chore': 0.5,
-}
-
 # Pioneer dividend — rewards the first quality contributor to each repository
 # Rates applied per follower position (1st follower pays most, diminishing after)
 # Dividend capped at PIONEER_DIVIDEND_MAX_RATIO × pioneer's own earned_score

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -351,13 +351,9 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
 
     scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
 
-    chosen_label = _resolve_trusted_scoring_label(pr, repo_config)
+    chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label
-    scored.label_multiplier = (
-        resolve_label_multiplier(chosen_label, repo_config)
-        if chosen_label
-        else repo_config.default_label_multiplier
-    )
+    scored.label_multiplier = label_multiplier
 
     scored.issue_multiplier = round(_calculate_issue_multiplier(scored), 2)
 
@@ -376,8 +372,11 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
         scored.review_quality_multiplier = 1.0
 
 
-def _resolve_trusted_scoring_label(pr: MirrorPullRequest, repo_config: RepositoryConfig) -> Optional[str]:
+def _resolve_trusted_scoring_label(pr: MirrorPullRequest, repo_config: RepositoryConfig) -> tuple[Optional[str], float]:
     """Pick the highest-multiplier currently-applied scoring label whose actor is trusted.
+
+    Returns ``(label_name, multiplier)``. Returns ``(None, default_label_multiplier)``
+    when no trusted scoring label is present.
 
     By default the actor must be in ``MAINTAINER_ASSOCIATIONS``. Repos opted into
     ``trusted_label_pipeline`` accept any actor — including GitHub-App actors that
@@ -387,20 +386,17 @@ def _resolve_trusted_scoring_label(pr: MirrorPullRequest, repo_config: Repositor
     auto-labelers (release-drafter, actions/labeler) and must keep the gate.
     """
     trusted = repo_config.trusted_label_pipeline
-    candidates = [
-        label
-        for label in pr.labels
-        if resolve_label_multiplier((label.name or '').lower(), repo_config) is not None
-        and (trusted or label.actor_association in MAINTAINER_ASSOCIATIONS)
-    ]
+    candidates: list[tuple[str, float]] = []
+    for label in pr.labels:
+        if not (trusted or label.actor_association in MAINTAINER_ASSOCIATIONS):
+            continue
+        mult = resolve_label_multiplier((label.name or '').lower(), repo_config)
+        if mult is not None:
+            candidates.append(((label.name or '').lower(), mult))
     if not candidates:
-        return None
+        return None, repo_config.default_label_multiplier
     # Highest multiplier wins; tie-broken by label name for deterministic output
-    best = max(
-        candidates,
-        key=lambda lbl: (resolve_label_multiplier(lbl.name.lower(), repo_config) or 0.0, lbl.name.lower()),
-    )
-    return best.name.lower()
+    return max(candidates, key=lambda t: (t[1], t[0]))
 
 
 # ============================================================================

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -29,7 +29,6 @@ import bittensor as bt
 from gittensor.classes import FileChange, PrScoringResult, ScoringCategory
 from gittensor.constants import (
     CONTRIBUTION_SCORE_FOR_FULL_BONUS,
-    LABEL_MULTIPLIERS,
     MAINTAINER_ASSOCIATIONS,
     MAINTAINER_ISSUE_MULTIPLIER,
     MAX_CONTRIBUTION_BONUS,
@@ -53,6 +52,7 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
+    resolve_label_multiplier,
     resolve_repo_weight,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
@@ -353,7 +353,11 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
 
     chosen_label = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label
-    scored.label_multiplier = LABEL_MULTIPLIERS.get(chosen_label, 1.0) if chosen_label else 1.0
+    if chosen_label:
+        mult = resolve_label_multiplier(chosen_label, repo_config)
+        scored.label_multiplier = mult if mult is not None else repo_config.default_label_multiplier
+    else:
+        scored.label_multiplier = repo_config.default_label_multiplier
 
     scored.issue_multiplier = round(_calculate_issue_multiplier(scored), 2)
 
@@ -386,13 +390,16 @@ def _resolve_trusted_scoring_label(pr: MirrorPullRequest, repo_config: Repositor
     candidates = [
         label
         for label in pr.labels
-        if (label.name or '').lower() in LABEL_MULTIPLIERS
+        if resolve_label_multiplier((label.name or '').lower(), repo_config) is not None
         and (trusted or label.actor_association in MAINTAINER_ASSOCIATIONS)
     ]
     if not candidates:
         return None
     # Highest multiplier wins; tie-broken by label name for deterministic output
-    best = max(candidates, key=lambda label: (LABEL_MULTIPLIERS[label.name.lower()], label.name.lower()))
+    best = max(
+        candidates,
+        key=lambda lbl: (resolve_label_multiplier(lbl.name.lower(), repo_config) or 0.0, lbl.name.lower()),
+    )
     return best.name.lower()
 
 

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -353,11 +353,11 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
 
     chosen_label = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label
-    if chosen_label:
-        mult = resolve_label_multiplier(chosen_label, repo_config)
-        scored.label_multiplier = mult if mult is not None else repo_config.default_label_multiplier
-    else:
-        scored.label_multiplier = repo_config.default_label_multiplier
+    scored.label_multiplier = (
+        resolve_label_multiplier(chosen_label, repo_config)
+        if chosen_label
+        else repo_config.default_label_multiplier
+    )
 
     scored.issue_multiplier = round(_calculate_issue_multiplier(scored), 2)
 

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -208,29 +208,33 @@ def calculate_review_collateral_multiplier(changes_requested_count: int, pr_numb
 
 
 def _resolve_label(
-    label_candidate: Optional[str],
+    timeline_order: tuple,
     current_labels: frozenset,
     repo_config: Optional[RepositoryConfig],
 ) -> tuple:
     """Resolve the scoring label and its multiplier from per-repo config.
 
-    Tries *label_candidate* (the last timeline-applied current label) first.
-    Falls back to the highest-multiplier matching label from *current_labels*.
-    Returns ``(None, default_label_multiplier)`` when nothing matches.
+    Tries labels in *timeline_order* (most recently applied first) and returns
+    the first that matches a per-repo pattern — preserving the last-applied-
+    scoring-label semantics of the original global-table approach.
+
+    Falls back to the highest-multiplier matching label from *current_labels*
+    for labels absent from the timeline (truncated history). Returns
+    ``(None, default_label_multiplier)`` when nothing matches at all.
     """
     default_mult = repo_config.default_label_multiplier if repo_config else 1.0
 
-    if label_candidate:
-        mult = resolve_label_multiplier(label_candidate, repo_config)
+    for lbl in timeline_order:
+        mult = resolve_label_multiplier(lbl, repo_config)
         if mult is not None:
-            return label_candidate, mult
+            return lbl, mult
 
     best_label: Optional[str] = None
     best_mult: Optional[float] = None
     for lbl in current_labels:
         mult = resolve_label_multiplier(lbl, repo_config)
         if mult is not None:
-            if best_mult is None or mult > best_mult or (mult == best_mult and lbl < (best_label or '')):
+            if best_mult is None or mult > best_mult or (mult == best_mult and lbl < best_label):
                 best_label = lbl
                 best_mult = mult
 
@@ -249,7 +253,7 @@ def calculate_pr_multipliers(
 
     pr.repo_weight_multiplier = resolve_repo_weight(repo_config)
     pr.issue_multiplier = round(calculate_issue_multiplier(pr), 2)
-    pr.label, pr.label_multiplier = _resolve_label(pr.label, pr.current_labels, repo_config)
+    pr.label, pr.label_multiplier = _resolve_label(pr.label_timeline_order, pr.current_labels, repo_config)
 
     if is_merged:
         # Spam multiplier is recalculated in finalize_miner_scores with total token score

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -208,10 +208,10 @@ def calculate_review_collateral_multiplier(changes_requested_count: int, pr_numb
 
 
 def _resolve_label(
-    timeline_order: tuple,
-    current_labels: frozenset,
+    timeline_order: tuple[str, ...],
+    current_labels: frozenset[str],
     repo_config: Optional[RepositoryConfig],
-) -> tuple:
+) -> tuple[Optional[str], float]:
     """Resolve the scoring label and its multiplier from per-repo config.
 
     Tries labels in *timeline_order* (most recently applied first) and returns
@@ -229,17 +229,15 @@ def _resolve_label(
         if mult is not None:
             return lbl, mult
 
-    best_label: Optional[str] = None
-    best_mult: Optional[float] = None
+    best: Optional[tuple[str, float]] = None
     for lbl in current_labels:
         mult = resolve_label_multiplier(lbl, repo_config)
         if mult is not None:
-            if best_mult is None or mult > best_mult or (mult == best_mult and lbl < best_label):
-                best_label = lbl
-                best_mult = mult
+            if best is None or mult > best[1] or (mult == best[1] and lbl < best[0]):
+                best = (lbl, mult)
 
-    if best_label is not None:
-        return best_label, best_mult
+    if best is not None:
+        return best
 
     return None, default_mult
 

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 from gittensor.constants import (
     EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
-    LABEL_MULTIPLIERS,
     MAINTAINER_ASSOCIATIONS,
     MAINTAINER_ISSUE_MULTIPLIER,
     MAX_ISSUE_CLOSE_WINDOW_DAYS,
@@ -41,7 +40,13 @@ from gittensor.utils.github_api_tools import (
 )
 from gittensor.validator.oss_contributions.credibility import check_eligibility
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
-from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig, resolve_repo_weight
+from gittensor.validator.utils.load_weights import (
+    LanguageConfig,
+    RepositoryConfig,
+    TokenConfig,
+    resolve_label_multiplier,
+    resolve_repo_weight,
+)
 
 
 def score_miner_prs(
@@ -202,6 +207,39 @@ def calculate_review_collateral_multiplier(changes_requested_count: int, pr_numb
     return multiplier
 
 
+def _resolve_label(
+    label_candidate: Optional[str],
+    current_labels: frozenset,
+    repo_config: Optional[RepositoryConfig],
+) -> tuple:
+    """Resolve the scoring label and its multiplier from per-repo config.
+
+    Tries *label_candidate* (the last timeline-applied current label) first.
+    Falls back to the highest-multiplier matching label from *current_labels*.
+    Returns ``(None, default_label_multiplier)`` when nothing matches.
+    """
+    default_mult = repo_config.default_label_multiplier if repo_config else 1.0
+
+    if label_candidate:
+        mult = resolve_label_multiplier(label_candidate, repo_config)
+        if mult is not None:
+            return label_candidate, mult
+
+    best_label: Optional[str] = None
+    best_mult: Optional[float] = None
+    for lbl in current_labels:
+        mult = resolve_label_multiplier(lbl, repo_config)
+        if mult is not None:
+            if best_mult is None or mult > best_mult or (mult == best_mult and lbl < (best_label or '')):
+                best_label = lbl
+                best_mult = mult
+
+    if best_label is not None:
+        return best_label, best_mult
+
+    return None, default_mult
+
+
 def calculate_pr_multipliers(
     pr: PullRequest, miner_eval: MinerEvaluation, master_repositories: Dict[str, RepositoryConfig]
 ) -> None:
@@ -211,7 +249,7 @@ def calculate_pr_multipliers(
 
     pr.repo_weight_multiplier = resolve_repo_weight(repo_config)
     pr.issue_multiplier = round(calculate_issue_multiplier(pr), 2)
-    pr.label_multiplier = LABEL_MULTIPLIERS.get(pr.label, 1.0) if pr.label else 1.0
+    pr.label, pr.label_multiplier = _resolve_label(pr.label, pr.current_labels, repo_config)
 
     if is_merged:
         # Spam multiplier is recalculated in finalize_miner_scores with total token score

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -2,12 +2,17 @@
 # Copyright © 2025 Entrius
 import json
 from dataclasses import dataclass, field
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import bittensor as bt
 
 from gittensor.constants import DEFAULT_REPO_WEIGHT, NON_CODE_EXTENSIONS
+
+_LABEL_MULTIPLIER_MIN = 0.0
+_LABEL_MULTIPLIER_MAX = 20.0
+_LABEL_MULTIPLIERS_MAX_ENTRIES = 10
 
 
 @dataclass
@@ -38,7 +43,13 @@ class RepositoryConfig:
             actor — including GitHub Apps that surface as ``actor_association=NULL``.
             Defaults to False; only enable on repos with an authoritative label
             pipeline. See ``_resolve_trusted_scoring_label`` for the threat model.
-
+        label_multipliers: Per-repo label-to-multiplier mapping. Keys support
+            fnmatch wildcards (e.g. ``"type/*"``, ``"*-dev"``). Each value must
+            be in [0.0, 20.0]; at most 10 entries. When None no label scoring
+            applies and ``default_label_multiplier`` is used for all PRs.
+        default_label_multiplier: Multiplier applied when no label on the PR
+            matches any pattern in ``label_multipliers``. Must be in [0.0, 20.0].
+            Defaults to 1.0 (neutral).
     """
 
     weight: float
@@ -46,6 +57,8 @@ class RepositoryConfig:
     additional_acceptable_branches: Optional[List[str]] = None
     mirror_enabled: bool = False
     trusted_label_pipeline: bool = False
+    label_multipliers: Optional[Dict[str, float]] = None
+    default_label_multiplier: float = 1.0
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -53,6 +66,22 @@ def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
     if repo_config is None:
         return DEFAULT_REPO_WEIGHT
     return repo_config.weight
+
+
+def resolve_label_multiplier(label: str, repo_config: Optional[RepositoryConfig]) -> Optional[float]:
+    """Return the per-repo multiplier for *label* using fnmatch pattern matching.
+
+    Patterns and label are compared in lowercase. Returns ``None`` when no
+    pattern matches — callers should then fall back to
+    ``repo_config.default_label_multiplier`` (or 1.0 if config is absent).
+    """
+    if repo_config is None or not repo_config.label_multipliers:
+        return None
+    label_lower = label.lower()
+    for pattern, multiplier in repo_config.label_multipliers.items():
+        if fnmatch(label_lower, pattern.lower()):
+            return multiplier
+    return None
 
 
 @dataclass
@@ -122,12 +151,46 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
             try:
+                raw_lm = metadata.get('label_multipliers')
+                label_multipliers: Optional[Dict[str, float]] = None
+                if raw_lm is not None:
+                    if not isinstance(raw_lm, dict):
+                        bt.logging.warning(f'{repo_name}: label_multipliers must be a dict, ignoring')
+                    elif len(raw_lm) > _LABEL_MULTIPLIERS_MAX_ENTRIES:
+                        bt.logging.warning(
+                            f'{repo_name}: label_multipliers has {len(raw_lm)} entries '
+                            f'(max {_LABEL_MULTIPLIERS_MAX_ENTRIES}), ignoring'
+                        )
+                    else:
+                        validated: Dict[str, float] = {}
+                        for k, v in raw_lm.items():
+                            fv = float(v)
+                            if not (_LABEL_MULTIPLIER_MIN <= fv <= _LABEL_MULTIPLIER_MAX):
+                                bt.logging.warning(
+                                    f'{repo_name}: label_multipliers["{k}"]={fv} out of '
+                                    f'[{_LABEL_MULTIPLIER_MIN}, {_LABEL_MULTIPLIER_MAX}], skipping entry'
+                                )
+                            else:
+                                validated[k] = fv
+                        label_multipliers = validated or None
+
+                raw_default = metadata.get('default_label_multiplier', 1.0)
+                default_label_multiplier = float(raw_default)
+                if not (_LABEL_MULTIPLIER_MIN <= default_label_multiplier <= _LABEL_MULTIPLIER_MAX):
+                    bt.logging.warning(
+                        f'{repo_name}: default_label_multiplier={default_label_multiplier} out of '
+                        f'[{_LABEL_MULTIPLIER_MIN}, {_LABEL_MULTIPLIER_MAX}], resetting to 1.0'
+                    )
+                    default_label_multiplier = 1.0
+
                 config = RepositoryConfig(
                     weight=float(metadata.get('weight', 0.01)),
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     mirror_enabled=bool(metadata.get('mirror_enabled', False)),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
+                    label_multipliers=label_multipliers,
+                    default_label_multiplier=default_label_multiplier,
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -101,16 +101,23 @@ def _pr(
     )
 
 
+_SCORING_LABEL = 'feature'
+_SCORING_MULT = 1.5
+_DEFAULT_LABEL_MULTIPLIERS = {_SCORING_LABEL: _SCORING_MULT, 'bug': 1.25}
+
+
 def _config(
     weight: float = 0.5,
     additional_branches: list | None = None,
     trusted_label_pipeline: bool = False,
+    label_multipliers: dict | None = None,
 ) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
         mirror_enabled=True,
         additional_acceptable_branches=additional_branches,
         trusted_label_pipeline=trusted_label_pipeline,
+        label_multipliers=_DEFAULT_LABEL_MULTIPLIERS if label_multipliers is None else label_multipliers,
     )
 
 
@@ -422,59 +429,38 @@ class TestLabelResolution:
         assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_non_maintainer_label_ignored(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
+        labels = [{'name': _SCORING_LABEL, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
         assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_null_actor_association_ignored_on_untrusted_repo(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': None, 'actor_association': None}]
+        labels = [{'name': _SCORING_LABEL, 'actor_github_id': None, 'actor_association': None}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
         assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_maintainer_set_scoring_label_returned(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
+        labels = [{'name': _SCORING_LABEL, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) == scoring_label.lower()
+        assert _resolve_trusted_scoring_label(scored.pr, _config()) == _SCORING_LABEL.lower()
 
     def test_highest_multiplier_wins(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_labels = list(LABEL_MULTIPLIERS.keys())
-        if len(scoring_labels) < 2:
-            pytest.skip('Need at least 2 scoring labels for this test')
-
-        a, b = scoring_labels[0], scoring_labels[1]
+        a, b = 'feature', 'bug'
+        config = _config(label_multipliers={a: 1.5, b: 1.25})
         labels = [
             {'name': a, 'actor_github_id': '1', 'actor_association': 'OWNER'},
             {'name': b, 'actor_github_id': '1', 'actor_association': 'OWNER'},
         ]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        chosen = _resolve_trusted_scoring_label(scored.pr, _config())
-        expected = max([a, b], key=lambda n: (LABEL_MULTIPLIERS[n], n)).lower()
-        assert chosen == expected
+        chosen = _resolve_trusted_scoring_label(scored.pr, config)
+        assert chosen == 'feature'
 
     def test_calculate_multipliers_threads_trusted_flag(self):
         """End-to-end issue #911 path: _calculate_pr_multipliers honors trusted_label_pipeline."""
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next((name for name, mult in LABEL_MULTIPLIERS.items() if mult != 1.0), None)
-        if scoring_label is None:
-            pytest.skip('Need at least one non-1.0x label for this test')
-
-        labels = [{'name': scoring_label, 'actor_github_id': '99', 'actor_association': None}]
+        labels = [{'name': _SCORING_LABEL, 'actor_github_id': '99', 'actor_association': None}]
 
         scored_trusted = ScoredMirrorPR(pr=_pr(labels=labels))
         _calculate_pr_multipliers(scored_trusted, _config(trusted_label_pipeline=True))
-        assert scored_trusted.label_multiplier == LABEL_MULTIPLIERS[scoring_label]
+        assert scored_trusted.label_multiplier == _SCORING_MULT
 
         scored_untrusted = ScoredMirrorPR(pr=_pr(labels=labels))
         _calculate_pr_multipliers(scored_untrusted, _config(trusted_label_pipeline=False))

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -421,27 +421,32 @@ class TestConvertMirrorFiles:
 class TestLabelResolution:
     def test_no_labels_returns_none(self):
         scored = ScoredMirrorPR(pr=_pr(labels=[]))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
+        label, _ = _resolve_trusted_scoring_label(scored.pr, _config())
+        assert label is None
 
     def test_non_scoring_labels_ignored(self):
         labels = [{'name': 'random', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
+        label, _ = _resolve_trusted_scoring_label(scored.pr, _config())
+        assert label is None
 
     def test_non_maintainer_label_ignored(self):
         labels = [{'name': _SCORING_LABEL, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
+        label, _ = _resolve_trusted_scoring_label(scored.pr, _config())
+        assert label is None
 
     def test_null_actor_association_ignored_on_untrusted_repo(self):
         labels = [{'name': _SCORING_LABEL, 'actor_github_id': None, 'actor_association': None}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
+        label, _ = _resolve_trusted_scoring_label(scored.pr, _config())
+        assert label is None
 
     def test_maintainer_set_scoring_label_returned(self):
         labels = [{'name': _SCORING_LABEL, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) == _SCORING_LABEL.lower()
+        label, _ = _resolve_trusted_scoring_label(scored.pr, _config())
+        assert label == _SCORING_LABEL.lower()
 
     def test_highest_multiplier_wins(self):
         a, b = 'feature', 'bug'
@@ -451,7 +456,7 @@ class TestLabelResolution:
             {'name': b, 'actor_github_id': '1', 'actor_association': 'OWNER'},
         ]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        chosen = _resolve_trusted_scoring_label(scored.pr, config)
+        chosen, _ = _resolve_trusted_scoring_label(scored.pr, config)
         assert chosen == 'feature'
 
     def test_calculate_multipliers_threads_trusted_flag(self):

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -680,18 +680,15 @@ class TestCollateralScoreAcceptsScoredMirrorPR:
 
 class TestPrMultipliers:
     def test_merged_pr_populates_all_multipliers(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'OWNER'}]
+        labels = [{'name': _SCORING_LABEL, 'actor_github_id': '1', 'actor_association': 'OWNER'}]
 
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
         scored.token_score = 100.0  # for completeness
         _calculate_pr_multipliers(scored, _config(weight=0.7, additional_branches=['test']))
 
         assert scored.repo_weight_multiplier == 0.7
-        assert scored.label == scoring_label.lower()
-        assert scored.label_multiplier == LABEL_MULTIPLIERS[scoring_label.lower()]
+        assert scored.label == _SCORING_LABEL.lower()
+        assert scored.label_multiplier == _SCORING_MULT
         assert 0.0 <= scored.time_decay_multiplier <= 1.0
         assert scored.review_quality_multiplier == 1.0  # 0 maintainer changes_requested
         assert scored.issue_multiplier == 1.0  # no linked_issues

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -279,16 +279,14 @@ def _load_from_dict(repo_dict: dict):
 
 def test_load_rejects_more_than_10_entries():
     lm = {f'label-{i}': 1.0 for i in range(11)}
-    repos = load_result = _load_from_dict({'owner/repo': {'weight': 1.0, 'label_multipliers': lm}})
+    repos = _load_from_dict({'owner/repo': {'weight': 1.0, 'label_multipliers': lm}})
     config = repos.get('owner/repo')
     assert config is not None
     assert config.label_multipliers is None
 
 
 def test_load_skips_out_of_range_entry():
-    repos = _load_from_dict(
-        {'owner/repo': {'weight': 1.0, 'label_multipliers': {'bug': 25.0, 'feature': 1.5}}}
-    )
+    repos = _load_from_dict({'owner/repo': {'weight': 1.0, 'label_multipliers': {'bug': 25.0, 'feature': 1.5}}})
     config = repos.get('owner/repo')
     assert config is not None
     assert config.label_multipliers is not None

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -1,17 +1,31 @@
 import pytest
 
 from gittensor.classes import PullRequest
-from gittensor.constants import LABEL_MULTIPLIERS
+from gittensor.validator.oss_contributions.scoring import _resolve_label
+from gittensor.validator.utils.load_weights import RepositoryConfig, resolve_label_multiplier
 
-
-@pytest.mark.parametrize('label,expected', list(LABEL_MULTIPLIERS.items()))
-def test_known_labels(label, expected):
-    assert LABEL_MULTIPLIERS.get(label, 1.0) == expected
-
-
-@pytest.mark.parametrize('label', ['docs', 'question', 'wontfix', 'kind/feature'])
-def test_unknown_labels_return_default(label):
-    assert LABEL_MULTIPLIERS.get(label, 1.0) == 1.0
+# Repo config that mirrors the old global LABEL_MULTIPLIERS table, used to keep
+# existing extraction test expectations unchanged.
+_LEGACY_CONFIG = RepositoryConfig(
+    weight=1.0,
+    label_multipliers={
+        'feature': 1.50,
+        'feat': 1.50,
+        'bug': 1.25,
+        'fix': 1.25,
+        'crash': 1.25,
+        'regression': 1.25,
+        'security': 1.25,
+        'enhancement': 1.10,
+        'improve': 1.10,
+        'perf': 1.10,
+        'refactor': 0.5,
+        'cleanup': 0.5,
+        'polish': 0.5,
+        'debt': 0.5,
+        'chore': 0.5,
+    },
+)
 
 
 def _pr_payload(current, timeline):
@@ -39,8 +53,11 @@ def _pr_payload(current, timeline):
     }
 
 
-def _parse(current, timeline):
-    return PullRequest.from_graphql_response(_pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh').label
+def _parse(current, timeline, config=_LEGACY_CONFIG):
+    """Construct a PR and run label resolution with *config*, return resolved label."""
+    pr = PullRequest.from_graphql_response(_pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh')
+    resolved_label, _ = _resolve_label(pr.label, pr.current_labels, config)
+    return resolved_label
 
 
 @pytest.mark.parametrize(
@@ -90,8 +107,253 @@ def test_label_extraction(current, timeline, expected):
 
 
 def test_missing_labels_key_does_not_crash():
-    """Backward-compat: payloads without the new 'labels' key yield None."""
+    """Backward-compat: payloads without the 'labels' key yield no resolved label."""
     payload = _pr_payload([], ['feature'])
     del payload['labels']
     pr = PullRequest.from_graphql_response(payload, uid=0, hotkey='hk', github_id='gh')
-    assert pr.label is None
+    resolved, _ = _resolve_label(pr.label, pr.current_labels, _LEGACY_CONFIG)
+    assert resolved is None
+
+
+# ============================================================================
+# resolve_label_multiplier — fnmatch pattern matching
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    'pattern,label,expected',
+    [
+        # Exact matches
+        ('bug', 'bug', 1.25),
+        ('feature', 'feature', 1.50),
+        # Wildcard: prefix glob
+        ('kind/*', 'kind/feature', 1.5),
+        ('kind/*', 'kind/bug-fix', 1.5),
+        ('kind/*', 'feature', None),
+        # Wildcard: suffix glob
+        ('*-dev', 'backend-dev', 0.5),
+        ('*-dev', 'frontend-dev', 0.5),
+        ('*-dev', 'backend-prod', None),
+        # Wildcard: type: prefix
+        ('type:*', 'type:bug-fix', 1.1),
+        ('type:*', 'type:feature', 1.1),
+        ('type:*', 'bug', None),
+        # Case insensitive
+        ('Bug', 'bug', 1.25),
+        ('BUG', 'Bug', 1.25),
+        # Release-prefixed labels
+        ('3.0/*', '3.0/feature', 2.0),
+        ('3.0/*', '4.0/feature', None),
+        # No config → always None
+        (None, 'bug', None),
+    ],
+)
+def test_resolve_label_multiplier_patterns(pattern, label, expected):
+    if pattern is None:
+        config = RepositoryConfig(weight=1.0)
+    else:
+        config = RepositoryConfig(weight=1.0, label_multipliers={pattern: expected or 1.25})
+    result = resolve_label_multiplier(label, config)
+    if expected is None:
+        assert result is None
+    else:
+        assert result == (expected or 1.25)
+
+
+def test_resolve_label_multiplier_no_config():
+    assert resolve_label_multiplier('feature', None) is None
+
+
+def test_resolve_label_multiplier_empty_map():
+    config = RepositoryConfig(weight=1.0, label_multipliers={})
+    assert resolve_label_multiplier('feature', config) is None
+
+
+def test_resolve_label_multiplier_first_match_wins():
+    """When multiple patterns match, first wins (dict ordering)."""
+    config = RepositoryConfig(weight=1.0, label_multipliers={'kind/*': 1.5, 'kind/bug': 0.5})
+    assert resolve_label_multiplier('kind/bug', config) == 1.5
+
+
+# ============================================================================
+# _resolve_label — label + multiplier resolution from PR context
+# ============================================================================
+
+
+def test_resolve_label_uses_candidate_first():
+    config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25, 'feature': 1.5})
+    label, mult = _resolve_label('bug', frozenset({'bug', 'feature'}), config)
+    assert label == 'bug'
+    assert mult == 1.25
+
+
+def test_resolve_label_falls_back_when_candidate_unmatched():
+    config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25})
+    label, mult = _resolve_label('lgtm', frozenset({'lgtm', 'bug'}), config)
+    assert label == 'bug'
+    assert mult == 1.25
+
+
+def test_resolve_label_highest_multiplier_wins_from_current():
+    config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25, 'feature': 1.5})
+    label, mult = _resolve_label(None, frozenset({'bug', 'feature'}), config)
+    assert label == 'feature'
+    assert mult == 1.5
+
+
+def test_resolve_label_returns_default_when_no_match():
+    config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25}, default_label_multiplier=0.8)
+    label, mult = _resolve_label(None, frozenset({'lgtm'}), config)
+    assert label is None
+    assert mult == 0.8
+
+
+def test_resolve_label_default_mult_when_no_config():
+    label, mult = _resolve_label(None, frozenset({'feature'}), None)
+    assert label is None
+    assert mult == 1.0
+
+
+# ============================================================================
+# RepositoryConfig JSON data constraints
+# ============================================================================
+
+
+@pytest.mark.parametrize('value', [0.0, 0.01, 1.0, 10.0, 20.0])
+def test_label_multiplier_value_valid_range(value):
+    """Values within [0.0, 20.0] are accepted."""
+    config = RepositoryConfig(weight=1.0, label_multipliers={'bug': value})
+    assert resolve_label_multiplier('bug', config) == value
+
+
+@pytest.mark.parametrize('value', [-0.01, 20.01, 100.0, -1.0])
+def test_label_multiplier_value_out_of_range_not_enforced_at_config_level(value):
+    """RepositoryConfig itself does not clamp; validation is in load_master_repo_weights."""
+    config = RepositoryConfig(weight=1.0, label_multipliers={'bug': value})
+    # The dataclass accepts any float; range enforcement happens during JSON loading.
+    assert resolve_label_multiplier('bug', config) == value
+
+
+@pytest.mark.parametrize('count', [1, 5, 10])
+def test_label_multipliers_within_entry_limit(count):
+    lm = {f'label-{i}': 1.0 for i in range(count)}
+    config = RepositoryConfig(weight=1.0, label_multipliers=lm)
+    assert config.label_multipliers is not None
+    assert len(config.label_multipliers) == count
+
+
+@pytest.mark.parametrize('default', [0.0, 1.0, 5.0, 20.0])
+def test_default_label_multiplier_valid(default):
+    config = RepositoryConfig(weight=1.0, default_label_multiplier=default)
+    _, mult = _resolve_label(None, frozenset(), config)
+    assert mult == default
+
+
+# ============================================================================
+# load_master_repo_weights constraint enforcement
+# ============================================================================
+
+
+def _load_from_dict(repo_dict: dict):
+    """Exercise load_master_repo_weights via a temp JSON file."""
+    import json
+    import tempfile
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from gittensor.validator.utils.load_weights import load_master_repo_weights
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(repo_dict, f)
+        tmp_path = Path(f.name)
+
+    weights_dir = tmp_path.parent
+    with patch('gittensor.validator.utils.load_weights._get_weights_dir', return_value=weights_dir):
+        # Rename to match the expected filename
+        target = weights_dir / 'master_repositories.json'
+        tmp_path.rename(target)
+        result = load_master_repo_weights()
+        target.unlink(missing_ok=True)
+    return result
+
+
+def test_load_rejects_more_than_10_entries():
+    lm = {f'label-{i}': 1.0 for i in range(11)}
+    repos = load_result = _load_from_dict({'owner/repo': {'weight': 1.0, 'label_multipliers': lm}})
+    config = repos.get('owner/repo')
+    assert config is not None
+    assert config.label_multipliers is None
+
+
+def test_load_skips_out_of_range_entry():
+    repos = _load_from_dict(
+        {'owner/repo': {'weight': 1.0, 'label_multipliers': {'bug': 25.0, 'feature': 1.5}}}
+    )
+    config = repos.get('owner/repo')
+    assert config is not None
+    assert config.label_multipliers is not None
+    assert 'bug' not in config.label_multipliers
+    assert config.label_multipliers.get('feature') == 1.5
+
+
+def test_load_resets_out_of_range_default():
+    repos = _load_from_dict({'owner/repo': {'weight': 1.0, 'default_label_multiplier': 99.0}})
+    config = repos.get('owner/repo')
+    assert config is not None
+    assert config.default_label_multiplier == 1.0
+
+
+def test_load_accepts_valid_config():
+    repos = _load_from_dict(
+        {
+            'owner/repo': {
+                'weight': 1.0,
+                'label_multipliers': {'kind/*': 1.5, 'type:*': 1.1},
+                'default_label_multiplier': 0.8,
+            }
+        }
+    )
+    config = repos.get('owner/repo')
+    assert config is not None
+    assert config.label_multipliers == {'kind/*': 1.5, 'type:*': 1.1}
+    assert config.default_label_multiplier == 0.8
+
+
+# ============================================================================
+# End-to-end wildcard matching tests
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    'label_multipliers,current,timeline,expected_label,expected_mult',
+    [
+        # kind/* pattern
+        ({'kind/*': 1.5}, ['kind/feature'], ['kind/feature'], 'kind/feature', 1.5),
+        ({'kind/*': 1.5}, ['kind/bug-fix', 'kind/feature'], ['kind/bug-fix', 'kind/feature'], 'kind/feature', 1.5),
+        ({'kind/*': 1.5}, ['size:m', 'kind/feature'], ['size:m', 'kind/feature'], 'kind/feature', 1.5),
+        # type:* pattern
+        ({'type:*': 1.1}, ['type:bug-fix'], ['type:bug-fix'], 'type:bug-fix', 1.1),
+        # *-dev suffix pattern
+        ({'*-dev': 0.5}, ['backend-dev'], ['backend-dev'], 'backend-dev', 0.5),
+        ({'*-dev': 0.5}, ['frontend-prod'], ['frontend-prod'], None, 1.0),
+        # Release-prefixed labels
+        ({'3.0/*': 2.0}, ['3.0/feature'], ['3.0/feature'], '3.0/feature', 2.0),
+        ({'3.0/*': 2.0}, ['4.0/feature'], ['4.0/feature'], None, 1.0),
+        # Multiple patterns: last applied wins if it matches
+        (
+            {'kind/*': 1.5, 'type:*': 1.1},
+            ['kind/feature', 'type:bug-fix'],
+            ['kind/feature', 'type:bug-fix'],
+            'type:bug-fix',
+            1.1,
+        ),
+        # No match → default multiplier applied
+        ({'kind/*': 1.5}, ['lgtm'], ['lgtm'], None, 1.0),
+    ],
+)
+def test_e2e_wildcard_matching(label_multipliers, current, timeline, expected_label, expected_mult):
+    config = RepositoryConfig(weight=1.0, label_multipliers=label_multipliers)
+    pr = PullRequest.from_graphql_response(_pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh')
+    resolved_label, resolved_mult = _resolve_label(pr.label, pr.current_labels, config)
+    assert resolved_label == expected_label
+    assert resolved_mult == pytest.approx(expected_mult)

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -56,7 +56,7 @@ def _pr_payload(current, timeline):
 def _parse(current, timeline, config=_LEGACY_CONFIG):
     """Construct a PR and run label resolution with *config*, return resolved label."""
     pr = PullRequest.from_graphql_response(_pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh')
-    resolved_label, _ = _resolve_label(pr.label, pr.current_labels, config)
+    resolved_label, _ = _resolve_label(pr.label_timeline_order, pr.current_labels, config)
     return resolved_label
 
 
@@ -111,7 +111,7 @@ def test_missing_labels_key_does_not_crash():
     payload = _pr_payload([], ['feature'])
     del payload['labels']
     pr = PullRequest.from_graphql_response(payload, uid=0, hotkey='hk', github_id='gh')
-    resolved, _ = _resolve_label(pr.label, pr.current_labels, _LEGACY_CONFIG)
+    resolved, _ = _resolve_label(pr.label_timeline_order, pr.current_labels, _LEGACY_CONFIG)
     assert resolved is None
 
 
@@ -180,36 +180,48 @@ def test_resolve_label_multiplier_first_match_wins():
 # ============================================================================
 
 
-def test_resolve_label_uses_candidate_first():
+def test_resolve_label_uses_timeline_order_first():
     config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25, 'feature': 1.5})
-    label, mult = _resolve_label('bug', frozenset({'bug', 'feature'}), config)
+    # 'bug' was applied last in timeline even though 'feature' has higher multiplier
+    label, mult = _resolve_label(('bug', 'feature'), frozenset({'bug', 'feature'}), config)
     assert label == 'bug'
     assert mult == 1.25
 
 
-def test_resolve_label_falls_back_when_candidate_unmatched():
+def test_resolve_label_skips_unmatched_timeline_entries():
     config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25})
-    label, mult = _resolve_label('lgtm', frozenset({'lgtm', 'bug'}), config)
+    # 'lgtm' is first in timeline order but doesn't match; 'bug' is next and does
+    label, mult = _resolve_label(('lgtm', 'bug'), frozenset({'lgtm', 'bug'}), config)
     assert label == 'bug'
     assert mult == 1.25
 
 
-def test_resolve_label_highest_multiplier_wins_from_current():
+def test_resolve_label_non_scoring_last_then_multiple_scoring_picks_last_applied():
+    """Key gap test: non-scoring label last + multiple scoring labels — last-applied scoring wins."""
+    config = RepositoryConfig(weight=1.0, label_multipliers={'feature': 1.5, 'bug': 1.25})
+    # Timeline (most recent first): lgtm, bug, feature — bug was applied after feature
+    label, mult = _resolve_label(('lgtm', 'bug', 'feature'), frozenset({'lgtm', 'bug', 'feature'}), config)
+    assert label == 'bug'  # not 'feature' (higher mult) — last-applied scoring label wins
+    assert mult == 1.25
+
+
+def test_resolve_label_highest_multiplier_wins_from_truncated_current():
     config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25, 'feature': 1.5})
-    label, mult = _resolve_label(None, frozenset({'bug', 'feature'}), config)
+    # Empty timeline (all truncated) — fall back to highest multiplier
+    label, mult = _resolve_label((), frozenset({'bug', 'feature'}), config)
     assert label == 'feature'
     assert mult == 1.5
 
 
 def test_resolve_label_returns_default_when_no_match():
     config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25}, default_label_multiplier=0.8)
-    label, mult = _resolve_label(None, frozenset({'lgtm'}), config)
+    label, mult = _resolve_label((), frozenset({'lgtm'}), config)
     assert label is None
     assert mult == 0.8
 
 
 def test_resolve_label_default_mult_when_no_config():
-    label, mult = _resolve_label(None, frozenset({'feature'}), None)
+    label, mult = _resolve_label((), frozenset({'feature'}), None)
     assert label is None
     assert mult == 1.0
 
@@ -245,7 +257,7 @@ def test_label_multipliers_within_entry_limit(count):
 @pytest.mark.parametrize('default', [0.0, 1.0, 5.0, 20.0])
 def test_default_label_multiplier_valid(default):
     config = RepositoryConfig(weight=1.0, default_label_multiplier=default)
-    _, mult = _resolve_label(None, frozenset(), config)
+    _, mult = _resolve_label((), frozenset(), config)
     assert mult == default
 
 
@@ -352,6 +364,6 @@ def test_load_accepts_valid_config():
 def test_e2e_wildcard_matching(label_multipliers, current, timeline, expected_label, expected_mult):
     config = RepositoryConfig(weight=1.0, label_multipliers=label_multipliers)
     pr = PullRequest.from_graphql_response(_pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh')
-    resolved_label, resolved_mult = _resolve_label(pr.label, pr.current_labels, config)
+    resolved_label, resolved_mult = _resolve_label(pr.label_timeline_order, pr.current_labels, config)
     assert resolved_label == expected_label
     assert resolved_mult == pytest.approx(expected_mult)

--- a/tests/validator/test_review_quality_multiplier.py
+++ b/tests/validator/test_review_quality_multiplier.py
@@ -249,7 +249,7 @@ class TestReviewCollateralMultiplierOnOpenPRCollateral:
 
 
 def _make_repo_config() -> dict:
-    return {'test/repo': RepositoryConfig(weight=1.0)}
+    return {'test/repo': RepositoryConfig(weight=1.0, label_multipliers={'fix': 1.25})}
 
 
 def _make_eval() -> MinerEvaluation:

--- a/tests/validator/test_review_quality_multiplier.py
+++ b/tests/validator/test_review_quality_multiplier.py
@@ -260,7 +260,8 @@ class TestReviewCollateralThroughScoringPipeline:
     def test_open_pr_collateral_uses_collateral_review_multiplier(self, builder):
         pr = builder.create(state=PRState.OPEN, repo='test/repo')
         pr.base_score = 80.0
-        pr.label = 'fix'
+        pr.label_timeline_order = ('fix',)
+        pr.current_labels = frozenset({'fix'})
         pr.changes_requested_count = 3
 
         calculate_pr_multipliers(pr, _make_eval(), _make_repo_config())


### PR DESCRIPTION
## Summary

Closes #1016.

Moves label-multiplier scoring from a single global table to per-repository configuration in `RepositoryConfig`. Each repo can now define its own label patterns (with fnmatch wildcard support) and a default multiplier, allowing custom label taxonomies like `kind/feature`, `type:bug-fix`, or release-prefixed labels such as `3.0/feature`.

## Changes

**Core**
- Remove global `LABEL_MULTIPLIERS` from `constants.py`
- Add `label_multipliers: Optional[Dict[str, float]]` and `default_label_multiplier: float = 1.0` to `RepositoryConfig`
- Add `resolve_label_multiplier(label, repo_config)` helper using `fnmatch` for wildcard pattern matching
- JSON loading validates multiplier values in `[0.0, 20.0]` and enforces a max of 10 entries per repo, logging warnings and skipping invalid entries

**Legacy scoring path**
- `PullRequest` now stores `current_labels: frozenset` (all currently-applied labels, set at construction)
- New `_resolve_label()` in `scoring.py`: tries the last timeline-applied label first, falls back to the highest-multiplier fnmatch match across all current labels, then defaults to `default_label_multiplier`

**Mirror scoring path**
- `_resolve_trusted_scoring_label` and `_calculate_pr_multipliers` use per-repo fnmatch instead of the global table

## Example config

```json
"entrius/gittensor": {
  "weight": 1.0,
  "label_multipliers": {
    "kind/feature": 1.5,
    "type/*": 1.1,
    "*-dev": 0.5
  },
  "default_label_multiplier": 1.0
}
```
## Tests

- All 17 original label-extraction test cases preserved, now driven through a per-repo config fixture that mirrors the old global table
- New parameterized tests for `resolve_label_multiplier`: exact matches, prefix/suffix/middle wildcards (`kind/*`, `type:*`, `*-dev`), case insensitivity, release-prefixed labels
- New tests for `_resolve_label` fallback logic: timeline candidate wins if it matches, falls back to highest-multiplier match from current labels, returns default multiplier when nothing matches
- Constraint enforcement tests via `load_master_repo_weights`: rejects dicts with >10 entries, skips individual entries outside `[0.0, 20.0]`, resets out-of-range `default_label_multiplier` to `1.0`, accepts valid configs end-to-end
- End-to-end wildcard matching tests: `kind/*`, `type:*`, `*-dev`, `3.0/*`, multi-pattern with last-applied-wins semantics, no-match fallback to default
- Mirror label-resolution tests updated to use explicit `label_multipliers` on the config fixture instead of the removed global table
