### PR TITLE
fix: update gitt miner post to show the correct error for GitHub and network failures

### DIFF
--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -109,10 +109,13 @@ def _print(message: str, json_mode: bool) -> None:
         console.print(message)
 
 
-def _error(msg: str, json_mode: bool) -> None:
+def _error(msg: str, json_mode: bool, error_code: str | None = None) -> None:
     """Print an error message in the appropriate format."""
     if json_mode:
-        click.echo(json.dumps({'success': False, 'error': msg}))
+        payload = {'success': False, 'error': msg}
+        if error_code is not None:
+            payload['error_code'] = error_code
+        click.echo(json.dumps(payload))
     else:
         console.print(f'[red]Error: {msg}[/red]')
 

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import os
 import sys
+from dataclasses import dataclass
 
 import click
 import requests
@@ -31,15 +32,32 @@ from gittensor.cli.miner_commands.helpers import (
     _status,
 )
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
-from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
+from gittensor.utils.github_api_tools import _is_rate_limited_response, make_graphql_headers, make_headers
 
 console = Console()
+
+_INVALID_PAT_MESSAGE = 'GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.'
 
 _PAT_POST_STATUS_MARKUP = {
     'accepted': '[green]✓[/green]',
     'rejected': '[red]✗[/red]',
     'no_response': '[yellow]—[/yellow]',
 }
+
+
+@dataclass(frozen=True)
+class PatValidationResult:
+    is_valid: bool
+    error_code: str | None = None
+    error_message: str | None = None
+
+    @classmethod
+    def valid(cls) -> 'PatValidationResult':
+        return cls(is_valid=True)
+
+    @classmethod
+    def failed(cls, error_code: str | None, error_message: str) -> 'PatValidationResult':
+        return cls(is_valid=False, error_code=error_code, error_message=error_message)
 
 
 @click.command()
@@ -98,10 +116,14 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
 
     # 1b. Validate PAT locally
     with _status('[bold]Validating PAT...', json_mode):
-        pat_valid = _validate_pat_locally(pat)
+        pat_validation = _validate_pat_locally(pat)
 
-    if not pat_valid:
-        _error('GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.', json_mode)
+    if not pat_validation.is_valid:
+        _error(
+            pat_validation.error_message or _INVALID_PAT_MESSAGE,
+            json_mode,
+            error_code=pat_validation.error_code,
+        )
         sys.exit(1)
 
     _print('[green]PAT is valid.[/green]', json_mode)
@@ -193,16 +215,23 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         _render_skipped_validators(excluded, json_mode)
 
 
-def _validate_pat_locally(pat: str) -> bool:
+def _validate_pat_locally(pat: str) -> PatValidationResult:
     """Validate PAT mirrors the validator-side checks: user identity + GraphQL access."""
     try:
         # Check basic auth
         user_resp = requests.get(
             f'{BASE_GITHUB_API_URL}/user', headers=make_headers(pat), timeout=GITHUB_HTTP_TIMEOUT_SECONDS
         )
-        if user_resp.status_code != 200:
-            return False
+    except requests.RequestException as e:
+        return PatValidationResult.failed(
+            'github_network_error',
+            f'Failed to reach GitHub API: {e}. Check your network and retry.',
+        )
 
