### PR TITLE
fix: use SOURCE-quality score for eligibility gates

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -197,6 +197,7 @@ class PullRequest:
 
     # Token scoring breakdown (after test weight applied)
     code_density: float = 0.0
+    source_token_score: float = 0.0  # SOURCE-only token score for eligibility gates
     token_score: float = 0.0
     structural_count: int = 0
     structural_score: float = 0.0
@@ -219,7 +220,8 @@ class PullRequest:
 
         A PR is eligible if it is merged and meets the minimum token score quality gate.
         """
-        return self.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        effective_score = self.source_token_score if self.source_token_score > 0 else self.token_score
+        return self.merged_at is not None and effective_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
 
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -80,6 +80,7 @@ class CachedSolvingPR:
 
     base_score: float
     token_score: float
+    source_token_score: float = 0.0
 
 
 @dataclass
@@ -241,7 +242,8 @@ def _build_solving_pr_cache(
     cache: Dict[Tuple[str, int], CachedSolvingPR] = {}
     for evaluation in miner_evaluations.values():
         for scored in evaluation.mirror_merged_prs:
-            if scored.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+            effective_score = scored.source_token_score if scored.source_token_score > 0 else scored.token_score
+            if effective_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
                 continue
             key = (scored.pr.repo_full_name, scored.pr.pr_number)
             if key in cache:
@@ -249,6 +251,7 @@ def _build_solving_pr_cache(
             cache[key] = CachedSolvingPR(
                 base_score=scored.base_score,
                 token_score=scored.token_score,
+                source_token_score=scored.source_token_score,
             )
     return cache
 
@@ -323,8 +326,9 @@ def _score_miner_mirror_issues(
             )
             continue
 
-        # Valid-solved gate (legacy parity): solving PR must meet the token threshold.
-        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        # Valid-solved gate (legacy parity): solving PR must meet the SOURCE token threshold.
+        effective_token_score = cached.source_token_score if cached.source_token_score > 0 else cached.token_score
+        if effective_token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
             valid_solved_count += 1
 
         # Same-account: discoverer == solver gets credibility only, no score
@@ -350,10 +354,10 @@ def _score_miner_mirror_issues(
 
         # Quality gate — matches legacy issue-discovery behavior: below-threshold
         # solving PRs add credibility only, no discovery score.
-        if cached.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        if effective_token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): solving PR '
-                f'#{solving_pr.pr_number} token_score {cached.token_score:.2f} < '
+                f'#{solving_pr.pr_number} source_token_score {effective_token_score:.2f} < '
                 f'{MIN_TOKEN_SCORE_FOR_BASE_SCORE} — credibility only'
             )
             continue
@@ -365,7 +369,7 @@ def _score_miner_mirror_issues(
         scored_issues.append(adapted)
         # Legacy parity: issue_token_score accumulates per-solving-PR token scores
         # for the open-issue spam multiplier threshold calc.
-        issue_token_score += cached.token_score
+        issue_token_score += effective_token_score
 
     # All issue-discovery fields are now mirror-only writers (legacy issue
     # discovery has been removed), so simple assignment — no need to merge
@@ -450,7 +454,11 @@ def _resolve_solving_pr_score(
         issue.repo_full_name, solving_pr.pr_number, files_response.files
     )
     result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
-    cached = CachedSolvingPR(base_score=result.base_score, token_score=result.token_score)
+    cached = CachedSolvingPR(
+        base_score=result.base_score,
+        token_score=result.token_score,
+        source_token_score=result.source_token_score,
+    )
     cache[key] = cached
     return cached
 

--- a/gittensor/validator/oss_contributions/credibility.py
+++ b/gittensor/validator/oss_contributions/credibility.py
@@ -52,8 +52,11 @@ def check_eligibility(merged_prs: Sequence[PrLike], closed_prs: Sequence[PrLike]
     """
     credibility = calculate_credibility(merged_prs, closed_prs)
 
