### PR TITLE
fix: paginate CHANGES_REQUESTED reviews past inline cap to count hidden maintainer reviews (#1053)

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -38,6 +38,7 @@ from gittensor.validator.utils.load_weights import RepositoryConfig
 
 # Beyond this many CHANGES_REQUESTED reviews the quality multiplier is already 0
 _MAX_CHANGES_REQUESTED_REVIEWS = ceil(1 / REVIEW_PENALTY_RATE)
+_CHANGES_REQUESTED_REVIEWS_PAGE_SIZE = 100
 
 
 class GitHubIdentityStatus(Enum):
@@ -137,6 +138,10 @@ QUERY = """
                 nodes {
                   authorAssociation
                 }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
               labels(first: 5) {
                 nodes { name }
@@ -149,6 +154,24 @@ QUERY = """
                   }
                 }
               }
+            }
+          }
+        }
+      }
+    }
+    """
+
+_CHANGES_REQUESTED_REVIEWS_QUERY = """
+    query($owner: String!, $name: String!, $pullNumber: Int!, $cursor: String, $limit: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $pullNumber) {
+          changesRequestedReviews: reviews(first: $limit, states: CHANGES_REQUESTED, after: $cursor) {
+            nodes {
+              authorAssociation
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
             }
           }
         }
@@ -781,11 +804,81 @@ def _has_resource_limit_errors(data: Dict) -> bool:
     return any(isinstance(e, dict) and e.get('type') == 'RESOURCE_LIMITS_EXCEEDED' for e in errors)
 
 
+def _count_maintainer_changes_requested_nodes(nodes: List[Dict]) -> int:
+    return sum(1 for review in nodes if review.get('authorAssociation') in MAINTAINER_ASSOCIATIONS)
+
+
+def _complete_changes_requested_reviews_if_needed(pr_raw: Dict, token: Optional[str]) -> None:
+    """Fetch later CHANGES_REQUESTED pages only when the inline capped window is ambiguous."""
+    if not token:
+        return
+
+    reviews = pr_raw.get('changesRequestedReviews')
+    if not isinstance(reviews, dict):
+        return
+
+    nodes = reviews.get('nodes')
+    if not isinstance(nodes, list):
+        return
+
+    maintainer_count = _count_maintainer_changes_requested_nodes(nodes)
+    page_info = reviews.get('pageInfo') or {}
+    cursor = page_info.get('endCursor')
+    has_next_page = bool(page_info.get('hasNextPage'))
+
+    if maintainer_count >= _MAX_CHANGES_REQUESTED_REVIEWS or not (has_next_page and cursor):
+        return
+
+    repository = pr_raw.get('repository') or {}
+    owner = (repository.get('owner') or {}).get('login')
+    name = repository.get('name')
+    pull_number = pr_raw.get('number')
+    if not (owner and name and pull_number):
+        return
+
+    while has_next_page and cursor and maintainer_count < _MAX_CHANGES_REQUESTED_REVIEWS:
+        data = execute_graphql_query(
+            _CHANGES_REQUESTED_REVIEWS_QUERY,
+            {
+                'owner': owner,
+                'name': name,
+                'pullNumber': pull_number,
+                'cursor': cursor,
+                'limit': _CHANGES_REQUESTED_REVIEWS_PAGE_SIZE,
+            },
+            token,
+            max_attempts=3,
+        )
+        if not data or data.get('errors'):
+            bt.logging.warning(
+                f'Could not complete CHANGES_REQUESTED review pages for PR #{pull_number} in {owner}/{name}'
+            )
+            return
+
+        next_reviews = (((data.get('data') or {}).get('repository') or {}).get('pullRequest') or {}).get(
+            'changesRequestedReviews'
+        )
+        if not isinstance(next_reviews, dict):
+            return
+
+        next_nodes = next_reviews.get('nodes') or []
+        if not isinstance(next_nodes, list):
+            return
+
+        nodes.extend(next_nodes)
+        maintainer_count += _count_maintainer_changes_requested_nodes(next_nodes)
+        next_page_info = next_reviews.get('pageInfo') or {}
+        next_cursor = next_page_info.get('endCursor')
+        has_next_page = bool(next_page_info.get('hasNextPage')) and next_cursor != cursor
+        cursor = next_cursor
+
+
 def try_add_open_or_closed_pr(
     miner_eval: MinerEvaluation,
     pr_raw: Dict,
     pr_state: str,
     lookback_date_filter: datetime,
+    token: Optional[str] = None,
 ) -> None:
     """
     Attempts to add an OPEN or CLOSED PR to miner_eval if eligible.
@@ -795,12 +888,14 @@ def try_add_open_or_closed_pr(
         pr_raw: Raw PR data from GraphQL
         pr_state: GitHub PR state (OPEN, CLOSED, MERGED)
         lookback_date_filter: Date filter for lookback period
+        token: GitHub PAT used for follow-up review-page completion when needed
     """
     # Ignore all maintainer contributions
     if not os.environ.get('DEV_MODE') and pr_raw.get('authorAssociation') in MAINTAINER_ASSOCIATIONS:
         return
 
     if pr_state == PRState.OPEN.value:
