### PR TITLE
fix: strictly parse mirror boolean fields

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -21,6 +21,21 @@ from gittensor.validator.utils.datetime_utils import (
 )
 
 
+def _parse_bool(value, field_name: str, default: bool = False) -> bool:
+    """Parse mirror boolean fields without treating non-empty strings as true."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == 'true':
+            return True
+        if normalized == 'false':
+            return False
+    raise ValueError(f'{field_name} must be a boolean, got {value!r}')
+
+
 @dataclass
 class MirrorLabel:
     """A label applied to a PR or issue, with the actor who applied it.
@@ -104,7 +119,7 @@ class MirrorLinkedIssue:
             created_at=parse_optional_github_iso_to_utc(data.get('created_at')),
             closed_at=parse_optional_github_iso_to_utc(data.get('closed_at')),
             updated_at=parse_optional_github_iso_to_utc(data.get('updated_at')),
-            is_transferred=bool(data.get('is_transferred', False)),
+            is_transferred=_parse_bool(data.get('is_transferred'), 'is_transferred'),
             solved_by_pr=data.get('solved_by_pr'),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
         )
@@ -169,7 +184,7 @@ class MirrorPullRequest:
             closed_at=parse_optional_github_iso_to_utc(data.get('closed_at')),
             merged_at=parse_optional_github_iso_to_utc(data.get('merged_at')),
             last_edited_at=parse_optional_github_iso_to_utc(data.get('last_edited_at')),
-            edited_after_merge=bool(data.get('edited_after_merge', False)),
+            edited_after_merge=_parse_bool(data.get('edited_after_merge'), 'edited_after_merge'),
             hours_since_merge=data.get('hours_since_merge'),
             merged_by_login=data.get('merged_by_login'),
             base_ref=data.get('base_ref'),
@@ -182,7 +197,7 @@ class MirrorPullRequest:
             additions=int(data.get('additions', 0)),
             deletions=int(data.get('deletions', 0)),
             commits_count=int(data.get('commits_count', 0)),
-            scoring_data_stored=bool(data.get('scoring_data_stored', False)),
+            scoring_data_stored=_parse_bool(data.get('scoring_data_stored'), 'scoring_data_stored'),
             review_summary=MirrorReviewSummary.from_dict(data.get('review_summary') or {}),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
             linked_issues=[MirrorLinkedIssue.from_dict(issue) for issue in data.get('linked_issues') or []],
@@ -217,7 +232,7 @@ class MirrorSolvingPR:
             state=data['state'],
             merged_at=parse_optional_github_iso_to_utc(data.get('merged_at')),
             hours_since_merge=data.get('hours_since_merge'),
-            edited_after_merge=bool(data.get('edited_after_merge', False)),
+            edited_after_merge=_parse_bool(data.get('edited_after_merge'), 'edited_after_merge'),
             head_sha=data.get('head_sha'),
             base_sha=data.get('base_sha'),
             merge_base_sha=data.get('merge_base_sha'),
@@ -269,7 +284,7 @@ class MirrorIssue:
             closed_at=parse_optional_github_iso_to_utc(data.get('closed_at')),
             updated_at=parse_optional_github_iso_to_utc(data.get('updated_at')),
             last_edited_at=parse_optional_github_iso_to_utc(data.get('last_edited_at')),
-            is_transferred=bool(data.get('is_transferred', False)),
+            is_transferred=_parse_bool(data.get('is_transferred'), 'is_transferred'),
             solved_by_pr=data.get('solved_by_pr'),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
             solving_pr=MirrorSolvingPR.from_dict(solving_pr_raw) if solving_pr_raw else None,
@@ -304,7 +319,7 @@ class MirrorFile:
             additions=int(data.get('additions', 0)),
             deletions=int(data.get('deletions', 0)),
             changes=int(data.get('changes', 0)),
-            is_binary=bool(data.get('is_binary', False)),
+            is_binary=_parse_bool(data.get('is_binary'), 'is_binary'),
             head_content=data.get('head_content'),
             base_content=data.get('base_content'),
         )
@@ -393,6 +408,6 @@ class MirrorPullRequestFilesResponse:
             head_sha=data.get('head_sha'),
             base_sha=data.get('base_sha'),
             merge_base_sha=data.get('merge_base_sha'),
-            scoring_data_stored=bool(data.get('scoring_data_stored', False)),
+            scoring_data_stored=_parse_bool(data.get('scoring_data_stored'), 'scoring_data_stored'),
             files=files,
         )

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -272,6 +272,16 @@ class TestMirrorLinkedIssue:
         li = MirrorLinkedIssue.from_dict(linked_issue_dict)
         assert li.labels == []
 
