### PR TITLE
fix: use GitHub IDs for legacy self-issue gate

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -472,11 +472,15 @@ def is_valid_issue(issue: Issue, pr: PullRequest) -> bool:
     """Check if issue is valid for bonus calculation (works for both merged and open PRs)."""
     is_merged = pr.pr_state == PRState.MERGED
 
-    if not issue.author_login:
+    if not issue.author_github_id and not issue.author_login:
         bt.logging.warning(f'Skipping issue #{issue.number} - Issue is missing author information')
         return False
 
-    if issue.author_login == pr.author_login:
+    if issue.author_github_id and pr.github_id and pr.github_id != '0':
+        if issue.author_github_id == pr.github_id:
+            bt.logging.warning(f'Skipping issue #{issue.number} - Issue has same author as PR (self-created issue)')
+            return False
+    elif issue.author_login == pr.author_login:
         bt.logging.warning(f'Skipping issue #{issue.number} - Issue has same author as PR (self-created issue)')
         return False
 

--- a/tests/validator/test_is_valid_issue.py
+++ b/tests/validator/test_is_valid_issue.py
@@ -77,6 +77,59 @@ class TestIsValidIssueCloseWindow:
         assert is_valid_issue(issue, pr) is expected
 
 
+class TestIsValidIssueSelfAuthorGate:
+    def test_rejects_same_github_id_when_logins_differ(self, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now, uid=42)
+        pr.author_login = 'renamed_miner'
+        pr.github_id = '12345'
+        pr.created_at = now - timedelta(days=1)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_github_id='12345',
+            author_login='old_miner_login',
+            created_at=now - timedelta(days=5),
+            closed_at=now,
+        )
+
+        assert is_valid_issue(issue, pr) is False
+
+    def test_missing_github_ids_falls_back_to_login_check(self, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'miner_user'
+        pr.github_id = None
+        pr.created_at = now - timedelta(days=1)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_github_id=None,
+            author_login='miner_user',
+            created_at=now - timedelta(days=5),
+            closed_at=now,
+        )
+
+        assert is_valid_issue(issue, pr) is False
+
+    def test_different_github_ids_allow_otherwise_valid_issue(self, pr_factory, issue_factory):
+        now = datetime.now(timezone.utc)
+        pr = pr_factory.merged(merged_at=now)
+        pr.author_login = 'same_visible_login'
+        pr.github_id = '12345'
+        pr.created_at = now - timedelta(days=1)
+        pr.last_edited_at = None
+
+        issue = issue_factory.create(
+            author_github_id='67890',
+            author_login='same_visible_login',
+            created_at=now - timedelta(days=5),
+            closed_at=now,
+        )
+
+        assert is_valid_issue(issue, pr) is True
+
+
 class TestIsValidIssueOpenPRCollateral:
     @pytest.mark.parametrize(
         'state_reason,expected',


### PR DESCRIPTION
## Summary

Closes #1049.

Updates the legacy issue multiplier self-issue gate to prefer immutable GitHub IDs when both the PR/miner GitHub ID and linked issue author GitHub ID are available. This aligns legacy OSS scoring with mirror scoring while preserving the existing login fallback for incomplete legacy data.

## Changes

- Use `issue.author_github_id == pr.github_id` for legacy self-issue detection when both IDs are present.
- Keep login comparison as a fallback when GitHub IDs are unavailable.
- Add regression tests for ID-based rejection, missing-ID fallback, and different-ID valid issues.

## Testing

```bash
python3 -m pytest tests/validator/test_is_valid_issue.py
python3 -m ruff check gittensor/validator/oss_contributions/scoring.py tests/validator/test_is_valid_issue.py
python3 -m ruff format --check gittensor/validator/oss_contributions/scoring.py tests/validator/test_is_valid_issue.py
pyright gittensor/validator/oss_contributions/scoring.py tests/validator/test_is_valid_issue.py
```