+        _complete_changes_requested_reviews_if_needed(pr_raw, token)
         miner_eval.add_open_pull_request(pr_raw)
 
     if pr_state == PRState.CLOSED.value:
@@ -1005,7 +1100,9 @@ def load_miners_prs(
                             continue
 
                     if pr_state in (PRState.OPEN.value, PRState.CLOSED.value):
-                        try_add_open_or_closed_pr(miner_eval, pr_raw, pr_state, lookback_date_filter)
+                        try_add_open_or_closed_pr(
+                            miner_eval, pr_raw, pr_state, lookback_date_filter, token=miner_eval.github_pat
+                        )
                         continue
 
                     should_skip, skip_reason = should_skip_merged_pr(
@@ -1016,6 +1113,7 @@ def load_miners_prs(
                         bt.logging.debug(skip_reason or '')
                         continue
 
+                    _complete_changes_requested_reviews_if_needed(pr_raw, miner_eval.github_pat)
                     miner_eval.add_merged_pull_request(pr_raw)
 
                 except Exception as e:

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1161,6 +1161,7 @@ def _make_pr_node(
         'mergedBy': {'login': 'maintainer'} if state == 'MERGED' else None,
         'closingIssuesReferences': closing_issues_refs,
         'reviews': {'nodes': [{'author': {'login': 'reviewer'}}]},
+        'changesRequestedReviews': {'nodes': []},
     }
 
 

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1126,10 +1126,13 @@ def _make_pr_node(
     default_branch='main',
     closing_issues_refs=None,
     head_repository=None,
+    changes_requested_reviews=None,
 ):
     """Build a single PR node matching the GraphQL QUERY schema."""
     if closing_issues_refs is None:
         closing_issues_refs = {'nodes': []}
+    if changes_requested_reviews is None:
+        changes_requested_reviews = {'nodes': []}
     return {
         'title': f'PR #{number}',
         'number': number,
@@ -1161,7 +1164,7 @@ def _make_pr_node(
         'mergedBy': {'login': 'maintainer'} if state == 'MERGED' else None,
         'closingIssuesReferences': closing_issues_refs,
         'reviews': {'nodes': [{'author': {'login': 'reviewer'}}]},
-        'changesRequestedReviews': {'nodes': []},
+        'changesRequestedReviews': changes_requested_reviews,
     }
 
 
@@ -1233,6 +1236,147 @@ class TestLoadMinersPrsErrorResilience:
         # Verify the warning was logged for the bad PR
         warning_calls = [str(c) for c in mock_logging.warning.call_args_list]
         assert any('PR #2' in w for w in warning_calls), f'Expected a warning about PR #2, got: {warning_calls}'
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_full_non_maintainer_review_window_fetches_later_maintainer_review(
+        self, mock_logging, mock_graphql_query, mock_execute_graphql
+    ):
+        """Non-maintainer reviews in the inline cap must not hide later maintainer reviews."""
+        from gittensor.classes import MinerEvaluation
+        from gittensor.utils.github_api_tools import _MAX_CHANGES_REQUESTED_REVIEWS
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        now = datetime.now(timezone.utc)
+        recent = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        recent_merge = (now - timedelta(days=4)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        pr = _make_pr_node(
+            7,
+            'goodorg',
+            'goodrepo',
+            created_at=recent,
+            merged_at=recent_merge,
+            changes_requested_reviews={
+                'nodes': [{'authorAssociation': 'CONTRIBUTOR'} for _ in range(_MAX_CHANGES_REQUESTED_REVIEWS)],
+                'pageInfo': {'hasNextPage': True, 'endCursor': 'review-cursor-1'},
+            },
+        )
+        mock_graphql_query.return_value = _make_graphql_response([pr])
+        mock_execute_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'pullRequest': {
+                        'changesRequestedReviews': {
+                            'nodes': [{'authorAssociation': 'OWNER'}],
+                            'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                        }
+                    }
+                }
+            }
+        }
+
+        master_repos = {'goodorg/goodrepo': RepositoryConfig(weight=1.0)}
+        miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
+
+        load_miners_prs(miner_eval, master_repos)
+
+        assert len(miner_eval.merged_pull_requests) == 1
+        assert miner_eval.merged_pull_requests[0].changes_requested_count == 1
+        mock_execute_graphql.assert_called_once()
+        query_arg, variables_arg, token_arg = mock_execute_graphql.call_args.args[:3]
+        assert 'reviews(first: $limit, states: CHANGES_REQUESTED, after: $cursor)' in query_arg
+        assert variables_arg == {
+            'owner': 'goodorg',
+            'name': 'goodrepo',
+            'pullNumber': 7,
+            'cursor': 'review-cursor-1',
+            'limit': 100,
+        }
+        assert token_arg == 'fake_pat'
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_inline_maintainer_review_cap_does_not_fetch_extra_pages(
+        self, mock_logging, mock_graphql_query, mock_execute_graphql
+    ):
+        """A full maintainer window already saturates scoring, so no follow-up is needed."""
+        from gittensor.classes import MinerEvaluation
+        from gittensor.utils.github_api_tools import _MAX_CHANGES_REQUESTED_REVIEWS
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        now = datetime.now(timezone.utc)
+        recent = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        recent_merge = (now - timedelta(days=4)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        pr = _make_pr_node(
+            8,
+            'goodorg',
+            'goodrepo',
+            created_at=recent,
+            merged_at=recent_merge,
+            changes_requested_reviews={
+                'nodes': [{'authorAssociation': 'OWNER'} for _ in range(_MAX_CHANGES_REQUESTED_REVIEWS)],
+                'pageInfo': {'hasNextPage': True, 'endCursor': 'review-cursor-1'},
+            },
+        )
+        mock_graphql_query.return_value = _make_graphql_response([pr])
+
+        master_repos = {'goodorg/goodrepo': RepositoryConfig(weight=1.0)}
+        miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
+
+        load_miners_prs(miner_eval, master_repos)
+
+        assert len(miner_eval.merged_pull_requests) == 1
+        assert miner_eval.merged_pull_requests[0].changes_requested_count == _MAX_CHANGES_REQUESTED_REVIEWS
+        mock_execute_graphql.assert_not_called()
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.get_github_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_open_pr_review_window_fetches_later_maintainer_review(
+        self, mock_logging, mock_graphql_query, mock_execute_graphql
+    ):
+        """Open PR collateral uses the same maintainer count source."""
+        from gittensor.classes import MinerEvaluation
+        from gittensor.utils.github_api_tools import _MAX_CHANGES_REQUESTED_REVIEWS
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        now = datetime.now(timezone.utc)
+        recent = (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        pr = _make_pr_node(
+            9,
+            'goodorg',
+            'goodrepo',
+            state='OPEN',
+            created_at=recent,
+            changes_requested_reviews={
+                'nodes': [{'authorAssociation': 'CONTRIBUTOR'} for _ in range(_MAX_CHANGES_REQUESTED_REVIEWS)],
+                'pageInfo': {'hasNextPage': True, 'endCursor': 'review-cursor-1'},
+            },
+        )
+        mock_graphql_query.return_value = _make_graphql_response([pr])
+        mock_execute_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'pullRequest': {
+                        'changesRequestedReviews': {
+                            'nodes': [{'authorAssociation': 'COLLABORATOR'}],
+                            'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                        }
+                    }
+                }
+            }
+        }
+
+        master_repos = {'goodorg/goodrepo': RepositoryConfig(weight=1.0)}
+        miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
+
+        load_miners_prs(miner_eval, master_repos)
+
+        assert len(miner_eval.open_pull_requests) == 1
+        assert miner_eval.open_pull_requests[0].changes_requested_count == 1
+        mock_execute_graphql.assert_called_once()
 
 
 class TestLoadMinersPrsFetchFailureSignal:


### PR DESCRIPTION
## Summary

Fixes #1053.

The inline GraphQL query caps `changesRequestedReviews` at `ceil(1 / REVIEW_PENALTY_RATE)` (7) nodes, but `PullRequest.from_graphql_response` filters the returned nodes by `authorAssociation` afterward. Non-maintainer `CHANGES_REQUESTED` reviews can fill the entire capped window and hide later maintainer reviews from the penalty calculation.

**Regression source:** PR #519 replaced `get_pull_request_maintainer_changes_requested_count` (which paginated all reviews via REST) with a capped inline GraphQL fetch. The PR review stated *"scoring output is identical before and after"* — that invariant does not hold when ≥7 non-maintainer `CHANGES_REQUESTED` reviews precede a maintainer one.

### Local proof (before fix)

```
{'fetched_nodes': 7, 'counted_maintainer_reviews': 0, 'actual_multiplier': 1.0, 'expected_if_next_review_owner': 0.85}
```

## Changes

- Add `_complete_changes_requested_reviews_if_needed()`: conditional follow-up pagination that fires **only** when the inline window is ambiguous (maintainer count < cap AND `hasNextPage`). Common-case PRs incur zero extra GraphQL calls.
- Add `pageInfo { hasNextPage endCursor }` to the inline `changesRequestedReviews` block so the helper has cursor data.
- Wire the helper for both **OPEN** and **MERGED** PR paths in `load_miners_prs`.
- Pass `token` through `try_add_open_or_closed_pr` (backward-compatible optional kwarg).

### Why conditional pagination over raising inline `first` to 100

1. A flat `first: 100` would bloat the user-PR-page query for every PR, including the 99%+ with zero `CHANGES_REQUESTED` reviews.
2. It would still silently truncate adversarial cases beyond 100.
3. The conditional follow-up keeps the hot path identical and is bounded by the maintainer-count saturation check (`>= _MAX_CHANGES_REQUESTED_REVIEWS`).

## Tests

Three regression tests added:

- **`test_full_non_maintainer_review_window_fetches_later_maintainer_review`** — direct repro: 7 CONTRIBUTOR reviews fill cap, 1 OWNER review on next page → `changes_requested_count == 1`, follow-up query fires.
- **`test_inline_maintainer_review_cap_does_not_fetch_extra_pages`** — 7 OWNER reviews saturate cap → no follow-up query (no perf regression).
- **`test_open_pr_review_window_fetches_later_maintainer_review`** — OPEN PR collateral path also completes.

Existing tripwire `test_max_changes_requested_reviews_covers_review_multipliers` preserved unchanged.

```
$ python -m pytest tests/ -q
1414 passed in 5.21s

$ ruff check gittensor/utils/github_api_tools.py tests/utils/test_github_api_tools.py
All checks passed!

$ pyright gittensor/utils/github_api_tools.py
0 errors, 0 warnings, 0 informations
```