+    def test_string_false_is_transferred_parses_false(self, linked_issue_dict):
+        linked_issue_dict['is_transferred'] = 'false'
+        li = MirrorLinkedIssue.from_dict(linked_issue_dict)
+        assert li.is_transferred is False
+
+    def test_invalid_is_transferred_rejected(self, linked_issue_dict):
+        linked_issue_dict['is_transferred'] = 'nope'
+        with pytest.raises(ValueError, match='is_transferred'):
+            MirrorLinkedIssue.from_dict(linked_issue_dict)
+
 
 # ============================================================================
 # MirrorPullRequest
@@ -351,6 +361,18 @@ class TestMirrorPullRequest:
         pr = MirrorPullRequest.from_dict(pull_request_dict)
         assert pr.head_repo_full_name is None
 
+    def test_string_false_booleans_parse_false(self, pull_request_dict):
+        pull_request_dict['edited_after_merge'] = 'false'
+        pull_request_dict['scoring_data_stored'] = 'false'
+        pr = MirrorPullRequest.from_dict(pull_request_dict)
+        assert pr.edited_after_merge is False
+        assert pr.scoring_data_stored is False
+
+    def test_invalid_scoring_data_stored_rejected(self, pull_request_dict):
+        pull_request_dict['scoring_data_stored'] = 'unknown'
+        with pytest.raises(ValueError, match='scoring_data_stored'):
+            MirrorPullRequest.from_dict(pull_request_dict)
+
 
 # ============================================================================
 # MirrorSolvingPR
@@ -367,6 +389,11 @@ class TestMirrorSolvingPR:
         assert sp.review_summary.maintainer_changes_requested_count == 1
         # solving_pr omits the other review counts; defaults kick in
         assert sp.review_summary.approved_count == 0
+
+    def test_string_false_edited_after_merge_parses_false(self, solving_pr_dict):
+        solving_pr_dict['edited_after_merge'] = 'false'
+        sp = MirrorSolvingPR.from_dict(solving_pr_dict)
+        assert sp.edited_after_merge is False
 
 
 # ============================================================================
@@ -400,6 +427,11 @@ class TestMirrorIssue:
         issue_dict['repo_full_name'] = 'Entrius/AllWays'
         issue = MirrorIssue.from_dict(issue_dict)
         assert issue.repo_full_name == 'entrius/allways'
+
+    def test_string_false_is_transferred_parses_false(self, issue_dict):
+        issue_dict['is_transferred'] = 'false'
+        issue = MirrorIssue.from_dict(issue_dict)
+        assert issue.is_transferred is False
 
 
 # ============================================================================
@@ -436,6 +468,11 @@ class TestMirrorFile:
         file_dict['previous_filename'] = 'src/old/MinerCard.tsx'
         f = MirrorFile.from_dict(file_dict)
         assert f.previous_filename == 'src/old/MinerCard.tsx'
+
+    def test_string_false_is_binary_parses_false(self, file_dict):
+        file_dict['is_binary'] = 'false'
+        f = MirrorFile.from_dict(file_dict)
+        assert f.is_binary is False
 
 
 # ============================================================================
@@ -540,6 +577,19 @@ class TestMirrorPullRequestFilesResponse:
         }
         resp = MirrorPullRequestFilesResponse.from_dict(payload)
         assert resp.files == []
+
+    def test_string_false_scoring_data_stored_parses_false(self):
+        payload = {
+            'repo_full_name': 'entrius/gittensor-ui',
+            'pr_number': 518,
+            'head_sha': 'h',
+            'base_sha': 'b',
+            'merge_base_sha': 'mb',
+            'scoring_data_stored': 'false',
+            'files': [],
+        }
+        resp = MirrorPullRequestFilesResponse.from_dict(payload)
+        assert resp.scoring_data_stored is False
 
     def test_repo_full_name_lowercased_at_parse(self, file_dict):
         payload = {


### PR DESCRIPTION
## Summary

- Add a strict mirror boolean parser so string values like `"false"` no longer become `True` via Python truthiness.
- Apply it to mirror response boolean fields used by scoring and anti-gaming gates: transferred flags, edited-after-merge flags, binary file metadata, and scoring-data availability flags.
- Add regression coverage for string `"false"` parsing and invalid boolean rejection in mirror model parsing.

## Related Issues

Closes #1068

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Validation performed:

```bash
python3 -m py_compile gittensor/utils/mirror/models.py tests/utils/test_mirror_models.py
git diff --check
```

Attempted but unavailable in this local environment:

```bash
python3 -m pytest tests/utils/test_mirror_models.py
python3 -m ruff check gittensor/utils/mirror/models.py tests/utils/test_mirror_models.py
```

The environment is missing `pytest`, `ruff`, and runtime dependency `bittensor`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
