### PR TITLE
fix: move legacy OSS scoring off event loop

### DIFF
--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from threading import Lock
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
@@ -30,6 +31,24 @@ from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryCon
 # NOTE: there was a circular import error, needed this if to resolve it
 if TYPE_CHECKING:
     from neurons.validator import Validator
+
+
+_legacy_scoring_lock = Lock()
+
+
+def _run_legacy_miner_scoring(
+    miner_eval: MinerEvaluation,
+    legacy_repos: Dict[str, RepositoryConfig],
+    programming_languages: Dict[str, LanguageConfig],
+    token_config: TokenConfig,
+) -> None:
+    """Run blocking legacy GitHub scoring inside one scoped session cache."""
+    # session_scope uses a module-level cache. Keep legacy scopes serialized even
+    # if an operator configures concurrent validator forwards.
+    with _legacy_scoring_lock:
+        with session_scope():
+            load_miners_prs(miner_eval, legacy_repos)
+            score_miner_prs(miner_eval, legacy_repos, programming_languages, token_config)
 
 
 async def evaluate_miners_pull_requests(
@@ -87,9 +106,13 @@ async def evaluate_miners_pull_requests(
     }
 
     if legacy_repos:
-        with session_scope():
-            load_miners_prs(miner_eval, legacy_repos)
-            score_miner_prs(miner_eval, legacy_repos, programming_languages, token_config)
+        await asyncio.to_thread(
+            _run_legacy_miner_scoring,
+            miner_eval,
+            legacy_repos,
+            programming_languages,
+            token_config,
+        )
 
     if mirror_repos:
         mirror_eval = MirrorMinerEvaluation(

--- a/tests/validator/oss_contributions/mirror/test_routing.py
+++ b/tests/validator/oss_contributions/mirror/test_routing.py
@@ -8,6 +8,7 @@ Verifies that:
 """
 
 import asyncio
+from threading import Event, get_ident
 from unittest.mock import patch
 
 import pytest
@@ -111,6 +112,62 @@ def test_all_legacy_repos_skips_mirror_path():
         mock_mirror_load.assert_not_called()
         mock_mirror_score.assert_not_called()
         mock_combine.assert_not_called()
+
+
+def test_legacy_scoring_yields_to_event_loop():
+    """Blocking legacy GitHub scoring should not starve sibling async tasks."""
+    configs = {
+        'a/legacy': RepositoryConfig(weight=0.5, mirror_enabled=False),
+    }
+    sibling_ran = Event()
+    observations = {
+        'load_saw_sibling': False,
+        'loop_thread': None,
+        'load_thread': None,
+        'score_thread': None,
+    }
+
+    def blocking_legacy_load(_miner_eval, _repos):
+        observations['load_thread'] = get_ident()
+        observations['load_saw_sibling'] = sibling_ran.wait(timeout=1.0)
+
+    def legacy_score(_miner_eval, _repos, _languages, _token_config):
+        observations['score_thread'] = get_ident()
+
+    async def run_with_sibling():
+        observations['loop_thread'] = get_ident()
+
+        async def sibling_task():
+            await asyncio.sleep(0.05)
+            sibling_ran.set()
+
+        task = asyncio.create_task(sibling_task())
+        result = await evaluate_miners_pull_requests(
+            uid=1,
+            hotkey='hk',
+            pat='fake-pat',
+            master_repositories=configs,
+            programming_languages={},
+            token_config=TokenConfig(),
+        )
+        await task
+        return result
+
+    with (
+        patch.object(reward_module, 'validate_response_and_initialize_miner_evaluation') as mock_init,
+        patch.object(reward_module, 'load_miners_prs', side_effect=blocking_legacy_load),
+        patch.object(reward_module, 'score_miner_prs', side_effect=legacy_score),
+        patch.object(reward_module, 'load_mirror_miner_prs') as mock_mirror_load,
+    ):
+        mock_init.return_value = _make_miner_eval()
+
+        result = _run(run_with_sibling())
+
+        assert observations['load_saw_sibling'] is True
+        assert observations['load_thread'] != observations['loop_thread']
+        assert observations['score_thread'] == observations['load_thread']
+        assert result.github_pat is None
+        mock_mirror_load.assert_not_called()
 
 
 def test_all_mirror_repos_skips_legacy_path():


### PR DESCRIPTION
## Summary

Moves the legacy PAT-based OSS scoring block in `evaluate_miners_pull_requests()` off the async validator event loop.

The legacy path still performs synchronous GitHub I/O through `requests` and retry backoff sleeps. This PR wraps the existing `session_scope()` + `load_miners_prs()` + `score_miner_prs()` sequence in one `asyncio.to_thread()` call so unrelated async tasks can continue being scheduled while legacy scoring runs.

A small lock keeps the legacy `session_scope()` lifecycle serialized because that scope uses a module-level non-reentrant session cache.

## Related Issues

Closes #1108

Related:

- #945
- #687

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated
- [x] Manually tested

Commands run:

```bash
uv run pytest tests/validator/oss_contributions/mirror/test_routing.py -q
uv run pytest tests/validator/oss_contributions -q
uv run pytest -q
uv run ruff check
uv run ruff format --check
uv run pyright
git diff --check
```

Results:

```text
6 passed
127 passed
1415 passed, 2 existing warnings
ruff clean
format check clean
pyright clean
git diff --check clean
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Regression test added
- [x] Changes are documented in PR description
