### PR TITLE
fix: clear cached_uids after issue discovery so fresh fields are persisted

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -71,6 +71,9 @@ async def forward(self: 'Validator') -> None:
             miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
         )
 
+        # cached UIDs now have fresh issue-discovery fields — persist them
+        cached_uids.clear()
+
         # 3. Issue bounties verification
         await issue_competitions(self, miner_evaluations)
 


### PR DESCRIPTION
## Summary

`store_or_use_cached_evaluation` returns `cached_uids` to skip re-storing
stale OSS data for miners restored from cache. However, `issue_discovery`
runs after and mutates fresh issue-discovery fields on those same
evaluations. `bulk_store_evaluation` then skips the entire row, so fresh
issue-discovery fields are used for emissions in the current round but
never written to DB.

## Root Cause

Call order in `forward.py`:
1. `oss_contributions` → returns `cached_uids`
2. `issue_discovery` → mutates fresh fields onto cached UID evaluations
3. `bulk_store_evaluation(skip_uids=cached_uids)` → drops those fresh fields

## Fix

Clear `cached_uids` after `issue_discovery` completes. OSS cache
fallback still works correctly — we just no longer skip persisting
the fresh issue-discovery fields that were written in step 2.

Fixes #1052