### PR TITLE
fix(cli): validate --repo filter on `gitt issues list` (#1061)

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -30,6 +30,7 @@ from .helpers import (
     print_network_header,
     read_issues_from_contract,
     validate_issue_id,
+    validate_repository,
     with_cli_behavior_options,
     with_network_contract_options,
 )
@@ -71,6 +72,18 @@ def issues_list(
     if issue_id is not None:
         try:
             validate_issue_id(issue_id, 'id')
+        except click.BadParameter as e:
+            handle_exception(as_json, str(e), 'bad_parameter')
+
+    # Normalize and validate the --repo filter before any contract reads so
+    # malformed input is rejected up-front and whitespace-padded valid input
+    # still matches `repository_full_name` from the contract. validate_repository
+    # strips whitespace, enforces owner/name format, and raises
+    # click.BadParameter on bad input — same contract used by mutating commands.
+    if repo_filter is not None:
+        try:
+            owner, repo_name = validate_repository(repo_filter, verify_exists=False)
+            repo_filter = f'{owner}/{repo_name}'
         except click.BadParameter as e:
             handle_exception(as_json, str(e), 'bad_parameter')
 

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -78,3 +78,98 @@ def test_issues_list_rejects_invalid_id_json(cli_root, runner, bad_id):
     assert payload['error']['type'] == 'bad_parameter'
     assert 'between 1 and 999999' in payload['error']['message']
     mock_read.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# --repo filter validation (regression for #1061)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('bad_repo', ['ownerrepo', 'owner//repo', 'owner/', '/repo', 'owner repo'])
+def test_issues_list_rejects_malformed_repo_filter_json(cli_root, runner, bad_repo):
+    """Malformed --repo input must fail validation up-front before any contract read."""
+    with patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as mock_read:
+        result = runner.invoke(
+            cli_root, ['issues', 'list', '--json', '--repo', bad_repo], catch_exceptions=False
+        )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'bad_parameter'
+    mock_read.assert_not_called()
+
+
+@pytest.mark.parametrize('bad_repo', ['ownerrepo', 'owner//repo'])
+def test_issues_list_rejects_malformed_repo_filter_human(cli_root, runner, bad_repo):
+    """Human-mode --repo malformed input must also exit non-zero before contract read."""
+    with patch('gittensor.cli.issue_commands.view.read_issues_from_contract') as mock_read:
+        result = runner.invoke(cli_root, ['issues', 'list', '--repo', bad_repo], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    mock_read.assert_not_called()
+
+
+def test_issues_list_repo_filter_strips_whitespace_json(cli_root, runner):
+    """Whitespace-padded valid --repo input must trim and match contract repository_full_name."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'list', '--json', '--repo', '  owner/repo  '],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload['success'] is True
+    assert payload['issue_count'] == 1
+    assert payload['issues'][0]['repository_full_name'] == 'owner/repo'
+
+
+def test_issues_list_repo_filter_case_insensitive_json(cli_root, runner):
+    """--repo filter should match contract entries regardless of case (preserved existing behavior)."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'list', '--json', '--repo', 'OWNER/REPO'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload['success'] is True
+    assert payload['issue_count'] == 1
+
+
+def test_issues_list_repo_filter_no_match_returns_empty_json(cli_root, runner):
+    """Valid but non-matching --repo input returns empty list, not all issues."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=FAKE_ISSUES),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'list', '--json', '--repo', 'other/repo'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload['success'] is True
+    assert payload['issue_count'] == 0
+    assert payload['issues'] == []


### PR DESCRIPTION
Fixes #1061. Reopened from PR #1112 — that one was rebased off a stale upstream main (had un-squashed copies of recently-merged PRs) and triggered an auto-close on the inflated diff. This branch is rebased onto current upstream main (`5530c42`) so the diff is exactly the +108 line fix.

## Problem
`--repo <owner/name>` on `gitt issues list` (added in #910) compares raw user input directly against `repository_full_name`:

```python
issues = [
    i for i in issues
    if i.get('repository_full_name', '').lower() == repo_filter.lower()
]
```

So:
- Malformed inputs like `ownerrepo` or `owner//repo` are silently accepted and quietly match nothing (no error feedback).
- Whitespace-padded valid inputs like `'  entrius/gittensor  '` fail to match real entries because the comparison string still contains the surrounding spaces.

## Fix
Reuse the existing `validate_repository(verify_exists=False)` helper before any contract read. It already:
- strips whitespace,
- enforces the `owner/repo` regex,
- raises `click.BadParameter` with `param_hint='--repo'` on bad input.

Surface that exception through the existing `handle_exception` path so JSON consumers get a structured `bad_parameter` error and human callers exit non-zero — same shape used by `--id` validation a few lines above.

The same validator is already used by mutating commands (`gitt issues register/cancel` in `mutations.py`), so the read-side `--repo` filter now matches the documented contract enforced everywhere else in the CLI.

## Tests added
6 new tests in `tests/cli/test_issues_list_json.py`:
- Malformed filters rejected with structured `bad_parameter` error in JSON mode (parametrized over `ownerrepo`, `owner//repo`, `owner/`, `/repo`, `owner repo`).
- Malformed filters exit non-zero in human mode.
- Whitespace-padded valid filter `'  owner/repo  '` correctly matches contract entries.
- Mixed-case filter `OWNER/REPO` still matches (preserves existing case-insensitive behavior).
- Valid non-matching filter returns empty list, not all issues.

All 19 tests in the file pass; `read_issues_from_contract` is asserted not-called for invalid input so we never burn a contract read on bad parameters.

## Diff size
- `gittensor/cli/issue_commands/view.py`: +13 lines (1 import + 11-line validation block w/ comment)
- `tests/cli/test_issues_list_json.py`: +95 lines (6 new tests)
- **Total: +108 lines, 0 deletions, 2 files**