### PR TITLE
fix: treat transient GitHub PAT identity checks as inconclusive

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -14,7 +14,7 @@ import requests
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.validator import pat_storage
-from gittensor.validator.utils.github_validation import validate_github_credentials
+from gittensor.validator.utils.github_validation import validate_github_credentials_result
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -24,6 +24,10 @@ def _get_hotkey(synapse: bt.Synapse) -> str:
     """Extract the caller's hotkey from a synapse, raising if missing."""
     assert synapse.dendrite is not None and synapse.dendrite.hotkey is not None
     return synapse.dendrite.hotkey
+
+
+def _github_identity_retry_message(action: str) -> str:
+    return f'GitHub API temporarily unavailable; retry the {action} in a few minutes.'
 
 
 # ---------------------------------------------------------------------------
@@ -48,10 +52,14 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
 
     uid = validator.metagraph.hotkeys.index(hotkey)
 
-    # 2. Validate PAT (checks it works, extracts github_id, verifies account age)
-    github_id, error = validate_github_credentials(uid, synapse.github_access_token)
-    if error:
-        return _reject(error)
+    # 2. Validate PAT (checks it works and extracts github_id)
+    validation = validate_github_credentials_result(uid, synapse.github_access_token)
+    if validation.transient_failure:
+        return _reject(_github_identity_retry_message('broadcast'))
+    if validation.error:
+        return _reject(validation.error)
+
+    github_id = validation.github_id
 
     # 3. Enforce GitHub identity pinning — same hotkey cannot switch GitHub accounts
     existing = pat_storage.get_pat_by_uid(uid)
@@ -66,7 +74,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     if test_error:
         return _reject(f'PAT test query failed: {test_error}')
 
-    # 5. Store PAT (github_id guaranteed non-None after validate_github_credentials success)
+    # 5. Store PAT (github_id guaranteed non-None after validate_github_credentials_result success)
     pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=github_id or '0')
 
     # Clear PAT from response so it isn't echoed back
@@ -117,11 +125,16 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
     synapse.has_pat = True
 
     # Re-validate the stored PAT
-    _, error = validate_github_credentials(uid, entry['pat'])
-    if error:
+    validation = validate_github_credentials_result(uid, entry['pat'], stored_github_id=entry.get('github_id'))
+    if validation.transient_failure:
+        synapse.pat_valid = None
+        synapse.rejection_reason = _github_identity_retry_message('check')
+        bt.logging.warning(f'PAT check result — UID: {uid}: GitHub identity lookup temporarily unavailable')
+        return synapse
+    if validation.error:
         synapse.pat_valid = False
