### PR TITLE
fix: use SOURCE-quality score for eligibility gates

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -198,6 +198,7 @@ class PullRequest:
     # Token scoring breakdown (after test weight applied)
     code_density: float = 0.0
     token_score: float = 0.0
+    source_token_score: Optional[float] = None
     structural_count: int = 0
     structural_score: float = 0.0
     leaf_count: int = 0
@@ -217,9 +218,10 @@ class PullRequest:
     def is_pioneer_eligible(self) -> bool:
         """Check if this PR qualifies for pioneer consideration.
 
-        A PR is eligible if it is merged and meets the minimum token score quality gate.
+        A PR is eligible if it is merged and meets the minimum SOURCE token score quality gate.
         """
-        return self.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        gate_score = self.source_token_score if self.source_token_score is not None else self.token_score
+        return self.merged_at is not None and gate_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
 
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
@@ -396,7 +398,7 @@ class MinerEvaluation:
     issue_credibility: float = 0.0
     is_issue_eligible: bool = False
     total_solved_issues: int = 0
-    total_valid_solved_issues: int = 0  # solved issues where solving PR has token_score >= 5
+    total_valid_solved_issues: int = 0  # solved issues where solving PR has SOURCE token_score >= 5
     total_closed_issues: int = 0
     total_open_issues: int = 0  # mirror-tracked open issues in lookback window (set by mirror_scan)
 

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -146,7 +146,8 @@ INLINE_TEST_PATTERNS: Dict[str, re.Pattern] = {
 # =============================================================================
 # Eligibility Gate (OSS Contributions)
 # =============================================================================
-MIN_VALID_MERGED_PRS = 5  # minimum "valid" merged PRs (token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE) to receive score
+# Minimum "valid" merged PRs with SOURCE token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+MIN_VALID_MERGED_PRS = 5
 MIN_CREDIBILITY = 0.80  # minimum credibility ratio to receive score
 CREDIBILITY_MULLIGAN_COUNT = 1  # number of closed PRs forgiven (erased from merged+closed counts entirely)
 
@@ -154,7 +155,8 @@ CREDIBILITY_MULLIGAN_COUNT = 1  # number of closed PRs forgiven (erased from mer
 # Issue Discovery
 # =============================================================================
 # Eligibility gate (stricter than OSS contributions)
-MIN_VALID_SOLVED_ISSUES = 7  # minimum solved issues where solving PR has token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+# Minimum solved issues where solving PR has SOURCE token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+MIN_VALID_SOLVED_ISSUES = 7
 MIN_ISSUE_CREDIBILITY = 0.80  # minimum issue credibility ratio
 
 # Review quality cliff model (different from OSS: has clean bonus + steeper penalty)

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -50,6 +50,10 @@ from gittensor.validator.issue_discovery.scoring import (
     calculate_open_issue_spam_multiplier,
     check_issue_eligibility,
 )
+from gittensor.validator.oss_contributions.credibility import (
+    meets_token_quality_gate,
+    source_quality_token_score,
+)
 from gittensor.validator.oss_contributions.mirror.adapters import mirror_files_to_legacy
 from gittensor.validator.oss_contributions.mirror.scoring import (
     calculate_base_score_for_pr_files,
@@ -80,6 +84,7 @@ class CachedSolvingPR:
 
     base_score: float
     token_score: float
+    source_token_score: Optional[float] = None
 
 
 @dataclass
@@ -241,7 +246,7 @@ def _build_solving_pr_cache(
     cache: Dict[Tuple[str, int], CachedSolvingPR] = {}
     for evaluation in miner_evaluations.values():
         for scored in evaluation.mirror_merged_prs:
-            if scored.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+            if not meets_token_quality_gate(scored):
                 continue
             key = (scored.pr.repo_full_name, scored.pr.pr_number)
             if key in cache:
@@ -249,6 +254,7 @@ def _build_solving_pr_cache(
             cache[key] = CachedSolvingPR(
                 base_score=scored.base_score,
                 token_score=scored.token_score,
+                source_token_score=scored.source_token_score,
             )
     return cache
 
@@ -315,7 +321,7 @@ def _score_miner_mirror_issues(
         )
         if cached is None:
             # Fetch failed — issue still counts for solved/credibility but not scored.
-            # Can't apply the valid-solved gate without a real token_score, so be
+            # Can't apply the valid-solved gate without real score data, so be
             # conservative and don't increment valid_solved_count.
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): solver score unavailable '
@@ -323,8 +329,8 @@ def _score_miner_mirror_issues(
             )
             continue
 
-        # Valid-solved gate (legacy parity): solving PR must meet the token threshold.
-        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        # Valid-solved gate (legacy parity): solving PR must meet the SOURCE token threshold.
+        if meets_token_quality_gate(cached):
             valid_solved_count += 1
 
         # Same-account: discoverer == solver gets credibility only, no score
@@ -350,10 +356,11 @@ def _score_miner_mirror_issues(
 
         # Quality gate — matches legacy issue-discovery behavior: below-threshold
         # solving PRs add credibility only, no discovery score.
-        if cached.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        if not meets_token_quality_gate(cached):
+            gate_score = source_quality_token_score(cached)
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): solving PR '
-                f'#{solving_pr.pr_number} token_score {cached.token_score:.2f} < '
+                f'#{solving_pr.pr_number} source_token_score {gate_score:.2f} < '
                 f'{MIN_TOKEN_SCORE_FOR_BASE_SCORE} — credibility only'
             )
             continue
@@ -450,7 +457,11 @@ def _resolve_solving_pr_score(
         issue.repo_full_name, solving_pr.pr_number, files_response.files
     )
     result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
-    cached = CachedSolvingPR(base_score=result.base_score, token_score=result.token_score)
+    cached = CachedSolvingPR(
+        base_score=result.base_score,
+        token_score=result.token_score,
+        source_token_score=result.source_token_score,
+    )
     cache[key] = cached
     return cached
 

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -74,7 +74,7 @@ def check_issue_eligibility(solved_count: int, valid_solved_count: int, closed_c
     """Check if a miner passes the issue discovery eligibility gate.
 
     Credibility uses total solved / total attempts (with mulligan).
-    The gate uses ``valid_solved_count`` (solving PR meets token threshold)
+    The gate uses ``valid_solved_count`` (solving PR meets SOURCE token threshold)
     so low-quality solves don't carry the miner past the minimum.
 
     Returns (is_eligible, issue_credibility, reason).

--- a/gittensor/validator/oss_contributions/credibility.py
+++ b/gittensor/validator/oss_contributions/credibility.py
@@ -20,6 +20,17 @@ if TYPE_CHECKING:
 PrLike = Union['PullRequest', 'ScoredMirrorPR']
 
 
+def source_quality_token_score(pr: object) -> float:
+    """SOURCE-only score for quality gates, falling back when absent or unset."""
+    source_token_score = getattr(pr, 'source_token_score', None)
+    token_score = getattr(pr, 'token_score')
+    return float(token_score if source_token_score is None else source_token_score)
+
+
+def meets_token_quality_gate(pr: object) -> bool:
+    return source_quality_token_score(pr) >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+
+
 def calculate_credibility(merged_prs: Sequence[PrLike], closed_prs: Sequence[PrLike]) -> float:
     """Calculate flat credibility ratio with mulligan applied.
 
@@ -42,7 +53,7 @@ def check_eligibility(merged_prs: Sequence[PrLike], closed_prs: Sequence[PrLike]
     """Check if a miner passes the eligibility gate.
 
     Gate requires:
-    1. At least MIN_VALID_MERGED_PRS merged PRs with token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+    1. At least MIN_VALID_MERGED_PRS merged PRs with SOURCE token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
        (after mulligan — if a closed PR was "valid", it no longer counts toward the minimum)
     2. At least MIN_CREDIBILITY credibility (after mulligan)
 
@@ -52,8 +63,8 @@ def check_eligibility(merged_prs: Sequence[PrLike], closed_prs: Sequence[PrLike]
     """
     credibility = calculate_credibility(merged_prs, closed_prs)
 
-    # Count valid merged PRs (token_score >= threshold)
-    valid_merged_count = sum(1 for pr in merged_prs if pr.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE)
+    # Count valid merged PRs (SOURCE token_score >= threshold)
+    valid_merged_count = sum(1 for pr in merged_prs if meets_token_quality_gate(pr))
 
     if valid_merged_count < MIN_VALID_MERGED_PRS:
         reason = f'{valid_merged_count}/{MIN_VALID_MERGED_PRS} valid merged PRs (need {MIN_VALID_MERGED_PRS})'

--- a/gittensor/validator/oss_contributions/mirror/adapters.py
+++ b/gittensor/validator/oss_contributions/mirror/adapters.py
@@ -141,6 +141,7 @@ def mirror_scored_pr_to_legacy_pull_request(
         total_nodes_scored=scored.total_nodes_scored,
         code_density=scored.code_density,
         token_score=scored.token_score,
+        source_token_score=scored.source_token_score,
         structural_count=scored.structural_count,
         structural_score=scored.structural_score,
         leaf_count=scored.leaf_count,

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -49,6 +49,7 @@ class ScoredMirrorPR:
     # Token scoring breakdown (populated when files are tokenized)
     code_density: float = 0.0
     token_score: float = 0.0
+    source_token_score: Optional[float] = None
     structural_count: int = 0
     structural_score: float = 0.0
     leaf_count: int = 0
@@ -84,12 +85,13 @@ class ScoredMirrorPR:
         return self.pr.merged_at
 
     def is_pioneer_eligible(self) -> bool:
-        """Pioneer-eligible iff merged AND meets the minimum token-score gate.
+        """Pioneer-eligible iff merged AND meets the minimum SOURCE token-score gate.
 
         Mirrors `PullRequest.is_pioneer_eligible` so the legacy pioneer math
         functions can be reused unchanged.
         """
-        return self.pr.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        gate_score = self.source_token_score if self.source_token_score is not None else self.token_score
+        return self.pr.merged_at is not None and gate_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
 
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -236,6 +236,7 @@ class BaseScoreResult:
 
     base_score: float
     token_score: float
+    source_token_score: float
     structural_count: int
     structural_score: float
     leaf_count: int
@@ -307,6 +308,7 @@ def calculate_base_score_for_pr_files(
     return BaseScoreResult(
         base_score=base_score,
         token_score=token_score,
+        source_token_score=source_token_score,
         structural_count=structural_count,
         structural_score=structural_score,
         leaf_count=leaf_count,
@@ -326,6 +328,7 @@ def _calculate_base_score(
     """Thin wrapper: run the shared helper and copy fields onto ScoredMirrorPR."""
     result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
     scored.token_score = result.token_score
+    scored.source_token_score = result.source_token_score
     scored.structural_count = result.structural_count
     scored.structural_score = result.structural_score
     scored.leaf_count = result.leaf_count

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -158,6 +158,7 @@ def calculate_base_score(
         pr.file_changes or [], file_contents, programming_languages, token_config
     )
     pr.token_score = result.token_score
+    pr.source_token_score = result.source_token_score
     pr.structural_count = result.structural_count
     pr.structural_score = result.structural_score
     pr.leaf_count = result.leaf_count
@@ -346,9 +347,9 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
             bt.logging.info('No merged or closed PRs - skipping evaluation')
             continue
 
-        # Check eligibility gate across both paths. check_eligibility only touches
-        # token_score on each PR; ScoredMirrorPR has the same field, so combining
-        # the lists works without adapting types.
+        # Check eligibility gate across both paths. check_eligibility uses the
+        # SOURCE-quality token score when present, falling back to token_score
+        # for older/test objects, so combining the lists works without adapting types.
         is_eligible, credibility, reason = check_eligibility(
             evaluation.merged_pull_requests + evaluation.mirror_merged_prs,
             evaluation.closed_pull_requests + evaluation.mirror_closed_prs,

--- a/tests/validator/conftest.py
+++ b/tests/validator/conftest.py
@@ -54,6 +54,7 @@ class PRBuilder:
         repo: Optional[str] = None,
         unique_repo: bool = False,
         token_score: float = 10.0,
+        source_token_score: Optional[float] = None,
         uid: int = 0,
         merged_at: Optional[datetime] = None,
     ) -> PullRequest:
@@ -81,6 +82,7 @@ class PRBuilder:
             earned_score=earned_score,
             collateral_score=collateral_score,
             token_score=token_score,
+            source_token_score=source_token_score,
         )
 
     def merged(self, **kwargs) -> PullRequest:

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -436,6 +436,16 @@ class TestSolvingPrCache:
         assert ('foo/poisoned', 1) not in cache
         assert ('foo/healthy', 2) in cache
 
+    def test_source_quality_below_threshold_prs_excluded_from_cache(self):
+        e1 = MinerEvaluation(uid=1, hotkey='hk1', github_id='g1')
+        test_only = _scored_mirror_pr('foo/test-only', 1, token_score=50.0, base_score=0.5)
+        test_only.source_token_score = 0.0
+        e1.mirror_merged_prs = [test_only]
+
+        cache = _build_solving_pr_cache({1: e1})
+
+        assert ('foo/test-only', 1) not in cache
+
     def test_cache_hit_reuses_base_score_no_fetch(self):
         """A solving PR already in cache must not trigger a get_pr_files call."""
         client = Mock()
@@ -458,7 +468,7 @@ class TestSolvingPrCache:
         client.get_pr_files.assert_not_called()
         # The cached token_score (100) flowed into issue_token_score
         assert eval_.issue_token_score == 100.0
-        # And the issue counted toward valid_solved (token_score >= MIN threshold)
+        # And the issue counted toward valid_solved (SOURCE-quality score >= MIN threshold)
         assert eval_.total_valid_solved_issues == 1
 
     def test_cache_miss_fetches_and_writes_back(self):
@@ -549,6 +559,55 @@ class TestSolvingPrCache:
 
         assert eval_.total_solved_issues == 1  # credibility
         assert eval_.total_valid_solved_issues == 0  # below gate
+        assert eval_.issue_discovery_score == 0
+
+    def test_fetched_test_only_solving_pr_counts_credibility_only(self):
+        """A large TEST-only solving PR can have aggregate token_score above the
+        threshold, but SOURCE quality is still below the valid-solved gate."""
+        test_code = '\n'.join(
+            f'def test_alpha_{i}():\n    value = {i}\n    adjusted = value + 1\n    assert adjusted == {i + 1}\n'
+            for i in range(80)
+        )
+        lines = len(test_code.splitlines())
+        client = Mock()
+        client.get_miner_issues.return_value = _response([_issue_dict()])
+        client.get_pr_files.return_value = MirrorPullRequestFilesResponse.from_dict(
+            {
+                'repo_full_name': 'entrius/gittensor-ui',
+                'pr_number': 100,
+                'head_sha': 'h',
+                'base_sha': 'b',
+                'merge_base_sha': 'mb',
+                'scoring_data_stored': True,
+                'files': [
+                    {
+                        'filename': 'tests/test_alpha.py',
+                        'previous_filename': None,
+                        'status': 'added',
+                        'additions': lines,
+                        'deletions': 0,
+                        'changes': lines,
+                        'is_binary': False,
+                        'head_content': test_code,
+                        'base_content': None,
+                    }
+                ],
+            }
+        )
+        eval_ = _eval()
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                load_weights.load_programming_language_weights(),
+                load_weights.load_token_config(),
+                client=client,
+            )
+        )
+
+        assert eval_.total_solved_issues == 1
+        assert eval_.total_valid_solved_issues == 0
         assert eval_.issue_discovery_score == 0
 
 

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -46,7 +46,11 @@ _EMPTY_TOKEN_CONFIG = TokenConfig()
 
 
 def _scored_mirror_pr(
-    repo: str, pr_number: int, token_score: float = 100.0, base_score: float = 42.0
+    repo: str,
+    pr_number: int,
+    token_score: float = 100.0,
+    base_score: float = 42.0,
+    source_token_score: float | None = None,
 ) -> ScoredMirrorPR:
     """Build a ScoredMirrorPR for cache pre-population in tests."""
     pr = MirrorPullRequest.from_dict(
@@ -81,6 +85,7 @@ def _scored_mirror_pr(
     )
     scored = ScoredMirrorPR(pr=pr)
     scored.token_score = token_score
+    scored.source_token_score = source_token_score
     scored.base_score = base_score
     return scored
 
@@ -405,15 +410,17 @@ class TestRunMirrorIssueDiscovery:
 class TestSolvingPrCache:
     def test_build_cache_from_multiple_miners(self):
         e1 = MinerEvaluation(uid=1, hotkey='hk1', github_id='g1')
-        e1.mirror_merged_prs = [_scored_mirror_pr('foo/a', 1, token_score=50, base_score=10)]
+        e1.mirror_merged_prs = [_scored_mirror_pr('foo/a', 1, token_score=50, base_score=10, source_token_score=12)]
         e2 = MinerEvaluation(uid=2, hotkey='hk2', github_id='g2')
-        e2.mirror_merged_prs = [_scored_mirror_pr('foo/b', 2, token_score=80, base_score=20)]
+        e2.mirror_merged_prs = [_scored_mirror_pr('foo/b', 2, token_score=80, base_score=20, source_token_score=34)]
 
         cache = _build_solving_pr_cache({1: e1, 2: e2})
         assert cache[('foo/a', 1)].token_score == 50
         assert cache[('foo/a', 1)].base_score == 10
+        assert cache[('foo/a', 1)].source_token_score == 12
         assert cache[('foo/b', 2)].token_score == 80
         assert cache[('foo/b', 2)].base_score == 20
+        assert cache[('foo/b', 2)].source_token_score == 34
 
     def test_cache_first_occurrence_wins_on_duplicate(self):
         # If the same (repo, pr_number) somehow appears in two miners' lists

--- a/tests/validator/oss_contributions/mirror/test_adapters.py
+++ b/tests/validator/oss_contributions/mirror/test_adapters.py
@@ -164,6 +164,7 @@ class TestMirrorScoredPrToLegacyPullRequest:
         scored.base_score = 30.5
         scored.earned_score = 25.0
         scored.token_score = 100.0
+        scored.source_token_score = 12.5
         scored.repo_weight_multiplier = 0.7
         scored.label_multiplier = 1.5
         scored.label = 'enhancement'
@@ -208,6 +209,7 @@ class TestMirrorScoredPrToLegacyPullRequest:
         assert adapted.base_score == 30.5
         assert adapted.earned_score == 25.0
         assert adapted.token_score == 100.0
+        assert adapted.source_token_score == 12.5
         assert adapted.repo_weight_multiplier == 0.7
         assert adapted.label_multiplier == 1.5
         assert adapted.label == 'enhancement'

--- a/tests/validator/oss_contributions/mirror/test_base_score_helper.py
+++ b/tests/validator/oss_contributions/mirror/test_base_score_helper.py
@@ -26,6 +26,7 @@ class TestEmptyInput:
         assert isinstance(result, BaseScoreResult)
         assert result.base_score == 0.0
         assert result.token_score == 0.0
+        assert result.source_token_score == 0.0
         assert result.total_nodes_scored == 0
         assert result.structural_count == 0
         assert result.leaf_count == 0
@@ -44,6 +45,7 @@ class TestResultShape:
         for field_name in [
             'base_score',
             'token_score',
+            'source_token_score',
             'structural_count',
             'structural_score',
             'leaf_count',

--- a/tests/validator/oss_contributions/mirror/test_scored_pr.py
+++ b/tests/validator/oss_contributions/mirror/test_scored_pr.py
@@ -2,7 +2,7 @@
 
 Covers:
 - Composition: raw response data accessed via .pr.<field>; scoring fields default neutrally
-- is_pioneer_eligible respects merged + token_score gate
+- is_pioneer_eligible respects merged + SOURCE token_score gate
 - calculate_final_earned_score multiplies base by every multiplier
 """
 
@@ -95,6 +95,12 @@ class TestPioneerEligible:
         scored = ScoredMirrorPR(pr=_make_pr())
         scored.token_score = 5.0  # equals MIN_TOKEN_SCORE_FOR_BASE_SCORE
         assert scored.is_pioneer_eligible() is True
+
+    def test_source_quality_below_threshold_not_eligible(self):
+        scored = ScoredMirrorPR(pr=_make_pr())
+        scored.token_score = 5.0
+        scored.source_token_score = 0.0
+        assert scored.is_pioneer_eligible() is False
 
     def test_merged_above_threshold_eligible(self):
         scored = ScoredMirrorPR(pr=_make_pr())

--- a/tests/validator/test_pioneer_dividend.py
+++ b/tests/validator/test_pioneer_dividend.py
@@ -46,8 +46,12 @@ class TestPioneerEligibility:
         assert not pr.is_pioneer_eligible()
 
     def test_ineligible_when_source_quality_score_below_threshold(self, builder):
-        pr = builder.create(state=PRState.MERGED, uid=1, token_score=MIN_TOKEN_SCORE_FOR_BASE_SCORE)
-        pr.source_token_score = 0.0
+        pr = builder.create(
+            state=PRState.MERGED,
+            uid=1,
+            token_score=MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+            source_token_score=0.0,
+        )
         assert not pr.is_pioneer_eligible()
 
     def test_ineligible_when_open(self, builder):

--- a/tests/validator/test_pioneer_dividend.py
+++ b/tests/validator/test_pioneer_dividend.py
@@ -45,6 +45,11 @@ class TestPioneerEligibility:
         pr = builder.create(state=PRState.MERGED, uid=1, token_score=MIN_TOKEN_SCORE_FOR_BASE_SCORE - 1)
         assert not pr.is_pioneer_eligible()
 
+    def test_ineligible_when_source_quality_score_below_threshold(self, builder):
+        pr = builder.create(state=PRState.MERGED, uid=1, token_score=MIN_TOKEN_SCORE_FOR_BASE_SCORE)
+        pr.source_token_score = 0.0
+        assert not pr.is_pioneer_eligible()
+
     def test_ineligible_when_open(self, builder):
         pr = builder.create(state=PRState.OPEN, uid=1)
         assert not pr.is_pioneer_eligible()

--- a/tests/validator/test_source_quality_gates.py
+++ b/tests/validator/test_source_quality_gates.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from gittensor.classes import FileChange, PRState, PullRequest
+from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE, MIN_VALID_MERGED_PRS
+from gittensor.utils.github_api_tools import FileContentPair
+from gittensor.validator.oss_contributions.credibility import check_eligibility
+from gittensor.validator.oss_contributions.mirror.scoring import calculate_base_score_for_pr_files
+from gittensor.validator.utils.load_weights import load_programming_language_weights, load_token_config
+
+
+def _generated_python_functions(prefix: str, count: int) -> str:
+    return '\n'.join(
+        f'def {prefix}_{i}():\n    value = {i}\n    adjusted = value + 1\n    return adjusted\n' for i in range(count)
+    )
+
+
+def _score_single_file(filename: str, content: str):
+    lines = len(content.splitlines())
+    change = FileChange(
+        pr_number=1,
+        repository_full_name='test/repo',
+        filename=filename,
+        changes=lines,
+        additions=lines,
+        deletions=0,
+        status='added',
+    )
+    return calculate_base_score_for_pr_files(
+        [change],
+        {filename: FileContentPair(old_content=None, new_content=content)},
+        load_programming_language_weights(),
+        load_token_config(),
+    )
+
+
+def _merged_pr(token_score: float, source_token_score: Optional[float]) -> PullRequest:
+    return PullRequest(
+        number=1,
+        repository_full_name='test/repo',
+        uid=1,
+        hotkey='hk',
+        github_id='gh',
+        title='t',
+        author_login='author',
+        merged_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        pr_state=PRState.MERGED,
+        token_score=token_score,
+        source_token_score=source_token_score,
+    )
+
+
+def test_test_only_tree_score_does_not_satisfy_merged_pr_eligibility():
+    result = _score_single_file('tests/test_alpha.py', _generated_python_functions('test_alpha', 80))
+    source_token_score = getattr(result, 'source_token_score', 0.0)
+
+    prs = [_merged_pr(result.token_score, source_token_score) for _ in range(MIN_VALID_MERGED_PRS)]
+    is_eligible, credibility, reason = check_eligibility(prs, [])
+
+    assert result.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+    assert result.base_score < 1.0
+    assert result.code_density == 0.0
+    assert source_token_score == 0.0
+    assert is_eligible is False
+    assert credibility == 1.0
+    assert reason == f'0/{MIN_VALID_MERGED_PRS} valid merged PRs (need {MIN_VALID_MERGED_PRS})'
+
+
+def test_source_tree_score_still_satisfies_merged_pr_eligibility():
+    result = _score_single_file('src/alpha.py', _generated_python_functions('alpha', 20))
+    source_token_score = result.source_token_score
+
+    prs = [_merged_pr(result.token_score, source_token_score) for _ in range(MIN_VALID_MERGED_PRS)]
+    is_eligible, credibility, reason = check_eligibility(prs, [])
+
+    assert source_token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+    assert result.code_density > 0.0
+    assert is_eligible is True
+    assert credibility == 1.0
+    assert reason == ''
+
+
+def test_missing_source_token_score_falls_back_to_token_score_for_compatibility():
+    prs = [_merged_pr(MIN_TOKEN_SCORE_FOR_BASE_SCORE, None) for _ in range(MIN_VALID_MERGED_PRS)]
+
+    is_eligible, credibility, reason = check_eligibility(prs, [])
+
+    assert is_eligible is True
+    assert credibility == 1.0
+    assert reason == ''


### PR DESCRIPTION
## Summary

Eligibility gates were incorrectly using aggregate `token_score`, which includes TEST/tree-diff contributions, while the base-score threshold is defined from SOURCE-only quality. A large test-only PR could therefore earn only the intended small contribution bonus but still count as a valid merged PR, a valid solved issue-discovery PR, or a pioneer-eligible PR.

This PR fixes that mismatch by:

- Persisting `source_token_score` from `calculate_base_score_for_pr_files()` alongside the aggregate `token_score`.
- Keeping aggregate `token_score` unchanged for contribution accounting and total token tracking.
- Switching merged-PR eligibility, mirror valid-solved gates, and legacy/mirror pioneer eligibility to SOURCE-quality scores.
- Falling back to aggregate `token_score` when `source_token_score` is absent, preserving compatibility with older cached/test objects.
- Adding regression coverage for TEST-only PRs, SOURCE-only PRs, fallback behavior, mirror solving-PR cache propagation, mirror-to-legacy adapter propagation, and pioneer eligibility setup.

## Related Issues

Fixes #1022.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

Commands run:

```bash
git diff --check
uv run --extra dev pytest tests/validator/issue_discovery/test_mirror_scan.py tests/validator/oss_contributions/mirror/test_adapters.py tests/validator/test_pioneer_dividend.py tests/validator/test_source_quality_gates.py -q
uv run --extra dev ruff check tests/validator/conftest.py tests/validator/issue_discovery/test_mirror_scan.py tests/validator/oss_contributions/mirror/test_adapters.py tests/validator/test_pioneer_dividend.py
uv run --extra dev ruff format --check tests/validator/conftest.py tests/validator/issue_discovery/test_mirror_scan.py tests/validator/oss_contributions/mirror/test_adapters.py tests/validator/test_pioneer_dividend.py
uv run --extra dev pyright tests/validator/conftest.py tests/validator/issue_discovery/test_mirror_scan.py tests/validator/oss_contributions/mirror/test_adapters.py tests/validator/test_pioneer_dividend.py
uv run --extra dev pytest tests/ -q
```

Results:

- Focused regression suite: `66 passed`
- Full test suite: `769 passed, 2 warnings`
- Ruff check: passed
- Ruff format check: passed
- Pyright on touched tests: `0 errors, 0 warnings`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented where applicable
