### PR TITLE
feat: Move label-multiplier scoring to RepositoryConfig

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -15,12 +15,12 @@ if TYPE_CHECKING:
     from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 
 from gittensor.constants import (
-    LABEL_MULTIPLIERS,
     MAINTAINER_ASSOCIATIONS,
     MAX_CODE_DENSITY_MULTIPLIER,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
 )
 from gittensor.utils.utils import parse_repo_name
+from gittensor.validator.utils.load_weights import RepositoryConfig, max_multiplier_for_label
 
 GITHUB_DOMAIN = 'https://github.com/'
 
@@ -183,7 +183,7 @@ class PullRequest:
     time_decay_multiplier: float = 1.0
     credibility_multiplier: float = 1.0
     review_quality_multiplier: float = 1.0  # Penalty for CHANGES_REQUESTED reviews from maintainers
-    label_multiplier: float = 1.0  # Multiplier based on PR label (exact match against known labels)
+    label_multiplier: float = 1.0  # Multiplier from repo ``label_multipliers`` / ``default_label_multiplier``
     label: Optional[str] = None  # Last label set on the PR
     changes_requested_count: int = 0  # Number of maintainer CHANGES_REQUESTED reviews
     earned_score: float = 0.0
@@ -244,7 +244,14 @@ class PullRequest:
         return self.earned_score
 
     @classmethod
-    def from_graphql_response(cls, pr_data: dict, uid: int, hotkey: str, github_id: Optional[str]) -> 'PullRequest':
+    def from_graphql_response(
+        cls,
+        pr_data: dict,
+        uid: int,
+        hotkey: str,
+        github_id: Optional[str],
+        repo_config: Optional[RepositoryConfig] = None,
+    ) -> 'PullRequest':
         """Create PullRequest from GraphQL API response for any PR state."""
         from gittensor.validator.utils.datetime_utils import parse_github_timestamp_to_cst
 
@@ -312,7 +319,8 @@ class PullRequest:
 
         current = {(n.get('name') or '').lower() for n in (pr_data.get('labels') or {}).get('nodes') or [] if n}
         label: Optional[str] = None
-        scoring_labels = current & LABEL_MULTIPLIERS.keys()
+        lm = (repo_config.label_multipliers or {}) if repo_config else {}
+        scoring_labels = {n for n in current if lm and max_multiplier_for_label(n, lm) is not None}
         if scoring_labels:
             for event in reversed((pr_data.get('timelineItems') or {}).get('nodes') or []):
                 name = ((event or {}).get('label') or {}).get('name', '').lower()
@@ -321,7 +329,11 @@ class PullRequest:
                     break
             if label is None:
                 # Timeline truncated — fall back to highest-multiplier currently-applied label
-                label = max(scoring_labels, key=lambda n: (LABEL_MULTIPLIERS[n], n))
+                def _label_tiebreak(name: str) -> tuple[float, str]:
+                    m = max_multiplier_for_label(name, lm)
+                    return (m if m is not None else float('-inf'), name)
+
+                label = max(scoring_labels, key=_label_tiebreak)
 
         return cls(
             number=pr_data['number'],
@@ -465,34 +477,36 @@ class MinerEvaluation:
                 all_file_changes.extend(file_changes)
         return all_file_changes
 
-    def add_merged_pull_request(self, raw_pr: Dict):
+    def add_merged_pull_request(self, raw_pr: Dict, repo_config: Optional[RepositoryConfig] = None):
         """Add a merged pull request that will be factored into scoring."""
         bt.logging.info(
             f"Accepting MERGED PR #{raw_pr['number']} in {parse_repo_name(raw_pr['repository'])} -> '{raw_pr['baseRefName']}'"
         )
         self.merged_pull_requests.append(
-            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
+            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id, repo_config)
         )
 
-    def add_open_pull_request(self, raw_pr: Dict):
+    def add_open_pull_request(self, raw_pr: Dict, repo_config: Optional[RepositoryConfig] = None):
         """Add an open pull request that will be factored into scoring."""
         bt.logging.info(f'Counting OPEN PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])}')
-        self.open_pull_requests.append(PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id))
+        self.open_pull_requests.append(
+            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id, repo_config)
+        )
 
-    def add_closed_pull_request(self, raw_pr: Dict):
+    def add_closed_pull_request(self, raw_pr: Dict, repo_config: Optional[RepositoryConfig] = None):
         """Add a closed pull request that will be factored into scoring."""
         bt.logging.info(
             f'CLOSED PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])} counting towards credibility'
         )
         self.closed_pull_requests.append(
-            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
+            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id, repo_config)
         )
 
