### PR TITLE
fix: filter cross-repo closing refs in bounty solver

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -424,7 +424,10 @@ query($owner: String!, $name: String!, $issueNumber: Int!) {
                 author { ... on User { databaseId login } }
                 baseRepository { nameWithOwner }
                 closingIssuesReferences(first: 20) {
-                  nodes { number }
+                  nodes {
+                    number
+                    repository { nameWithOwner }
+                  }
                 }
                 reviews(first: 1, states: APPROVED) { totalCount }
               }
@@ -445,6 +448,20 @@ def _resolve_pr_state(raw_state: str, merged: bool = False) -> str:
     return (raw_state or '').upper() or 'OPEN'
 
 
+def _closing_issue_numbers_for_repo(closing_ref: Optional[Dict[str, Any]], repo: str) -> List[int]:
+    """Return only closing issue numbers whose GraphQL repository matches ``repo``."""
+    target_repo = repo.lower()
+    closing_numbers: List[int] = []
+    for node in (closing_ref or {}).get('nodes') or []:
+        if not node:
+            continue
+        issue_number = node.get('number')
+        issue_repo = ((node.get('repository') or {}).get('nameWithOwner') or '').lower()
+        if issue_number is not None and issue_repo == target_repo:
+            closing_numbers.append(issue_number)
+    return closing_numbers
+
+
 def _search_issue_referencing_prs_graphql(
     repo: str, issue_number: int, token: str, open_only: bool = False
 ) -> Optional[List[PRInfo]]:
@@ -458,6 +475,7 @@ def _search_issue_referencing_prs_graphql(
     name = name.strip()
     if not owner or not name:
         return []
+    target_repo = f'{owner}/{name}'.lower()
 
     result = execute_graphql_query(
         query=_PR_TIMELINE_QUERY,
@@ -488,7 +506,7 @@ def _search_issue_referencing_prs_graphql(
             continue
 
         base_repo = pr.get('baseRepository', {}).get('nameWithOwner', '')
-        if base_repo.lower() != repo.lower():
+        if base_repo.lower() != target_repo:
             continue
 
         pr_number = pr.get('number')
@@ -501,8 +519,7 @@ def _search_issue_referencing_prs_graphql(
 
         author = pr.get('author') or {}
         reviews = pr.get('reviews') or {}
-        closing = pr.get('closingIssuesReferences', {}).get('nodes', [])
-        closing_numbers = [n.get('number') for n in closing if n.get('number') is not None]
+        closing_numbers = _closing_issue_numbers_for_repo(pr.get('closingIssuesReferences'), target_repo)
 
         pr_info: PRInfo = {
             'number': pr_number,

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -815,8 +815,21 @@ def _graphql_response(nodes):
     }
 
 
+def _closing_issue_node(number, repo='owner/repo'):
+    node = {'number': number}
+    if repo is not None:
+        node['repository'] = {'nameWithOwner': repo}
+    return node
+
+
 def _pr_node(
-    number, merged=True, merged_at='2025-06-01T00:00:00Z', user_id=42, base_repo='owner/repo', closing_issues=None
+    number,
+    merged=True,
+    merged_at='2025-06-01T00:00:00Z',
+    user_id=42,
+    base_repo='owner/repo',
+    closing_issues=None,
+    closing_repo='owner/repo',
 ):
     """Helper to build a single cross-referenced PR node."""
     return {
@@ -827,7 +840,7 @@ def _pr_node(
             'author': {'databaseId': user_id},
             'baseRepository': {'nameWithOwner': base_repo},
             'closingIssuesReferences': {
-                'nodes': [{'number': n} for n in (closing_issues or [])],
+                'nodes': [_closing_issue_node(n, closing_repo) for n in (closing_issues or [])],
             },
         },
     }
@@ -895,6 +908,36 @@ class TestFindSolverFromCrossReferences:
 
         assert solver_id is None
         assert pr_number is None
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_cross_repo_closing_issue_number_collision_is_filtered_out(self, mock_logging, mock_graphql):
+        """A PR closing another repo's same-numbered issue must not solve this bounty issue."""
+        mock_graphql.return_value = _graphql_response(
+            [
+                _pr_node(number=14, user_id=42, closing_issues=[12], closing_repo='other/repo'),
+            ]
+        )
+
+        solver_id, pr_number = find_solver_from_cross_references('owner/repo', 12, 'fake_token')
+
+        assert solver_id is None
+        assert pr_number is None
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_closing_issue_repo_check_is_case_insensitive(self, mock_logging, mock_graphql):
+        """GitHub repository names are case-insensitive when validating closing refs."""
+        mock_graphql.return_value = _graphql_response(
+            [
+                _pr_node(number=14, user_id=42, closing_issues=[12], closing_repo='Owner/Repo'),
+            ]
+        )
+
+        solver_id, pr_number = find_solver_from_cross_references('owner/repo', 12, 'fake_token')
+
+        assert solver_id == 42
+        assert pr_number == 14
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
     @patch('gittensor.utils.github_api_tools.bt.logging')


### PR DESCRIPTION
## Summary

`_PR_TIMELINE_QUERY` used by issue-bounty solver lookup fetched `closingIssuesReferences` as bare issue numbers. When a PR targeting the bounty repo closed a same-numbered issue in another repository, `find_solver_from_cross_references` could match by number alone and credit the wrong solver.

This PR adds `repository { nameWithOwner }` to the timeline query's `closingIssuesReferences` nodes and filters closing issue numbers to the bounty issue's repository before solver selection.

## Why

GitHub supports cross-repo closing syntax like `Closes owner/repo#N`. Without repository qualification, `other/repo#12` and `owner/repo#12` are indistinguishable to the bounty solver path. That can lead validators to call `vote_solution` for the wrong miner.

Closes #1041

## Changes

- Fetch repository identity for `_PR_TIMELINE_QUERY` closing issue references.
- Keep only closing issue numbers whose `repository.nameWithOwner` matches the bounty repo.
- Add regression coverage for same-number cross-repo collisions.
- Add coverage for case-insensitive repository matching.

## Testing

- `uv run pytest tests/utils/test_github_api_tools.py -k "cross_references or solver" -q`
- `uv run pytest tests/utils/test_github_api_tools.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pyright`
