### PR TITLE
feat: add mirror repo scoring overrides

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -34,6 +34,7 @@ class ScoredMirrorPR:
     review_quality_multiplier: float = 1.0
     label_multiplier: float = 1.0
     label: Optional[str] = None
+    eligibility_mode: bool = True
 
     # Pioneer attribution (per-repo, populated post per-PR scoring)
     pioneer_dividend: float = 0.0

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -153,7 +153,10 @@ async def score_mirror_pr(
     scored.leaf_score = result.leaf_score
     scored.total_nodes_scored = result.total_nodes_scored
     scored.code_density = result.code_density
-    scored.base_score = result.base_score
+    scored.base_score = (
+        repo_config.fixed_base_score if repo_config.fixed_base_score is not None else result.base_score
+    )
+    scored.eligibility_mode = repo_config.eligibility_mode
 
     _calculate_pr_multipliers(scored, repo_config)
 

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -360,18 +360,27 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
         evaluation.is_eligible = is_eligible
         evaluation.credibility = credibility
 
-        if not is_eligible:
-            bt.logging.info(f'UID {uid} ineligible: {reason} — score set to 0')
-            continue
-
         # Calculate spam multiplier once per miner using combined total token score
         merged_prs = evaluation.merged_pull_requests + evaluation.mirror_merged_prs
+        bypass_eligible_prs = [
+            pr for pr in evaluation.mirror_merged_prs if not getattr(pr, 'eligibility_mode', True)
+        ]
+        if not is_eligible:
+            if not bypass_eligible_prs:
+                bt.logging.info(f'UID {uid} ineligible: {reason} — score set to 0')
+                continue
+            bt.logging.info(
+                f'UID {uid} ineligible: {reason} — scoring {len(bypass_eligible_prs)} '
+                'mirror PR(s) from eligibility-disabled repos only'
+            )
+
         preliminary_token_score = sum(pr.token_score for pr in merged_prs)
         spam_multiplier = calculate_pr_spam_penalty_multiplier(evaluation.total_open_prs, preliminary_token_score)
 
-        for pr in merged_prs:
+        scoreable_prs = merged_prs if is_eligible else bypass_eligible_prs
+        for pr in scoreable_prs:
             pr.open_pr_spam_multiplier = spam_multiplier
-            pr.credibility_multiplier = round(credibility, 2)
+            pr.credibility_multiplier = round(credibility, 2) if is_eligible else 1.0
             pr.calculate_final_earned_score()
 
             evaluation.total_token_score += pr.token_score

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -42,6 +42,11 @@ class RepositoryConfig:
             same fnmatch wildcard syntax as ``additional_acceptable_branches``.
         default_label_multiplier: Multiplier used when no configured label
             pattern matches. Defaults to neutral scoring.
+        fixed_base_score: Optional base score override for mirror-scored PRs.
+            Clamped to [0.0, 100.0] at load time.
+        eligibility_mode: When True, the global miner eligibility gate applies.
+            When False, mirror PRs in this repo may earn even if the miner fails
+            that gate. Defaults to True.
 
     """
 
@@ -52,6 +57,8 @@ class RepositoryConfig:
     trusted_label_pipeline: bool = False
     label_multipliers: Optional[Dict[str, float]] = None
     default_label_multiplier: float = 1.0
+    fixed_base_score: Optional[float] = None
+    eligibility_mode: bool = True
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -59,6 +66,12 @@ def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
     if repo_config is None:
         return DEFAULT_REPO_WEIGHT
     return repo_config.weight
+
+
+def _clamp_fixed_base_score(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    return max(0.0, min(100.0, float(value)))
 
 
 @dataclass
@@ -140,6 +153,8 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                         else None
                     ),
                     default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
+                    fixed_base_score=_clamp_fixed_base_score(metadata.get('fixed_base_score')),
+                    eligibility_mode=bool(metadata.get('eligibility_mode', True)),
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -61,11 +61,13 @@ def _pr(
     maintainer_changes_requested_count: int = 0,
     labels: list | None = None,
     linked_issues: list | None = None,
+    repo_full_name: str = 'entrius/gittensor-ui',
+    pr_number: int = 100,
 ) -> MirrorPullRequest:
     return MirrorPullRequest.from_dict(
         {
-            'repo_full_name': 'entrius/gittensor-ui',
-            'pr_number': 100,
+            'repo_full_name': repo_full_name,
+            'pr_number': pr_number,
             'title': 't',
             'body': 'b',
             'state': state,
@@ -108,6 +110,8 @@ def _config(
     trusted_label_pipeline: bool = False,
     label_multipliers: dict | None = None,
     default_label_multiplier: float = 1.0,
+    fixed_base_score: float | None = None,
+    eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
@@ -116,6 +120,8 @@ def _config(
         trusted_label_pipeline=trusted_label_pipeline,
         label_multipliers=label_multipliers,
         default_label_multiplier=default_label_multiplier,
+        fixed_base_score=fixed_base_score,
+        eligibility_mode=eligibility_mode,
     )
 
 
@@ -332,6 +338,105 @@ class TestScoringDataStoredGate:
         client.get_pr_files.assert_not_called()
         assert scored.files is None
         assert scored.base_score == 0.0
+
+
+class TestRepositoryScoringOverrides:
+    def test_fixed_base_score_replaces_token_derived_base_but_keeps_multipliers(self, monkeypatch):
+        labels = [{'name': 'feature', 'actor_github_id': '1', 'actor_association': 'OWNER'}]
+        small = ScoredMirrorPR(pr=_pr(labels=labels, pr_number=1))
+        large = ScoredMirrorPR(pr=_pr(labels=labels, pr_number=2, repo_full_name='entrius/other-repo'))
+        client = Mock()
+        client.get_pr_files.return_value.files = [
+            MirrorFile.from_dict(
+                {
+                    'filename': 'src/foo.py',
+                    'previous_filename': None,
+                    'status': 'modified',
+                    'additions': 1,
+                    'deletions': 0,
+                    'changes': 1,
+                    'is_binary': False,
+                    'byte_size': 10,
+                    'head_content': 'x = 1\n',
+                    'base_content': '',
+                }
+            )
+        ]
+        results = iter(
+            [
+                scoring_module.BaseScoreResult(0.01, 1.0, 1, 1.0, 0, 0.0, 1, 1.0),
+                scoring_module.BaseScoreResult(0.5, 100.0, 10, 50.0, 10, 50.0, 20, 1.0),
+            ]
+        )
+        monkeypatch.setattr(scoring_module, 'calculate_base_score_for_pr_files', lambda *args: next(results))
+        repo_config = _config(fixed_base_score=1.0, label_multipliers={'feature': 1.5})
+        normal_config = _config(label_multipliers={'feature': 1.5})
+
+        asyncio.run(
+            score_mirror_pr(
+                small,
+                mirror_eval=Mock(),
+                mirror_repos={small.pr.repo_full_name: repo_config, large.pr.repo_full_name: normal_config},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+        asyncio.run(
+            score_mirror_pr(
+                large,
+                mirror_eval=Mock(),
+                mirror_repos={small.pr.repo_full_name: repo_config, large.pr.repo_full_name: normal_config},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert small.base_score == pytest.approx(1.0)
+        assert small.token_score == pytest.approx(1.0)
+        assert small.label_multiplier == pytest.approx(1.5)
+        assert small.eligibility_mode is True
+        assert large.base_score == pytest.approx(0.5)
+        assert small.calculate_final_earned_score() > large.calculate_final_earned_score()
+
+    def test_score_mirror_pr_copies_repo_eligibility_mode(self, monkeypatch):
+        scored = ScoredMirrorPR(pr=_pr())
+        client = Mock()
+        client.get_pr_files.return_value.files = [
+            MirrorFile.from_dict(
+                {
+                    'filename': 'src/foo.py',
+                    'previous_filename': None,
+                    'status': 'modified',
+                    'additions': 1,
+                    'deletions': 0,
+                    'changes': 1,
+                    'is_binary': False,
+                    'byte_size': 10,
+                    'head_content': 'x = 1\n',
+                    'base_content': '',
+                }
+            )
+        ]
+        monkeypatch.setattr(
+            scoring_module,
+            'calculate_base_score_for_pr_files',
+            lambda *args: scoring_module.BaseScoreResult(10.0, 10.0, 1, 5.0, 1, 5.0, 2, 1.0),
+        )
+
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=Mock(),
+                mirror_repos={scored.pr.repo_full_name: _config(eligibility_mode=False)},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert scored.eligibility_mode is False
 
 
 # ============================================================================
@@ -758,3 +863,36 @@ class TestPrMultipliers:
         assert scored.time_decay_multiplier == 1.0
         assert scored.credibility_multiplier == 1.0
         assert scored.review_quality_multiplier == 1.0
+
+
+class TestEligibilityModeFinalize:
+    def test_ineligible_miner_earns_only_from_eligibility_disabled_mirror_repos(self):
+        from gittensor.classes import MinerEvaluation
+        from gittensor.validator.oss_contributions.scoring import finalize_miner_scores
+
+        ungated = ScoredMirrorPR(pr=_pr(repo_full_name='entrius/ungated', pr_number=1))
+        ungated.base_score = 10.0
+        ungated.token_score = 10.0
+        ungated.eligibility_mode = False
+
+        gated = ScoredMirrorPR(pr=_pr(repo_full_name='entrius/gated', pr_number=2))
+        gated.base_score = 20.0
+        gated.token_score = 20.0
+        gated.eligibility_mode = True
+
+        eval_ = MinerEvaluation(uid=1, hotkey='hk')
+        eval_.mirror_merged_prs = [ungated, gated]
+        eval_.mirror_closed_prs = [
+            ScoredMirrorPR(pr=_pr(state='CLOSED', repo_full_name='entrius/closed', pr_number=100 + i))
+            for i in range(10)
+        ]
+        eval_.unique_repos_contributed_to = {'entrius/ungated', 'entrius/gated'}
+
+        finalize_miner_scores({1: eval_})
+
+        assert eval_.is_eligible is False
+        assert eval_.credibility < 0.8
+        assert ungated.earned_score == pytest.approx(10.0)
+        assert ungated.credibility_multiplier == pytest.approx(1.0)
+        assert gated.earned_score == pytest.approx(0.0)
+        assert eval_.total_score == pytest.approx(10.0)

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -139,6 +139,17 @@ class TestLoadMasterRepositories:
                 f'{repo_name} trusted_label_pipeline should be bool, got {type(config.trusted_label_pipeline)}'
             )
 
+    def test_new_scoring_fields_have_defaults_on_live_configs(self):
+        """Live entries without repo-level overrides preserve existing behavior."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            assert config.fixed_base_score is None or 0.0 <= config.fixed_base_score <= 100.0, (
+                f'{repo_name} fixed_base_score should be None or clamped into range'
+            )
+            assert isinstance(config.eligibility_mode, bool), (
+                f'{repo_name} eligibility_mode should be bool, got {type(config.eligibility_mode)}'
+            )
+
     def test_entrius_repos_have_trusted_label_pipeline(self):
         """All entrius/* entries opt into trusted_label_pipeline (issue #911)."""
         repos = load_master_repo_weights()
