### PR TITLE
fix: Retry malformed GitHub GraphQL 200 responses in PR fetch

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -601,6 +601,16 @@ def execute_graphql_query(
     return None
 
 
+def _graphql_response_body_preview(response: requests.Response, max_chars: int = 200) -> str:
+    """Return a compact preview for malformed GraphQL response bodies."""
+    try:
+        body = response.text or ''
+    except Exception as exc:
+        return f'<response body unavailable: {exc}>'
+
+    return ' '.join(body.split())[:max_chars]
+
+
 @dataclass
 class GraphQLPageResult:
     """Result of a paginated GraphQL query."""
@@ -659,8 +669,25 @@ def get_github_graphql_query(
                 # Check for RESOURCE_LIMITS_EXCEEDED in response body (GitHub returns 200 with errors)
                 try:
                     data = response.json()
-                except Exception:
-                    return GraphQLPageResult(response=response, page_size=limit)
+                except Exception as e:
+                    # Malformed 2xx body (HTML error page from a proxy, truncated JSON, ...)
+                    # is a transient transport failure - retry within this loop instead of
+                    # surfacing the bad response to the caller.
+                    preview = _graphql_response_body_preview(response)
+                    if attempt < (max_attempts - 1):
+                        backoff_delay = backoff_seconds(attempt)
+                        bt.logging.warning(
+                            f'GraphQL 200 response with malformed JSON '
+                            f'(attempt {attempt + 1}/{max_attempts}): {e}; body preview: {preview!r}; '
+                            f'retrying in {backoff_delay}s...'
+                        )
+                        time.sleep(backoff_delay)
+                        continue
+                    bt.logging.error(
+                        f'GraphQL 200 response with malformed JSON after {max_attempts} attempts: '
+                        f'{e}; body preview: {preview!r}'
+                    )
+                    return GraphQLPageResult(response=None, page_size=limit)
 
                 if _has_resource_limit_errors(data):
                     if attempt < (max_attempts - 1):

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -348,6 +348,45 @@ class TestGraphQLRetryLogic:
         mock_sleep.assert_has_calls(expected_delays)
         assert mock_sleep.call_count == 7, 'Should sleep 7 times for 8 attempts'
 
+    @patch('gittensor.utils.github_api_tools.requests.post')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_malformed_200_then_success_retries(self, mock_logging, mock_sleep, mock_post, graphql_params):
+        """Malformed JSON on a 200 response should be retried, not surfaced to the caller."""
+        bad_response = Mock(status_code=200, text='<html>bad gateway</html>')
+        bad_response.json.side_effect = ValueError('Expecting value')
+
+        good_response = Mock(status_code=200)
+        good_response.json.return_value = {'data': {}}
+
+        mock_post.side_effect = [bad_response, good_response]
+
+        result = get_github_graphql_query(**graphql_params)
+
+        assert mock_post.call_count == 2, 'Should retry once after malformed JSON'
+        assert mock_sleep.call_count == 1, 'Should sleep once between retries'
+        assert result.response is good_response, 'Should return the good response on retry success'
+        mock_sleep.assert_has_calls([call(5)])
+        mock_logging.warning.assert_called()
+
+    @patch('gittensor.utils.github_api_tools.requests.post')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_persistent_malformed_200_returns_none_after_max_attempts(
+        self, mock_logging, mock_sleep, mock_post, graphql_params
+    ):
+        """If every attempt returns a malformed 200, the function exhausts retries and returns response=None."""
+        bad_response = Mock(status_code=200, text='<html>bad gateway</html>')
+        bad_response.json.side_effect = ValueError('Expecting value')
+        mock_post.return_value = bad_response
+
+        result = get_github_graphql_query(**graphql_params)
+
+        assert mock_post.call_count == 8, 'Should try exactly 8 times'
+        assert mock_sleep.call_count == 7, 'Should sleep 7 times between attempts'
+        assert result.response is None, 'Should not surface the malformed response to the caller'
+        mock_logging.error.assert_called()
+
 
 # ============================================================================
 # Other GitHub API Functions Tests
@@ -1227,6 +1266,37 @@ class TestLoadMinersPrsFetchFailureSignal:
 
         assert miner_eval.github_pr_fetch_failed is True
         assert miner_eval.failed_reason == 'GitHub GraphQL error: Something went wrong'
+
+    @patch('gittensor.utils.github_api_tools.requests.post')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_malformed_200_recovery_does_not_set_fetch_failed(self, mock_logging, mock_sleep, mock_post):
+        """A transient malformed 200 followed by a valid 200 should not mark the miner as failed."""
+        from gittensor.classes import MinerEvaluation
+
+        bad_response = Mock(status_code=200, text='<html>bad gateway</html>')
+        bad_response.json.side_effect = ValueError('Expecting value')
+
+        good_response = Mock(status_code=200)
+        good_response.json.return_value = {
+            'data': {
+                'node': {
+                    'issues': {'totalCount': 0},
+                    'pullRequests': {
+                        'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                        'nodes': [],
+                    },
+                }
+            }
+        }
+        mock_post.side_effect = [bad_response, good_response]
+
+        miner_eval = MinerEvaluation(uid=1, hotkey='hk', github_id='123', github_pat='token')
+
+        load_miners_prs(miner_eval, {}, max_prs=10)
+
+        assert miner_eval.github_pr_fetch_failed is False
+        assert mock_post.call_count == 2, 'Helper should retry the malformed 200 internally'
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes the GitHub PR-list GraphQL retry path so malformed HTTP 200 responses are handled as transient fetch failures instead of being returned to the caller as usable responses.

Previously, if GitHub or a proxy returned a 200 response with invalid JSON, `get_github_graphql_query()` returned that bad response immediately. `load_miners_prs()` then failed while parsing it and marked the PR fetch as failed after a single request.

This change keeps malformed 200 JSON inside the existing retry loop. It logs a short response-body preview, retries with backoff, and only returns `response=None` after all attempts are exhausted.

Close: #1036 

## Changes

- Added a small helper to create compact previews of malformed GraphQL response bodies.
- Retried malformed HTTP 200 GraphQL JSON responses in `get_github_graphql_query()`.
- Returned `GraphQLPageResult(response=None, page_size=limit)` only after retry exhaustion.
- Added tests for retry success, retry exhaustion, and the `load_miners_prs()` caller behavior.

## Testing

```bash
uv run pytest tests/utils/test_github_api_tools.py
uv run ruff check gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py
uv run ruff format --check gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py
```
