### PR TITLE
refactor: dedupe label-resolution fallback by delegating to resolve_highest_label_multiplier

### DIFF
--- a/gittensor/validator/oss_contributions/label_resolution.py
+++ b/gittensor/validator/oss_contributions/label_resolution.py
@@ -37,24 +37,12 @@ def resolve_legacy_label_multiplier(
     the fallback mirrors the current-label behavior by choosing the highest
     multiplier, then the label name for deterministic ties.
     """
-    default_multiplier = get_default_label_multiplier(repo_config)
-
     for label in label_timeline_order:
         multiplier = get_label_multiplier(label, repo_config)
         if multiplier is not None:
             return label, multiplier
 
-    candidates = []
-    for label in current_labels:
-        multiplier = get_label_multiplier(label, repo_config)
-        if multiplier is not None:
-            candidates.append((label, multiplier))
-
-    if not candidates:
-        return None, default_multiplier
-
-    label, multiplier = max(candidates, key=lambda candidate: (candidate[1], candidate[0]))
-    return label, multiplier
+    return resolve_highest_label_multiplier(current_labels, repo_config)
 
 
 def resolve_highest_label_multiplier(


### PR DESCRIPTION
## Summary

`resolve_legacy_label_multiplier` and `resolve_highest_label_multiplier` in [gittensor/validator/oss_contributions/label_resolution.py](gittensor/validator/oss_contributions/label_resolution.py) share the same "highest-multiplier-with-name-tiebreak" fallback shape: build `(label, multiplier)` candidates from a label set, return the `max(..., key=(multiplier, label))`, or fall back to the repo default if none match.

`resolve_legacy_label_multiplier` already runs that exact block inline on its fallback path (after the timeline-order short-circuit). This PR replaces the inlined fallback with a single call to `resolve_highest_label_multiplier` so the shared logic lives in one place.

```diff
 def resolve_legacy_label_multiplier(...) -> tuple[Optional[str], float]:
     """..."""
-    default_multiplier = get_default_label_multiplier(repo_config)
-
     for label in label_timeline_order:
         multiplier = get_label_multiplier(label, repo_config)
         if multiplier is not None:
             return label, multiplier
-
-    candidates = []
-    for label in current_labels:
-        multiplier = get_label_multiplier(label, repo_config)
-        if multiplier is not None:
-            candidates.append((label, multiplier))
-
-    if not candidates:
-        return None, default_multiplier
-
-    label, multiplier = max(candidates, key=lambda candidate: (candidate[1], candidate[0]))
-    return label, multiplier
+    return resolve_highest_label_multiplier(current_labels, repo_config)
```

The timeline short-circuit at the top is preserved verbatim — only the truncated-timeline / unmatched-timeline path changes shape, and the delegated call returns identical values for that path. No behaviour change.

Net: **+1 / -13 lines**.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/validator/test_label_multiplier.py -v` — all 29 tests pass (covers timeline order, current-label fallback, wildcard patterns, default multiplier, name tiebreak, missing-labels payload).
- `pytest tests/` — all 1414 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)