### PR TITLE
fix: Ink! 5 packed root storage key derivation + CLI network priority

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -632,8 +632,9 @@ def resolve_network(network: Optional[str] = None, rpc_url: Optional[str] = None
     Priority:
         1. --rpc-url (explicit URL always wins)
         2. --network (mapped to known endpoint)
-        3. Config file ws_endpoint / network
-        4. Default: finney (mainnet)
+        3. Config file `network` (when set to a known network)
+        4. Config file `ws_endpoint` (custom URL fallback)
+        5. Default: finney (mainnet)
 
     Args:
         network: Network name from --network option (test/finney/local)
@@ -655,16 +656,19 @@ def resolve_network(network: Optional[str] = None, rpc_url: Optional[str] = None
         # Treat unknown network value as a custom URL
         return network, 'custom'
 
-    # Fall back to config file
+    # Fall back to config file. Prefer an explicit, recognized `network` over
+    # `ws_endpoint`: a stale dev `ws_endpoint` (e.g. localhost) shouldn't silently
+    # override a user who set `network: finney` to point at mainnet.
     config = load_config()
-    if config.get('ws_endpoint'):
-        endpoint = config['ws_endpoint']
-        name = _URL_TO_NETWORK.get(endpoint, config.get('network', 'custom'))
-        return endpoint, name
 
     config_network = config.get('network', '').lower()
     if config_network and config_network in NETWORK_MAP:
         return NETWORK_MAP[config_network], config_network
+
+    if config.get('ws_endpoint'):
+        endpoint = config['ws_endpoint']
+        name = _URL_TO_NETWORK.get(endpoint, config.get('network', 'custom'))
+        return endpoint, name
 
     # Default: finney (mainnet)
     return NETWORK_MAP['finney'], 'finney'

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -135,7 +135,7 @@ class IssueCompetitionContractClient:
     def _read_packed_storage(self) -> Optional[dict]:
         """Read the packed root storage from the contract"""
         try:
-            packed = read_contract_packed_storage(self.subtensor.substrate, self.contract_address, page_size=10)
+            packed = read_contract_packed_storage(self.subtensor.substrate, self.contract_address)
             if not packed:
                 return None
             return {
@@ -571,7 +571,7 @@ class IssueCompetitionContractClient:
             Total stake amount (0 if no stake found)
         """
         try:
-            packed = read_contract_packed_storage(self.subtensor.substrate, self.contract_address, page_size=10)
+            packed = read_contract_packed_storage(self.subtensor.substrate, self.contract_address)
             if not packed:
                 bt.logging.debug('Cannot get treasury stake: packed storage unavailable')
                 return 0

--- a/gittensor/validator/issue_competitions/storage_utils.py
+++ b/gittensor/validator/issue_competitions/storage_utils.py
@@ -36,13 +36,13 @@ class DecodedIssueStorage:
 
 def _extract_trie_id_bytes(contract_info) -> Optional[bytes]:
     """Extract contract trie ID bytes from substrate contract info."""
-    info = contract_info.value if hasattr(contract_info, "value") else contract_info
-    if not info or "trie_id" not in info:
+    info = contract_info.value if hasattr(contract_info, 'value') else contract_info
+    if not info or 'trie_id' not in info:
         return None
 
-    trie_id = info["trie_id"]  # type: ignore[call-overload]
+    trie_id = info['trie_id']  # type: ignore[call-overload]
     if isinstance(trie_id, str):
-        return bytes.fromhex(trie_id.replace("0x", ""))
+        return bytes.fromhex(trie_id.replace('0x', ''))
     if isinstance(trie_id, (tuple, list)):
         if len(trie_id) == 1 and isinstance(trie_id[0], (tuple, list)):
             trie_id = trie_id[0]
@@ -54,7 +54,7 @@ def _extract_trie_id_bytes(contract_info) -> Optional[bytes]:
 
 def get_contract_child_storage_key(substrate, contract_addr: str) -> Optional[str]:
     """Build the child storage key prefix for a deployed contract."""
-    contract_info = substrate.query("Contracts", "ContractInfoOf", [contract_addr])
+    contract_info = substrate.query('Contracts', 'ContractInfoOf', [contract_addr])
     if not contract_info:
         return None
 
@@ -62,19 +62,19 @@ def get_contract_child_storage_key(substrate, contract_addr: str) -> Optional[st
     if trie_id_bytes is None:
         return None
 
-    prefix = b":child_storage:default:"
-    return "0x" + (prefix + trie_id_bytes).hex()
+    prefix = b':child_storage:default:'
+    return '0x' + (prefix + trie_id_bytes).hex()
 
 
 def compute_ink5_lazy_key(root_key_hex: str, encoded_key: bytes) -> str:
     """Compute Ink! 5 mapping key using blake2_128concat."""
-    root_key = bytes.fromhex(root_key_hex.replace("0x", ""))
+    root_key = bytes.fromhex(root_key_hex.replace('0x', ''))
     data = root_key + encoded_key
     h = hashlib.blake2b(data, digest_size=16).digest()
-    return "0x" + (h + data).hex()
+    return '0x' + (h + data).hex()
 
 
-_PACKED_ROOT_STORAGE_KEY = compute_ink5_lazy_key("00000000", b"")
+_PACKED_ROOT_STORAGE_KEY = compute_ink5_lazy_key('00000000', b'')
 
 # owner (32) + treasury hotkey (32) + netuid (2) + next_issue_id (8) + alpha_pool (16)
 _PACKED_CONTRACT_STORAGE_SIZE = 32 + 32 + 2 + 8 + 16
@@ -82,13 +82,11 @@ _PACKED_CONTRACT_STORAGE_SIZE = 32 + 32 + 2 + 8 + 16
 
 def read_contract_packed_storage_bytes(substrate, child_key: str) -> Optional[bytes]:
     """Read packed root storage bytes from contract child storage."""
-    val_result = substrate.rpc_request(
-        "childstate_getStorage", [child_key, _PACKED_ROOT_STORAGE_KEY, None]
-    )
-    raw_hex = val_result.get("result")
+    val_result = substrate.rpc_request('childstate_getStorage', [child_key, _PACKED_ROOT_STORAGE_KEY, None])
+    raw_hex = val_result.get('result')
     if not raw_hex:
         return None
-    return bytes.fromhex(raw_hex.replace("0x", ""))
+    return bytes.fromhex(raw_hex.replace('0x', ''))
 
 
 def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorage]:
@@ -102,14 +100,14 @@ def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorag
         offset += 32
         treasury_hotkey = data[offset : offset + 32]
         offset += 32
-        netuid = struct.unpack_from("<H", data, offset)[0]
+        netuid = struct.unpack_from('<H', data, offset)[0]
         offset += 2
-        next_issue_id = struct.unpack_from("<Q", data, offset)[0]
+        next_issue_id = struct.unpack_from('<Q', data, offset)[0]
         offset += 8
-        alpha_pool_lo, alpha_pool_hi = struct.unpack_from("<QQ", data, offset)
+        alpha_pool_lo, alpha_pool_hi = struct.unpack_from('<QQ', data, offset)
         alpha_pool = alpha_pool_lo + (alpha_pool_hi << 64)
     except (struct.error, IndexError) as e:
-        logger.debug("Failed to decode packed contract storage: %s", e)
+        logger.debug('Failed to decode packed contract storage: %s', e)
         return None
 
     return PackedContractStorage(
@@ -121,9 +119,7 @@ def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorag
     )
 
 
-def read_contract_packed_storage(
-    substrate, contract_addr: str
-) -> Optional[PackedContractStorage]:
+def read_contract_packed_storage(substrate, contract_addr: str) -> Optional[PackedContractStorage]:
     """Read and decode packed root storage for a contract."""
     child_key = get_contract_child_storage_key(substrate, contract_addr)
     if not child_key:
@@ -140,7 +136,7 @@ def decode_issue_from_storage(data: bytes) -> Optional[DecodedIssueStorage]:
     """Decode one issue mapping value from contract child storage."""
     try:
         offset = 0
-        stored_issue_id = struct.unpack_from("<Q", data, offset)[0]
+        stored_issue_id = struct.unpack_from('<Q', data, offset)[0]
         offset += 8
 
         github_url_hash = data[offset : offset + 32]
@@ -157,24 +153,24 @@ def decode_issue_from_storage(data: bytes) -> Optional[DecodedIssueStorage]:
             str_len = 0
             offset += 1
 
-        repo_name = data[offset : offset + str_len].decode("utf-8", errors="replace")
+        repo_name = data[offset : offset + str_len].decode('utf-8', errors='replace')
         offset += str_len
 
-        issue_number = struct.unpack_from("<I", data, offset)[0]
+        issue_number = struct.unpack_from('<I', data, offset)[0]
         offset += 4
 
-        bounty_lo, bounty_hi = struct.unpack_from("<QQ", data, offset)
+        bounty_lo, bounty_hi = struct.unpack_from('<QQ', data, offset)
         bounty_amount = bounty_lo + (bounty_hi << 64)
         offset += 16
 
-        target_lo, target_hi = struct.unpack_from("<QQ", data, offset)
+        target_lo, target_hi = struct.unpack_from('<QQ', data, offset)
         target_bounty = target_lo + (target_hi << 64)
         offset += 16
 
         status_byte = data[offset]
         offset += 1
 
-        registered_at_block = struct.unpack_from("<I", data, offset)[0]
+        registered_at_block = struct.unpack_from('<I', data, offset)[0]
 
         return DecodedIssueStorage(
             id=stored_issue_id,
@@ -187,5 +183,5 @@ def decode_issue_from_storage(data: bytes) -> Optional[DecodedIssueStorage]:
             registered_at_block=registered_at_block,
         )
     except (IndexError, struct.error, ValueError) as e:
-        logger.debug("Failed to decode issue storage entry: %s", e)
+        logger.debug('Failed to decode issue storage entry: %s', e)
         return None

--- a/gittensor/validator/issue_competitions/storage_utils.py
+++ b/gittensor/validator/issue_competitions/storage_utils.py
@@ -36,13 +36,13 @@ class DecodedIssueStorage:
 
 def _extract_trie_id_bytes(contract_info) -> Optional[bytes]:
     """Extract contract trie ID bytes from substrate contract info."""
-    info = contract_info.value if hasattr(contract_info, 'value') else contract_info
-    if not info or 'trie_id' not in info:
+    info = contract_info.value if hasattr(contract_info, "value") else contract_info
+    if not info or "trie_id" not in info:
         return None
 
-    trie_id = info['trie_id']  # type: ignore[call-overload]
+    trie_id = info["trie_id"]  # type: ignore[call-overload]
     if isinstance(trie_id, str):
-        return bytes.fromhex(trie_id.replace('0x', ''))
+        return bytes.fromhex(trie_id.replace("0x", ""))
     if isinstance(trie_id, (tuple, list)):
         if len(trie_id) == 1 and isinstance(trie_id[0], (tuple, list)):
             trie_id = trie_id[0]
@@ -54,7 +54,7 @@ def _extract_trie_id_bytes(contract_info) -> Optional[bytes]:
 
 def get_contract_child_storage_key(substrate, contract_addr: str) -> Optional[str]:
     """Build the child storage key prefix for a deployed contract."""
-    contract_info = substrate.query('Contracts', 'ContractInfoOf', [contract_addr])
+    contract_info = substrate.query("Contracts", "ContractInfoOf", [contract_addr])
     if not contract_info:
         return None
 
@@ -62,40 +62,33 @@ def get_contract_child_storage_key(substrate, contract_addr: str) -> Optional[st
     if trie_id_bytes is None:
         return None
 
-    prefix = b':child_storage:default:'
-    return '0x' + (prefix + trie_id_bytes).hex()
+    prefix = b":child_storage:default:"
+    return "0x" + (prefix + trie_id_bytes).hex()
 
 
 def compute_ink5_lazy_key(root_key_hex: str, encoded_key: bytes) -> str:
     """Compute Ink! 5 mapping key using blake2_128concat."""
-    root_key = bytes.fromhex(root_key_hex.replace('0x', ''))
+    root_key = bytes.fromhex(root_key_hex.replace("0x", ""))
     data = root_key + encoded_key
     h = hashlib.blake2b(data, digest_size=16).digest()
-    return '0x' + (h + data).hex()
+    return "0x" + (h + data).hex()
 
 
-def find_packed_storage_key(substrate, child_key: str, page_size: int = 100) -> Optional[str]:
-    """Find the packed root storage key (suffix 00000000)."""
-    keys_result = substrate.rpc_request('childstate_getKeysPaged', [child_key, '0x', page_size, None, None])
-    keys = keys_result.get('result', [])
-    return next((key for key in keys if key.endswith('00000000')), None)
-
-
-def read_contract_packed_storage_bytes(substrate, child_key: str, page_size: int = 100) -> Optional[bytes]:
-    """Read packed root storage bytes from contract child storage."""
-    packed_key = find_packed_storage_key(substrate, child_key, page_size=page_size)
-    if not packed_key:
-        return None
-
-    val_result = substrate.rpc_request('childstate_getStorage', [child_key, packed_key, None])
-    raw_hex = val_result.get('result')
-    if not raw_hex:
-        return None
-    return bytes.fromhex(raw_hex.replace('0x', ''))
-
+_PACKED_ROOT_STORAGE_KEY = compute_ink5_lazy_key("00000000", b"")
 
 # owner (32) + treasury hotkey (32) + netuid (2) + next_issue_id (8) + alpha_pool (16)
 _PACKED_CONTRACT_STORAGE_SIZE = 32 + 32 + 2 + 8 + 16
+
+
+def read_contract_packed_storage_bytes(substrate, child_key: str) -> Optional[bytes]:
+    """Read packed root storage bytes from contract child storage."""
+    val_result = substrate.rpc_request(
+        "childstate_getStorage", [child_key, _PACKED_ROOT_STORAGE_KEY, None]
+    )
+    raw_hex = val_result.get("result")
+    if not raw_hex:
+        return None
+    return bytes.fromhex(raw_hex.replace("0x", ""))
 
 
 def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorage]:
@@ -109,14 +102,14 @@ def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorag
         offset += 32
         treasury_hotkey = data[offset : offset + 32]
         offset += 32
-        netuid = struct.unpack_from('<H', data, offset)[0]
+        netuid = struct.unpack_from("<H", data, offset)[0]
         offset += 2
-        next_issue_id = struct.unpack_from('<Q', data, offset)[0]
+        next_issue_id = struct.unpack_from("<Q", data, offset)[0]
         offset += 8
-        alpha_pool_lo, alpha_pool_hi = struct.unpack_from('<QQ', data, offset)
+        alpha_pool_lo, alpha_pool_hi = struct.unpack_from("<QQ", data, offset)
         alpha_pool = alpha_pool_lo + (alpha_pool_hi << 64)
     except (struct.error, IndexError) as e:
-        logger.debug('Failed to decode packed contract storage: %s', e)
+        logger.debug("Failed to decode packed contract storage: %s", e)
         return None
 
     return PackedContractStorage(
@@ -129,14 +122,14 @@ def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorag
 
 
 def read_contract_packed_storage(
-    substrate, contract_addr: str, page_size: int = 100
+    substrate, contract_addr: str
 ) -> Optional[PackedContractStorage]:
     """Read and decode packed root storage for a contract."""
     child_key = get_contract_child_storage_key(substrate, contract_addr)
     if not child_key:
         return None
 
-    packed_bytes = read_contract_packed_storage_bytes(substrate, child_key, page_size=page_size)
+    packed_bytes = read_contract_packed_storage_bytes(substrate, child_key)
     if not packed_bytes:
         return None
 
@@ -147,7 +140,7 @@ def decode_issue_from_storage(data: bytes) -> Optional[DecodedIssueStorage]:
     """Decode one issue mapping value from contract child storage."""
     try:
         offset = 0
-        stored_issue_id = struct.unpack_from('<Q', data, offset)[0]
+        stored_issue_id = struct.unpack_from("<Q", data, offset)[0]
         offset += 8
 
         github_url_hash = data[offset : offset + 32]
@@ -164,24 +157,24 @@ def decode_issue_from_storage(data: bytes) -> Optional[DecodedIssueStorage]:
             str_len = 0
             offset += 1
 
-        repo_name = data[offset : offset + str_len].decode('utf-8', errors='replace')
+        repo_name = data[offset : offset + str_len].decode("utf-8", errors="replace")
         offset += str_len
 
-        issue_number = struct.unpack_from('<I', data, offset)[0]
+        issue_number = struct.unpack_from("<I", data, offset)[0]
         offset += 4
 
-        bounty_lo, bounty_hi = struct.unpack_from('<QQ', data, offset)
+        bounty_lo, bounty_hi = struct.unpack_from("<QQ", data, offset)
         bounty_amount = bounty_lo + (bounty_hi << 64)
         offset += 16
 
-        target_lo, target_hi = struct.unpack_from('<QQ', data, offset)
+        target_lo, target_hi = struct.unpack_from("<QQ", data, offset)
         target_bounty = target_lo + (target_hi << 64)
         offset += 16
 
         status_byte = data[offset]
         offset += 1
 
-        registered_at_block = struct.unpack_from('<I', data, offset)[0]
+        registered_at_block = struct.unpack_from("<I", data, offset)[0]
 
         return DecodedIssueStorage(
             id=stored_issue_id,
@@ -194,5 +187,5 @@ def decode_issue_from_storage(data: bytes) -> Optional[DecodedIssueStorage]:
             registered_at_block=registered_at_block,
         )
     except (IndexError, struct.error, ValueError) as e:
-        logger.debug('Failed to decode issue storage entry: %s', e)
+        logger.debug("Failed to decode issue storage entry: %s", e)
         return None


### PR DESCRIPTION
## Summary

- **Decoder bug**: `read_contract_packed_storage_bytes` was using a heuristic ("first key ending in `00000000`" from a paged-10 batch) to find the contract's packed root cell. Once the contract's child trie grew enough entries, the heuristic silently picked an `issues[N]` mapping entry instead of the root, decoding 90 bytes of an issue struct as packed root and producing a junk `next_issue_id` of ~4.7e17. Both the validator forward pass and `gitt i list` aborted on the unreasonable-id guard, so cancel/solution votes never landed for any active issue (including [entrius/gittensor-ui#722](https://github.com/entrius/gittensor-ui/issues/722), the trigger for this investigation).
- Replaced the heuristic with `compute_ink5_lazy_key('00000000', b'')`, which derives the actual on-chain trie key via `blake2_128_concat` — exactly how `pallet-contracts` writes contract storage. Verified against a live finney probe: derived key matches the on-chain key bit-for-bit, and `gitt i list` now returns the live issues.
- **CLI bonus fix**: `resolve_network` consulted `ws_endpoint` from config before `network`, so a stale dev `ws_endpoint: ws://127.0.0.1:9944` silently overrode `network: finney` in the same config — users had to pass `--network finney` on every invocation. Swapped the two config branches; CLI flags still trump config, so private-RPC users are unaffected.

## Why

Issue 722 in entrius/gittensor-ui got merged with a PR by an ineligible miner; the validator should have voted to cancel the bounty but the bounty stayed `Active` and the UI kept showing it as "available." Validator logs surfaced `next_issue_id (469762048000000000) unreasonably large`, which `get_issues_by_status` early-returns on — so the forward loop processed 0 issues every cycle and never voted on anything.

## Test plan

- [x] `pytest tests/utils/test_issue_competitions_storage_utils.py` — 14/14 pass
- [x] `pytest tests/validator/test_contract_client_transactions.py tests/validator/test_issue_competitions_forward.py tests/cli/test_issues_list_json.py tests/cli/test_cli_json_error_output.py` — 38/38 pass
- [x] Live verification: `gitt i list --network finney` returns the populated issue list (was empty / warning before)
- [x] Live verification: `gitt i list` (no flag) resolves to finney via config after stale `ws_endpoint` removed
- [ ] Post-merge: confirm validator log shows `Found N active issues` (N>0) and `unreasonably large` warning is gone
- [ ] Post-merge: confirm cancel vote fires for #722 — `docker logs gt-vali | grep -E "gittensor-ui#722|not in eligible miners"`