### PR TITLE
perf: parse GraphQL response JSON once per page

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -663,7 +663,7 @@ def execute_graphql_query(
 class GraphQLPageResult:
     """Result of a paginated GraphQL query."""
 
-    response: Optional[requests.Response]
+    data: Optional[Dict[str, Any]]
     page_size: int  # actual page size used (may have been reduced on retry)
 
 
@@ -717,8 +717,9 @@ def get_github_graphql_query(
                 # Check for RESOURCE_LIMITS_EXCEEDED in response body (GitHub returns 200 with errors)
                 try:
                     data = response.json()
-                except Exception:
-                    return GraphQLPageResult(response=response, page_size=limit)
+                except Exception as e:
+                    bt.logging.error(f'Failed to parse GraphQL JSON response: {e}')
+                    return GraphQLPageResult(data=None, page_size=limit)
 
                 if _has_resource_limit_errors(data):
                     if attempt < (max_attempts - 1):
@@ -735,9 +736,9 @@ def get_github_graphql_query(
                         bt.logging.error(
                             f'GraphQL RESOURCE_LIMITS_EXCEEDED at page size {limit} after {max_attempts} attempts'
                         )
-                        return GraphQLPageResult(response=None, page_size=limit)
+                        return GraphQLPageResult(data=None, page_size=limit)
 
-                return GraphQLPageResult(response=response, page_size=limit)
+                return GraphQLPageResult(data=data, page_size=limit)
 
             # HTTP error - log and retry
             if attempt < (max_attempts - 1):
@@ -768,9 +769,9 @@ def get_github_graphql_query(
                 time.sleep(backoff_delay)
             else:
                 bt.logging.error(f'GraphQL request failed after {max_attempts} attempts: {e}')
-                return GraphQLPageResult(response=None, page_size=limit)
+                return GraphQLPageResult(data=None, page_size=limit)
 
-    return GraphQLPageResult(response=None, page_size=limit)
+    return GraphQLPageResult(data=None, page_size=limit)
 
 
 def _has_resource_limit_errors(data: Dict) -> bool:
@@ -950,17 +951,12 @@ def load_miners_prs(
             # Carry reduced page size forward for subsequent pages
             current_page_size = result.page_size
 
-            if not result.response:
+            if result.data is None:
                 bt.logging.warning('No response from github, breaking fetch loop...')
                 miner_eval.github_pr_fetch_failed = True
                 break
 
-            try:
-                data: Dict = result.response.json()
-            except Exception as e:
-                bt.logging.error(f'Failed to parse GraphQL JSON response: {e}')
-                miner_eval.github_pr_fetch_failed = True
-                break
+            data: Dict = result.data
 
             # Resource limit errors are already handled in get_github_graphql_query; break on others
             if 'errors' in data:

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -95,8 +95,7 @@ class TestGraphQLRetryLogic:
 
         assert mock_post.call_count == 3, 'Should retry 3 times total'
         assert mock_sleep.call_count == 2, 'Should sleep twice between retries'
-        assert result.response is not None
-        assert result.response.status_code == 200
+        assert result.data is not None
 
         # Verify exponential backoff: 5s, 10s
         mock_sleep.assert_has_calls([call(5), call(10)])
@@ -115,7 +114,7 @@ class TestGraphQLRetryLogic:
 
         result = get_github_graphql_query(**graphql_params)
 
-        assert result.response.status_code == 200
+        assert result.data is not None
         # Initial limit=100, halved to 50 after first 502, halved to 25 after second 502
         limits = [c.kwargs['json']['variables']['limit'] for c in mock_post.call_args_list]
         assert limits == [100, 50, 25]
@@ -148,7 +147,7 @@ class TestGraphQLRetryLogic:
 
         result = get_github_graphql_query(**graphql_params)
 
-        assert result.response.status_code == 200
+        assert result.data is not None
         limits = [c.kwargs['json']['variables']['limit'] for c in mock_post.call_args_list]
         assert limits == [100, 100, 100], 'Page size should stay at 100 for non-5xx errors'
 
@@ -167,7 +166,7 @@ class TestGraphQLRetryLogic:
 
         result = get_github_graphql_query(**graphql_params)
 
-        assert result.response.status_code == 200
+        assert result.data is not None
         limits = [c.kwargs['json']['variables']['limit'] for c in mock_post.call_args_list]
         assert limits == [100, 50, 25]
 
@@ -192,7 +191,7 @@ class TestGraphQLRetryLogic:
         }
         result = get_github_graphql_query(**params)
 
-        assert result.response.status_code == 200
+        assert result.data is not None
         # Initial limit = min(100, 100-85) = 15, halved to 10, stays at 10
         limits = [c.kwargs['json']['variables']['limit'] for c in mock_post.call_args_list]
         assert limits == [15, 10, 10]
@@ -209,7 +208,7 @@ class TestGraphQLRetryLogic:
 
         assert mock_post.call_count == 8, 'Should try exactly 8 times'
         assert mock_sleep.call_count == 7, 'Should sleep 7 times between attempts'
-        assert result.response is None
+        assert result.data is None
         mock_logging.error.assert_called()
 
     @patch('gittensor.utils.github_api_tools.requests.post')
@@ -228,7 +227,7 @@ class TestGraphQLRetryLogic:
 
         assert mock_post.call_count == 2, 'Should retry once after 503'
         assert mock_sleep.call_count == 1, 'Should sleep once'
-        assert result.response is not None
+        assert result.data is not None
 
     @patch('gittensor.utils.github_api_tools.requests.post')
     @patch('gittensor.utils.github_api_tools.time.sleep')
@@ -245,7 +244,7 @@ class TestGraphQLRetryLogic:
         result = get_github_graphql_query(**graphql_params)
 
         assert mock_post.call_count == 2, 'Should retry once after 504'
-        assert result.response is not None
+        assert result.data is not None
 
     @patch('gittensor.utils.github_api_tools.requests.post')
     @patch('gittensor.utils.github_api_tools.time.sleep')
@@ -263,7 +262,7 @@ class TestGraphQLRetryLogic:
 
         assert mock_post.call_count == 2, 'Should retry on 401'
         assert mock_sleep.call_count == 1, 'Should sleep once'
-        assert result.response is not None
+        assert result.data is not None
 
     @patch('gittensor.utils.github_api_tools.requests.post')
     @patch('gittensor.utils.github_api_tools.time.sleep')
@@ -301,7 +300,7 @@ class TestGraphQLRetryLogic:
 
         assert mock_post.call_count == 3, 'Should retry after connection errors'
         assert mock_sleep.call_count == 2, 'Should sleep twice'
-        assert result.response is not None
+        assert result.data is not None
 
         # Verify exponential backoff: 5s, 10s
         mock_sleep.assert_has_calls([call(5), call(10)])
@@ -318,7 +317,7 @@ class TestGraphQLRetryLogic:
         result = get_github_graphql_query(**graphql_params)
 
         assert mock_post.call_count == 8, 'Should try 8 times before giving up'
-        assert result.response is None
+        assert result.data is None
 
     @patch('gittensor.utils.github_api_tools.requests.post')
     @patch('gittensor.utils.github_api_tools.bt.logging')
@@ -331,8 +330,7 @@ class TestGraphQLRetryLogic:
         result = get_github_graphql_query(**graphql_params)
 
         assert mock_post.call_count == 1, 'Should only call once on success'
-        assert result.response is not None
-        assert result.response.status_code == 200
+        assert result.data is not None
 
     @patch('gittensor.utils.github_api_tools.requests.post')
     @patch('gittensor.utils.github_api_tools.time.sleep')
@@ -1166,21 +1164,21 @@ def _make_pr_node(
 
 def _make_graphql_response(pr_nodes):
     """Wrap PR nodes in the full GraphQL response structure."""
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        'data': {
-            'node': {
-                'pullRequests': {
-                    'pageInfo': {'hasNextPage': False, 'endCursor': None},
-                    'nodes': pr_nodes,
-                }
-            }
-        }
-    }
     from gittensor.utils.github_api_tools import GraphQLPageResult
 
-    return GraphQLPageResult(response=mock_response, page_size=100)
+    return GraphQLPageResult(
+        data={
+            'data': {
+                'node': {
+                    'pullRequests': {
+                        'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                        'nodes': pr_nodes,
+                    }
+                }
+            }
+        },
+        page_size=100,
+    )
 
 
 class TestLoadMinersPrsErrorResilience:
@@ -1243,20 +1241,20 @@ class TestLoadMinersPrsFetchFailureSignal:
         from gittensor.classes import MinerEvaluation
         from gittensor.utils.github_api_tools import GraphQLPageResult
 
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            'data': {
-                'node': {
-                    'issues': {'totalCount': 0},
-                    'pullRequests': {
-                        'pageInfo': {'hasNextPage': False, 'endCursor': None},
-                        'nodes': [],
-                    },
+        mock_graphql_query.return_value = GraphQLPageResult(
+            data={
+                'data': {
+                    'node': {
+                        'issues': {'totalCount': 0},
+                        'pullRequests': {
+                            'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                            'nodes': [],
+                        },
+                    }
                 }
-            }
-        }
-        mock_graphql_query.return_value = GraphQLPageResult(response=mock_response, page_size=100)
+            },
+            page_size=100,
+        )
 
         miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
 
@@ -1271,7 +1269,7 @@ class TestLoadMinersPrsFetchFailureSignal:
         from gittensor.classes import MinerEvaluation
         from gittensor.utils.github_api_tools import GraphQLPageResult
 
-        mock_graphql_query.return_value = GraphQLPageResult(response=None, page_size=100)
+        mock_graphql_query.return_value = GraphQLPageResult(data=None, page_size=100)
 
         miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
 
@@ -1285,12 +1283,13 @@ class TestLoadMinersPrsFetchFailureSignal:
         from gittensor.classes import MinerEvaluation
         from gittensor.utils.github_api_tools import GraphQLPageResult
 
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            'errors': [{'message': 'Something went wrong'}],
-            'data': None,
-        }
-        mock_graphql_query.return_value = GraphQLPageResult(response=mock_response, page_size=100)
+        mock_graphql_query.return_value = GraphQLPageResult(
+            data={
+                'errors': [{'message': 'Something went wrong'}],
+                'data': None,
+            },
+            page_size=100,
+        )
 
         miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
 

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from typing import cast
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from gittensor.classes import FileChange, Issue, MinerEvaluation, MinerEvaluationCache, PRState, PullRequest
 from gittensor.utils.github_api_tools import GraphQLPageResult, load_miners_prs
@@ -95,12 +95,13 @@ class TestStoreOrUseCachedEvaluation:
         validator = _DummyValidator()
         validator.evaluation_cache.store(_build_eval(uid=1, merged_prs=1, fetch_failed=False))
 
-        response = Mock()
-        response.json.return_value = {
-            'errors': [{'message': 'Something went wrong'}],
-            'data': None,
-        }
-        mock_graphql_query.return_value = GraphQLPageResult(response=response, page_size=100)
+        mock_graphql_query.return_value = GraphQLPageResult(
+            data={
+                'errors': [{'message': 'Something went wrong'}],
+                'data': None,
+            },
+            page_size=100,
+        )
 
         current_eval = MinerEvaluation(uid=1, hotkey='hotkey_1', github_id='12345', github_pat='bad_scope_pat')
         load_miners_prs(current_eval, {})


### PR DESCRIPTION
## Summary

`get_github_graphql_query()` parses the response body to detect `RESOURCE_LIMITS_EXCEEDED`, then returns the raw `requests.Response` so `load_miners_prs()` can parse it again. This PR has `GraphQLPageResult` carry the already-parsed `data` dict, eliminating the second `response.json()` per page.

Hot path: every PR-fetch page on every miner on every scoring round avoids one redundant JSON decode of a tens-to-hundreds-of-KB body.

## Changes

- `GraphQLPageResult.response: Optional[requests.Response]` → `data: Optional[Dict[str, Any]]`.
- `get_github_graphql_query()` returns the parsed dict; failure paths return `data=None`. JSON-decode failure is now logged inside the producer instead of the consumer.
- `load_miners_prs()` consumes `result.data` directly; removed the duplicate `try/except response.json()` block.
- Tests updated to assert against `result.data` and to construct `GraphQLPageResult` with the parsed dict.

## Test plan

- [x] `pytest -q` — 1411 passed
- [x] `pyright` — 0 errors
- [x] `ruff check` + `ruff format --check` — clean

## Out of scope

`execute_graphql_query()` and its callers exhibit the same double-parse pattern. Happy to do that as a follow-up to keep this diff focused.

Closes #1056