### PR TITLE
fix: evict duplicate-penalty cache snapshots

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -721,6 +721,12 @@ class MinerEvaluationCache:
 
         return self._isolate_for_downstream(cached.evaluation)
 
+    def evict_many(self, uids: Set[int]) -> None:
+        """Remove cached evaluations for all provided UIDs."""
+        for uid in uids:
+            if self._cache.pop(uid, None) is not None:
+                bt.logging.debug(f'Evicted cached evaluation for UID {uid}')
+
     @staticmethod
     def _build_cache_entry(evaluation: 'MinerEvaluation') -> 'MinerEvaluation':
         # Cached evaluations feed only the GitHub-fetch-failure fallback path

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -171,6 +171,9 @@ async def get_rewards(
     # removed from cached_uids and their zeroed scores are written to DB.
     penalized_uids = detect_and_penalize_miners_sharing_github(miner_evaluations)
     cached_uids -= penalized_uids
+    # The cache store path ran before the penalty. Drop those snapshots so a
+    # future fetch failure cannot restore pre-penalty PR scores.
+    self.evaluation_cache.evict_many(penalized_uids)
 
     # Finalize scores: apply eligibility gate, credibility, pioneer dividends, collateral
     finalize_miner_scores(miner_evaluations, master_repositories)

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -1,29 +1,36 @@
 # Entrius 2025
 
+import asyncio
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import cast
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from gittensor.classes import FileChange, Issue, MinerEvaluation, MinerEvaluationCache, PRState, PullRequest
 from gittensor.utils.github_api_tools import GraphQLPageResult, load_miners_prs
 from gittensor.utils.mirror.models import MirrorFile, MirrorPullRequest, MirrorReviewSummary
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
+from gittensor.validator.oss_contributions.reward import get_rewards
 from neurons.validator import Validator
 
 
 class _DummyValidator:
     def __init__(self):
         self.evaluation_cache = MinerEvaluationCache()
+        self.metagraph = SimpleNamespace(hotkeys=[])
+
+    def store_or_use_cached_evaluation(self, miner_evaluations):
+        return Validator.store_or_use_cached_evaluation(cast(Validator, self), miner_evaluations)
 
 
-def _make_pr(uid: int) -> PullRequest:
+def _make_pr(uid: int, hotkey: str = 'hotkey_1', github_id: str = '12345') -> PullRequest:
     now = datetime.now(timezone.utc)
     return PullRequest(
         number=1,
         repository_full_name='owner/repo',
         uid=uid,
-        hotkey='hotkey_1',
-        github_id='12345',
+        hotkey=hotkey,
+        github_id=github_id,
         title='cached pr',
         author_login='miner',
         merged_at=now,
@@ -38,9 +45,11 @@ def _build_eval(
     merged_prs: int,
     fetch_failed: bool,
     mirror_pr_fetch_failed: bool = False,
+    hotkey: str = 'hotkey_1',
+    github_id: str = '12345',
 ) -> MinerEvaluation:
-    eval_ = MinerEvaluation(uid=uid, hotkey='hotkey_1', github_id='12345')
-    eval_.merged_pull_requests = [_make_pr(uid) for _ in range(merged_prs)]
+    eval_ = MinerEvaluation(uid=uid, hotkey=hotkey, github_id=github_id)
+    eval_.merged_pull_requests = [_make_pr(uid, hotkey=hotkey, github_id=github_id) for _ in range(merged_prs)]
     eval_.github_pr_fetch_failed = fetch_failed
     eval_.mirror_pr_fetch_failed = mirror_pr_fetch_failed
     return eval_
@@ -113,6 +122,73 @@ class TestStoreOrUseCachedEvaluation:
         assert cached_uids == set()
         assert miner_evaluations[1] is current_eval
         assert miner_evaluations[1].total_prs == 0
+
+    def test_duplicate_penalty_evicts_pre_penalty_cache_entries(self):
+        validator = _DummyValidator()
+        validator.metagraph = SimpleNamespace(hotkeys=['unused', 'hotkey_1', 'hotkey_2'])
+        shared_github_id = 'shared-gh'
+
+        evaluations = {
+            1: _build_eval(
+                uid=1,
+                merged_prs=1,
+                fetch_failed=False,
+                hotkey='hotkey_1',
+                github_id=shared_github_id,
+            ),
+            2: _build_eval(
+                uid=2,
+                merged_prs=1,
+                fetch_failed=False,
+                hotkey='hotkey_2',
+                github_id=shared_github_id,
+            ),
+        }
+
+        async def evaluate(uid, *_args, **_kwargs):
+            return evaluations[uid]
+
+        with (
+            patch(
+                'gittensor.validator.oss_contributions.reward.pat_storage.load_all_pats',
+                return_value=[
+                    {'uid': 1, 'hotkey': 'hotkey_1', 'pat': 'pat_1'},
+                    {'uid': 2, 'hotkey': 'hotkey_2', 'pat': 'pat_2'},
+                ],
+            ),
+            patch(
+                'gittensor.validator.oss_contributions.reward.evaluate_miners_pull_requests',
+                new=AsyncMock(side_effect=evaluate),
+            ),
+        ):
+            _, _, cached_uids, penalized_uids = asyncio.run(
+                get_rewards(
+                    cast(Validator, validator),
+                    {1, 2},
+                    {},
+                    {},
+                    Mock(),
+                )
+            )
+
+        assert cached_uids == set()
+        assert penalized_uids == {1, 2}
+        assert validator.evaluation_cache.get(1, 'hotkey_1', shared_github_id) is None
+        assert validator.evaluation_cache.get(2, 'hotkey_2', shared_github_id) is None
+
+        future_eval = _build_eval(
+            uid=1,
+            merged_prs=0,
+            fetch_failed=True,
+            hotkey='hotkey_1',
+            github_id=shared_github_id,
+        )
+        future_evaluations = {1: future_eval}
+
+        future_cached_uids = Validator.store_or_use_cached_evaluation(cast(Validator, validator), future_evaluations)
+
+        assert future_cached_uids == set()
+        assert future_evaluations[1] is future_eval
 
 
 class TestMirrorFailureCacheFallback:


### PR DESCRIPTION
## Summary

Fixes #1039.

Duplicate-GitHub penalties currently run after `store_or_use_cached_evaluation()`. That means a miner can be cached with a successful, pre-penalty evaluation before `detect_and_penalize_miners_sharing_github()` zeroes the live round state.

This PR evicts cache entries for duplicate-penalized UIDs so future GitHub fetch-failure fallback cannot restore the old pre-penalty snapshot.

## Problem

`get_rewards()` currently performs cache store/restore before duplicate-account detection:

```python
cached_uids = self.store_or_use_cached_evaluation(miner_evaluations)
penalized_uids = detect_and_penalize_miners_sharing_github(miner_evaluations)
cached_uids -= penalized_uids
```

PR #600 fixed the current-round DB persistence path by removing penalized UIDs from `cached_uids`, so their zeroed evaluations are written to DB.

However, the in-memory cache entry itself was still left untouched. If the cache store path ran before the penalty, the cache could retain a pre-penalty evaluation with full PR buckets and `failed_reason=None`.

In a later round, if GitHub fetch fails for that UID and the duplicate partner is no longer present, cache fallback can restore that stale pre-penalty snapshot. Duplicate detection then no longer trips, so the old scores can re-enter the reward path.

## Fix

This PR adds explicit cache eviction for penalized UIDs:

- `MinerEvaluationCache.evict(uid)` removes one cached evaluation.
- `MinerEvaluationCache.evict_many(uids)` removes a set of cached evaluations.
- `get_rewards()` calls `self.evaluation_cache.evict_many(penalized_uids)` immediately after duplicate detection.

This keeps the existing ordering intact:

1. cache restore still happens before duplicate detection, so restored evaluations can still be inspected for persistent duplicates
2. duplicate penalty still runs before final scoring
3. penalized UIDs are still removed from `cached_uids` so current-round zeroed evaluations reach DB
4. pre-penalty cache snapshots are now removed so future fallback cannot resurrect them

## Changes

- Add `MinerEvaluationCache.evict()`.
- Add `MinerEvaluationCache.evict_many()`.
- Evict duplicate-penalized UIDs from the evaluation cache in `get_rewards()`.
- Add regression coverage for:
  - duplicate-penalized UIDs being removed from `cached_uids`
  - pre-penalty cache entries being evicted
  - a later fetch-failure round not restoring the old pre-penalty cached evaluation

## Testing

```bash
UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/validator/oss_contributions tests/validator/test_validator_cache_fallback.py tests/validator/test_duplicate_penalty_propagation.py -q
```

Result:

```text
134 passed
```

```bash
UV_CACHE_DIR=/tmp/uv-cache uv run ruff check gittensor/classes.py gittensor/validator/oss_contributions/reward.py tests/validator/test_validator_cache_fallback.py
UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check gittensor/classes.py gittensor/validator/oss_contributions/reward.py tests/validator/test_validator_cache_fallback.py
UV_CACHE_DIR=/tmp/uv-cache uv run pre-commit run --files gittensor/classes.py gittensor/validator/oss_contributions/reward.py tests/validator/test_validator_cache_fallback.py
git diff --check
```

All passed.

Also verified touched files with pyright using a temp config pointing at the local venv:

```bash
UV_CACHE_DIR=/tmp/uv-cache uv run pyright -p /tmp/pyright-gittensor-cache-fix.json
```

Result:

```text
0 errors, 0 warnings, 0 informations
```
