### PR TITLE
fix: resolve_network crash on non-string config network

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -656,13 +656,17 @@ def resolve_network(network: Optional[str] = None, rpc_url: Optional[str] = None
     # override a user who set `network: finney` to point at mainnet.
     config = load_config()
 
-    config_network = config.get('network', '').lower()
+    raw_config_network = config.get('network', '')
+    config_network = raw_config_network.lower() if isinstance(raw_config_network, str) else ''
     if config_network and config_network in NETWORK_MAP:
         return NETWORK_MAP[config_network], config_network
 
     if config.get('ws_endpoint'):
         endpoint = config['ws_endpoint']
-        name = _URL_TO_NETWORK.get(endpoint, config.get('network', 'custom'))
+        name = _URL_TO_NETWORK.get(
+            endpoint,
+            raw_config_network if isinstance(raw_config_network, str) else 'custom',
+        )
         return endpoint, name
 
     # Default: finney (mainnet)


### PR DESCRIPTION
## Description
Fix #1084 - `resolve_network()` no longer crashes on non-string config values for `network`.

## Changes
- Defensively check type before calling `.lower()` on config network value
- Ensure fallback name is a string when `ws_endpoint` is used
- Non-string values (`null`, `123`, `false`) now fall through to `ws_endpoint` or finney default

## Testing
- [x] `{"network": null, "ws_endpoint": "wss://custom"}` returns `("wss://custom", "custom")`
- [x] `{"network": 123, "ws_endpoint": "wss://custom"}` returns `("wss://custom", "custom")`
- [x] `{"network": false}` falls back to finney
- [x] Valid string config behavior unchanged