### PR TITLE
fix: tolerate null mirror numeric fields

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -11,7 +11,7 @@ from https://mirror.gittensor.io/api/v1/*.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import bittensor as bt
 
@@ -19,6 +19,10 @@ from gittensor.validator.utils.datetime_utils import (
     parse_github_iso_to_utc,
     parse_optional_github_iso_to_utc,
 )
+
+
+def _int_or_zero(value: Any) -> int:
+    return int(value or 0)
 
 
 @dataclass
@@ -179,9 +183,9 @@ class MirrorPullRequest:
             head_sha=data.get('head_sha'),
             base_sha=data.get('base_sha'),
             merge_base_sha=data.get('merge_base_sha'),
-            additions=int(data.get('additions', 0)),
-            deletions=int(data.get('deletions', 0)),
-            commits_count=int(data.get('commits_count', 0)),
+            additions=_int_or_zero(data.get('additions')),
+            deletions=_int_or_zero(data.get('deletions')),
+            commits_count=_int_or_zero(data.get('commits_count')),
             scoring_data_stored=bool(data.get('scoring_data_stored', False)),
             review_summary=MirrorReviewSummary.from_dict(data.get('review_summary') or {}),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
@@ -301,9 +305,9 @@ class MirrorFile:
             filename=data['filename'],
             previous_filename=data.get('previous_filename'),
             status=data['status'],
-            additions=int(data.get('additions', 0)),
-            deletions=int(data.get('deletions', 0)),
-            changes=int(data.get('changes', 0)),
+            additions=_int_or_zero(data.get('additions')),
+            deletions=_int_or_zero(data.get('deletions')),
+            changes=_int_or_zero(data.get('changes')),
             is_binary=bool(data.get('is_binary', False)),
             head_content=data.get('head_content'),
             base_content=data.get('base_content'),

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -351,6 +351,38 @@ class TestMirrorPullRequest:
         pr = MirrorPullRequest.from_dict(pull_request_dict)
         assert pr.head_repo_full_name is None
 
+    def test_null_numeric_fields_default_to_zero(self, pull_request_dict):
+        pull_request_dict['additions'] = None
+        pull_request_dict['deletions'] = None
+        pull_request_dict['commits_count'] = None
+
+        pr = MirrorPullRequest.from_dict(pull_request_dict)
+
+        assert pr.additions == 0
+        assert pr.deletions == 0
+        assert pr.commits_count == 0
+
+    def test_missing_numeric_fields_default_to_zero(self, pull_request_dict):
+        for key in ('additions', 'deletions', 'commits_count'):
+            pull_request_dict.pop(key)
+
+        pr = MirrorPullRequest.from_dict(pull_request_dict)
+
+        assert pr.additions == 0
+        assert pr.deletions == 0
+        assert pr.commits_count == 0
+
+    def test_numeric_string_fields_parse_normally(self, pull_request_dict):
+        pull_request_dict['additions'] = '12'
+        pull_request_dict['deletions'] = '3'
+        pull_request_dict['commits_count'] = '4'
+
+        pr = MirrorPullRequest.from_dict(pull_request_dict)
+
+        assert pr.additions == 12
+        assert pr.deletions == 3
+        assert pr.commits_count == 4
+
 
 # ============================================================================
 # MirrorSolvingPR
@@ -436,6 +468,17 @@ class TestMirrorFile:
         file_dict['previous_filename'] = 'src/old/MinerCard.tsx'
         f = MirrorFile.from_dict(file_dict)
         assert f.previous_filename == 'src/old/MinerCard.tsx'
+
+    def test_null_numeric_fields_default_to_zero(self, file_dict):
+        file_dict['additions'] = None
+        file_dict['deletions'] = None
+        file_dict['changes'] = None
+
+        f = MirrorFile.from_dict(file_dict)
+
+        assert f.additions == 0
+        assert f.deletions == 0
+        assert f.changes == 0
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Closes #1082.

Prevents validator mirror parsing from crashing when DAS returns explicit `null` values for numeric fields in mirror PR or file responses.

## Changes

- Add a shared `_int_or_zero()` helper for nullable numeric JSON fields.
- Normalize `MirrorPullRequest` numeric fields:
  - `additions`
  - `deletions`
  - `commits_count`
- Normalize `MirrorFile` numeric fields:
  - `additions`
  - `deletions`
  - `changes`
- Add regression tests for null, missing, and numeric-string values.

## Out of scope

- No DAS schema or API response changes.
- No changes to scoring logic beyond safe mirror response parsing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated
- [x] Manually tested

Validation:

```bash
python3 -m pytest tests/utils/test_mirror_models.py
python3 -m ruff check gittensor/utils/mirror/models.py tests/utils/test_mirror_models.py
python3 -m ruff format --check gittensor/utils/mirror/models.py tests/utils/test_mirror_models.py
python3 -m pyright gittensor/utils/mirror/models.py tests/utils/test_mirror_models.py
git diff --check
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented, if applicable