-        synapse.rejection_reason = error
-        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {error}')
+        synapse.rejection_reason = validation.error
+        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {validation.error}')
         return synapse
 
     test_error = _test_pat_against_repo(entry['pat'])

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -3,12 +3,14 @@
 """Tests for PAT broadcast and check handlers."""
 
 import asyncio
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
 from bittensor.core.synapse import TerminalInfo
 
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
+from gittensor.utils.github_api_tools import GitHubIdentityResult, GitHubIdentityStatus
 from gittensor.validator import pat_storage
 from gittensor.validator.pat_handler import (
     _test_pat_against_repo,
@@ -17,6 +19,7 @@ from gittensor.validator.pat_handler import (
     handle_pat_broadcast,
     handle_pat_check,
 )
+from gittensor.validator.utils.github_validation import GitHubCredentialValidation
 
 
 def _run(coro):
@@ -57,6 +60,14 @@ def _make_check_synapse(hotkey: str) -> PatCheckSynapse:
     return synapse
 
 
+def _validation(
+    github_id: Optional[str] = 'github_42',
+    error: Optional[str] = None,
+    transient_failure: bool = False,
+) -> GitHubCredentialValidation:
+    return GitHubCredentialValidation(github_id, error, transient_failure=transient_failure)
+
+
 # ---------------------------------------------------------------------------
 # Blacklist tests
 # ---------------------------------------------------------------------------
@@ -93,7 +104,7 @@ class TestBlacklistPatCheck:
 
 class TestHandlePatBroadcast:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
     def test_valid_pat_accepted(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_valid')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -110,6 +121,8 @@ class TestHandlePatBroadcast:
         assert entry['hotkey'] == 'hotkey_1'
         assert entry['uid'] == 1
         assert entry['github_id'] == 'github_42'
+        mock_validate.assert_called_once_with(1, 'ghp_valid')
+        mock_test_query.assert_called_once_with('ghp_valid')
 
     def test_unregistered_hotkey_rejected(self, mock_validator):
         synapse = _make_broadcast_synapse('unknown_hotkey')
@@ -118,7 +131,10 @@ class TestHandlePatBroadcast:
         assert result.accepted is False
         assert 'not registered' in (result.rejection_reason or '')
 
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=(None, 'PAT invalid'))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_validation(None, 'PAT invalid'),
+    )
     def test_invalid_pat_rejected(self, mock_validate, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_bad')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -129,8 +145,27 @@ class TestHandlePatBroadcast:
         # Verify PAT was NOT stored
         assert pat_storage.get_pat_by_uid(1) is None
 
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo')
+    @patch(
+        'gittensor.validator.utils.github_validation.get_github_identity',
+        return_value=GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE),
+    )
+    def test_transient_identity_lookup_rejected_with_retry_message(
+        self, mock_get_identity, mock_test_query, mock_validator
+    ):
+        synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_valid_during_outage')
+        result = _run(handle_pat_broadcast(mock_validator, synapse))
+
+        assert result.accepted is False
+        assert result.github_access_token == ''
+        assert result.rejection_reason == 'GitHub API temporarily unavailable; retry the broadcast in a few minutes.'
+        assert 'Could not validate Github id' not in (result.rejection_reason or '')
+        assert pat_storage.get_pat_by_uid(1) is None
+        mock_get_identity.assert_called_once_with('ghp_valid_during_outage')
+        mock_test_query.assert_not_called()
+
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value='GitHub API returned 403')
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
     def test_test_query_failure_rejected(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -139,7 +174,7 @@ class TestHandlePatBroadcast:
         assert '403' in (result.rejection_reason or '')
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation('github_99'))
     def test_github_identity_change_rejected(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey cannot switch to a different GitHub account."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_old', 'github_42')
@@ -156,7 +191,7 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
     def test_pat_rotation_same_github_accepted(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey can rotate PATs if GitHub identity stays the same."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_old', 'github_42')
@@ -171,7 +206,7 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation('github_99'))
     def test_new_miner_on_uid_can_use_any_github(self, mock_validate, mock_test_query, mock_validator):
         """A new hotkey on the same UID (new miner) can register any GitHub account."""
         pat_storage.save_pat(1, 'old_hotkey', 'ghp_old', 'github_42')
@@ -188,7 +223,7 @@ class TestHandlePatBroadcast:
 
 class TestHandlePatCheck:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
     def test_valid_pat(self, mock_validate, mock_test_query, mock_validator):
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_test', 'github_42')
 
@@ -197,6 +232,8 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is True
         assert result.rejection_reason is None
+        mock_validate.assert_called_once_with(1, 'ghp_test', stored_github_id='github_42')
+        mock_test_query.assert_called_once_with('ghp_test')
 
     def test_missing_pat(self, mock_validator):
         synapse = _make_check_synapse('hotkey_1')
@@ -213,8 +250,29 @@ class TestHandlePatCheck:
         assert result.has_pat is False
         assert result.pat_valid is False
 
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo')
+    @patch(
+        'gittensor.validator.utils.github_validation.get_github_identity',
+        return_value=GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE),
+    )
+    def test_transient_identity_lookup_reports_inconclusive(self, mock_get_identity, mock_test_query, mock_validator):
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_stored', 'github_42')
+
+        synapse = _make_check_synapse('hotkey_1')
+        result = _run(handle_pat_check(mock_validator, synapse))
+
+        assert result.has_pat is True
+        assert result.pat_valid is None
+        assert result.rejection_reason == 'GitHub API temporarily unavailable; retry the check in a few minutes.'
+        assert 'Could not validate Github id' not in (result.rejection_reason or '')
+        mock_get_identity.assert_called_once_with('ghp_stored')
+        mock_test_query.assert_not_called()
+
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=(None, 'PAT expired'))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_validation(None, 'PAT expired'),
+    )
     def test_stored_but_invalid_pat(self, mock_validate, mock_test_query, mock_validator):
         """PAT is stored but fails re-validation."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_expired', 'github_42')


### PR DESCRIPTION
## Summary

Fix validator-side PAT broadcast/check handling for transient GitHub `/user` failures.

After #932, scoring uses `validate_github_credentials_result()` so transient GitHub identity lookup failures can be distinguished from invalid PATs. The validator PAT handlers still used the legacy `(github_id, error)` wrapper, which dropped `transient_failure=True` and treated temporary GitHub `/user` failures as normal validation errors.

## Changes

- Use `validate_github_credentials_result()` in PAT broadcast/check handlers.
- Return a retry-oriented message for transient broadcast failures.
- Return inconclusive check results for transient stored PAT validation:
  - `has_pat = True`
  - `pat_valid = None`
  - retry-oriented `rejection_reason`
- Keep normal invalid PAT behavior unchanged.
- Add regression tests for transient `/user` failures in both broadcast and check flows.

## Testing

```bash
UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest tests/validator/test_pat_handler.py tests/validator/test_github_identity_fallback.py tests/validator/test_validator_cache_fallback.py tests/cli/test_miner_commands.py -q
UV_CACHE_DIR=/tmp/uv-cache uv run ruff check gittensor/ tests/
UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check gittensor/ tests/
```

Targeted pyright on the changed files with local venv paths: 0 errors.

Note: full validator-suite runs in this sandbox hit pre-existing hangs in mirror/issue-discovery tests before reaching this change.

## Related
Closes #1106