### PR TITLE
fix: validate repo_filter in gitt issues list

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -30,6 +30,7 @@ from .helpers import (
     print_network_header,
     read_issues_from_contract,
     validate_issue_id,
+    validate_repository,
     with_cli_behavior_options,
     with_network_contract_options,
 )
@@ -73,6 +74,14 @@ def issues_list(
             validate_issue_id(issue_id, 'id')
         except click.BadParameter as e:
             handle_exception(as_json, str(e), 'bad_parameter')
+
+    # Validate and normalize repo_filter
+    if repo_filter:
+        try:
+            repo_filter = validate_repository(repo_filter, verify_exists=False)
+        except click.BadParameter as e:
+            handle_exception(as_json, str(e), 'bad_parameter')
+            return
 
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(
         contract,


### PR DESCRIPTION
## Description
Fix #1061 - Add validation for `--repo` flag using `validate_repository()` helper.

## Changes
- Import `validate_repository` from helpers
- Validate and normalize `repo_filter` before filtering issues
- Reject malformed repo filters with clear error message

## Testing
- [x] `gitt issues list --repo " entrius/gittensor "` now works (whitespace trimmed)
- [x] `gitt issues list --repo ownerrepo` now fails with clear error
- [x] `gitt issues list --repo entrius/gittensor` works as expected