### PR TITLE
fix: git issues list --repo silently accepts malformed repo filters and exact-matches untrimmed input

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -30,6 +30,7 @@ from .helpers import (
     print_network_header,
     read_issues_from_contract,
     validate_issue_id,
+    validate_repository,
     with_cli_behavior_options,
     with_network_contract_options,
 )
@@ -73,6 +74,13 @@ def issues_list(
             validate_issue_id(issue_id, 'id')
         except click.BadParameter as e:
             handle_exception(as_json, str(e), 'bad_parameter')
+
+    if repo_filter:
+        try:
+            owner, repo_name = validate_repository(repo_filter, verify_exists=False)
+        except click.BadParameter as e:
+            handle_exception(as_json, str(e), 'bad_parameter')
+        repo_filter = f'{owner}/{repo_name}'
 
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(
         contract,

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -17,6 +17,14 @@ FAKE_ISSUES = [
         'target_bounty': 100_000_000_000,
         'status': 'Active',
     },
+    {
+        'id': 2,
+        'repository_full_name': 'other/repo',
+        'issue_number': 11,
+        'bounty_amount': 25_000_000_000,
+        'target_bounty': 100_000_000_000,
+        'status': 'Active',
+    },
 ]
 
 
@@ -77,4 +85,63 @@ def test_issues_list_rejects_invalid_id_json(cli_root, runner, bad_id):
     assert payload['success'] is False
     assert payload['error']['type'] == 'bad_parameter'
     assert 'between 1 and 999999' in payload['error']['message']
+    mock_read.assert_not_called()
+
+
+def test_issues_list_repo_filter_strips_whitespace_json(cli_root, runner):
+    """A valid --repo pasted with whitespace should still match the repository."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json', '--repo', '  owner/repo  '], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload['success'] is True
+    assert payload['issue_count'] == 1
+    assert payload['issues'][0]['repository_full_name'] == 'owner/repo'
+
+
+def test_issues_list_repo_filter_strips_whitespace_human(cli_root, runner):
+    """Human table mode should use the same normalized --repo filter."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--repo', '  owner/repo  '], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert 'owner/repo' in result.output
+    assert 'other/repo' not in result.output
+
+
+@pytest.mark.parametrize('bad_repo', ['ownerrepo', 'owner//repo', 'https://github.com/owner/repo'])
+def test_issues_list_rejects_invalid_repo_human(cli_root, runner, bad_repo):
+    """Malformed --repo values must fail before contract reads."""
+    with patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as mock_read:
+        result = runner.invoke(cli_root, ['issues', 'list', '--repo', bad_repo], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'owner/repo format' in result.output
+    mock_read.assert_not_called()
+
+
+@pytest.mark.parametrize('bad_repo', ['ownerrepo', 'owner//repo', 'https://github.com/owner/repo'])
+def test_issues_list_rejects_invalid_repo_json(cli_root, runner, bad_repo):
+    """JSON mode should report invalid --repo as a structured bad_parameter error."""
+    with patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as mock_read:
+        result = runner.invoke(cli_root, ['issues', 'list', '--json', '--repo', bad_repo], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'bad_parameter'
+    assert 'owner/repo format' in payload['error']['message']
     mock_read.assert_not_called()


### PR DESCRIPTION
## Summary
Fixes `gitt issues list --repo` so repository filters are normalized and validated before filtering issues.
Merged PR #910 added `--repo <owner/name>`, but the implementation compared raw user input directly against `repository_full_name`. That caused valid filters with surrounding whitespace to return no results, and malformed filters to be silently accepted.
## Related Issue
Fixes: #1061 
## Real Behavior Proof
Before this change, `gittensor/cli/issue_commands/view.py` filtered with the raw CLI value:
```python
if repo_filter and issue_id is None:
    issues = [
        i for i in issues
        if i.get('repository_full_name', '').lower() == repo_filter.lower()
    ]
```
So this valid input failed to match:
```bash
gitt issues list --repo " owner/repo "
```
And malformed inputs were accepted as filters:
```bash
gitt issues list --repo ownerrepo
gitt issues list --repo owner//repo
gitt issues list --repo https://github.com/owner/repo
```
## Solution
`issues_list` now reuses the existing repository validator:
```python
owner, repo_name = validate_repository(repo_filter, verify_exists=False)
repo_filter = f'{owner}/{repo_name}'
```
This makes `--repo` behavior consistent with other issue commands.

## Updated Behavior
Whitespace-padded valid filters are normalized:
```bash
gitt issues list --repo " owner/repo "
```
now behaves like:
```bash
gitt issues list --repo owner/repo
```
Malformed filters now fail before contract reads with a bad parameter error.
## Validation Notes
Added tests for:
- `--repo " owner/repo "` in JSON mode
- `--repo " owner/repo "` in human table mode
- invalid `--repo ownerrepo`
- invalid `--repo owner//repo`
- invalid URL-like repo input
- JSON `bad_parameter` response shape

Local checks run:
```bash
python3 -m py_compile gittensor/cli/issue_commands/view.py tests/cli/test_issues_list_json.py
git diff --check
```
Both passed.
Full pytest could not be run in this environment because `pytest`, `uv`, and `pip` are not installed.