### PR TITLE
fix: sync pr_state for stale-closed mirror PRs excluded from scoring

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -383,6 +383,8 @@ class MinerEvaluation:
     mirror_merged_prs: List['ScoredMirrorPR'] = field(default_factory=list)
     mirror_open_prs: List['ScoredMirrorPR'] = field(default_factory=list)
     mirror_closed_prs: List['ScoredMirrorPR'] = field(default_factory=list)
+    # Mirror counterpart to ``stale_closed_pull_requests`` (see #769).
+    mirror_stale_closed_prs: List['ScoredMirrorPR'] = field(default_factory=list)
 
     unique_repos_contributed_to: Set[str] = field(default_factory=set)
 

--- a/gittensor/validator/oss_contributions/mirror/combine.py
+++ b/gittensor/validator/oss_contributions/mirror/combine.py
@@ -27,6 +27,7 @@ def combine(legacy_eval: MinerEvaluation, mirror_eval: MirrorMinerEvaluation) ->
     legacy_eval.mirror_merged_prs = mirror_eval.merged_prs
     legacy_eval.mirror_open_prs = mirror_eval.open_prs
     legacy_eval.mirror_closed_prs = mirror_eval.closed_prs
+    legacy_eval.mirror_stale_closed_prs = mirror_eval.stale_closed_prs
 
     legacy_eval.unique_repos_contributed_to |= mirror_eval.unique_repos_contributed_to
 

--- a/gittensor/validator/oss_contributions/mirror/evaluation.py
+++ b/gittensor/validator/oss_contributions/mirror/evaluation.py
@@ -27,6 +27,9 @@ class MirrorMinerEvaluation:
     merged_prs: List[ScoredMirrorPR] = field(default_factory=list)
     open_prs: List[ScoredMirrorPR] = field(default_factory=list)
     closed_prs: List[ScoredMirrorPR] = field(default_factory=list)
+    # Storage-only: persisted to flip pr_state OPEN→CLOSED, excluded from
+    # scoring. Mirror parity for stale_closed_pull_requests (see #769).
+    stale_closed_prs: List[ScoredMirrorPR] = field(default_factory=list)
 
     # Set-union into MinerEvaluation.unique_repos_contributed_to at combine
     # time. Populated by score_mirror_pr as it processes each MERGED PR.

--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -9,7 +9,8 @@ Filtering applied at load time (legacy parity):
 - Repo not in mirror_repos: dropped (mirror returns all tracked repos)
 - PR created after repo became inactive: dropped
 - PR author is a maintainer (OWNER/MEMBER/COLLABORATOR): silently dropped
