### PR TITLE
fix: validate base branch when default_branch missing

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -191,10 +191,10 @@ def _should_skip_merged_mirror_pr(scored: ScoredMirrorPR, repo_config: Repositor
     and other multipliers still apply.
 
     When the mirror response is missing a field (older data predating the
-    schema additions), the affected check falls through rather than
-    false-positive-blocking. Concretely: missing ``head_ref`` or
-    ``head_repo_full_name`` skips the head_ref check; missing ``default_branch``
-    narrows the acceptable set to ``additional_acceptable_branches`` only.
+    schema additions), some checks fall through rather than false-positive-
+    blocking. Concretely: missing ``head_ref`` or ``head_repo_full_name`` skips
+    the head_ref check. Missing ``default_branch`` falls back to ``main``
+    (legacy parity with GraphQL path).
     """
     pr = scored.pr
 
@@ -210,10 +210,11 @@ def _should_skip_merged_mirror_pr(scored: ScoredMirrorPR, repo_config: Repositor
             return True, f'PR #{pr.pr_number} self-merged without external approval'
 
     additional = repo_config.additional_acceptable_branches or []
-    acceptable = ([pr.default_branch] if pr.default_branch else []) + additional
+    default_branch = pr.default_branch or 'main'
+    acceptable = [default_branch] + additional
 
-    # base_ref check — only enforce when we have an acceptable set to compare against.
-    if acceptable and not branch_matches_pattern(pr.base_ref or '', acceptable):
+    # base_ref check.
+    if not branch_matches_pattern(pr.base_ref or '', acceptable):
         return True, (f'PR #{pr.pr_number} merged to {pr.base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -192,11 +192,17 @@ class TestEligibilityGate:
         assert skip is True
         assert "merged to 'whatever'" in reason
 
-    def test_no_default_branch_no_additional_accepts_any_base_ref(self):
-        # When BOTH default_branch and additional are missing (older mirror rows
-        # predating default_branch exposure), there's no acceptable set to
-        # check against — fall through rather than false-positive.
+    def test_no_default_branch_no_additional_blocks_non_main_base_ref(self):
+        # Legacy parity: if default_branch is missing, fallback to 'main' so
+        # non-main base refs are still rejected.
         scored = ScoredMirrorPR(pr=_pr(base_ref='whatever', default_branch=None))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
+        assert skip is True
+        assert "merged to 'whatever'" in reason
+
+    def test_no_default_branch_no_additional_allows_main_base_ref(self):
+        # Fallback default branch is 'main' when mirror omits default_branch.
+        scored = ScoredMirrorPR(pr=_pr(base_ref='main', default_branch=None))
         skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
         assert skip is False
 


### PR DESCRIPTION
## Summary

Fix mirror path bug where merged PRs to wrong branches (like dev) were being accepted when mirror data was missing the default branch. Legacy path always falls back to "main", so mirror path should too.

## Related Issues

Fixes #958

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)