### PR TITLE
fix: quantize PR lookback cutoff to UTC day so validators agree on boundary

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -5,7 +5,7 @@ import os
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from math import ceil
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
@@ -32,7 +32,7 @@ from gittensor.constants import (
     REVIEW_PENALTY_RATE,
 )
 from gittensor.utils.models import PRInfo
-from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
+from gittensor.validator.utils.datetime_utils import lookback_cutoff, parse_github_iso_to_utc
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
 # Beyond this many CHANGES_REQUESTED reviews the quality multiplier is already 0
@@ -872,7 +872,7 @@ def load_miners_prs(
         bt.logging.warning(f'UID {miner_eval.uid} has no github_pat, skipping PR fetch')
         return
 
-    lookback_date_filter = datetime.now(timezone.utc) - timedelta(days=PR_LOOKBACK_DAYS)
+    lookback_date_filter = lookback_cutoff(PR_LOOKBACK_DAYS)
     global_user_id = base64.b64encode(f'04:User{miner_eval.github_id}'.encode()).decode()
 
     cursor = None

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -33,7 +33,7 @@ the cache so sibling discoveries benefit.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
@@ -54,7 +54,7 @@ from gittensor.validator.oss_contributions.mirror.adapters import mirror_files_t
 from gittensor.validator.oss_contributions.mirror.scoring import (
     calculate_base_score_for_pr_files,
 )
-from gittensor.validator.utils.datetime_utils import calculate_time_decay
+from gittensor.validator.utils.datetime_utils import calculate_time_decay, lookback_cutoff
 from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
@@ -128,7 +128,7 @@ async def run_mirror_issue_discovery(
         return
 
     client = client or MirrorClient()
-    lookback_date = datetime.now(timezone.utc) - timedelta(days=PR_LOOKBACK_DAYS)
+    lookback_date = lookback_cutoff(PR_LOOKBACK_DAYS)
     enabled_names: Set[str] = set(mirror_repos.keys())
 
     solving_pr_cache: Dict[Tuple[str, int], CachedSolvingPR] = _build_solving_pr_cache(miner_evaluations)

--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -15,7 +15,7 @@ Filtering applied at load time (legacy parity):
 """
 
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Dict, Optional
 
 import bittensor as bt
@@ -26,7 +26,7 @@ from gittensor.utils.mirror.models import MirrorPullRequest
 from gittensor.validator.oss_contributions.mirror.evaluation import MirrorMinerEvaluation
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 from gittensor.validator.oss_contributions.mirror.scoring import _should_skip_merged_mirror_pr
-from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
+from gittensor.validator.utils.datetime_utils import lookback_cutoff, parse_github_iso_to_utc
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
 
@@ -54,7 +54,7 @@ def load_mirror_miner_prs(
         return
 
     client = client or MirrorClient()
-    lookback_date = datetime.now(timezone.utc) - timedelta(days=PR_LOOKBACK_DAYS)
+    lookback_date = lookback_cutoff(PR_LOOKBACK_DAYS)
 
     try:
         response = client.get_miner_pulls(mirror_eval.github_id, since=lookback_date)

--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -1,5 +1,5 @@
 import math
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import pytz
@@ -45,6 +45,13 @@ def parse_github_timestamp_to_cst(timestamp_str: str) -> datetime:
     GitHub returns timestamps like: 2024-01-15T10:30:00Z
     """
     return parse_github_iso_to_utc(timestamp_str).astimezone(CHICAGO_TZ)
+
+
+def lookback_cutoff(lookback_days: int) -> datetime:
+    """Return ``now - lookback_days`` floored to 00:00:00 UTC of that day."""
+    return (datetime.now(timezone.utc) - timedelta(days=lookback_days)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
 
 
 def calculate_time_decay(merged_at: datetime) -> float:

--- a/tests/validator/utils/test_datetime_utils.py
+++ b/tests/validator/utils/test_datetime_utils.py
@@ -1,0 +1,68 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for shared datetime helpers — focus on the cross-validator-deterministic
+``lookback_cutoff`` quantization (issue #1003)."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from gittensor.validator.utils.datetime_utils import lookback_cutoff
+
+
+class TestLookbackCutoff:
+    def test_returns_midnight_utc(self):
+        # Given any wall-clock read mid-day, the cutoff must floor to 00:00:00 UTC.
+        with patch('gittensor.validator.utils.datetime_utils.datetime') as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 6, 14, 37, 23, 451000, tzinfo=timezone.utc)
+            mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+            cutoff = lookback_cutoff(35)
+
+        assert cutoff == datetime(2026, 4, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+        assert cutoff.tzinfo == timezone.utc
+
+    def test_two_validators_within_same_utc_day_get_identical_cutoff(self):
+        # The bug being fixed: two validators reading datetime.now() seconds apart
+        # used to disagree on the cutoff, flipping a boundary PR's include/exclude.
+        v1_now = datetime(2026, 5, 6, 14, 37, 23, 451000, tzinfo=timezone.utc)
+        v2_now = v1_now + timedelta(seconds=5)
+
+        with patch('gittensor.validator.utils.datetime_utils.datetime') as mock_dt:
+            mock_dt.now.return_value = v1_now
+            mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+            v1_cutoff = lookback_cutoff(35)
+
+        with patch('gittensor.validator.utils.datetime_utils.datetime') as mock_dt:
+            mock_dt.now.return_value = v2_now
+            mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+            v2_cutoff = lookback_cutoff(35)
+
+        assert v1_cutoff == v2_cutoff
+
+    def test_two_validators_straddling_midnight_get_one_day_offset(self):
+        # Validators reading on opposite sides of UTC-midnight resolve to cutoffs
+        # 1 day apart. This is the residual divergence — coarser than seconds and
+        # accepted as the design tradeoff (issue #1003 suggested fix shape).
+        v1_now = datetime(2026, 5, 6, 23, 59, 59, tzinfo=timezone.utc)
+        v2_now = datetime(2026, 5, 7, 0, 0, 1, tzinfo=timezone.utc)
+
+        with patch('gittensor.validator.utils.datetime_utils.datetime') as mock_dt:
+            mock_dt.now.return_value = v1_now
+            mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+            v1_cutoff = lookback_cutoff(35)
+
+        with patch('gittensor.validator.utils.datetime_utils.datetime') as mock_dt:
+            mock_dt.now.return_value = v2_now
+            mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+            v2_cutoff = lookback_cutoff(35)
+
+        assert v2_cutoff - v1_cutoff == timedelta(days=1)
+
+    def test_subtracts_correct_number_of_days(self):
+        with patch('gittensor.validator.utils.datetime_utils.datetime') as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 6, 12, 0, 0, tzinfo=timezone.utc)
+            mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+            assert lookback_cutoff(0) == datetime(2026, 5, 6, 0, 0, 0, tzinfo=timezone.utc)
+            assert lookback_cutoff(1) == datetime(2026, 5, 5, 0, 0, 0, tzinfo=timezone.utc)
+            assert lookback_cutoff(35) == datetime(2026, 4, 1, 0, 0, 0, tzinfo=timezone.utc)
+            assert lookback_cutoff(365) == datetime(2025, 5, 6, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

The 35-day PR/issue lookback cutoff is computed at three sites as `datetime.now(timezone.utc) - timedelta(days=PR_LOOKBACK_DAYS)`. Each validator reads its own wall clock, so two validators starting their forward pass a few seconds apart end up with different cutoffs and disagree on whether a PR near the 35-day boundary is in or out of the window. The disagreement is a full include/exclude flip — the PR's entire `earned_score` shifts between validators, not a small numeric drift.

## Fix

Add a small `lookback_cutoff(lookback_days)` helper in `gittensor/validator/utils/datetime_utils.py` that returns `now - lookback_days` floored to `00:00:00 UTC`. All three call sites switch to it:

- `gittensor/utils/github_api_tools.py:875`
- `gittensor/validator/oss_contributions/mirror/load.py:57`
- `gittensor/validator/issue_discovery/mirror_scan.py:131`

Validators reading their clock at any point during the same UTC day now compute the same cutoff. The residual disagreement is one full day at UTC midnight rollovers, which is the tradeoff Option 1 in #1003 suggests.

Function signatures don't change — `should_skip_merged_pr`, `try_add_open_or_closed_pr`, and `_maybe_add_pr` still take a `datetime`; only the value passed in is now quantized.

## Out of scope

`calculate_time_decay` and the four non-scoring `datetime.now()` reads (`pat_storage.py`, `classes.py`, `validator/utils/storage.py`) are not touched. Per the analysis in #1003, their per-validator skew is below the uint16 weight quantization grain, so they don't produce the discrete divergence this PR fixes.

## Testing

New: `tests/validator/utils/test_datetime_utils.py` (4 cases)

- `test_returns_midnight_utc` — cutoff floors to 00:00:00 UTC.
- `test_two_validators_within_same_utc_day_get_identical_cutoff` — regression test for the bug: two `datetime.now()` reads 5 seconds apart produce the same cutoff.
- `test_two_validators_straddling_midnight_get_one_day_offset` — pins the residual divergence at exactly 1 day.
- `test_subtracts_correct_number_of_days` — arithmetic sanity for 0, 1, 35, 365.

Full suite: 766 passing. Ruff and Pyright clean.

## Related

Closes #1003
