### PR TITLE
fix(cli): route --json commands through loading_context for spinner consistency

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -234,7 +234,7 @@ def _handle_command_error(e: Exception) -> None:
     raise SystemExit(1)
 
 
-def loading_context(message: str, as_json: bool, spinner: str = 'dots', color='cyan') -> ContextManager[Any]:
+def loading_context(message: str, as_json: bool, spinner: str = 'dots', color: str = 'cyan') -> ContextManager[Any]:
     """Return a spinner context in human mode, or a no-op context in JSON mode."""
     return (
         nullcontext()


### PR DESCRIPTION
Closes #898 

## What

Five `--json`-accepting commands call `console.status(...)` directly instead of the existing `loading_context(msg, as_json)` helper, leaving the Rich spinner running in JSON mode:

- `gitt issues list` - view.py:71
- `gitt issues bounty-pool` - view.py:197
- `gitt issues pending-harvest` - view.py:246
- `gitt admin info` - view.py:300
- `gitt vote list` - vote.py:240

`submissions.py:72` already follows the right pattern.

## How

Mechanical swap at each site:

```python
# Before
with console.status('[bold cyan]Reading issues from contract...', spinner='dots'):
    ...

# After
with loading_context('Reading issues from contract...', as_json, color='bold cyan'):
    ...
