### PR TITLE
fix: apply branch gate to mirror self-merge

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -220,7 +220,7 @@ def _should_skip_merged_mirror_pr(scored: ScoredMirrorPR, repo_config: Repositor
     # branch. Only applies to same-repo PRs: fork branch names are arbitrary.
     # Falls through when head_ref or head_repo_full_name is missing (older data).
     is_same_repo = pr.head_repo_full_name is not None and pr.head_repo_full_name == pr.repo_full_name
-    if additional and pr.head_ref and is_same_repo and branch_matches_pattern(pr.head_ref, acceptable):
+    if acceptable and pr.head_ref and is_same_repo and branch_matches_pattern(pr.head_ref, acceptable):
         return True, (
             f'PR #{pr.pr_number} source branch {pr.head_ref!r} is itself in '
             f'acceptable branches — merging between acceptable branches not allowed'

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -215,6 +215,24 @@ class TestEligibilityGate:
         assert skip is True
         assert "source branch 'test'" in reason
 
+    def test_head_ref_in_default_branch_blocks_same_repo_without_additional(self):
+        # Regression: even when additional_acceptable_branches is empty, head_ref
+        # must still be checked against acceptable=['default_branch'].
+        scored = ScoredMirrorPR(
+            pr=_pr(
+                base_ref='main',
+                head_ref='main',
+                head_repo_full_name='entrius/gittensor-ui',
+                default_branch='main',
+            )
+        )
+        skip, reason = _should_skip_merged_mirror_pr(
+            scored,
+            _config(additional_branches=None),
+        )
+        assert skip is True
+        assert "source branch 'main'" in reason
+
     def test_head_ref_in_additional_passes_for_fork(self):
         # Fork PR whose head branch happens to collide with an acceptable
         # branch — fork branch names are arbitrary, legacy skips this case


### PR DESCRIPTION
## Summary

Fixes a mirror eligibility-gate parity bug where same-repo PRs could bypass the “source branch is acceptable” self-merge block when `additional_acceptable_branches` was empty.  
The head-ref gate now correctly evaluates against the computed `acceptable` branch set (which includes `default_branch`), not only when additional branches are configured.

Also adds a regression test to ensure this case remains blocked:
- same-repo merged PR
- `default_branch='main'`
- `head_ref='main'`
- no `additional_acceptable_branches`

## Related Issues

Fixes #959

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)