### PR TITLE
fix: require same-repo linked issues for issue multiplier

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -258,6 +258,14 @@ class PullRequest:
         for issue in raw_issues:
             if is_merged and not (issue.get('closedAt') and issue.get('state') == 'CLOSED'):
                 continue
+            issue_repo = ((issue.get('repository') or {}).get('nameWithOwner') or '').lower()
+            if issue_repo and issue_repo != repository_full_name:
+                bt.logging.warning(
+                    f'Skipping issue #{issue.get("number")} - cross-repo link '
+                    f'(issue in {issue_repo}, PR in {repository_full_name})'
+                )
+                continue
+            issue_repository_full_name = issue_repo or repository_full_name
             issue_author = issue.get('author') or {}
             author_db_id = issue_author.get('databaseId')
 
@@ -288,7 +296,7 @@ class PullRequest:
                 Issue(
                     number=issue['number'],
                     pr_number=pr_data['number'],
-                    repository_full_name=repository_full_name,
+                    repository_full_name=issue_repository_full_name,
                     title=issue['title'],
                     created_at=parse_github_timestamp_to_cst(issue['createdAt']) if issue.get('createdAt') else None,
                     closed_at=parse_github_timestamp_to_cst(issue['closedAt']) if issue.get('closedAt') else None,

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -97,6 +97,7 @@ QUERY = """
                   createdAt
                   closedAt
                   updatedAt
+                  repository { nameWithOwner }
                   author {
                     login
                     ... on User { databaseId }

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -96,6 +96,71 @@ def test_is_test_file_detects_conftest_at_any_depth(filename):
     assert _file_change(filename).is_test_file() is True
 
 
+def _issue_node(number: int, name_with_owner=None):
+    node = {
+        'number': number,
+        'title': f'Issue #{number}',
+        'state': 'CLOSED',
+        'stateReason': 'COMPLETED',
+        'createdAt': '2026-04-01T00:00:00Z',
+        'closedAt': '2026-04-16T00:00:00Z',
+        'updatedAt': '2026-04-16T00:00:00Z',
+        'author': {'login': 'maintainer_b', 'databaseId': 999},
+        'authorAssociation': 'OWNER',
+        'userContentEdits': {'nodes': []},
+        'timelineItems': {'nodes': []},
+    }
+    if name_with_owner is not None:
+        node['repository'] = {'nameWithOwner': name_with_owner}
+    return node
+
+
+def _pr_data_with_issues(issue_nodes):
+    return {
+        'number': 42,
+        'repository': {'owner': {'login': 'entrius'}, 'name': 'gittensor'},
+        'state': 'MERGED',
+        'closingIssuesReferences': {'nodes': issue_nodes},
+        'bodyText': 'fixes things',
+        'lastEditedAt': None,
+        'mergedAt': '2026-04-16T00:00:00Z',
+        'timelineItems': {'nodes': []},
+        'title': 'fix: things',
+        'author': {'login': 'miner'},
+        'authorAssociation': 'CONTRIBUTOR',
+        'createdAt': '2026-04-15T00:00:00Z',
+        'additions': 3,
+        'deletions': 1,
+        'commits': {'totalCount': 1},
+        'headRefOid': 'abc123',
+        'baseRefOid': 'def456',
+    }
+
+
+def test_pull_request_skips_cross_repo_closing_issue_references():
+    pr_data = _pr_data_with_issues(
+        [
+            _issue_node(1, 'entrius/gittensor'),
+            _issue_node(2, 'entrius/other-repo'),
+            _issue_node(3, 'ENTRIUS/Gittensor'),
+        ]
+    )
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.issues is not None
+    assert sorted(i.number for i in pr.issues) == [1, 3]
+
+
+def test_pull_request_keeps_issue_when_repository_field_missing():
+    pr_data = _pr_data_with_issues([_issue_node(7)])
+
+    pr = PullRequest.from_graphql_response(pr_data, uid=1, hotkey='5Hotkey', github_id='123')
+
+    assert pr.issues is not None
+    assert [i.number for i in pr.issues] == [7]
+
+
 def test_pull_request_handles_deleted_label_event():
     pr_data = {
         'number': 42,


### PR DESCRIPTION
## Summary

GitHub can surface cross-repository `closes owner/repo#N` links in `closingIssuesReferences`. The validator previously constructed those linked issues with the PR's repository name, even when GitHub provided that the issue actually belonged to another repo. That allowed a cross-repo issue to grant an issue multiplier to a PR in a different repository.

This PR narrows the fix to the legacy OSS issue-multiplier path: it fetches `repository { nameWithOwner }` for each linked issue in the main PR GraphQL query and skips only issue nodes whose repository is known and different from the PR repo. Older cached/payload shapes without `repository` identity are still accepted by falling back to the PR repo, so existing same-repo issue multiplier behavior is preserved.

Out of scope: bounty solver cross-reference filtering is left to #1042, and mirror scoring is not changed because live mirror linked-issue payloads do not currently guarantee linked issue repository identity.

## Related Issues

Fixes #1019

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Commands run after narrowing the diff:

- `uv run pytest tests/test_classes.py -q`
- `uv run ruff check gittensor/classes.py gittensor/utils/github_api_tools.py tests/test_classes.py`
- `uv run ruff format --check gittensor/classes.py gittensor/utils/github_api_tools.py tests/test_classes.py`

Manual repro before the fix granted `1.66`; after the fix a known cross-repo issue is skipped and the multiplier remains `1.0`. A linked issue with missing repository identity is still kept for backward compatibility.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)