### PR TITLE
docs: drop stale "account age" wording from PAT validation

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -71,7 +71,7 @@ _PAT_POST_STATUS_MARKUP = {
 def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, json_mode):
     """Broadcast your GitHub PAT to all validators on the network.
 
-    Validators will validate your PAT (test GitHub API access, check account age),
+    Validators will validate your PAT (test GitHub API access),
     then store it locally for use during scoring rounds.
 
     \b

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -8,7 +8,7 @@ class PatBroadcastSynapse(bt.Synapse):
     """Miner-initiated push synapse to broadcast their GitHub PAT to validators.
 
     The miner sets github_access_token on the request. The validator validates the PAT
-    (checks it works, extracts GitHub ID, verifies account age, runs a test query)
+    (checks it works, extracts GitHub ID, runs a test query)
     and responds with accepted/rejection_reason.
     """
 

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -48,7 +48,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
 
     uid = validator.metagraph.hotkeys.index(hotkey)
 
-    # 2. Validate PAT (checks it works, extracts github_id, verifies account age)
+    # 2. Validate PAT (checks it works, extracts github_id)
     github_id, error = validate_github_credentials(uid, synapse.github_access_token)
     if error:
         return _reject(error)


### PR DESCRIPTION
## Summary

Three docstrings/comments claim PAT validation "verifies account age", but the actual code path never consults the GitHub account `created_at` field and there is no `MIN_ACCOUNT_AGE` constant or comparison anywhere in the validator.

The wording appears in:
- [`gittensor/synapses.py:11`](gittensor/synapses.py#L11) — `PatBroadcastSynapse` docstring
- [`gittensor/validator/pat_handler.py:51`](gittensor/validator/pat_handler.py#L51) — step-2 inline comment
- [`gittensor/cli/miner_commands/post.py:74`](gittensor/cli/miner_commands/post.py#L74) — `miner post` `--help` text shown to miners

What `validate_github_credentials` actually does (via `get_github_identity` in [`gittensor/utils/github_api_tools.py:253`](gittensor/utils/github_api_tools.py#L253)):

1. `GET /user` with the PAT.
2. Read `user_data.get('id')`.
3. Return `(github_id, status)`.

`created_at` is never read. Grep confirms no constant or call site implements an account-age threshold.

This PR trims the misleading clause from each location so the comments match the implementation. No behavior change.

## Test plan

- [ ] `grep -rn "account.age\|account_age" gittensor/` returns no matches after this PR.
- [ ] `gitt miner post --help` no longer claims an account-age check.
