### PR TITLE
fix: fail closed on corrupt PAT storage writes

### DIFF
--- a/gittensor/validator/pat_storage.py
+++ b/gittensor/validator/pat_storage.py
@@ -20,6 +20,10 @@ PATS_FILE = Path(__file__).resolve().parents[2] / 'data' / 'miner_pats.json'
 _lock = threading.Lock()
 
 
+class PatStorageError(RuntimeError):
+    """Raised when stored PAT data cannot be safely modified."""
+
+
 def ensure_pats_file() -> None:
     """Create the PATs file with an empty list if it doesn't exist. Called on validator boot."""
     with _lock:
@@ -36,7 +40,7 @@ def load_all_pats() -> list[dict]:
 def save_pat(uid: int, hotkey: str, pat: str, github_id: str) -> None:
     """Upsert a PAT entry by UID. Creates the file if needed."""
     with _lock:
-        entries = _read_file()
+        entries = _read_file(strict=True)
 
         entry = {
             'uid': uid,
@@ -68,7 +72,7 @@ def get_pat_by_uid(uid: int) -> Optional[dict]:
 def remove_pat(uid: int) -> bool:
     """Remove a PAT entry by UID. Returns True if an entry was removed."""
     with _lock:
-        entries = _read_file()
+        entries = _read_file(strict=True)
         filtered = [e for e in entries if e.get('uid') != uid]
         if len(filtered) == len(entries):
             return False
@@ -76,13 +80,15 @@ def remove_pat(uid: int) -> bool:
         return True
 
 
-def _read_file() -> list[dict]:
+def _read_file(strict: bool = False) -> list[dict]:
     """Read and parse the JSON file. Must be called while holding _lock."""
     if not PATS_FILE.exists():
         return []
     try:
         return json.loads(PATS_FILE.read_text())
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError) as exc:
+        if strict:
+            raise PatStorageError(f'Cannot safely read PAT storage file {PATS_FILE}: {exc}') from exc
         return []
 
 

--- a/tests/validator/test_pat_storage.py
+++ b/tests/validator/test_pat_storage.py
@@ -71,6 +71,15 @@ class TestSavePat:
         entries = pat_storage.load_all_pats()
         assert len(entries) == 3
 
+    def test_save_rejects_corrupt_existing_file(self, use_tmp_pats_file):
+        corrupt_content = 'not json{{{'
+        use_tmp_pats_file.write_text(corrupt_content)
+
+        with pytest.raises(pat_storage.PatStorageError):
+            pat_storage.save_pat(1, 'hotkey_1', 'ghp_abc', 'user_1')
+
+        assert use_tmp_pats_file.read_text() == corrupt_content
+
 
 class TestLoadAllPats:
     def test_load_empty_when_no_file(self):
@@ -119,6 +128,15 @@ class TestRemovePat:
         entries = pat_storage.load_all_pats()
         assert len(entries) == 1
         assert entries[0]['uid'] == 2
+
+    def test_remove_rejects_corrupt_existing_file(self, use_tmp_pats_file):
+        corrupt_content = 'not json{{{'
+        use_tmp_pats_file.write_text(corrupt_content)
+
+        with pytest.raises(pat_storage.PatStorageError):
+            pat_storage.remove_pat(1)
+
+        assert use_tmp_pats_file.read_text() == corrupt_content
 
 
 class TestConcurrency:


### PR DESCRIPTION
## Summary

Closes #1079.

Prevents corrupt `miner_pats.json` from being treated as empty during mutating PAT storage operations. `save_pat()` and `remove_pat()` now fail closed when the existing storage file cannot be parsed, preserving the corrupt file instead of overwriting it.

## Changes

- Add `PatStorageError` for unsafe PAT storage mutations.
- Make `save_pat()` and `remove_pat()` use strict reads before writing.
- Preserve existing read-only behavior for `load_all_pats()`, which still returns `[]` for missing or corrupt storage.
- Add regression tests covering corrupt-file preservation on save and remove.

## Testing

- `python3 -m pytest tests/validator/test_pat_storage.py`
- `python3 -m ruff check gittensor/validator/pat_storage.py tests/validator/test_pat_storage.py`
- `python3 -m ruff format --check gittensor/validator/pat_storage.py tests/validator/test_pat_storage.py`
- `python3 -m pyright gittensor/validator/pat_storage.py tests/validator/test_pat_storage.py`
