### PR TITLE
docs/remove-stale-account-age-comment

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -71,7 +71,7 @@ _PAT_POST_STATUS_MARKUP = {
 def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, json_mode):
     """Broadcast your GitHub PAT to all validators on the network.
 
-    Validators will validate your PAT (test GitHub API access, check account age),
+    Validators will validate your PAT (test GitHub API access),
     then store it locally for use during scoring rounds.
 
     \b

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -8,7 +8,7 @@ class PatBroadcastSynapse(bt.Synapse):
     """Miner-initiated push synapse to broadcast their GitHub PAT to validators.
 
     The miner sets github_access_token on the request. The validator validates the PAT
-    (checks it works, extracts GitHub ID, verifies account age, runs a test query)
+    (checks it works, extracts GitHub ID, runs a test query)
     and responds with accepted/rejection_reason.
     """
 

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -48,7 +48,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
 
     uid = validator.metagraph.hotkeys.index(hotkey)
 
-    # 2. Validate PAT (checks it works, extracts github_id, verifies account age)
+    # 2. Validate PAT (checks it works, extracts github_id)
     github_id, error = validate_github_credentials(uid, synapse.github_access_token)
     if error:
         return _reject(error)


### PR DESCRIPTION
## Summary

Several docstrings and user-facing comments state that PAT validation checks GitHub account age, but the validator does not currently implement any account-age verification.

Affected locations:

* `gittensor/synapses.py` — `PatBroadcastSynapse` docstring
* `gittensor/validator/pat_handler.py` — inline validation comment
* `gittensor/cli/miner_commands/post.py` — `miner post --help` text

The current validation flow in `validate_github_credentials` (via `get_github_identity`) only:

1. Sends `GET /user` using the provided PAT.
2. Reads `user_data.get("id")`.
3. Returns `(github_id, status)`.

The GitHub `created_at` field is never referenced, and there is no account-age threshold or related validation logic in the codebase.

This PR removes the inaccurate account-age wording so the documentation and CLI output accurately reflect the current implementation. No functional changes are introduced.

## Test Plan

* [ ] Verify `grep -rn "account.age\|account_age" gittensor/` returns no relevant matches.
* [ ] Verify `gitt miner post --help` no longer references GitHub account-age validation.