+    if user_resp.status_code != 200:
+        return _classify_user_lookup_failure(user_resp)
+
+    try:
         # Check GraphQL access (same test the validator runs during PAT broadcast)
         gql_resp = requests.post(
             f'{BASE_GITHUB_API_URL}/graphql',
@@ -214,8 +243,23 @@ def _validate_pat_locally(pat: str) -> bool:
             console.print(
                 '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
             )
-            return False
+            return PatValidationResult.failed(None, _INVALID_PAT_MESSAGE)
 
-        return True
+        return PatValidationResult.valid()
     except requests.RequestException:
-        return False
+        return PatValidationResult.failed(None, _INVALID_PAT_MESSAGE)
+
+
+def _classify_user_lookup_failure(response: requests.Response) -> PatValidationResult:
+    status_code = response.status_code
+    if _is_rate_limited_response(response):
+        return PatValidationResult.failed(
+            'github_rate_limited',
+            'GitHub API rate limit reached. Retry later.',
+        )
+    if status_code == 408 or 500 <= status_code <= 599:
+        return PatValidationResult.failed(
+            'github_unavailable',
+            f'GitHub API is currently unavailable (HTTP {status_code}). Retry in a few minutes.',
+        )
+    return PatValidationResult.failed('pat_invalid', _INVALID_PAT_MESSAGE)

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -4,9 +4,11 @@
 
 import json
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
+import requests
 from click.testing import CliRunner
 
 from gittensor import __version__
@@ -17,6 +19,7 @@ from gittensor.cli.miner_commands.helpers import (
     _pat_post_aggregate_counts,
     _pat_post_row_category,
 )
+from gittensor.cli.miner_commands.post import PatValidationResult, _validate_pat_locally
 
 
 def _fake_metagraph(rows: list[tuple[float, bool, float]]):
@@ -27,6 +30,20 @@ def _fake_metagraph(rows: list[tuple[float, bool, float]]):
         validator_trust=[vt for vt, _, _ in rows],
         S=[stake for _, _, stake in rows],
         axons=[SimpleNamespace(is_serving=serving, hotkey=f'5Hk{i:02d}') for i, (_, serving, _) in enumerate(rows)],
+    )
+
+
+def _response(status_code: int, *, headers: Optional[dict] = None, body: bytes = b'{}') -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers.update(headers or {})
+    response._content = body
+    return response
+
+
+def _invalid_pat_result() -> PatValidationResult:
+    return PatValidationResult.failed(
+        'pat_invalid', 'GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.'
     )
 
 
@@ -48,7 +65,7 @@ class TestMinerPost:
         output = json.loads(result.output)
         assert output['success'] is False
 
-    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=_invalid_pat_result())
     def test_pat_flag_used(self, mock_validate, runner, monkeypatch):
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
         result = runner.invoke(cli, ['miner', 'post', '--pat', 'ghp_test123', '--wallet', 'test', '--hotkey', 'test'])
@@ -56,12 +73,111 @@ class TestMinerPost:
         assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
         mock_validate.assert_called_once_with('ghp_test123')
 
-    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=False)
+    @patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=_invalid_pat_result())
     def test_invalid_pat_exits(self, mock_validate, runner, monkeypatch):
         monkeypatch.setenv('GITTENSOR_MINER_PAT', 'ghp_invalid')
         result = runner.invoke(cli, ['miner', 'post', '--wallet', 'test', '--hotkey', 'test'])
         assert result.exit_code != 0
         assert 'invalid' in result.output.lower() or 'expired' in result.output.lower()