@@ -286,6 +297,61 @@ class TestRepositoryConfigLabelMultipliers:
         assert 0.0 <= float(metadata['default_label_multiplier']) <= 20.0, (
             f'{repo_name} default_label_multiplier must be within [0.0, 20.0]'
         )
+
+
+class TestRepositoryConfigScoringOverrides:
+    """Dataclass + JSON-parsing tests for per-repo mirror scoring overrides."""
+
+    def test_defaults_preserve_existing_behavior(self):
+        config = RepositoryConfig(weight=0.5)
+
+        assert config.fixed_base_score is None
+        assert config.eligibility_mode is True
+
+    def test_loader_parses_new_scoring_fields(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/defaults': {'weight': 0.3},
+                    'foo/overrides': {
+                        'weight': 0.5,
+                        'fixed_base_score': 42.5,
+                        'eligibility_mode': False,
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/defaults'].fixed_base_score is None
+        assert repos['foo/defaults'].eligibility_mode is True
+        assert repos['foo/overrides'].fixed_base_score == pytest.approx(42.5)
+        assert repos['foo/overrides'].eligibility_mode is False
+
+    @pytest.mark.parametrize(
+        'raw,expected',
+        [
+            (-5.0, 0.0),
+            (250.0, 100.0),
+        ],
+    )
+    def test_loader_clamps_fixed_base_score(self, tmp_path, monkeypatch, raw, expected):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps({'foo/repo': {'weight': 0.5, 'fixed_base_score': raw}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/repo'].fixed_base_score == pytest.approx(expected)
 
 
 class TestBannedOrganizations:


### PR DESCRIPTION
## Summary

Adds per-repository mirror scoring controls for fixed base scores and eligibility gate bypasses.

- Parses `fixed_base_score` and `eligibility_mode` from repository metadata, defaulting to existing behavior
- Clamps `fixed_base_score` into `[0.0, 100.0]` at load time
- Applies fixed base scores in the mirror PR scoring path while preserving downstream multipliers
- Allows `eligibility_mode=false` mirror repos to earn when a miner fails the global gate, without awarding gated repos in the same round

## Related Issues

Fixes #1110

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Validation run:

- `uv run --python 3.12 --extra dev pytest tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_scoring.py -q` -> 743 passed
- `uv run --python 3.12 --extra dev pytest tests/validator/oss_contributions tests/validator/test_review_quality_multiplier.py tests/validator/test_pioneer_dividend.py tests/validator/test_scoring_classes.py -q` -> 182 passed
- `uv run --python 3.12 --extra dev ruff check gittensor/validator/utils/load_weights.py gittensor/validator/oss_contributions/mirror/scored_pr.py gittensor/validator/oss_contributions/mirror/scoring.py gittensor/validator/oss_contributions/scoring.py tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_scoring.py` -> All checks passed
- `uv run --python 3.12 --extra dev pytest -q` -> 1422 passed, 2 warnings

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)