-    def add_stale_closed_pull_request(self, raw_pr: Dict):
+    def add_stale_closed_pull_request(self, raw_pr: Dict, repo_config: Optional[RepositoryConfig] = None):
         """Track a stale CLOSED PR so storage can refresh its pull_requests row."""
         bt.logging.info(f'Stale CLOSED PR #{raw_pr["number"]} in {parse_repo_name(raw_pr["repository"])}')
         self.stale_closed_pull_requests.append(
-            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id)
+            PullRequest.from_graphql_response(raw_pr, self.uid, self.hotkey, self.github_id, repo_config)
         )
 
 

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -83,29 +83,6 @@ CONTRIBUTION_SCORE_FOR_FULL_BONUS = 1500
 # Boosts
 MAX_CODE_DENSITY_MULTIPLIER = 1.15
 
-# Label multipliers - applied based on the last label set on the PR (requires triage+ access)
-LABEL_MULTIPLIERS: dict[str, float] = {
-    # features
-    'feature': 1.50,
-    'feat': 1.50,
-    # bug fixes
-    'bug': 1.25,
-    'fix': 1.25,
-    'crash': 1.25,
-    'regression': 1.25,
-    'security': 1.25,
-    # enhancements
-    'enhancement': 1.10,
-    'improve': 1.10,
-    'perf': 1.10,
-    # refactors
-    'refactor': 0.5,
-    'cleanup': 0.5,
-    'polish': 0.5,
-    'debt': 0.5,
-    'chore': 0.5,
-}
-
 # Pioneer dividend — rewards the first quality contributor to each repository
 # Rates applied per follower position (1st follower pays most, diminishing after)
 # Dividend capped at PIONEER_DIVIDEND_MAX_RATIO × pioneer's own earned_score

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -728,6 +728,7 @@ def try_add_open_or_closed_pr(
     pr_raw: Dict,
     pr_state: str,
     lookback_date_filter: datetime,
+    repo_config: Optional[RepositoryConfig] = None,
 ) -> None:
     """
     Attempts to add an OPEN or CLOSED PR to miner_eval if eligible.
@@ -743,7 +744,7 @@ def try_add_open_or_closed_pr(
         return
 
     if pr_state == PRState.OPEN.value:
-        miner_eval.add_open_pull_request(pr_raw)
+        miner_eval.add_open_pull_request(pr_raw, repo_config)
 
     if pr_state == PRState.CLOSED.value:
         closed_at = pr_raw.get('closedAt')
@@ -761,11 +762,11 @@ def try_add_open_or_closed_pr(
 
         # This allows users to close old PRs without receiving a fresh credibility penalty.
         if created_dt < lookback_date_filter:
-            miner_eval.add_stale_closed_pull_request(pr_raw)
+            miner_eval.add_stale_closed_pull_request(pr_raw, repo_config)
             return
 
         if closed_dt >= lookback_date_filter:
-            miner_eval.add_closed_pull_request(pr_raw)
+            miner_eval.add_closed_pull_request(pr_raw, repo_config)
 
 
 def should_skip_merged_pr(
@@ -947,7 +948,7 @@ def load_miners_prs(
                             continue
 
                     if pr_state in (PRState.OPEN.value, PRState.CLOSED.value):
-                        try_add_open_or_closed_pr(miner_eval, pr_raw, pr_state, lookback_date_filter)
+                        try_add_open_or_closed_pr(miner_eval, pr_raw, pr_state, lookback_date_filter, repo_config)
                         continue
 
                     should_skip, skip_reason = should_skip_merged_pr(
@@ -958,7 +959,7 @@ def load_miners_prs(
                         bt.logging.debug(skip_reason or '')
                         continue
 
-                    miner_eval.add_merged_pull_request(pr_raw)
+                    miner_eval.add_merged_pull_request(pr_raw, repo_config)
 
                 except Exception as e:
                     pr_number = pr_raw.get('number', '?')

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -29,7 +29,6 @@ import bittensor as bt
 from gittensor.classes import FileChange, PrScoringResult, ScoringCategory
 from gittensor.constants import (
     CONTRIBUTION_SCORE_FOR_FULL_BONUS,
-    LABEL_MULTIPLIERS,
     MAINTAINER_ASSOCIATIONS,
     MAINTAINER_ISSUE_MULTIPLIER,
     MAX_CONTRIBUTION_BONUS,
@@ -41,7 +40,7 @@ from gittensor.constants import (
 )
 from gittensor.utils.github_api_tools import FileContentPair, branch_matches_pattern
 from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
-from gittensor.utils.mirror.models import MirrorLinkedIssue, MirrorPullRequest
+from gittensor.utils.mirror.models import MirrorLabel, MirrorLinkedIssue, MirrorPullRequest
 from gittensor.validator.oss_contributions.mirror.adapters import mirror_files_to_legacy
 from gittensor.validator.oss_contributions.mirror.evaluation import MirrorMinerEvaluation
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
@@ -53,6 +52,8 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
+    max_multiplier_for_label,
+    resolve_label_multiplier,
     resolve_repo_weight,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
@@ -353,7 +354,7 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
 
     chosen_label = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label
-    scored.label_multiplier = LABEL_MULTIPLIERS.get(chosen_label, 1.0) if chosen_label else 1.0
+    scored.label_multiplier = resolve_label_multiplier(repo_config, chosen_label)
 
     scored.issue_multiplier = round(_calculate_issue_multiplier(scored), 2)
 
@@ -383,17 +384,31 @@ def _resolve_trusted_scoring_label(pr: MirrorPullRequest, repo_config: Repositor
     auto-labelers (release-drafter, actions/labeler) and must keep the gate.
     """
     trusted = repo_config.trusted_label_pipeline
