### PR TITLE
feat: add mirror repo scoring config fields

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -126,34 +126,45 @@ async def score_mirror_pr(
     # mirror_eval.merged_prs contains only eligibility-passed PRs — legacy parity
     # with load_miners_prs which applies should_skip_merged_pr pre-append.
 
+    has_fixed_base = repo_config.fixed_base_score is not None
+
     # Mirror signals it has no stored files for this PR (pending backfill, in-flight
-    # file job, etc.) — skip the round trip.
-    if not pr.scoring_data_stored:
+    # file job, etc.) — skip the round trip unless the repo explicitly supplies
+    # a fixed base score.
+    if not pr.scoring_data_stored and not has_fixed_base:
         return
 
     # Fetch file contents via the mirror's lazy /pulls/.../files endpoint.
-    try:
-        files = (await asyncio.to_thread(client.get_pr_files, pr.repo_full_name, pr.pr_number)).files
-    except MirrorRequestError as e:
-        bt.logging.warning(f'Mirror file fetch failed for PR #{pr.pr_number}: {e}')
-        return
-    scored.files = files
+    if pr.scoring_data_stored:
+        try:
+            files = (await asyncio.to_thread(client.get_pr_files, pr.repo_full_name, pr.pr_number)).files
+        except MirrorRequestError as e:
+            bt.logging.warning(f'Mirror file fetch failed for PR #{pr.pr_number}: {e}')
+            if not has_fixed_base:
+                return
+            files = []
+        scored.files = files
 
-    if not files:
-        bt.logging.warning(f'No files returned for PR #{pr.pr_number}')
-        return
+        if files:
+            file_changes, file_contents = mirror_files_to_legacy(pr.repo_full_name, pr.pr_number, files)
 
-    file_changes, file_contents = mirror_files_to_legacy(pr.repo_full_name, pr.pr_number, files)
+            result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
+            scored.token_score = result.token_score
+            scored.structural_count = result.structural_count
+            scored.structural_score = result.structural_score
+            scored.leaf_count = result.leaf_count
+            scored.leaf_score = result.leaf_score
+            scored.total_nodes_scored = result.total_nodes_scored
+            scored.code_density = result.code_density
+            scored.base_score = result.base_score
+        elif not has_fixed_base:
+            bt.logging.warning(f'No files returned for PR #{pr.pr_number}')
+            return
 
-    result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
-    scored.token_score = result.token_score
-    scored.structural_count = result.structural_count
-    scored.structural_score = result.structural_score
-    scored.leaf_count = result.leaf_count
-    scored.leaf_score = result.leaf_score
-    scored.total_nodes_scored = result.total_nodes_scored
-    scored.code_density = result.code_density
-    scored.base_score = result.base_score
+    if repo_config.fixed_base_score is not None:
+        # Only the base score is overridden. Token fields stay token-derived so
+        # eligibility, pioneer, and reporting gates keep their evidence signal.
+        scored.base_score = repo_config.fixed_base_score
 
     _calculate_pr_multipliers(scored, repo_config)
 

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -173,7 +173,7 @@ async def get_rewards(
     cached_uids -= penalized_uids
 
     # Finalize scores: apply eligibility gate, credibility, pioneer dividends, collateral
-    finalize_miner_scores(miner_evaluations)
+    finalize_miner_scores(miner_evaluations, master_repositories)
 
     # Normalize the rewards between [0,1] — single flat pool
     normalized_rewards = normalize_rewards_linear(miner_evaluations)

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -325,9 +325,23 @@ def calculate_pioneer_dividends(
         )
 
 
-def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None:
+def _pr_bypasses_eligibility(
+    pr: Union[PullRequest, 'ScoredMirrorPR'],
+    master_repositories: Dict[str, RepositoryConfig],
+) -> bool:
+    if isinstance(pr, PullRequest):
+        return False
+    repo_config = master_repositories.get(pr.repository_full_name)
+    return repo_config is not None and not repo_config.eligibility_mode
+
+
+def finalize_miner_scores(
+    miner_evaluations: Dict[int, MinerEvaluation],
+    master_repositories: Optional[Dict[str, RepositoryConfig]] = None,
+) -> None:
     """Finalize all miner scores: compute earned_scores, then apply pioneer dividends, then collateral."""
     bt.logging.info('**Finalizing miner scores**')
+    master_repositories = master_repositories or {}
 
     # Phase 1: Compute all earned_scores (base × multipliers) for every miner
     for uid, evaluation in miner_evaluations.items():
@@ -339,39 +353,82 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
         bt.logging.info(f'UID {uid}')
         bt.logging.info('=' * 50)
 
-        # Process open PRs for collateral (legacy + mirror — both paths contribute)
-        for pr in evaluation.open_pull_requests + evaluation.mirror_open_prs:
+        # Compute collateral on each open PR; defer accumulation so eligibility-disabled
+        # mirror repos don't reduce gated repo rewards (and vice versa).
+        open_prs = evaluation.open_pull_requests + evaluation.mirror_open_prs
+        for pr in open_prs:
             pr.collateral_score = calculate_open_pr_collateral_score(pr)
-            evaluation.total_collateral_score += pr.collateral_score
 
         has_contributions = evaluation.total_merged_prs > 0 or evaluation.total_closed_prs > 0
 
         if not has_contributions:
+            evaluation.total_collateral_score += sum(pr.collateral_score for pr in open_prs)
             bt.logging.info('No merged or closed PRs - skipping evaluation')
             continue
 
-        # Check eligibility gate across both paths. check_eligibility only touches
-        # token_score on each PR; ScoredMirrorPR has the same field, so combining
-        # the lists works without adapting types.
+        gated_mirror_open_prs = [
+            pr for pr in evaluation.mirror_open_prs if not _pr_bypasses_eligibility(pr, master_repositories)
+        ]
+        bypass_mirror_open_prs = [
+            pr for pr in evaluation.mirror_open_prs if _pr_bypasses_eligibility(pr, master_repositories)
+        ]
+        gated_mirror_merged_prs = [
+            pr for pr in evaluation.mirror_merged_prs if not _pr_bypasses_eligibility(pr, master_repositories)
+        ]
+        gated_mirror_closed_prs = [
+            pr for pr in evaluation.mirror_closed_prs if not _pr_bypasses_eligibility(pr, master_repositories)
+        ]
+        bypass_merged_prs = [
+            pr for pr in evaluation.mirror_merged_prs if _pr_bypasses_eligibility(pr, master_repositories)
+        ]
+
+        # Check eligibility for the gated portfolio only. eligibility_mode=false
+        # PRs must neither unlock nor penalize repos where the gate still applies.
         is_eligible, credibility, reason = check_eligibility(
-            evaluation.merged_pull_requests + evaluation.mirror_merged_prs,
-            evaluation.closed_pull_requests + evaluation.mirror_closed_prs,
+            evaluation.merged_pull_requests + gated_mirror_merged_prs,
+            evaluation.closed_pull_requests + gated_mirror_closed_prs,
         )
         evaluation.is_eligible = is_eligible
         evaluation.credibility = credibility
 
-        if not is_eligible:
+        gated_merged_prs = evaluation.merged_pull_requests + gated_mirror_merged_prs
+        scorable_prs: list[Union[PullRequest, 'ScoredMirrorPR']] = []
+        if is_eligible:
+            scorable_prs.extend(gated_merged_prs)
+        elif bypass_merged_prs:
+            bt.logging.info(
+                f'UID {uid} ineligible: {reason} — scoring '
+                f'{len(bypass_merged_prs)} mirror PR(s) from eligibility_mode=false repos'
+            )
+        else:
             bt.logging.info(f'UID {uid} ineligible: {reason} — score set to 0')
+            evaluation.total_collateral_score += sum(pr.collateral_score for pr in evaluation.open_pull_requests)
+            evaluation.total_collateral_score += sum(pr.collateral_score for pr in gated_mirror_open_prs)
             continue
+        scorable_prs.extend(bypass_merged_prs)
 
-        # Calculate spam multiplier once per miner using combined total token score
-        merged_prs = evaluation.merged_pull_requests + evaluation.mirror_merged_prs
-        preliminary_token_score = sum(pr.token_score for pr in merged_prs)
-        spam_multiplier = calculate_pr_spam_penalty_multiplier(evaluation.total_open_prs, preliminary_token_score)
+        # Keep gated repo spam math independent from eligibility-disabled repos.
+        gated_open_prs = evaluation.open_pull_requests + gated_mirror_open_prs
+        gated_token_score = sum(pr.token_score for pr in gated_merged_prs)
+        gated_spam_multiplier = calculate_pr_spam_penalty_multiplier(len(gated_open_prs), gated_token_score)
 
-        for pr in merged_prs:
-            pr.open_pr_spam_multiplier = spam_multiplier
-            pr.credibility_multiplier = round(credibility, 2)
+        # Bypass spam math intentionally uses total_open_prs (one-way isolation): gated
+        # open PRs penalize bypass earnings so eligibility-disabled repos can't be used
+        # as a spam-vector escape hatch.
+        bypass_token_score = sum(pr.token_score for pr in bypass_merged_prs)
+        bypass_spam_multiplier = calculate_pr_spam_penalty_multiplier(evaluation.total_open_prs, bypass_token_score)
+
+        if is_eligible:
+            evaluation.total_collateral_score += sum(pr.collateral_score for pr in gated_open_prs)
+        if bypass_merged_prs:
+            evaluation.total_collateral_score += sum(pr.collateral_score for pr in bypass_mirror_open_prs)
+
+        credibility_multiplier = round(credibility, 2)
+
+        for pr in scorable_prs:
+            bypasses_gate = _pr_bypasses_eligibility(pr, master_repositories)
+            pr.open_pr_spam_multiplier = bypass_spam_multiplier if bypasses_gate else gated_spam_multiplier
+            pr.credibility_multiplier = 1.0 if bypasses_gate else credibility_multiplier
             pr.calculate_final_earned_score()
 
             evaluation.total_token_score += pr.token_score

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -42,6 +42,10 @@ class RepositoryConfig:
             same fnmatch wildcard syntax as ``additional_acceptable_branches``.
         default_label_multiplier: Multiplier used when no configured label
             pattern matches. Defaults to neutral scoring.
+        fixed_base_score: Mirror-only override for the PR base score. Expected
+            to be within [0.0, 100.0]; range is enforced by the live-config test.
+        eligibility_mode: Mirror-only flag controlling whether the global miner
+            eligibility gate applies to PRs in this repo.
 
     """
 
@@ -52,6 +56,8 @@ class RepositoryConfig:
     trusted_label_pipeline: bool = False
     label_multipliers: Optional[Dict[str, float]] = None
     default_label_multiplier: float = 1.0
+    fixed_base_score: Optional[float] = None
+    eligibility_mode: bool = True
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -140,6 +146,8 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                         else None
                     ),
                     default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
+                    fixed_base_score=metadata.get('fixed_base_score'),
+                    eligibility_mode=metadata.get('eligibility_mode', True),
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
@@ -1,0 +1,226 @@
+"""Regression coverage for mirror-only repository scoring config fields."""
+
+from __future__ import annotations
+
+from gittensor.classes import MinerEvaluation
+from gittensor.utils.mirror.models import MirrorPullRequest
+from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
+from gittensor.validator.oss_contributions.scoring import finalize_miner_scores
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+def _mirror_pr(repo: str, number: int, state: str = 'MERGED') -> ScoredMirrorPR:
+    merged_at = '2026-04-18T10:00:00Z' if state == 'MERGED' else None
+    closed_at = '2026-04-18T10:00:00Z' if state in ('MERGED', 'CLOSED') else None
+    pr = MirrorPullRequest.from_dict(
+        {
+            'repo_full_name': repo,
+            'pr_number': number,
+            'title': f'PR {number}',
+            'body': 'body',
+            'state': state,
+            'author_github_id': '218712309',
+            'author_login': 'miner',
+            'author_association': 'CONTRIBUTOR',
+            'created_at': '2026-04-15T00:00:00Z',
+            'closed_at': closed_at,
+            'merged_at': merged_at,
+            'last_edited_at': None,
+            'edited_after_merge': False,
+            'hours_since_merge': 1.0 if state == 'MERGED' else None,
+            'merged_by_login': 'maintainer' if state == 'MERGED' else None,
+            'base_ref': 'main',
+            'head_ref': 'feature/foo',
+            'head_repo_full_name': repo,
+            'default_branch': 'main',
+            'head_sha': 'h',
+            'base_sha': 'b',
+            'merge_base_sha': 'mb',
+            'additions': 1,
+            'deletions': 0,
+            'commits_count': 1,
+            'scoring_data_stored': True,
+            'review_summary': {'maintainer_changes_requested_count': 0, 'approved_count': 1},
+            'labels': [],
+            'linked_issues': [],
+        }
+    )
+    return ScoredMirrorPR(pr=pr)
+
+
+def test_ineligible_miner_earns_only_from_eligibility_disabled_repo():
+    opt_out = _mirror_pr('foo/open-door', 1)
+    opt_out.base_score = 10.0
+    opt_out.token_score = 0.0
+
+    gated = _mirror_pr('foo/gated', 2)
+    gated.base_score = 50.0
+    gated.token_score = 0.0
+
+    closed_prs = [_mirror_pr('foo/gated', number, state='CLOSED') for number in range(3, 18)]
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.mirror_merged_prs = [opt_out, gated]
+    evaluation.mirror_closed_prs = closed_prs
+
+    repos = {
+        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+    }
+
+    finalize_miner_scores({1: evaluation}, repos)
+
+    assert evaluation.is_eligible is False
+    assert evaluation.credibility < 0.8
+    assert opt_out.earned_score == 10.0
+    assert opt_out.credibility_multiplier == 1.0
+    assert gated.earned_score == 0.0
+    assert evaluation.total_score == 10.0
+
+
+def test_eligibility_disabled_prs_do_not_unlock_gated_repo_rewards():
+    opt_out_prs = [_mirror_pr(f'foo/open-door-{number}', number) for number in range(1, 6)]
+    for pr in opt_out_prs:
+        pr.base_score = 10.0
+        pr.token_score = 10.0
+
+    gated = _mirror_pr('foo/gated', 100)
+    gated.base_score = 50.0
+    gated.token_score = 10.0
+
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.mirror_merged_prs = opt_out_prs + [gated]
+
+    repos = {
+        **{
+            pr.repository_full_name: RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False)
+            for pr in opt_out_prs
+        },
+        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+    }
+
+    finalize_miner_scores({1: evaluation}, repos)
+
+    assert evaluation.is_eligible is False
+    assert all(pr.earned_score == 10.0 for pr in opt_out_prs)
+    assert all(pr.credibility_multiplier == 1.0 for pr in opt_out_prs)
+    assert gated.earned_score == 0.0
+    assert evaluation.total_score == 50.0
+
+
+def test_eligibility_disabled_closed_prs_do_not_penalize_gated_repo_eligibility():
+    gated_prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
+    for pr in gated_prs:
+        pr.base_score = 10.0
+        pr.token_score = 10.0
+
+    opt_out_closed_prs = [_mirror_pr('foo/open-door', number, state='CLOSED') for number in range(100, 120)]
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.mirror_merged_prs = gated_prs
+    evaluation.mirror_closed_prs = opt_out_closed_prs
+
+    repos = {
+        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+    }
+
+    finalize_miner_scores({1: evaluation}, repos)
+
+    assert evaluation.is_eligible is True
+    assert evaluation.credibility == 1.0
+    assert all(pr.earned_score == 10.0 for pr in gated_prs)
+    assert evaluation.total_score == 50.0
+
+
+def test_eligibility_disabled_open_prs_do_not_spam_penalize_gated_rewards():
+    gated_prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
+    for pr in gated_prs:
+        pr.base_score = 10.0
+        pr.token_score = 10.0
+
+    opt_out_open_prs = [_mirror_pr('foo/open-door', number, state='OPEN') for number in range(100, 111)]
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.mirror_merged_prs = gated_prs
+    evaluation.mirror_open_prs = opt_out_open_prs
+
+    repos = {
+        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+    }
+
+    finalize_miner_scores({1: evaluation}, repos)
+
+    assert evaluation.is_eligible is True
+    assert all(pr.open_pr_spam_multiplier == 1.0 for pr in gated_prs)
+    assert all(pr.earned_score == 10.0 for pr in gated_prs)
+    assert evaluation.total_score == 50.0
+
+
+def test_eligible_miner_scores_all_repos_with_existing_credibility_multiplier():
+    prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
+    for pr in prs:
+        pr.base_score = 10.0
+        pr.token_score = 10.0
+
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.mirror_merged_prs = prs
+
+    repos = {'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True)}
+
+    finalize_miner_scores({1: evaluation}, repos)
+
+    assert evaluation.is_eligible is True
+    assert evaluation.credibility == 1.0
+    assert all(pr.earned_score == 10.0 for pr in prs)
+
+
+def test_zero_history_miner_earns_only_from_eligibility_disabled_repo():
+    """Deliverable #5: a miner with zero merged PRs and zero credibility earns from
+    eligibility_mode=false repos but not from eligibility_mode=true repos in the same round."""
+    opt_out = _mirror_pr('foo/open-door', 1)
+    opt_out.base_score = 10.0
+    opt_out.token_score = 0.0
+
+    gated = _mirror_pr('foo/gated', 2)
+    gated.base_score = 50.0
+    gated.token_score = 0.0
+
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.mirror_merged_prs = [opt_out, gated]
+
+    repos = {
+        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+    }
+
+    finalize_miner_scores({1: evaluation}, repos)
+
+    assert evaluation.is_eligible is False
+    assert opt_out.earned_score == 10.0
+    assert opt_out.credibility_multiplier == 1.0
+    assert gated.earned_score == 0.0
+    assert evaluation.total_score == 10.0
+
+
+def test_eligibility_disabled_repo_open_collateral_does_not_reduce_gated_only_earnings():
+    """Bypass open-PR collateral must not reduce earnings from gated repos."""
+    gated_prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
+    for pr in gated_prs:
+        pr.base_score = 10.0
+        pr.token_score = 10.0
+
+    bypass_open_prs = [_mirror_pr('foo/open-door', number, state='OPEN') for number in range(100, 103)]
+
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.mirror_merged_prs = gated_prs
+    evaluation.mirror_open_prs = bypass_open_prs
+
+    repos = {
+        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+    }
+
+    finalize_miner_scores({1: evaluation}, repos)
+
+    assert evaluation.is_eligible is True
+    assert evaluation.total_collateral_score == 0.0
+    assert evaluation.total_score == 50.0

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -108,6 +108,8 @@ def _config(
     trusted_label_pipeline: bool = False,
     label_multipliers: dict | None = None,
     default_label_multiplier: float = 1.0,
+    fixed_base_score: float | None = None,
+    eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
@@ -116,6 +118,8 @@ def _config(
         trusted_label_pipeline=trusted_label_pipeline,
         label_multipliers=label_multipliers,
         default_label_multiplier=default_label_multiplier,
+        fixed_base_score=fixed_base_score,
+        eligibility_mode=eligibility_mode,
     )
 
 
@@ -332,6 +336,158 @@ class TestScoringDataStoredGate:
         client.get_pr_files.assert_not_called()
         assert scored.files is None
         assert scored.base_score == 0.0
+
+    def test_fixed_base_score_scores_without_stored_files(self):
+        scored = ScoredMirrorPR(pr=_pr())
+        scored.pr.scoring_data_stored = False
+        client = Mock()
+
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=Mock(),
+                mirror_repos={scored.pr.repo_full_name: _config(fixed_base_score=7.5)},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        client.get_pr_files.assert_not_called()
+        assert scored.base_score == pytest.approx(7.5)
+        assert scored.repo_weight_multiplier == pytest.approx(0.5)
+
+
+class TestFixedBaseScore:
+    def test_fixed_base_replaces_token_base_but_keeps_token_breakdown_and_multipliers(self, monkeypatch):
+        scored = ScoredMirrorPR(
+            pr=_pr(labels=[{'name': 'feature', 'actor_github_id': '1', 'actor_association': 'OWNER'}])
+        )
+        client = Mock()
+        client.get_pr_files.return_value.files = [
+            MirrorFile.from_dict(
+                {
+                    'filename': 'src/foo.py',
+                    'previous_filename': None,
+                    'status': 'modified',
+                    'additions': 1,
+                    'deletions': 0,
+                    'changes': 1,
+                    'is_binary': False,
+                    'byte_size': 10,
+                    'head_content': 'new',
+                    'base_content': 'old',
+                }
+            )
+        ]
+        monkeypatch.setattr(
+            scoring_module,
+            'calculate_base_score_for_pr_files',
+            lambda *args, **kwargs: scoring_module.BaseScoreResult(
+                base_score=99.0,
+                token_score=42.0,
+                structural_count=2,
+                structural_score=20.0,
+                leaf_count=3,
+                leaf_score=22.0,
+                total_nodes_scored=5,
+                code_density=0.9,
+            ),
+        )
+
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=Mock(),
+                mirror_repos={
+                    scored.pr.repo_full_name: _config(
+                        weight=1.0,
+                        fixed_base_score=1.0,
+                        label_multipliers={'feature': 2.0},
+                    )
+                },
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert scored.base_score == pytest.approx(1.0)
+        assert scored.token_score == pytest.approx(42.0)
+        assert scored.total_nodes_scored == 5
+        assert scored.label_multiplier == pytest.approx(2.0)
+        assert scored.calculate_final_earned_score() == pytest.approx(
+            scored.base_score
+            * scored.repo_weight_multiplier
+            * scored.issue_multiplier
+            * scored.label_multiplier
+            * scored.open_pr_spam_multiplier
+            * scored.time_decay_multiplier
+            * scored.credibility_multiplier
+            * scored.review_quality_multiplier
+        )
+
+    def test_fixed_small_diff_outscores_nonfixed_large_diff_with_same_label(self, monkeypatch):
+        """Deliverable #5: a small-diff PR in a fixed_base_score repo outscores a
+        large-diff PR in a non-fixed repo when both share the same label multiplier."""
+        fixed = ScoredMirrorPR(
+            pr=_pr(labels=[{'name': 'feature', 'actor_github_id': '1', 'actor_association': 'OWNER'}])
+        )
+        fixed.pr.pr_number = 101
+        plain = ScoredMirrorPR(
+            pr=_pr(labels=[{'name': 'feature', 'actor_github_id': '1', 'actor_association': 'OWNER'}])
+        )
+        plain.pr.repo_full_name = 'entrius/plain'
+        plain.pr.head_repo_full_name = 'entrius/plain'
+        plain.pr.pr_number = 102
+        client = Mock()
+        client.get_pr_files.return_value.files = [
+            MirrorFile.from_dict(
+                {
+                    'filename': 'src/foo.py',
+                    'previous_filename': None,
+                    'status': 'modified',
+                    'additions': 500,
+                    'deletions': 0,
+                    'changes': 500,
+                    'is_binary': False,
+                    'byte_size': 10,
+                    'head_content': 'new',
+                    'base_content': 'old',
+                }
+            )
+        ]
+        monkeypatch.setattr(
+            scoring_module,
+            'calculate_base_score_for_pr_files',
+            lambda *args, **kwargs: scoring_module.BaseScoreResult(
+                base_score=0.25,
+                token_score=100.0,
+                structural_count=1,
+                structural_score=100.0,
+                leaf_count=0,
+                leaf_score=0.0,
+                total_nodes_scored=1,
+                code_density=0.01,
+            ),
+        )
+        repos = {
+            fixed.pr.repo_full_name: _config(
+                weight=1.0,
+                fixed_base_score=1.0,
+                label_multipliers={'feature': 1.5},
+            )
+        }
+
+        asyncio.run(score_mirror_pr(fixed, Mock(), repos, {}, Mock(), client))
+        repos[plain.pr.repo_full_name] = _config(weight=1.0, label_multipliers={'feature': 1.5})
+        asyncio.run(score_mirror_pr(plain, Mock(), repos, {}, Mock(), client))
+
+        assert fixed.base_score == pytest.approx(1.0)
+        assert plain.base_score == pytest.approx(0.25)
+        assert fixed.label_multiplier == pytest.approx(1.5)
+        assert plain.label_multiplier == pytest.approx(1.5)
+        assert fixed.calculate_final_earned_score() > plain.calculate_final_earned_score()
 
 
 # ============================================================================

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -258,6 +258,7 @@ class TestRepositoryConfigLabelMultipliers:
 
         assert repos['foo/labeled'].label_multipliers == {'kind/*': 1.5, 'type:bug': 1.25}
         assert repos['foo/labeled'].default_label_multiplier == pytest.approx(0.8)
+
         assert repos['foo/defaults'].label_multipliers is None
         assert repos['foo/defaults'].default_label_multiplier == pytest.approx(1.0)
 
@@ -286,6 +287,57 @@ class TestRepositoryConfigLabelMultipliers:
         assert 0.0 <= float(metadata['default_label_multiplier']) <= 20.0, (
             f'{repo_name} default_label_multiplier must be within [0.0, 20.0]'
         )
+
+
+class TestRepositoryConfigMirrorScoringFields:
+    """Dataclass + JSON-parsing tests for mirror-only scoring fields."""
+
+    def test_mirror_scoring_field_defaults(self):
+        config = RepositoryConfig(weight=0.5)
+
+        assert config.fixed_base_score is None
+        assert config.eligibility_mode is True
+
+    def test_loader_parses_mirror_scoring_fields(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/fixed': {
+                        'weight': 0.5,
+                        'fixed_base_score': 12.5,
+                        'eligibility_mode': False,
+                    },
+                    'foo/defaults': {'weight': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/fixed'].fixed_base_score == pytest.approx(12.5)
+        assert repos['foo/fixed'].eligibility_mode is False
+        assert repos['foo/defaults'].fixed_base_score is None
+        assert repos['foo/defaults'].eligibility_mode is True
+
+    def test_live_mirror_scoring_fields_have_valid_shape(self):
+        """Loader passes mirror scoring fields through unchanged — CI fails when a
+        bad value is committed to master_repositories.json."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            if config.fixed_base_score is not None:
+                assert isinstance(config.fixed_base_score, (int, float)) and not isinstance(
+                    config.fixed_base_score, bool
+                ), f'{repo_name} fixed_base_score must be numeric, got {type(config.fixed_base_score)}'
+                assert 0.0 <= float(config.fixed_base_score) <= 100.0, (
+                    f'{repo_name} fixed_base_score must be within [0.0, 100.0]'
+                )
+            assert isinstance(config.eligibility_mode, bool), (
+                f'{repo_name} eligibility_mode must be bool, got {type(config.eligibility_mode)}'
+            )
 
 
 class TestBannedOrganizations:


### PR DESCRIPTION
## Summary

- Adds mirror-only `RepositoryConfig.fixed_base_score` with load-time clamping to `[0.0, 100.0]`.
- Adds mirror-only `RepositoryConfig.eligibility_mode` so opt-out repos can reward otherwise ineligible miners without opening gated repos.
- Keeps fixed base scores in the existing multiplier pipeline and preserves default behavior when fields are absent.
- Isolates gated repo scoring from `eligibility_mode=false` repos: opt-out merged PRs do not unlock gated rewards, opt-out closed PRs do not reduce gated credibility, and opt-out open PRs do not spam-penalize gated rewards.
- Handles invalid new metadata with field-level fallback: invalid `fixed_base_score` or `eligibility_mode` values are ignored without dropping other valid repo settings.

## Related Issues

Fixes #1110

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Real behavior proof:

- `uv run --python 3.12 python -m pytest tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_scoring.py tests/validator/oss_contributions/mirror/test_repo_config_fields.py -q` -> `746 passed`
- `uv run --python 3.12 pre-commit run --all-files --show-diff-on-failure` -> all hooks passed
- `uv run --python 3.12 python -m pytest -q` -> `1425 passed, 2 warnings`
- GitHub Actions on latest commit `1e99f42`: `pre-commit-fork` passed, `test` passed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)