-    # Count valid merged PRs (token_score >= threshold)
-    valid_merged_count = sum(1 for pr in merged_prs if pr.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE)
+    # Count valid merged PRs (source_token_score with fallback to token_score >= threshold)
+    valid_merged_count = sum(
+        1 for pr in merged_prs
+        if (pr.source_token_score if pr.source_token_score > 0 else pr.token_score) >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+    )
 
     if valid_merged_count < MIN_VALID_MERGED_PRS:
         reason = f'{valid_merged_count}/{MIN_VALID_MERGED_PRS} valid merged PRs (need {MIN_VALID_MERGED_PRS})'

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -49,6 +49,7 @@ class ScoredMirrorPR:
     # Token scoring breakdown (populated when files are tokenized)
     code_density: float = 0.0
     token_score: float = 0.0
+    source_token_score: float = 0.0
     structural_count: int = 0
     structural_score: float = 0.0
     leaf_count: int = 0
@@ -89,7 +90,8 @@ class ScoredMirrorPR:
         Mirrors `PullRequest.is_pioneer_eligible` so the legacy pioneer math
         functions can be reused unchanged.
         """
-        return self.pr.merged_at is not None and self.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        effective_score = self.source_token_score if self.source_token_score > 0 else self.token_score
+        return self.pr.merged_at is not None and effective_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
 
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -235,13 +235,14 @@ class BaseScoreResult:
     """
 
     base_score: float
+    source_token_score: float = 0.0
     token_score: float