+    lm = repo_config.label_multipliers or {}
+    if not lm:
+        return None
+
+    def _candidate_mult(lbl: MirrorLabel) -> Optional[float]:
+        name = (lbl.name or '').lower()
+        if not name:
+            return None
+        return max_multiplier_for_label(name, lm)
+
     candidates = [
         label
         for label in pr.labels
-        if (label.name or '').lower() in LABEL_MULTIPLIERS
-        and (trusted or label.actor_association in MAINTAINER_ASSOCIATIONS)
+        if _candidate_mult(label) is not None and (trusted or label.actor_association in MAINTAINER_ASSOCIATIONS)
     ]
     if not candidates:
         return None
-    # Highest multiplier wins; tie-broken by label name for deterministic output
-    best = max(candidates, key=lambda label: (LABEL_MULTIPLIERS[label.name.lower()], label.name.lower()))
-    return best.name.lower()
+
+    def _tiebreak(lbl: MirrorLabel) -> tuple[float, str]:
+        name = (lbl.name or '').lower()
+        m = max_multiplier_for_label(name, lm)
+        return (m if m is not None else float('-inf'), name)
+
+    best = max(candidates, key=_tiebreak)
+    return (best.name or '').lower()
 
 
 # ============================================================================

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
 from gittensor.constants import (
     EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
-    LABEL_MULTIPLIERS,
     MAINTAINER_ASSOCIATIONS,
     MAINTAINER_ISSUE_MULTIPLIER,
     MAX_ISSUE_CLOSE_WINDOW_DAYS,
@@ -41,7 +40,13 @@ from gittensor.utils.github_api_tools import (
 )
 from gittensor.validator.oss_contributions.credibility import check_eligibility
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
-from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig, resolve_repo_weight
+from gittensor.validator.utils.load_weights import (
+    LanguageConfig,
+    RepositoryConfig,
+    TokenConfig,
+    resolve_label_multiplier,
+    resolve_repo_weight,
+)
 
 
 def score_miner_prs(
@@ -211,7 +216,7 @@ def calculate_pr_multipliers(
 
     pr.repo_weight_multiplier = resolve_repo_weight(repo_config)
     pr.issue_multiplier = round(calculate_issue_multiplier(pr), 2)
-    pr.label_multiplier = LABEL_MULTIPLIERS.get(pr.label, 1.0) if pr.label else 1.0
+    pr.label_multiplier = resolve_label_multiplier(repo_config, pr.label)
 
     if is_merged:
         # Spam multiplier is recalculated in finalize_miner_scores with total token score

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -1,5 +1,6 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
+import fnmatch
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -8,6 +9,41 @@ from typing import Dict, List, Optional
 import bittensor as bt
 
 from gittensor.constants import DEFAULT_REPO_WEIGHT, NON_CODE_EXTENSIONS
+
+# Default when ``default_label_multiplier`` is omitted from master_repositories.json
+DEFAULT_LABEL_MULTIPLIER = 1.0
+
+
+def max_multiplier_for_label(label_name: str, label_multipliers: Dict[str, float]) -> Optional[float]:
+    """Return the highest multiplier among ``label_multipliers`` keys that match ``label_name``.
+
+    Keys use the same ``fnmatch`` wildcard semantics as ``additional_acceptable_branches``
+    (see ``branch_matches_pattern``). ``label_name`` is matched case-insensitively.
+    """
+    label_lower = label_name.lower()
+    best: Optional[float] = None
+    for pattern, mult in label_multipliers.items():
+        if fnmatch.fnmatch(label_lower, (pattern or '').lower()):
+            if best is None or mult > best:
+                best = mult
+    return best
+
+
+def resolve_label_multiplier(repo_config: Optional['RepositoryConfig'], chosen_label: Optional[str]) -> float:
+    """Label multiplier for a PR given the repo config and the resolved scoring label (if any).
+
+    When ``label_multipliers`` is empty or missing, every PR uses ``default_label_multiplier``.
+    When labels exist but none match a configured pattern, the resolved label is ``None`` and
+    this returns ``default_label_multiplier`` as well.
+    """
+    default_m = repo_config.default_label_multiplier if repo_config else DEFAULT_LABEL_MULTIPLIER
+    if not repo_config or not chosen_label:
+        return default_m
+    lm = repo_config.label_multipliers
+    if not lm:
+        return default_m
+    matched = max_multiplier_for_label(chosen_label, lm)
+    return matched if matched is not None else default_m
 
 
 @dataclass
@@ -38,6 +74,12 @@ class RepositoryConfig:
             actor — including GitHub Apps that surface as ``actor_association=NULL``.
             Defaults to False; only enable on repos with an authoritative label
             pipeline. See ``_resolve_trusted_scoring_label`` for the threat model.
+        label_multipliers: Optional mapping of wildcard label patterns to multipliers.
+            When omitted or empty, PR labels do not affect scoring (every PR uses
+            ``default_label_multiplier``). Pattern syntax matches
+            ``additional_acceptable_branches`` (``fnmatch``).
+        default_label_multiplier: Multiplier applied when no configured pattern
+            matches, or when the PR has no scoring label. Defaults to 1.0.
 
     """
 
@@ -46,6 +88,8 @@ class RepositoryConfig:
     additional_acceptable_branches: Optional[List[str]] = None
     mirror_enabled: bool = False
     trusted_label_pipeline: bool = False
+    label_multipliers: Optional[Dict[str, float]] = None
+    default_label_multiplier: float = DEFAULT_LABEL_MULTIPLIER
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -122,12 +166,22 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
             try:
+                raw_lm = metadata.get('label_multipliers')
+                label_multipliers: Optional[Dict[str, float]] = None
+                if isinstance(raw_lm, dict) and raw_lm:
+                    label_multipliers = {str(k): float(v) for k, v in raw_lm.items()}
+
+                dlm_raw = metadata.get('default_label_multiplier')
+                default_label_multiplier = float(dlm_raw) if dlm_raw is not None else DEFAULT_LABEL_MULTIPLIER
+
                 config = RepositoryConfig(
                     weight=float(metadata.get('weight', 0.01)),
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     mirror_enabled=bool(metadata.get('mirror_enabled', False)),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
+                    label_multipliers=label_multipliers,
+                    default_label_multiplier=default_label_multiplier,
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -105,12 +105,16 @@ def _config(
     weight: float = 0.5,
     additional_branches: list | None = None,
     trusted_label_pipeline: bool = False,
+    label_multipliers: dict | None = None,
+    default_label_multiplier: float = 1.0,
 ) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
         mirror_enabled=True,
         additional_acceptable_branches=additional_branches,
         trusted_label_pipeline=trusted_label_pipeline,
+        label_multipliers=label_multipliers,
+        default_label_multiplier=default_label_multiplier,
     )
 
 
@@ -411,6 +415,9 @@ class TestConvertMirrorFiles:
 # ============================================================================
 
 
+_LM_TWO = {'alpha': 1.0, 'beta': 2.0}
+
+
 class TestLabelResolution:
     def test_no_labels_returns_none(self):
         scored = ScoredMirrorPR(pr=_pr(labels=[]))
@@ -422,63 +429,64 @@ class TestLabelResolution:
         assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
 
     def test_non_maintainer_label_ignored(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
+        labels = [{'name': 'bug', 'actor_github_id': '1', 'actor_association': 'CONTRIBUTOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config(label_multipliers={'bug': 1.25})) is None
 
     def test_null_actor_association_ignored_on_untrusted_repo(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': None, 'actor_association': None}]
+        labels = [{'name': 'bug', 'actor_github_id': None, 'actor_association': None}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) is None
+        assert _resolve_trusted_scoring_label(scored.pr, _config(label_multipliers={'bug': 1.25})) is None
 
     def test_maintainer_set_scoring_label_returned(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
-        labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
+        labels = [{'name': 'bug', 'actor_github_id': '1', 'actor_association': 'COLLABORATOR'}]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        assert _resolve_trusted_scoring_label(scored.pr, _config()) == scoring_label.lower()
+        assert _resolve_trusted_scoring_label(scored.pr, _config(label_multipliers={'bug': 1.25})) == 'bug'
 
     def test_highest_multiplier_wins(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_labels = list(LABEL_MULTIPLIERS.keys())
-        if len(scoring_labels) < 2:
-            pytest.skip('Need at least 2 scoring labels for this test')
-
-        a, b = scoring_labels[0], scoring_labels[1]
         labels = [
-            {'name': a, 'actor_github_id': '1', 'actor_association': 'OWNER'},
-            {'name': b, 'actor_github_id': '1', 'actor_association': 'OWNER'},
+            {'name': 'alpha', 'actor_github_id': '1', 'actor_association': 'OWNER'},
+            {'name': 'beta', 'actor_github_id': '1', 'actor_association': 'OWNER'},
         ]
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
-        chosen = _resolve_trusted_scoring_label(scored.pr, _config())
-        expected = max([a, b], key=lambda n: (LABEL_MULTIPLIERS[n], n)).lower()
-        assert chosen == expected
+        chosen = _resolve_trusted_scoring_label(scored.pr, _config(label_multipliers=_LM_TWO))
+        assert chosen == 'beta'
 
     def test_calculate_multipliers_threads_trusted_flag(self):
         """End-to-end issue #911 path: _calculate_pr_multipliers honors trusted_label_pipeline."""
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next((name for name, mult in LABEL_MULTIPLIERS.items() if mult != 1.0), None)
-        if scoring_label is None:
-            pytest.skip('Need at least one non-1.0x label for this test')
-
-        labels = [{'name': scoring_label, 'actor_github_id': '99', 'actor_association': None}]
+        labels = [{'name': 'kind/feature', 'actor_github_id': '99', 'actor_association': None}]
+        lm = {'kind/*': 1.5}
 
         scored_trusted = ScoredMirrorPR(pr=_pr(labels=labels))
-        _calculate_pr_multipliers(scored_trusted, _config(trusted_label_pipeline=True))
-        assert scored_trusted.label_multiplier == LABEL_MULTIPLIERS[scoring_label]
+        _calculate_pr_multipliers(scored_trusted, _config(trusted_label_pipeline=True, label_multipliers=lm))
+        assert scored_trusted.label == 'kind/feature'
+        assert scored_trusted.label_multiplier == pytest.approx(1.5)
 
         scored_untrusted = ScoredMirrorPR(pr=_pr(labels=labels))
-        _calculate_pr_multipliers(scored_untrusted, _config(trusted_label_pipeline=False))
-        assert scored_untrusted.label_multiplier == 1.0
+        _calculate_pr_multipliers(scored_untrusted, _config(trusted_label_pipeline=False, label_multipliers=lm))
+        assert scored_untrusted.label is None
+        assert scored_untrusted.label_multiplier == pytest.approx(1.0)
+
+    def test_wildcard_pattern_resolves_multiplier(self):
+        labels = [{'name': 'type/perf', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
+        scored = ScoredMirrorPR(pr=_pr(labels=labels))
+        _calculate_pr_multipliers(scored, _config(label_multipliers={'type/*': 1.1, 'kind/feature': 1.5}))
+        assert scored.label == 'type/perf'
+        assert scored.label_multiplier == pytest.approx(1.1)
+
+    def test_no_label_multipliers_repo_uses_default_only(self):
+        labels = [{'name': 'feature', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
+        scored = ScoredMirrorPR(pr=_pr(labels=labels))
+        _calculate_pr_multipliers(scored, _config(label_multipliers=None, default_label_multiplier=1.0))
+        assert scored.label is None
+        assert scored.label_multiplier == pytest.approx(1.0)
+
+    def test_custom_default_when_no_pattern_match(self):
+        labels = [{'name': 'unlisted', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
+        scored = ScoredMirrorPR(pr=_pr(labels=labels))
+        _calculate_pr_multipliers(scored, _config(label_multipliers={'kind/*': 1.5}, default_label_multiplier=0.8))
+        assert scored.label is None
+        assert scored.label_multiplier == pytest.approx(0.8)
 
 
 # ============================================================================
@@ -694,18 +702,19 @@ class TestCollateralScoreAcceptsScoredMirrorPR:
 
 class TestPrMultipliers:
     def test_merged_pr_populates_all_multipliers(self):
-        from gittensor.constants import LABEL_MULTIPLIERS
-
-        scoring_label = next(iter(LABEL_MULTIPLIERS.keys()))
+        scoring_label = 'bug'
         labels = [{'name': scoring_label, 'actor_github_id': '1', 'actor_association': 'OWNER'}]
 
         scored = ScoredMirrorPR(pr=_pr(labels=labels))
         scored.token_score = 100.0  # for completeness
-        _calculate_pr_multipliers(scored, _config(weight=0.7, additional_branches=['test']))
+        _calculate_pr_multipliers(
+            scored,
+            _config(weight=0.7, additional_branches=['test'], label_multipliers={'bug': 1.25}),
+        )
 
         assert scored.repo_weight_multiplier == 0.7
         assert scored.label == scoring_label.lower()
-        assert scored.label_multiplier == LABEL_MULTIPLIERS[scoring_label.lower()]
+        assert scored.label_multiplier == pytest.approx(1.25)
         assert 0.0 <= scored.time_decay_multiplier <= 1.0
         assert scored.review_quality_multiplier == 1.0  # 0 maintainer changes_requested
         assert scored.issue_multiplier == 1.0  # no linked_issues

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -1,17 +1,37 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Label scoring: per-repo ``label_multipliers`` + GraphQL label extraction."""
+
 import pytest
 
 from gittensor.classes import PullRequest
-from gittensor.constants import LABEL_MULTIPLIERS
+from gittensor.validator.utils.load_weights import (
+    RepositoryConfig,
+    max_multiplier_for_label,
+    resolve_label_multiplier,
+)
 
+# Mirrors the old global table closely enough for timeline / tie-break regression tests.
+_LEGACY_LABEL_MULTIPLIERS = {
+    'feature': 1.50,
+    'feat': 1.50,
+    'bug': 1.25,
+    'fix': 1.25,
+    'crash': 1.25,
+    'regression': 1.25,
+    'security': 1.25,
+    'enhancement': 1.10,
+    'improve': 1.10,
+    'perf': 1.10,
+    'refactor': 0.5,
+    'cleanup': 0.5,
+    'polish': 0.5,
+    'debt': 0.5,
+    'chore': 0.5,
+}
 
-@pytest.mark.parametrize('label,expected', list(LABEL_MULTIPLIERS.items()))
-def test_known_labels(label, expected):
-    assert LABEL_MULTIPLIERS.get(label, 1.0) == expected
-
-
-@pytest.mark.parametrize('label', ['docs', 'question', 'wontfix', 'kind/feature'])
-def test_unknown_labels_return_default(label):
-    assert LABEL_MULTIPLIERS.get(label, 1.0) == 1.0
+_REPO_WITH_LEGACY_LABELS = RepositoryConfig(weight=0.01, label_multipliers=dict(_LEGACY_LABEL_MULTIPLIERS))
 
 
 def _pr_payload(current, timeline):
@@ -39,49 +59,36 @@ def _pr_payload(current, timeline):
     }
 
 
-def _parse(current, timeline):
-    return PullRequest.from_graphql_response(_pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh').label
+def _parse(current, timeline, repo_config=None):
+    cfg = repo_config if repo_config is not None else _REPO_WITH_LEGACY_LABELS
+    return PullRequest.from_graphql_response(
+        _pr_payload(current, timeline), uid=0, hotkey='hk', github_id='gh', repo_config=cfg
+    ).label
 
 
 @pytest.mark.parametrize(
     'current,timeline,expected',
     [
-        # Single scoring label — unchanged behavior
         (['feature'], ['feature'], 'feature'),
-        # dify case: refactor masked by lgtm added after — fix picks refactor
         (['size:M', 'refactor', 'lgtm'], ['size:M', 'refactor', 'lgtm'], 'refactor'),
-        # godot case: bug masked by topic:* added after — fix picks bug
         (['bug', 'topic:editor', 'topic:shaders'], ['bug', 'topic:editor', 'topic:shaders'], 'bug'),
-        # Reclassification: feature then bug — last scoring label wins
         (['feature', 'bug'], ['feature', 'bug'], 'bug'),
-        # Label added then removed — not in current, skipped
         ([], ['feature'], None),
-        # No labels
         ([], [], None),
-        # Only non-scoring labels
         (['size:M', 'lgtm', 'ci'], ['size:M', 'lgtm', 'ci'], None),
-        # Case insensitive
         (['Bug'], ['Bug'], 'bug'),
-        # Null label node (PR #553 — deleted repo label)
         (['feature'], [None, 'feature'], 'feature'),
         (['feature'], [None], 'feature'),
-        # Remove-and-replace: feature removed, bug added
         (['bug'], ['feature', 'bug'], 'bug'),
-        # Only scoring label was removed
         (['lgtm'], ['feature'], None),
-        # Timeline truncated: scoring label in current but not in last-5 events (#646)
         (
             ['bug', 'size:s', 'area:test', 'priority:low', 'status:triaged'],
             ['size:s', 'area:test', 'priority:low', 'status:triaged', 'lgtm'],
             'bug',
         ),
-        # Timeline truncated: penalty label still applied via fallback
         (['refactor', 'size:M', 'lgtm'], ['size:M', 'lgtm'], 'refactor'),
-        # Timeline truncated: multiple scoring labels both truncated — highest multiplier wins
         (['feature', 'bug'], [], 'feature'),
-        # Timeline partially truncated: one scoring label in timeline wins over truncated one
         (['feature', 'bug'], ['bug'], 'bug'),
-        # Empty timeline with scoring label in current
         (['enhancement'], [], 'enhancement'),
     ],
 )
@@ -89,9 +96,75 @@ def test_label_extraction(current, timeline, expected):
     assert _parse(current, timeline) == expected
 
 
+def test_no_repo_config_yields_default_scoring_label():
+    """Without repo_config, default label_multipliers apply."""
+    assert _parse(['feature'], ['feature'], repo_config=None) == 'feature'
+
+
 def test_missing_labels_key_does_not_crash():
     """Backward-compat: payloads without the new 'labels' key yield None."""
     payload = _pr_payload([], ['feature'])
     del payload['labels']
-    pr = PullRequest.from_graphql_response(payload, uid=0, hotkey='hk', github_id='gh')
+    pr = PullRequest.from_graphql_response(
+        payload, uid=0, hotkey='hk', github_id='gh', repo_config=_REPO_WITH_LEGACY_LABELS
+    )
     assert pr.label is None
+
+
+@pytest.mark.parametrize(
+    'label,mapping,expected',
+    [
+        ('kind/feature', {'kind/feature': 1.5}, 1.5),
+        ('kind/feature', {'kind/*': 1.5}, 1.5),
+        ('type/perf', {'type/*': 1.1}, 1.1),
+        ('3.0-dev', {'*-dev': 0.5}, 0.5),
+        ('v2-dev', {'*-dev': 0.5}, 0.5),
+        ('no-match', {'kind/*': 1.1}, None),
+    ],
+)
+def test_max_multiplier_fnmatch(label, mapping, expected):
+    got = max_multiplier_for_label(label, mapping)
+    if expected is None:
+        assert got is None
+    else:
+        assert got == pytest.approx(expected)
+
+
+def test_max_multiplier_picks_highest_when_multiple_patterns_match():
+    assert max_multiplier_for_label('type/perf', {'type/*': 1.1, 'type/perf': 2.0}) == 2.0
+
+
+def test_resolve_label_multiplier_no_configured_table():
+    cfg = RepositoryConfig(weight=0.1)
+    assert resolve_label_multiplier(cfg, None) == 1.0
+    assert resolve_label_multiplier(cfg, 'anything') == 1.0
+
+
+def test_resolve_label_multiplier_custom_default():
+    cfg = RepositoryConfig(weight=0.1, default_label_multiplier=0.75)
+    assert resolve_label_multiplier(cfg, None) == pytest.approx(0.75)
+    assert resolve_label_multiplier(cfg, 'unlisted') == pytest.approx(0.75)
+
+
+def test_resolve_label_multiplier_with_match():
+    cfg = RepositoryConfig(
+        weight=0.1,
+        label_multipliers={'kind/feature': 1.5, 'type/*': 1.1},
+        default_label_multiplier=1.0,
+    )
+    assert resolve_label_multiplier(cfg, 'kind/feature') == pytest.approx(1.5)
+    assert resolve_label_multiplier(cfg, 'type/perf') == pytest.approx(1.1)
+
+
+def test_calculate_pr_multipliers_legacy_path_respects_wildcards():
+    from gittensor.classes import MinerEvaluation
+    from gittensor.validator.oss_contributions.scoring import calculate_pr_multipliers
+
+    raw = _pr_payload(['type/perf'], ['type/perf'])
+    rc = RepositoryConfig(weight=0.2, label_multipliers={'type/*': 1.1, 'kind/feature': 1.5})
+    pr = PullRequest.from_graphql_response(raw, 0, 'hk', 'gh', rc)
+    master = {pr.repository_full_name: rc}
+    ev = MinerEvaluation(uid=0, hotkey='hk', github_id='1', github_pat='token')
+    calculate_pr_multipliers(pr, ev, master)
+    assert pr.label == 'type/perf'
+    assert pr.label_multiplier == pytest.approx(1.1)

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -218,6 +218,36 @@ class TestRepositoryConfigTrustedLabelPipeline:
         assert repos['foo/explicit-off'].trusted_label_pipeline is False
 
 
+class TestRepositoryConfigLabelFields:
+    """JSON parsing for per-repo ``label_multipliers`` / ``default_label_multiplier``."""
+
+    def test_loader_parses_label_multipliers_and_default(self, tmp_path, monkeypatch):
+        import json
+
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'org/r1': {
+                        'weight': 0.1,
+                        'label_multipliers': {'kind/*': 1.2, 'bug': 1.25},
+                        'default_label_multiplier': 0.9,
+                    },
+                    'org/r2': {'weight': 0.2},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['org/r1'].label_multipliers == {'kind/*': 1.2, 'bug': 1.25}
+        assert repos['org/r1'].default_label_multiplier == pytest.approx(0.9)
+        assert repos['org/r2'].label_multipliers is None
+        assert repos['org/r2'].default_label_multiplier == 1.0
+
+
 class TestBannedOrganizations:
     """Tests ensuring banned organizations are not active in the repository list.
 

--- a/tests/validator/test_master_repositories_label_shape.py
+++ b/tests/validator/test_master_repositories_label_shape.py
@@ -1,0 +1,50 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Bounds on per-repo label scoring fields in ``master_repositories.json``."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gittensor.validator.utils.load_weights import load_master_repo_weights
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MASTER_JSON = _REPO_ROOT / 'gittensor' / 'validator' / 'weights' / 'master_repositories.json'
+
+
+def _raw_entries():
+    with open(_MASTER_JSON, encoding='utf-8') as f:
+        data = json.load(f)
+    assert isinstance(data, dict)
+    return sorted(data.items())
+
+
+@pytest.mark.parametrize('repo_name,metadata', _raw_entries())
+def test_repo_label_fields_shape(repo_name, metadata):
+    """Every repo: ≤10 label_multipliers keys, multipliers in [0,20], default in [0,20]."""
+    lm = metadata.get('label_multipliers')
+    if lm is not None:
+        assert isinstance(lm, dict), f'{repo_name}: label_multipliers must be an object'
+        assert len(lm) <= 10, f'{repo_name}: at most 10 label_multipliers entries'
+        for key, val in lm.items():
+            assert isinstance(val, (int, float)), f'{repo_name}: multiplier for {key!r} must be numeric'
+            assert 0.0 <= float(val) <= 20.0, f'{repo_name}: multiplier for {key!r} out of [0, 20]'
+
+    dlm = metadata.get('default_label_multiplier')
+    if dlm is not None:
+        v = float(dlm)
+        assert 0.0 <= v <= 20.0, f'{repo_name}: default_label_multiplier out of [0, 20]'
+
+
+def test_loaded_repository_config_matches_bounds():
+    """``load_master_repo_weights`` produces configs consistent with raw JSON rules."""
+    repos = load_master_repo_weights()
+    assert repos
+    for name, cfg in repos.items():
+        if cfg.label_multipliers:
+            assert len(cfg.label_multipliers) <= 10, name
+            for mult in cfg.label_multipliers.values():
+                assert 0.0 <= mult <= 20.0, name
+        assert 0.0 <= cfg.default_label_multiplier <= 20.0, name

--- a/tests/validator/test_review_quality_multiplier.py
+++ b/tests/validator/test_review_quality_multiplier.py
@@ -249,7 +249,7 @@ class TestReviewCollateralMultiplierOnOpenPRCollateral:
 
 
 def _make_repo_config() -> dict:
-    return {'test/repo': RepositoryConfig(weight=1.0)}
+    return {'test/repo': RepositoryConfig(weight=1.0, label_multipliers={'fix': 1.25, 'bug': 1.25})}
 
 
 def _make_eval() -> MinerEvaluation:


### PR DESCRIPTION
## Summary

Moves PR label multiplier scoring from the global `LABEL_MULTIPLIERS` table into per-repository configuration (`RepositoryConfig`).

### Key Changes
- **Configuration Updates**: Added `label_multipliers` (dict of patterns to floats) and `default_label_multiplier` (float, default 1.0) to `RepositoryConfig`. New functions `max_multiplier_for_label` and `resolve_label_multiplier` handle pattern matching and resolution.
- **Scoring Logic**: Updated PR scoring in `classes.py`, `scoring.py`, and mirror scoring to use repo-specific configs instead of the global table. PR label resolution now considers maintainer-set labels with pattern matching.
- **API Adjustments**: Modified `PullRequest.from_graphql_response` and `MinerEvaluation` methods to accept and pass `RepositoryConfig`.
- **Constants Removal**: Eliminated `LABEL_MULTIPLIERS` from `constants.py`.
- **Tests**: Refactored tests to use per-repo configs, added new test cases for wildcard patterns, defaults, and bounds validation (e.g., multipliers in [0, 20], ≤10 patterns per repo).

### Preserved behavior

- Legacy scoring still respects existing tie-breaking (latest/strongest match rules)
- Mirror scoring still applies trusted-label / actor gating before scoring
- Existing scoring flow semantics remain unchanged outside label source

### Validation / tests

- Per-repo configs are bounded via tests (not runtime enforcement):
   - multiplier range: 0.0–20.0
   - max 10 label entries per repo
   - wildcard matching covered in integration-style tests
   - explicit test for “no label config → default multiplier for all PRs”

## Related Issues
Closes #1016.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [x] Tests added/updated
- [x] Manually tested

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)