### PR TITLE
fix: use cached issue-discovery scores when DAS mirror fetch fails

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from math import prod
-from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
@@ -664,6 +664,21 @@ class CachedEvaluation:
     cached_at: datetime
 
 
+# Fields owned by the issue-discovery phase. store() preserves these across
+# rounds so the OSS-phase write doesn't clobber the prior round's refresh;
+# update_issue_discovery() is the authoritative writer.
+_ISSUE_DISCOVERY_FIELDS: Tuple[str, ...] = (
+    'issue_discovery_score',
+    'issue_token_score',
+    'issue_credibility',
+    'is_issue_eligible',
+    'total_solved_issues',
+    'total_valid_solved_issues',
+    'total_closed_issues',
+    'total_open_issues',
+)
+
+
 class MinerEvaluationCache:
     """
     In-memory cache for successful miner evaluations, keyed by UID.
@@ -671,13 +686,27 @@ class MinerEvaluationCache:
     Used as fallback when GitHub API is unavailable. Validates that
     hotkey and github_id match before returning cached data to handle
     miner re-registration on the same UID.
+
+    The cache has two independent writers: store() is called by the OSS
+    phase with a freshly-fetched MinerEvaluation whose issue-discovery
+    fields are dataclass defaults, and update_issue_discovery() is called
+    by the issue-discovery phase after scoring. store() therefore preserves
+    any prior round's issue-discovery fields when identity matches, so a
+    later same-round mirror outage can fall back to a non-zero score.
     """
 
     def __init__(self):
         self._cache: Dict[int, CachedEvaluation] = {}
 
     def store(self, evaluation: 'MinerEvaluation') -> None:
-        """Store a successful evaluation in the cache."""
+        """Store a successful evaluation in the cache.
+
+        Preserves the prior entry's issue-discovery fields when the UID's
+        identity (hotkey, github_id) is unchanged — the caller (OSS phase)
+        is not authoritative for those fields and writes dataclass defaults
+        every round. Identity mismatch (re-registration) drops the prior
+        issue-discovery state along with the rest of the entry.
+        """
         if evaluation.failed_reason is not None:
             return
 
@@ -685,6 +714,11 @@ class MinerEvaluationCache:
             return
 
         cached_eval = self._build_cache_entry(evaluation)
+
+        existing = self._cache.get(evaluation.uid)
+        if existing is not None and existing.hotkey == evaluation.hotkey and existing.github_id == evaluation.github_id:
+            for name in _ISSUE_DISCOVERY_FIELDS:
+                setattr(cached_eval, name, getattr(existing.evaluation, name))
 
         self._cache[evaluation.uid] = CachedEvaluation(
             hotkey=evaluation.hotkey,
@@ -694,6 +728,33 @@ class MinerEvaluationCache:
         )
 
         bt.logging.debug(f'Cached successful evaluation for UID {evaluation.uid}')