-    structural_count: int
-    structural_score: float
-    leaf_count: int
-    leaf_score: float
-    total_nodes_scored: int
-    code_density: float
+    structural_count: int = 0
+    structural_score: float = 0.0
+    leaf_count: int = 0
+    leaf_score: float = 0.0
+    total_nodes_scored: int = 0
+    code_density: float = 0.0
 
 
 def calculate_base_score_for_pr_files(
@@ -306,6 +307,7 @@ def calculate_base_score_for_pr_files(
 
     return BaseScoreResult(
         base_score=base_score,
+        source_token_score=source_token_score,
         token_score=token_score,
         structural_count=structural_count,
         structural_score=structural_score,
@@ -326,6 +328,7 @@ def _calculate_base_score(
     """Thin wrapper: run the shared helper and copy fields onto ScoredMirrorPR."""
     result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
     scored.token_score = result.token_score
+    scored.source_token_score = result.source_token_score
     scored.structural_count = result.structural_count
     scored.structural_score = result.structural_score
     scored.leaf_count = result.leaf_count

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -158,6 +158,7 @@ def calculate_base_score(
         pr.file_changes or [], file_contents, programming_languages, token_config
     )
     pr.token_score = result.token_score
+    pr.source_token_score = result.source_token_score
     pr.structural_count = result.structural_count
     pr.structural_score = result.structural_score
     pr.leaf_count = result.leaf_count

--- a/tests/validator/test_source_quality_gates.py
+++ b/tests/validator/test_source_quality_gates.py
@@ -1,0 +1,113 @@
+"""Tests for SOURCE-quality score eligibility gates (#1023)."""
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from gittensor.constants import MIN_TOKEN_SCORE_FOR_BASE_SCORE
+
+
+# ---------------------------------------------------------------------------
+# Helpers: lightweight stand-ins for PullRequest / ScoredMirrorPR
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FakePR:
+    """Minimal duck-type matching PullRequest / PrLike."""
+    merged_at: Optional[str] = "2026-01-01T00:00:00Z"
+    source_token_score: float = 0.0
+    token_score: float = 0.0
+
+    @property
+    def is_pioneer_eligible(self) -> bool:
+        score = self.source_token_score if self.source_token_score > 0 else self.token_score
+        return self.merged_at is not None and score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
+
+
+def _effective(pr: FakePR) -> float:
+    """Replicate the fallback logic used in eligibility gates."""
+    return pr.source_token_score if pr.source_token_score > 0 else pr.token_score
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTestOnlyPRNotEligible:
+    """A PR with high aggregate token_score but 0 source_token_score is not eligible."""
+
+    def test_pioneer_gate(self):
+        pr = FakePR(token_score=100.0, source_token_score=0.0)
+        assert not pr.is_pioneer_eligible
+
+    def test_credibility_gate(self):
+        from gittensor.validator.oss_contributions.credibility import check_eligibility
+        prs = [FakePR(token_score=100.0, source_token_score=0.0)]
+        # check_eligibility expects at least MIN_VALID_MERGED_PRS valid PRs
+        eligible, reason = check_eligibility(prs, [])
+        assert not eligible
+
+
+class TestSourceOnlyPREligible:
+    """A PR with only source contributions should be eligible."""
+
+    def test_pioneer_gate(self):
+        pr = FakePR(token_score=10.0, source_token_score=10.0)
+        assert pr.is_pioneer_eligible
+
+    def test_effective_score(self):
+        pr = FakePR(token_score=15.0, source_token_score=10.0)
+        assert _effective(pr) == 10.0
+
+
+class TestFallbackBehavior:
+    """When source_token_score is 0 (old cached data), fall back to token_score."""
+
+    def test_falls_back_to_aggregate(self):
+        pr = FakePR(token_score=10.0, source_token_score=0.0)
+        assert _effective(pr) == 10.0
+
+    def test_uses_source_when_present(self):
+        pr = FakePR(token_score=50.0, source_token_score=5.0)
+        assert _effective(pr) == 5.0
+
+    def test_exactly_at_threshold(self):
+        pr = FakePR(token_score=MIN_TOKEN_SCORE_FOR_BASE_SCORE, source_token_score=0.0)
+        assert _effective(pr) == MIN_TOKEN_SCORE_FOR_BASE_SCORE
+        assert pr.is_pioneer_eligible
+
+    def test_just_below_threshold(self):
+        pr = FakePR(token_score=MIN_TOKEN_SCORE_FOR_BASE_SCORE - 0.01, source_token_score=0.0)
+        assert not pr.is_pioneer_eligible
+
+
+class TestZeroBothNotEligible:
+    """Both scores at 0 → not eligible."""
+
+    def test_pioneer(self):
+        pr = FakePR(token_score=0.0, source_token_score=0.0)
+        assert not pr.is_pioneer_eligible
+
+    def test_unmerged(self):
+        pr = FakePR(merged_at=None, token_score=100.0, source_token_score=100.0)
+        assert not pr.is_pioneer_eligible
+
+
+class TestCachedSolvingPRPropagation:
+    """source_token_score propagates through CachedSolvingPR."""
+
+    def test_cache_holds_source_score(self):
+        from gittensor.validator.issue_discovery.mirror_scan import CachedSolvingPR
+        cached = CachedSolvingPR(
+            base_score=1.0, token_score=50.0, source_token_score=10.0
+        )
+        assert cached.source_token_score == 10.0
+        effective = cached.source_token_score if cached.source_token_score > 0 else cached.token_score
+        assert effective == 10.0
+
+    def test_cache_fallback(self):
+        from gittensor.validator.issue_discovery.mirror_scan import CachedSolvingPR
+        cached = CachedSolvingPR(base_score=1.0, token_score=10.0, source_token_score=0.0)
+        effective = cached.source_token_score if cached.source_token_score > 0 else cached.token_score
+        assert effective == 10.0


### PR DESCRIPTION
## Summary

Eligibility gates (merged PR validity, mirror valid-solved, pioneer eligibility) were incorrectly using aggregate `token_score` which includes TEST/tree-diff contributions. A TEST-only PR could earn a small contribution bonus but still count as valid — this PR fixes that mismatch.

## Changes

- Add `source_token_score` field to `BaseScoreResult`, `PullRequest`, `ScoredMirrorPR`, `CachedSolvingPR`
- Persist `source_token_score` through all scoring paths (OSS + legacy + issue discovery)
- Switch all eligibility gates to use `source_token_score` with fallback to aggregate `token_score` for backward compatibility
- Add comprehensive test coverage in `test_source_quality_gates.py`

## Key gates updated
- `PullRequest.is_pioneer_eligible()` → uses `source_token_score`
- `ScoredMirrorPR.is_pioneer_eligible()` → uses `source_token_score`
- `check_eligibility()` in credibility.py → counts valid PRs by `source_token_score`
- mirror_scan.py cache building + valid-solved gate + quality gate → uses `source_token_score`

## Fallback pattern
```python
score = pr.source_token_score if pr.source_token_score > 0 else pr.token_score
```

Fixes #1022
Fixes #1023