### PR TITLE
fix: Repository label multiplier config accepts negative and non-finite values

### DIFF
--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 import json
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -105,6 +106,42 @@ def _get_weights_dir() -> Path:
     return Path(__file__).parent.parent / 'weights'
 
 
+def _load_non_negative_finite_float(value: object, default: float, source: str) -> float:
+    """Coerce a config multiplier, falling back when the value can poison scoring."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as e:
+        bt.logging.warning(f'Could not parse {source}: {value!r} - {e}; using default {default}')
+        return default
+
+    if not math.isfinite(parsed) or parsed < 0:
+        bt.logging.warning(f'Rejecting out-of-range {source}: {value!r}; using default {default}')
+        return default
+
+    return parsed
+
+
+def _load_label_multipliers(repo_name: str, metadata: dict) -> Optional[Dict[str, float]]:
+    raw_multipliers = metadata.get('label_multipliers')
+    if raw_multipliers is None:
+        return None
+    if not isinstance(raw_multipliers, dict):
+        bt.logging.warning(
+            f'Could not parse label_multipliers for {repo_name}: expected dict, '
+            f'got {type(raw_multipliers).__name__}; using defaults'
+        )
+        return None
+
+    return {
+        str(label): _load_non_negative_finite_float(
+            multiplier,
+            1.0,
+            f'label_multipliers[{label!r}] for {repo_name}',
+        )
+        for label, multiplier in raw_multipliers.items()
+    }
+
+
 def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
     """
     Load repository weights from the local JSON file.
@@ -134,12 +171,12 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     mirror_enabled=bool(metadata.get('mirror_enabled', False)),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
-                    label_multipliers=(
-                        {str(label): float(multiplier) for label, multiplier in metadata['label_multipliers'].items()}
-                        if metadata.get('label_multipliers') is not None
-                        else None
+                    label_multipliers=_load_label_multipliers(repo_name, metadata),
+                    default_label_multiplier=_load_non_negative_finite_float(
+                        metadata.get('default_label_multiplier', 1.0),
+                        1.0,
+                        f'default_label_multiplier for {repo_name}',
                     ),
-                    default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -230,6 +230,15 @@ class TestRepositoryConfigTrustedLabelPipeline:
 class TestRepositoryConfigLabelMultipliers:
     """Dataclass + JSON-parsing tests for per-repo label multiplier config."""
 
+    def _load_repos_from_metadata(self, tmp_path, monkeypatch, metadata):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(json.dumps(metadata))
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        return lw.load_master_repo_weights()
+
     def test_label_multiplier_defaults(self):
         config = RepositoryConfig(weight=0.5)
 
@@ -260,6 +269,68 @@ class TestRepositoryConfigLabelMultipliers:
         assert repos['foo/labeled'].default_label_multiplier == pytest.approx(0.8)
         assert repos['foo/defaults'].label_multipliers is None
         assert repos['foo/defaults'].default_label_multiplier == pytest.approx(1.0)
+
+    @pytest.mark.parametrize('bad_multiplier', [-1.0, 'NaN', 'inf'])
+    def test_loader_rejects_bad_label_multiplier_values(self, tmp_path, monkeypatch, bad_multiplier):
+        from gittensor.validator.utils import load_weights as lw
+
+        warnings: list[str] = []
+        monkeypatch.setattr(lw.bt.logging, 'warning', warnings.append)
+
+        repos = self._load_repos_from_metadata(
+            tmp_path,
+            monkeypatch,
+            {
+                'foo/labeled': {
+                    'weight': 0.5,
+                    'label_multipliers': {'feature': bad_multiplier, 'bug': 1.25},
+                    'default_label_multiplier': 0.8,
+                },
+            },
+        )
+
+        assert repos['foo/labeled'].label_multipliers == {'feature': 1.0, 'bug': 1.25}
+        assert repos['foo/labeled'].default_label_multiplier == pytest.approx(0.8)
+        assert any('foo/labeled' in warning and 'feature' in warning for warning in warnings)
+
+    @pytest.mark.parametrize('bad_default', [-1.0, 'NaN', 'inf'])
+    def test_loader_rejects_bad_default_label_multiplier_values(self, tmp_path, monkeypatch, bad_default):
+        from gittensor.validator.utils import load_weights as lw
+
+        warnings: list[str] = []
+        monkeypatch.setattr(lw.bt.logging, 'warning', warnings.append)
+
+        repos = self._load_repos_from_metadata(
+            tmp_path,
+            monkeypatch,
+            {
+                'foo/labeled': {
+                    'weight': 0.5,
+                    'label_multipliers': {'feature': 1.5},
+                    'default_label_multiplier': bad_default,
+                },
+            },
+        )
+
+        assert repos['foo/labeled'].label_multipliers == {'feature': 1.5}
+        assert repos['foo/labeled'].default_label_multiplier == pytest.approx(1.0)
+        assert any('foo/labeled' in warning and 'default_label_multiplier' in warning for warning in warnings)
+
+    def test_loader_preserves_zero_label_multiplier_values(self, tmp_path, monkeypatch):
+        repos = self._load_repos_from_metadata(
+            tmp_path,
+            monkeypatch,
+            {
+                'foo/labeled': {
+                    'weight': 0.5,
+                    'label_multipliers': {'feature': 0.0},
+                    'default_label_multiplier': 0.0,
+                },
+            },
+        )
+
+        assert repos['foo/labeled'].label_multipliers == {'feature': 0.0}
+        assert repos['foo/labeled'].default_label_multiplier == pytest.approx(0.0)
 
     @pytest.mark.parametrize('repo_name,metadata', _live_master_repo_metadata())
     def test_live_label_multiplier_maps_are_bounded(self, repo_name, metadata):


### PR DESCRIPTION
## Summary
- Added validation for repository-scoped label multiplier config loaded from `master_repositories.json`.
- `label_multipliers` and `default_label_multiplier` now reject negative, `NaN`, and infinite values.
- Invalid values fall back to neutral multiplier `1.0` and emit a warning with the affected repo/key.
- Valid `0.0` multiplier values are preserved.
## Related Issue
Fixes: #1063 
## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Tests added/updated

##Real Behavior Proof
Before this change, config like:
```json
{
  "foo/repo": {
    "weight": 0.5,
    "label_multipliers": {
      "feature": -2.0,
      "bug": "NaN"
    },
    "default_label_multiplier": "inf"
  }
}
```
was accepted by `float(...)` and could flow into scoring.
After this change:
- `feature: -2.0` becomes `1.0`
- `bug: "NaN"` becomes `1.0`
- `default_label_multiplier: "inf"` becomes `1.0`
- warnings are logged naming `foo/repo` and the bad key
## Root Cause
PR `#1027` introduced per-repository label multiplier config, but the loader parsed these new fields with plain `float(...)`.
Python accepts values like:
```python
float("NaN")
float("inf")
float("-2.0")
```
so invalid scoring multipliers were not rejected at load time.
## User-Visible / Behavior Changes
- Bad label multiplier config no longer poisons or inverts PR scoring.
- Operators get warning logs pointing to the invalid repo/key.
- Valid configs behave the same as before.
- `0.0` remains valid for intentionally disabling a label/default multiplier.

## Tests Added
- Reject negative `label_multipliers`
- Reject `NaN` / `inf` `label_multipliers`
- Reject negative / `NaN` / `inf` `default_label_multiplier`
- Preserve valid `0.0` values

## Verification
- Passed syntax check:
```bash
python3 -m py_compile gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py
```
- Could not run full pytest/ruff locally because `uv`, `pytest`, and `ruff` are not installed in this environment.