-- CLOSED PRs created before the lookback window: dropped
+- CLOSED PRs created before the lookback window: routed to ``stale_closed_prs``
+  (storage-only, excluded from scoring; flips OPEN→CLOSED. See #769.)
 - MERGED PRs that fail ``_should_skip_merged_mirror_pr`` (base_ref, head_ref,
   self-merge w/o approval, etc.): dropped
 """
@@ -71,7 +72,8 @@ def load_mirror_miner_prs(
 
     bt.logging.info(
         f'Mirror fetched {len(mirror_eval.merged_prs)} merged, '
-        f'{len(mirror_eval.open_prs)} open, {len(mirror_eval.closed_prs)} closed'
+        f'{len(mirror_eval.open_prs)} open, {len(mirror_eval.closed_prs)} closed, '
+        f'{len(mirror_eval.stale_closed_prs)} stale-closed (storage-only)'
     )
 
 
@@ -108,9 +110,10 @@ def _maybe_add_pr(
     if pr.state == 'OPEN':
         mirror_eval.open_prs.append(ScoredMirrorPR(pr=pr))
     elif pr.state == 'CLOSED':
-        # Skip stale CLOSED PRs created before the lookback window (legacy parity:
-        # closing an old PR shouldn't trigger a fresh credibility penalty).
         if pr.created_at < lookback_date:
+            # Stale: skip scoring (no fresh credibility penalty for an old close)
+            # but persist to flip pr_state OPEN→CLOSED. See #769.
+            mirror_eval.stale_closed_prs.append(ScoredMirrorPR(pr=pr))
             return
         mirror_eval.closed_prs.append(ScoredMirrorPR(pr=pr))
     elif pr.state == 'MERGED':

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -62,18 +62,21 @@ class DatabaseStorage:
                     for s in scored_list
                 ]
 
-            result.stored_counts['merged_pull_requests'] = self.repo.store_pull_requests_bulk(
-                miner_eval.merged_pull_requests + _adapt_mirror(miner_eval.mirror_merged_prs), commit=False
-            )
-            result.stored_counts['open_pull_requests'] = self.repo.store_pull_requests_bulk(
-                miner_eval.open_pull_requests + _adapt_mirror(miner_eval.mirror_open_prs), commit=False
-            )
-            result.stored_counts['closed_pull_requests'] = self.repo.store_pull_requests_bulk(
-                miner_eval.closed_pull_requests + _adapt_mirror(miner_eval.mirror_closed_prs), commit=False
-            )
-            result.stored_counts['stale_closed_pull_requests'] = self.repo.store_pull_requests_bulk(
-                miner_eval.stale_closed_pull_requests, commit=False
-            )
+            # Order is observed by tests via call_args_list[0..3].
+            pr_buckets = [
+                ('merged_pull_requests', miner_eval.merged_pull_requests, miner_eval.mirror_merged_prs),
+                ('open_pull_requests', miner_eval.open_pull_requests, miner_eval.mirror_open_prs),
+                ('closed_pull_requests', miner_eval.closed_pull_requests, miner_eval.mirror_closed_prs),
+                (
+                    'stale_closed_pull_requests',
+                    miner_eval.stale_closed_pull_requests,
+                    miner_eval.mirror_stale_closed_prs,
+                ),
+            ]
+            for key, legacy, mirror in pr_buckets:
+                result.stored_counts[key] = self.repo.store_pull_requests_bulk(
+                    legacy + _adapt_mirror(mirror), commit=False
+                )
             result.stored_counts['issues'] = self.repo.store_issues_bulk(miner_eval.get_all_issues(), commit=False)
             result.stored_counts['file_changes'] = self.repo.store_file_changes_bulk(
                 miner_eval.get_all_file_changes(), commit=False

--- a/tests/validator/oss_contributions/mirror/test_combine.py
+++ b/tests/validator/oss_contributions/mirror/test_combine.py
@@ -81,6 +81,7 @@ class TestCombinePopulated:
         mirror_eval.merged_prs = [_scored(1), _scored(2)]
         mirror_eval.open_prs = [_scored(3, state='OPEN')]
         mirror_eval.closed_prs = [_scored(4, state='CLOSED')]
+        mirror_eval.stale_closed_prs = [_scored(5, state='CLOSED')]
         mirror_eval.unique_repos_contributed_to = {'entrius/gittensor-ui', 'entrius/allways'}
         return legacy, mirror_eval
 
@@ -90,6 +91,7 @@ class TestCombinePopulated:
         assert legacy.mirror_merged_prs is mirror_eval.merged_prs
         assert legacy.mirror_open_prs is mirror_eval.open_prs
         assert legacy.mirror_closed_prs is mirror_eval.closed_prs
+        assert legacy.mirror_stale_closed_prs is mirror_eval.stale_closed_prs
 
     def test_counters_left_alone(self):
         """combine() does NOT touch token/nodes/collateral counters — those

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -230,8 +230,9 @@ class TestInactiveRepo:
 
 
 class TestStaleClosedPR:
-    def test_closed_pr_created_before_lookback_dropped(self):
-        # Lookback is 35 days before "now"; a CLOSED PR created 50 days ago should drop
+    def test_stale_closed_pr_routed_to_storage_only_bucket(self):
+        # Pre-lookback CLOSED skips scoring but lands in stale_closed_prs for
+        # the pr_state OPEN→CLOSED refresh. Mirror parity for #769.
         old = (datetime.now(timezone.utc) - timedelta(days=50)).isoformat().replace('+00:00', 'Z')
         recent = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
 
@@ -247,6 +248,9 @@ class TestStaleClosedPR:
 
         assert len(eval_.closed_prs) == 1
         assert eval_.closed_prs[0].pr.pr_number == 2
+        assert len(eval_.stale_closed_prs) == 1
+        assert eval_.stale_closed_prs[0].pr.pr_number == 1
+        assert eval_.total_closed_prs == 1  # scoring bucket only
 
 
 # ============================================================================

--- a/tests/validator/utils/test_storage_mirror.py
+++ b/tests/validator/utils/test_storage_mirror.py
@@ -165,19 +165,26 @@ class TestStoreEvaluationCombinesBothLists:
         assert merged_arg[0].number == 100
         assert isinstance(merged_arg[0], PullRequest)
 
-    def test_stale_closed_prs_are_stored_separately(self):
+    def test_stale_closed_lists_concatenated(self):
+        """Legacy + mirror stale-closed flow into call_args[3] adapted as
+        PullRequest; don't inflate total_closed_prs. Mirror parity for #769."""
         storage, mock_repo = _make_storage_with_mock_repo()
 
         eval_ = MinerEvaluation(uid=1, hotkey='hk', github_id='123')
         eval_.stale_closed_pull_requests = [_legacy_pr(7, state=PRState.CLOSED)]
+        eval_.mirror_stale_closed_prs = [_mirror_scored(207, state='CLOSED')]
 
         storage.store_evaluation(eval_)
 
-        stale_call = mock_repo.store_pull_requests_bulk.call_args_list[3]
-        stale_arg = stale_call.args[0]
-        assert len(stale_arg) == 1
+        stale_arg = mock_repo.store_pull_requests_bulk.call_args_list[3].args[0]
+        assert len(stale_arg) == 2
+        for pr in stale_arg:
+            assert isinstance(pr, PullRequest)
+        # legacy first (order preserved by + concatenation)
         assert stale_arg[0].number == 7
-        assert stale_arg[0].pr_state == PRState.CLOSED
+        assert stale_arg[1].number == 207
+        assert stale_arg[1].pr_state == PRState.CLOSED
+        assert stale_arg[1].uid == 1
         assert eval_.total_closed_prs == 0
 
 


### PR DESCRIPTION
## Summary

Stale CLOSED PRs from the mirror path now land in a storage-only bucket so the `pull_requests` row's `pr_state` flips from OPEN to CLOSED on the next evaluation. Before this change, the loader returned early without recording them, leaving phantom OPEN rows on dashboards for every `mirror_enabled: true` repo.

The fix mirrors PR #769, which solved the same problem on the legacy GraphQL path. The storage layer was already wired (`stale_closed_pull_requests` flows through `store_pull_requests_bulk`, and `pr_state` is in the `DO UPDATE SET` clause of `BULK_UPSERT_PULL_REQUESTS`), so the work is to add the matching mirror bucket and route it into the existing call.

Changes:
* `MirrorMinerEvaluation` gains a `stale_closed_prs` field
* `_maybe_add_pr` appends pre-lookback CLOSED PRs there instead of returning silently
* `MinerEvaluation` gains a parallel `mirror_stale_closed_prs` slot
* `combine` propagates the bucket onto the legacy evaluation
* `DatabaseStorage.store_evaluation` concatenates the adapted mirror list onto the existing stale storage call (the four parallel `store_pull_requests_bulk` calls also get folded into a single loop over a `pr_buckets` table for clarity)
* The mirror summary log now reports stale-closed count for observability

These PRs do not enter scoring or credibility math, so totals (`total_closed_prs`, `merged_count` for `check_eligibility`, etc.) stay correct.

## Related Issues

Fixes #1031 

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation
* [ ] Other (describe below)

## Testing

* [x] Tests added/updated
* [x] Manually tested

Test coverage:

* `tests/validator/oss_contributions/mirror/test_load.py`: the existing stale-closed test now also asserts the PR lands in `stale_closed_prs` and that `total_closed_prs` reflects only the scoring bucket
* `tests/validator/oss_contributions/mirror/test_combine.py`: setup now seeds a stale entry, and `test_aggregate_pr_count_properties_sum_both_paths` proves it does not inflate `total_closed_prs`
* `tests/validator/utils/test_storage_mirror.py`: new `test_stale_closed_lists_concatenated` covers legacy plus mirror concatenation, `PullRequest` adaptation, and identity propagation through the call at `call_args_list[3]`

Full suite: 602 passed, ruff clean.

## Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] Changes are documented (if applicable)