### PR TITLE
fix: Legacy label fallback still truncates current labels

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -124,7 +124,7 @@ QUERY = """
                   authorAssociation
                 }
               }
-              labels(first: 5) {
+              labels(first: 50) {
                 nodes { name }
               }
               timelineItems(itemTypes: [LABELED_EVENT], last: 5) {

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -36,6 +36,16 @@ check_github_issue_closed = github_api_tools.check_github_issue_closed
 
 
 # ============================================================================
+# GraphQL Query Shape Tests
+# ============================================================================
+
+
+def test_pull_request_query_fetches_enough_current_labels_for_fallback():
+    assert 'labels(first: 50)' in github_api_tools.QUERY
+    assert 'labels(first: 5)' not in github_api_tools.QUERY
+
+
+# ============================================================================
 # Fixtures
 # ============================================================================
 


### PR DESCRIPTION
## Summary
Fixed the legacy GitHub GraphQL PR query so current PR labels are no longer truncated to only 5 labels.
The query now fetches:
```graphql
labels(first: 50)
```
instead of:
```graphql
labels(first: 5)
```
This makes the label fallback more reliable for PRs with many labels.
## Related Issue
Fixes: #1048 
## Problem
The legacy scoring path uses currently-applied labels as a fallback when the relevant `LABELED_EVENT` is missing from the limited timeline window.

Before this change, that fallback was also limited because `current_labels` came from `labels(first: 5)`. A scoring label applied to a PR could be missed if the PR had more than 5 labels.

## Real Behavior Proof
Before:
```graphql
labels(first: 5) {
  nodes { name }
}
```
After:
```graphql
labels(first: 50) {
  nodes { name }
}
```
This directly fixes the fallback source by allowing up to 50 current labels to be considered.
## Expected Behavior
A PR with more than 5 labels can still receive the correct label multiplier if its scoring label is currently applied and appears within the first 50 labels returned by GitHub.
## Impact
This reduces false default label scoring on heavily labeled PRs.
It is especially useful for the label fallback path, where the scoring label event may no longer appear in `timelineItems(last: 5)`.
## Validation Notes
Syntax validation passed:
```bash
python3 -m py_compile gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py
```
Focused pytest could not be run because `pytest` is not installed in the environment:

```text
/usr/bin/python3: No module named pytest
```
## Remaining Consideration
This fix greatly improves the fallback, but it is still not full pagination. If a PR has more than 50 labels and the scoring label appears after the first 50, it could still be missed. Full correctness would require paginating the labels connection.