### PR TITLE
fix: preserve null author_github_id in MirrorPullRequest and MirrorSolvingPR

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -124,7 +124,7 @@ class MirrorPullRequest:
     title: str
     body: Optional[str]
     state: str
-    author_github_id: str
+    author_github_id: Optional[str]
     author_login: str
     author_association: Optional[str]
     created_at: datetime
@@ -162,7 +162,7 @@ class MirrorPullRequest:
             title=data.get('title', ''),
             body=data.get('body'),
             state=data['state'],
-            author_github_id=str(data['author_github_id']),
+            author_github_id=str(data['author_github_id']) if data.get('author_github_id') is not None else None,
             author_login=data.get('author_login', ''),
             author_association=data.get('author_association'),
             created_at=parse_github_iso_to_utc(data['created_at']),
@@ -198,7 +198,7 @@ class MirrorSolvingPR:
     """
 
     pr_number: int
-    author_github_id: str
+    author_github_id: Optional[str]
     state: str
     merged_at: Optional[datetime]
     hours_since_merge: Optional[float]
@@ -213,7 +213,7 @@ class MirrorSolvingPR:
     def from_dict(cls, data: dict) -> 'MirrorSolvingPR':
         return cls(
             pr_number=data['pr_number'],
-            author_github_id=str(data['author_github_id']),
+            author_github_id=str(data['author_github_id']) if data.get('author_github_id') is not None else None,
             state=data['state'],
             merged_at=parse_optional_github_iso_to_utc(data.get('merged_at')),
             hours_since_merge=data.get('hours_since_merge'),


### PR DESCRIPTION
## Summary

`MirrorPullRequest.from_dict` and `MirrorSolvingPR.from_dict` both call
`str(data['author_github_id'])`, which coerces an upstream `null` to the
literal string `'None'` instead of `None`.

This silently bypasses two anti-gaming equality checks downstream:

- `mirror/scoring.py:446` — self-issue gate compares `li.author_github_id == pr.author_github_id`
- `mirror_scan.py:332` — discoverer/solver same-account gate compares `issue.author_github_id == solving_pr.author_github_id`

Both `MirrorLinkedIssue` and `MirrorIssue` already use the correct
null-preserving pattern. This fix applies the same pattern to the two
inconsistent classes and tightens their field types to `Optional[str]`.

## Changes

- `MirrorPullRequest.author_github_id`: `str` → `Optional[str]`
- `MirrorSolvingPR.author_github_id`: `str` → `Optional[str]`
- Both `from_dict` methods now preserve `None` instead of coercing to `'None'`

Fixes #1089