### PR TITLE
fix: check_registered exits with code 1 instead of 0 on unregistered hotkey (#1011)

### DIFF
--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -136,7 +136,7 @@ class BaseNeuron(ABC):
                         f'Wallet: {self.wallet} is not registered on netuid {self.config.netuid}.'
                         f' Please register the hotkey using `btcli subnets register` before trying again'
                     )
-                    exit()
+                    exit(1)
                 return  # Success
             except ConnectionClosedError as e:
                 bt.logging.warning(


### PR DESCRIPTION
## Description

Fix #1011 — `check_registered` calls bare `exit()` (defaults to exit code 0 / success) when the hotkey is not registered, making it impossible for supervisors/systemd/CI to detect the failure.

## Changes

- `exit()` → `exit(1)` so the process exits with a failure code when unregistered

## Testing

- [x] Registered hotkey still succeeds (returns normally)
- [x] Unregistered hotkey now exits with code 1 instead of 0