+
+    def test_local_pat_validation_classifies_invalid_user_auth(self):
+        with patch('gittensor.cli.miner_commands.post.requests.get', return_value=_response(401)):
+            result = _validate_pat_locally('ghp_invalid')
+
+        assert result.is_valid is False
+        assert result.error_code == 'pat_invalid'
+        assert result.error_message is not None
+        assert 'invalid or expired' in result.error_message
+
+    def test_local_pat_validation_classifies_github_unavailable(self):
+        with patch('gittensor.cli.miner_commands.post.requests.get', return_value=_response(500)):
+            result = _validate_pat_locally('ghp_valid')
+
+        assert result.is_valid is False
+        assert result.error_code == 'github_unavailable'
+        assert result.error_message is not None
+        assert 'HTTP 500' in result.error_message
+
+    def test_local_pat_validation_classifies_github_timeout_status(self):
+        with patch('gittensor.cli.miner_commands.post.requests.get', return_value=_response(408)):
+            result = _validate_pat_locally('ghp_valid')
+
+        assert result.is_valid is False
+        assert result.error_code == 'github_unavailable'
+        assert result.error_message is not None
+        assert 'HTTP 408' in result.error_message
+
+    def test_local_pat_validation_classifies_rate_limit_status(self):
+        with patch('gittensor.cli.miner_commands.post.requests.get', return_value=_response(429)):
+            result = _validate_pat_locally('ghp_valid')
+
+        assert result.is_valid is False
+        assert result.error_code == 'github_rate_limited'
+
+    def test_local_pat_validation_classifies_rate_limited_403(self):
+        response = _response(403, headers={'x-ratelimit-remaining': '0'})
+        with patch('gittensor.cli.miner_commands.post.requests.get', return_value=response):
+            result = _validate_pat_locally('ghp_valid')
+
+        assert result.is_valid is False
+        assert result.error_code == 'github_rate_limited'
+
+    def test_local_pat_validation_classifies_network_error(self):
+        with patch('gittensor.cli.miner_commands.post.requests.get', side_effect=requests.Timeout('timed out')):
+            result = _validate_pat_locally('ghp_valid')
+
+        assert result.is_valid is False
+        assert result.error_code == 'github_network_error'
+        assert result.error_message is not None
+        assert 'timed out' in result.error_message
+
+    def test_local_pat_validation_keeps_graphql_permission_behavior(self):
+        with (
+            patch('gittensor.cli.miner_commands.post.requests.get', return_value=_response(200)),
+            patch('gittensor.cli.miner_commands.post.requests.post', return_value=_response(403)),
+        ):
+            result = _validate_pat_locally('ghp_no_graphql_access')
+
+        assert result.is_valid is False
+        assert result.error_code is None
+        assert result.error_message is not None
+        assert 'invalid or expired' in result.error_message
+
+    def test_local_pat_validation_keeps_graphql_network_error_behavior(self):
+        with (
+            patch('gittensor.cli.miner_commands.post.requests.get', return_value=_response(200)),
+            patch('gittensor.cli.miner_commands.post.requests.post', side_effect=requests.Timeout('timed out')),
+        ):
+            result = _validate_pat_locally('ghp_valid')
+
+        assert result.is_valid is False
+        assert result.error_code is None
+        assert result.error_message is not None
+        assert 'invalid or expired' in result.error_message
+
+    def test_json_mode_includes_error_code_for_local_network_failure(self, runner, monkeypatch):
+        monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+        with patch('gittensor.cli.miner_commands.post.requests.get', side_effect=requests.Timeout('timed out')):
+            result = runner.invoke(
+                cli,
+                [
+                    'miner',
+                    'post',
+                    '--json-output',
+                    '--pat',
+                    'ghp_validToken',
+                    '--wallet',
+                    'alice',
+                    '--hotkey',
+                    'default',
+                ],
+            )
+
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output['success'] is False
+        assert output['error_code'] == 'github_network_error'
+        assert 'timed out' in output['error']
 
     def test_help_text(self, runner):
         result = runner.invoke(cli, ['miner', 'post', '--help'])
@@ -96,7 +212,7 @@ class TestMinerPost:
                 return responses
 
         with (
-            patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=True),
+            patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value=PatValidationResult.valid()),
             patch(
                 'gittensor.cli.miner_commands.post._connect_bittensor',
                 return_value=(wallet, object(), metagraph, FakeDendrite()),


### PR DESCRIPTION
## Summary

Fix `gitt miner post` so GitHub `/user` preflight failures are reported with the correct reason instead of always saying the PAT is invalid.

`_validate_pat_locally()` returned only `True` or `False`, so these different failures all produced the same message:

> GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.

That message is correct for a bad token, but misleading for GitHub downtime, rate limiting, timeouts, DNS failures, or other network problems.

This change preserves the real `/user` failure reason and adds machine-readable JSON error codes for automation.

Close: #1046

## Changes

- Return a structured PAT validation result instead of a bare boolean.
- Classify `/user` failures as:
  - `pat_invalid`
  - `github_unavailable`
  - `github_rate_limited`
  - `github_network_error`
- Include `error_code` in JSON output when the failure has a machine-readable reason.
- Keep the existing GraphQL permission-check behavior unchanged.

## Testing

```bash
pytest tests/cli/test_miner_commands.py -q
pytest tests/ -q
ruff check gittensor/cli/miner_commands/helpers.py gittensor/cli/miner_commands/post.py tests/cli/test_miner_commands.py
```

Manual timeout repro now returns:

```json
{
  "success": false,
  "error": "Failed to reach GitHub API: timed out. Check your network and retry.",
  "error_code": "github_network_error"
}
```