+
+    def update_issue_discovery(self, evaluation: 'MinerEvaluation') -> None:
+        """Refresh issue-discovery fields on an existing cache entry.
+
+        No-op when no entry exists for this UID — the cache only holds
+        entries backed by an OSS-phase store(), so writing issue-discovery
+        fields alone would leave a half-populated entry that the OSS
+        fallback path could later restore.
+        """
+        existing = self._cache.get(evaluation.uid)
+        if existing is None:
+            return
+
+        if existing.hotkey != evaluation.hotkey or existing.github_id != evaluation.github_id:
+            bt.logging.debug(
+                f'Skipping issue-discovery refresh for UID {evaluation.uid}: identity mismatch '
+                f'(cached hotkey={existing.hotkey[:8]}..., github_id={existing.github_id} vs '
+                f'current hotkey={evaluation.hotkey[:8]}..., github_id={evaluation.github_id}). '
+                'Removing cached evaluation'
+            )
+            del self._cache[evaluation.uid]
+            return
+
+        for name in _ISSUE_DISCOVERY_FIELDS:
+            setattr(existing.evaluation, name, getattr(evaluation, name))
+
+        bt.logging.debug(f'Refreshed cached issue discovery for UID {evaluation.uid}')
 
     def get(self, uid: int, hotkey: str, github_id: str) -> Optional['MinerEvaluation']:
         """

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -2,12 +2,12 @@
 # Copyright © 2025 Entrius
 
 import asyncio
-from typing import TYPE_CHECKING, Dict, Set, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
 import numpy as np
 
-from gittensor.classes import MinerEvaluation
+from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.constants import (
     ISSUE_DISCOVERY_EMISSION_SHARE,
     ISSUES_TREASURY_EMISSION_SHARE,
@@ -68,7 +68,12 @@ async def forward(self: 'Validator') -> None:
 
         # 2. Score issue discovery
         issue_rewards = await issue_discovery(
-            miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
+            miner_evaluations,
+            master_repositories,
+            programming_languages,
+            token_config,
+            miner_uids,
+            evaluation_cache=self.evaluation_cache,
         )
 
         # cached UIDs now have fresh issue-discovery fields — persist them
@@ -120,6 +125,7 @@ async def issue_discovery(
     programming_languages: Dict,
     token_config,
     miner_uids: set[int],
+    evaluation_cache: Optional[MinerEvaluationCache] = None,
 ) -> np.ndarray:
     """Score issue discovery and return normalized rewards array.
 
@@ -137,7 +143,13 @@ async def issue_discovery(
     }
 
     if mirror_repos:
-        await run_mirror_issue_discovery(miner_evaluations, mirror_repos, programming_languages, token_config)
+        await run_mirror_issue_discovery(
+            miner_evaluations,
+            mirror_repos,
+            programming_languages,
+            token_config,
+            evaluation_cache=evaluation_cache,
+        )
     else:
         bt.logging.info('No mirror-enabled repos — issue discovery skipped for this round')
 

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -39,7 +39,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
-from gittensor.classes import Issue, MinerEvaluation
+from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache
 from gittensor.constants import (
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     PR_LOOKBACK_DAYS,
@@ -107,6 +107,7 @@ async def run_mirror_issue_discovery(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     client: Optional[MirrorClient] = None,
+    evaluation_cache: Optional[MinerEvaluationCache] = None,
 ) -> None:
     """Score issue discovery for mirror-enabled repos. Mutates miner_evaluations.
 
@@ -143,6 +144,7 @@ async def run_mirror_issue_discovery(
     skipped_failed = 0
     fetch_errors = 0
     no_issues = 0
+    cacheable_uids: Set[int] = set()
 
     # Phase 1: fetch each miner's issues.  The one-issue-per-PR rule is round-
     # global, so scoring is deferred until every miner's batch is in hand.
@@ -159,11 +161,14 @@ async def run_mirror_issue_discovery(
             response = await asyncio.to_thread(client.get_miner_issues, evaluation.github_id, since=lookback_date)
         except MirrorRequestError as e:
             bt.logging.warning(f'├─ UID {uid}: mirror issue fetch failed ({e}) — skipped this miner')
+            _restore_issue_discovery_from_cache(evaluation, evaluation_cache)
             fetch_errors += 1
             continue
 
         filtered = [i for i in response.issues if i.repo_full_name in enabled_names]
         if not filtered:
+            _clear_issue_discovery_fields(evaluation)
+            cacheable_uids.add(uid)
             no_issues += 1
             continue
 
@@ -177,7 +182,7 @@ async def run_mirror_issue_discovery(
 
     canonical_pr_owners = _build_canonical_pr_owners(pending)
     for evaluation, filtered, open_issue_count in pending:
-        await _score_miner_mirror_issues(
+        complete = await _score_miner_mirror_issues(
             evaluation,
             filtered,
             mirror_repos,
@@ -189,6 +194,16 @@ async def run_mirror_issue_discovery(
             open_issue_count=open_issue_count,
             canonical_pr_owners=canonical_pr_owners,
         )
+        if complete:
+            cacheable_uids.add(evaluation.uid)
+
+    if evaluation_cache is not None:
+        # Issue-discovery is not authoritative for the PR-side fields, so we
+        # write through update_issue_discovery() rather than store(). The OSS
+        # phase already stored a fresh entry for this UID (or restored from
+        # cache on OSS failure); we only refresh the issue-discovery fields.
+        for uid in cacheable_uids:
+            evaluation_cache.update_issue_discovery(miner_evaluations[uid])
 
     bt.logging.info('')
     bt.logging.info(
@@ -200,6 +215,51 @@ async def run_mirror_issue_discovery(
         f'({cache_stats.misses - cache_stats.fetch_failures} fetched OK, '
         f'{cache_stats.fetch_failures} fetch failures)'
     )
+
+
+def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
+    """Reset issue-discovery aggregates after a successful fetch with no mirror issues."""
+    evaluation.issue_discovery_score = 0.0
+    evaluation.issue_token_score = 0.0
+    evaluation.issue_credibility = 0.0
+    evaluation.is_issue_eligible = False
+    evaluation.total_solved_issues = 0
+    evaluation.total_valid_solved_issues = 0
+    evaluation.total_closed_issues = 0
+    evaluation.total_open_issues = 0
+
+
+def _copy_issue_discovery_fields(target: MinerEvaluation, source: MinerEvaluation) -> None:
+    target.issue_discovery_score = source.issue_discovery_score
+    target.issue_token_score = source.issue_token_score
+    target.issue_credibility = source.issue_credibility
+    target.is_issue_eligible = source.is_issue_eligible
+    target.total_solved_issues = source.total_solved_issues
+    target.total_valid_solved_issues = source.total_valid_solved_issues
+    target.total_closed_issues = source.total_closed_issues
+    target.total_open_issues = source.total_open_issues
+
+
+def _restore_issue_discovery_from_cache(
+    evaluation: MinerEvaluation,
+    evaluation_cache: Optional[MinerEvaluationCache],
+) -> bool:
+    """Restore cached issue-discovery aggregates for a transient DAS fetch failure."""
+    if evaluation_cache is None:
+        return False
+
+    cached = evaluation_cache.get(evaluation.uid, evaluation.hotkey, evaluation.github_id or '')
+    if cached is None:
+        bt.logging.warning(f'├─ UID {evaluation.uid}: no cached issue-discovery evaluation available')
+        return False
+
+    _copy_issue_discovery_fields(evaluation, cached)
+    bt.logging.info(
+        f'├─ UID {evaluation.uid}: restored cached issue discovery '
+        f'(score={cached.issue_discovery_score:.2f}, solved={cached.total_solved_issues}, '
+        f'valid={cached.total_valid_solved_issues})'
+    )
+    return True
 
 
 def _build_canonical_pr_owners(
@@ -265,7 +325,7 @@ async def _score_miner_mirror_issues(
     token_config: TokenConfig,
     open_issue_count: int,
     canonical_pr_owners: Dict[Tuple[str, int], Tuple[datetime, int, int]],
-) -> None:
+) -> bool:
     """Classify + score one miner's mirror issues, populate MinerEvaluation fields.
 
     ``open_issue_count`` is the miner's currently-OPEN issue count across
@@ -274,11 +334,15 @@ async def _score_miner_mirror_issues(
 
     ``canonical_pr_owners`` enforces the cross-miner one-issue-per-PR rule:
     only the marker-matching issue scores, siblings count for credibility.
+
+    Returns ``True`` when all required solving-PR score data was available, so
+    the caller can safely refresh the cache with this complete issue snapshot.
     """
     solved_count = 0
     valid_solved_count = 0
     closed_count = 0
     issue_token_score = 0.0
+    score_fetch_failed = False
     scored_issues: List[Issue] = []
 
     issues_sorted = sorted(
@@ -318,6 +382,7 @@ async def _score_miner_mirror_issues(
             # Fetch failed — issue still counts for solved/credibility but not scored.
             # Can't apply the valid-solved gate without a real token_score, so be
             # conservative and don't increment valid_solved_count.
+            score_fetch_failed = True
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): solver score unavailable '
                 f'(fetch failed) — credibility only'
@@ -387,7 +452,7 @@ async def _score_miner_mirror_issues(
             f'{solved_count} solved ({valid_solved_count} valid) | {closed_count} closed | '
             f'{open_issue_count} open'
         )
-        return
+        return not score_fetch_failed
 
     spam_mult = calculate_open_issue_spam_multiplier(open_issue_count, issue_token_score)
 
@@ -414,6 +479,7 @@ async def _score_miner_mirror_issues(
         f'credibility={credibility:.2f} | spam_mult={spam_mult:.1f} | '
         f'mirror_score={total_discovery_score:.2f}'
     )
+    return not score_fetch_failed
 
 
 async def _resolve_solving_pr_score(

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -21,6 +21,7 @@ mirror_client_mod = pytest.importorskip('gittensor.utils.mirror.client')
 classes = pytest.importorskip('gittensor.classes')
 load_weights = pytest.importorskip('gittensor.validator.utils.load_weights')
 scored_pr_module = pytest.importorskip('gittensor.validator.oss_contributions.mirror.scored_pr')
+normalize_module = pytest.importorskip('gittensor.validator.issue_discovery.normalize')
 
 run_mirror_issue_discovery = mirror_scan_module.run_mirror_issue_discovery
 _classify_issue = mirror_scan_module._classify_issue
@@ -32,9 +33,11 @@ MirrorPullRequest = mirror_models.MirrorPullRequest
 MirrorPullRequestFilesResponse = mirror_models.MirrorPullRequestFilesResponse
 MirrorRequestError = mirror_client_mod.MirrorRequestError
 MinerEvaluation = classes.MinerEvaluation
+MinerEvaluationCache = classes.MinerEvaluationCache
 RepositoryConfig = load_weights.RepositoryConfig
 TokenConfig = load_weights.TokenConfig
 ScoredMirrorPR = scored_pr_module.ScoredMirrorPR
+normalize_issue_discovery_rewards = normalize_module.normalize_issue_discovery_rewards
 
 
 # Representative defaults for the plumbed-through token scoring args. The
@@ -395,6 +398,216 @@ class TestRunMirrorIssueDiscovery:
         )
         assert failing.total_solved_issues == 0
         assert working.total_solved_issues == 1
+
+    def test_mirror_request_error_restores_cached_issue_discovery_fields(self):
+        cache = MinerEvaluationCache()
+        cached = MinerEvaluation(uid=1, hotkey='hk1', github_id='fails')
+        cached.issue_discovery_score = 8.12
+        cached.issue_token_score = 700.0
+        cached.issue_credibility = 1.0
+        cached.is_issue_eligible = True
+        cached.total_solved_issues = 7
+        cached.total_valid_solved_issues = 7
+        cache.store(cached)
+
+        client = Mock()
+        working_issues = [
+            _issue_dict(issue_number=20 + i, author_github_id='B', solved_by_pr=300 + i) for i in range(7)
+        ]
+
+        def _per_miner(github_id, since=None):
+            if github_id == 'fails':
+                raise MirrorRequestError('boom')
+            return _response(working_issues)
+
+        client.get_miner_issues.side_effect = _per_miner
+
+        failing = MinerEvaluation(uid=1, hotkey='hk1', github_id='fails')
+        working = _eval(uid=2, github_id='works')
+        working.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr) for pr in range(300, 307)]
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: failing, 2: working},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        assert failing.issue_discovery_score == 8.12
+        assert failing.issue_token_score == 700.0
+        assert failing.issue_credibility == 1.0
+        assert failing.is_issue_eligible is True
+        assert failing.total_solved_issues == 7
+        assert failing.total_valid_solved_issues == 7
+        assert working.issue_discovery_score > 0
+
+        rewards = normalize_issue_discovery_rewards({1: failing, 2: working})
+        assert rewards[1] < 1.0
+        assert rewards[2] < 1.0
+        assert sum(rewards.values()) == pytest.approx(1.0)
+
+    def test_successful_issue_fetch_refreshes_cache_after_scoring(self):
+        cache = MinerEvaluationCache()
+        client = Mock()
+        client.get_miner_issues.return_value = _response(
+            [_issue_dict(issue_number=10 + i, author_github_id='A', solved_by_pr=200 + i) for i in range(7)]
+        )
+
+        eval_ = _eval(uid=1, github_id='999')
+        eval_.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr) for pr in range(200, 207)]
+        # Mimic the OSS-phase store that happens before issue discovery runs.
+        # update_issue_discovery() only refreshes existing entries.
+        cache.store(eval_)
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        cached = cache.get(uid=1, hotkey='hk', github_id='999')
+        assert cached is not None
+        assert cached.issue_discovery_score == eval_.issue_discovery_score
+        assert cached.issue_discovery_score > 0
+        assert cached.total_solved_issues == 7
+        assert cached.total_valid_solved_issues == 7
+
+    def test_oss_store_preserves_cached_issue_fields_across_rounds(self):
+        """Regression: prior round's issue-discovery refresh must survive the
+        next round's OSS-phase store() so a same-round mirror failure can
+        restore the prior score. Without store()'s identity-match preserve
+        logic, the fresh-eval store wipes the entry and the restore reads
+        zeros — defeating the entire fallback (issue #1065)."""
+        cache = MinerEvaluationCache()
+
+        # --- Round N-1: full success.
+        # OSS phase stores the eval. At OSS-phase time the eval has the
+        # MinerEvaluation dataclass defaults for the issue-discovery fields
+        # (all zero/False) because issue discovery has not run yet this round.
+        round_n_minus_1 = _eval(uid=1, github_id='999')
+        round_n_minus_1.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr) for pr in range(300, 307)]
+        cache.store(round_n_minus_1)
+
+        # Issue phase finishes and refreshes the cached issue-discovery fields.
+        round_n_minus_1.issue_discovery_score = 8.12
+        round_n_minus_1.issue_token_score = 700.0
+        round_n_minus_1.issue_credibility = 1.0
+        round_n_minus_1.is_issue_eligible = True
+        round_n_minus_1.total_solved_issues = 7
+        round_n_minus_1.total_valid_solved_issues = 7
+        cache.update_issue_discovery(round_n_minus_1)
+
+        # --- Round N: a fresh MinerEvaluation with all issue fields at
+        # dataclass defaults. The OSS phase stores it. Without merge-on-store
+        # this would clobber the round-N-1 refresh.
+        round_n = _eval(uid=1, github_id='999')
+        round_n.mirror_merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr) for pr in range(300, 307)]
+        cache.store(round_n)
+
+        # Mirror fetch fails in round N. _restore_issue_discovery_from_cache
+        # reads the entry that store() should have preserved.
+        client = Mock()
+        client.get_miner_issues.side_effect = MirrorRequestError('boom')
+
+        _run(
+            run_mirror_issue_discovery(
+                {1: round_n},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        assert round_n.issue_discovery_score == 8.12
+        assert round_n.issue_token_score == 700.0
+        assert round_n.issue_credibility == 1.0
+        assert round_n.is_issue_eligible is True
+        assert round_n.total_solved_issues == 7
+        assert round_n.total_valid_solved_issues == 7
+
+    def test_successful_no_issue_fetch_clears_stale_cached_issue_fields(self):
+        cache = MinerEvaluationCache()
+        stale = _eval(uid=1, github_id='999')
+        stale.issue_discovery_score = 8.12
+        stale.issue_token_score = 700.0
+        stale.issue_credibility = 1.0
+        stale.is_issue_eligible = True
+        stale.total_solved_issues = 7
+        stale.total_valid_solved_issues = 7
+        cache.store(stale)
+
+        client = Mock()
+        client.get_miner_issues.return_value = _response([_issue_dict(repo='foo/not-enabled')])
+
+        eval_ = _eval(uid=1, github_id='999')
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        assert eval_.issue_discovery_score == 0.0
+        assert eval_.issue_token_score == 0.0
+        assert eval_.issue_credibility == 0.0
+        assert eval_.is_issue_eligible is False
+        assert eval_.total_solved_issues == 0
+        assert eval_.total_valid_solved_issues == 0
+
+        cached = cache.get(uid=1, hotkey='hk', github_id='999')
+        assert cached is not None
+        assert cached.issue_discovery_score == 0.0
+        assert cached.total_solved_issues == 0
+
+    def test_solving_pr_file_fetch_failure_does_not_overwrite_cached_issue_fields(self):
+        cache = MinerEvaluationCache()
+        stale = _eval(uid=1, github_id='999')
+        stale.issue_discovery_score = 8.12
+        stale.issue_token_score = 700.0
+        stale.issue_credibility = 1.0
+        stale.is_issue_eligible = True
+        stale.total_solved_issues = 7
+        stale.total_valid_solved_issues = 7
+        cache.store(stale)
+
+        client = Mock()
+        client.get_miner_issues.return_value = _response([_issue_dict()])
+        client.get_pr_files.side_effect = MirrorRequestError('files fetch failed')
+
+        eval_ = _eval(uid=1, github_id='999')
+        _run(
+            run_mirror_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        assert eval_.issue_discovery_score == 0.0
+        assert eval_.total_solved_issues == 1
+
+        cached = cache.get(uid=1, hotkey='hk', github_id='999')
+        assert cached is not None
+        assert cached.issue_discovery_score == 8.12
+        assert cached.total_solved_issues == 7
 
 
 # ============================================================================

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -311,6 +311,104 @@ class TestCacheIsolation:
         assert cached_issues[0].discovery_earned_score == 0.0
 
 
+class TestIssueDiscoveryFieldOwnership:
+    """The cache has two writers: store() (OSS phase, owns PR fields) and
+    update_issue_discovery() (issue phase, owns issue fields). Each must not
+    clobber the other's field group, or the issue-discovery fallback breaks."""
+
+    def _eval(self, uid: int = 1, hotkey: str = 'hotkey_1', github_id: str = '12345') -> MinerEvaluation:
+        ev = MinerEvaluation(uid=uid, hotkey=hotkey, github_id=github_id)
+        ev.merged_pull_requests = [_make_pr(uid=uid, hotkey=hotkey, github_id=github_id)]
+        return ev
+
+    def test_store_preserves_prior_issue_discovery_fields_when_identity_matches(self):
+        cache = MinerEvaluationCache()
+        first = self._eval()
+        cache.store(first)
+
+        # Issue-discovery phase refresh.
+        first.issue_discovery_score = 8.12
+        first.issue_token_score = 700.0
+        first.issue_credibility = 1.0
+        first.is_issue_eligible = True
+        first.total_solved_issues = 7
+        first.total_valid_solved_issues = 7
+        first.total_closed_issues = 2
+        first.total_open_issues = 3
+        cache.update_issue_discovery(first)
+
+        # Next round: a fresh MinerEvaluation has all issue-discovery fields
+        # back at dataclass defaults. store() must merge the prior entry's
+        # issue fields rather than overwriting with the fresh zeros.
+        next_round = self._eval()
+        assert next_round.issue_discovery_score == 0.0  # confirms the threat
+        cache.store(next_round)
+
+        cached = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert cached is not None
+        assert cached.issue_discovery_score == 8.12
+        assert cached.issue_token_score == 700.0
+        assert cached.issue_credibility == 1.0
+        assert cached.is_issue_eligible is True
+        assert cached.total_solved_issues == 7
+        assert cached.total_valid_solved_issues == 7
+        assert cached.total_closed_issues == 2
+        assert cached.total_open_issues == 3
+
+    def test_store_drops_prior_issue_discovery_on_identity_mismatch(self):
+        cache = MinerEvaluationCache()
+        first = self._eval(hotkey='hotkey_old', github_id='12345')
+        cache.store(first)
+        first.issue_discovery_score = 8.12
+        cache.update_issue_discovery(first)
+
+        # Re-registration: same UID, different hotkey. Prior issue-discovery
+        # belonged to a different miner — must not carry over.
+        rereg = self._eval(hotkey='hotkey_new', github_id='12345')
+        cache.store(rereg)
+
+        cached = cache.get(uid=1, hotkey='hotkey_new', github_id='12345')
+        assert cached is not None
+        assert cached.issue_discovery_score == 0.0
+
+    def test_update_issue_discovery_no_op_when_no_existing_entry(self):
+        """The cache only holds entries backed by an OSS-phase store; an
+        issue-only entry would have no PR data and the OSS fallback path
+        would later restore a half-populated MinerEvaluation."""
+        cache = MinerEvaluationCache()
+        ev = self._eval()
+        ev.issue_discovery_score = 8.12
+
+        cache.update_issue_discovery(ev)
+
+        assert cache.get(uid=1, hotkey='hotkey_1', github_id='12345') is None
+
+    def test_update_issue_discovery_evicts_on_identity_mismatch(self):
+        cache = MinerEvaluationCache()
+        cache.store(self._eval(hotkey='hotkey_old', github_id='12345'))
+
+        rereg = self._eval(hotkey='hotkey_new', github_id='12345')
+        rereg.issue_discovery_score = 8.12
+        cache.update_issue_discovery(rereg)
+
+        assert cache.get(uid=1, hotkey='hotkey_old', github_id='12345') is None
+        assert cache.get(uid=1, hotkey='hotkey_new', github_id='12345') is None
+
+    def test_update_issue_discovery_writes_through_when_identity_matches(self):
+        cache = MinerEvaluationCache()
+        ev = self._eval()
+        cache.store(ev)
+
+        ev.issue_discovery_score = 8.12
+        ev.total_solved_issues = 7
+        cache.update_issue_discovery(ev)
+
+        cached = cache.get(uid=1, hotkey='hotkey_1', github_id='12345')
+        assert cached is not None
+        assert cached.issue_discovery_score == 8.12
+        assert cached.total_solved_issues == 7
+
+
 def _make_mirror_pr_with_file_blob(blob: str, pr_number: int = 7) -> ScoredMirrorPR:
     now = datetime.now(timezone.utc)
     pr = MirrorPullRequest(


### PR DESCRIPTION
## Description

Restores a miner's cached issue-discovery score when a per-miner DAS mirror issue fetch fails, instead of leaving the miner at zero and redistributing their issue-discovery share to other miners.

The first revision missed the case #1065 actually describes: `store_or_use_cached_evaluation` (OSS phase) runs **before** issue discovery and calls `evaluation_cache.store(miner_eval)` for every miner with `total_prs > 0`. `_build_cache_entry` is a plain `copy.copy(eval)` with no merge — so the cache entry copies the fresh eval's dataclass-default `issue_discovery_score = 0.0`, wiping the prior round's issue-phase refresh. A later same-round mirror failure would then restore zeros.

This revision splits cache ownership so the OSS-phase write can no longer clobber the issue-discovery snapshot.

Closes: #1065

## Changes

### `MinerEvaluationCache` — two-writer split (`gittensor/classes.py`)

- `store()` (OSS-phase writer) now **preserves the prior entry's issue-discovery fields when the UID's identity (hotkey, github_id) matches**. Identity mismatch (re-registration) drops the prior state along with the rest of the entry.
- New `update_issue_discovery()` (issue-phase authoritative writer):
  - No-op when no entry exists (the cache only holds entries backed by an OSS-phase store, so writing issue fields alone would leave a half-populated entry the OSS fallback path could later restore).
  - Evicts on identity mismatch.
  - Writes through only the 8 issue-discovery fields on identity match.
- The owned field set is centralized in `_ISSUE_DISCOVERY_FIELDS`:
  `issue_discovery_score`, `issue_token_score`, `issue_credibility`, `is_issue_eligible`, `total_solved_issues`, `total_valid_solved_issues`, `total_closed_issues`, `total_open_issues`.

### Mirror issue discovery (`gittensor/validator/issue_discovery/mirror_scan.py`)

- Accepts an optional `evaluation_cache: MinerEvaluationCache`.
- On `MirrorRequestError` from `get_miner_issues()`, calls `_restore_issue_discovery_from_cache(evaluation, evaluation_cache)` to copy the cached issue fields onto the failing evaluation (identity-gated by `cache.get`).
- After scoring, refreshes the cache for "complete" UIDs only via `evaluation_cache.update_issue_discovery(...)`. `_score_miner_mirror_issues` now returns a `complete: bool` flag that is `False` when any solving-PR file fetch failed, so partial scores don't poison the cache.
- On a successful fetch that returns no mirror-enabled issues, `_clear_issue_discovery_fields()` writes zeros and the UID is still added to `cacheable_uids` so stale prior-round scores are cleared from cache.

### Forward wiring (`gittensor/validator/forward.py`)

- Plumbs `self.evaluation_cache` into `issue_discovery(...)` → `run_mirror_issue_discovery(...)`.
- Clears `cached_uids` after issue discovery so refreshed issue-discovery fields are persisted to DB by `bulk_store_evaluation` (otherwise `skip_uids=cached_uids` would discard them).

## Tests

### Regression for the OSS-store / issue-refresh interaction (`tests/validator/issue_discovery/test_mirror_scan.py`)

- `test_oss_store_preserves_cached_issue_fields_across_rounds` — drives the exact two-round flow flagged in review: round N-1 OSS-store → `update_issue_discovery` (score=8.12) → round N OSS-store on the same UID → mirror failure → asserts the restored round-N score is 8.12, not 0.
- `test_mirror_request_error_restores_cached_issue_discovery_fields` — per-miner mirror failure with another miner succeeding; verifies the failing miner keeps their cached score and normalization sums to 1.0.
- `test_successful_issue_fetch_refreshes_cache_after_scoring` — cache holds the latest scored values after a successful round.
- `test_successful_no_issue_fetch_clears_stale_cached_issue_fields` — stale cached scores are cleared when the miner stops solving.
- `test_solving_pr_file_fetch_failure_does_not_overwrite_cached_issue_fields` — partial scores from solving-PR file-fetch failures don't poison the cache.

### Cache ownership invariants (`tests/validator/test_validator_cache_fallback.py::TestIssueDiscoveryFieldOwnership`)

- `test_store_preserves_prior_issue_discovery_fields_when_identity_matches`
- `test_store_drops_prior_issue_discovery_on_identity_mismatch`
- `test_update_issue_discovery_no_op_when_no_existing_entry`
- `test_update_issue_discovery_evicts_on_identity_mismatch`
- `test_update_issue_discovery_writes_through_when_identity_matches`

## Validation

```
ruff check
pytest tests/validator/issue_discovery tests/validator/test_validator_cache_fallback.py tests/validator/oss_contributions/mirror -q
pytest tests -q       # 1415 passed
```
`