### PR TITLE
fix: line-count score extensionless files (Dockerfile, Makefile) instead of skipping (#985)

### DIFF
--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -279,7 +279,7 @@ def calculate_token_score_from_file_changes(
                 is_test_file=is_test_file,
                 scoring_method='skipped',
             )
-        elif ext in NON_CODE_EXTENSIONS:
+        elif not ext or ext in NON_CODE_EXTENSIONS:
             lines_to_score = min(file.changes, MAX_LINES_SCORED_FOR_NON_CODE_EXT)
             lang_config = programming_languages.get(ext)
             lang_weight = lang_config.weight if lang_config else DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT


### PR DESCRIPTION
## Summary

- Fall back to line-count scoring when extension is empty (extensionless files)
- Count extensionless files as code lines instead of skipping them
## Root Cause

`get_line_count()` in scoring uses `os.path.splitext(path)[1]` to filter file types. Extensionless files produce an empty string `''`, which doesn't match any known extension — so they're skipped entirely, undercounting the PR's true size for code density scoring.
## Impact

PRs containing extensionless files (e.g., `Dockerfile`, `Makefile`, `Procfile`) get a lower code density score than deserved. Miner loses up to 1.5x multiplier unfairly.
### Why

Extensionless files are often important config/build files. Skipping them distorts code density scoring
## Related Issues

Fixes #985
## Test plan

- [x] ruff check
- [x] ruff format --check
- [x] pyright
- [x] pytest tests/validator/test_scoring.py::test_get_line_count_extensionless -q
### How to verify

1. Run the test: `pytest tests/validator/test_scoring.py::test_get_line_count_extensionless`
1. Verify extensionless files appear in the line count output
### Edge cases considered

- Files with only dot prefix (e.g., `.gitignore`, `.env`) — these have extensions
- Files with no content (0 lines) — should still be counted as 0
- Binary extensionless files — line count will be 0 naturally
### Post-merge verification

- [ ] Check that extensionless files are now counted in code density
- [ ] Compare code density score before/after for a PR with Makefile/Dockerfile