### PR TITLE
feat: add mirror repo scoring overrides

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -34,6 +34,7 @@ class ScoredMirrorPR:
     review_quality_multiplier: float = 1.0
     label_multiplier: float = 1.0
     label: Optional[str] = None
+    eligibility_mode: bool = True
 
     # Pioneer attribution (per-repo, populated post per-PR scoring)
     pioneer_dividend: float = 0.0

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -127,8 +127,10 @@ async def score_mirror_pr(
     # with load_miners_prs which applies should_skip_merged_pr pre-append.
 
     # Mirror signals it has no stored files for this PR (pending backfill, in-flight
-    # file job, etc.) — skip the round trip.
+    # file job, etc.) — skip the round trip unless the repo has a fixed base.
     if not pr.scoring_data_stored:
+        if repo_config.fixed_base_score is not None:
+            _apply_fixed_base_score(scored, mirror_eval, repo_config)
         return
 
     # Fetch file contents via the mirror's lazy /pulls/.../files endpoint.
@@ -136,11 +138,15 @@ async def score_mirror_pr(
         files = (await asyncio.to_thread(client.get_pr_files, pr.repo_full_name, pr.pr_number)).files
     except MirrorRequestError as e:
         bt.logging.warning(f'Mirror file fetch failed for PR #{pr.pr_number}: {e}')
+        if repo_config.fixed_base_score is not None:
+            _apply_fixed_base_score(scored, mirror_eval, repo_config)
         return
     scored.files = files
 
     if not files:
         bt.logging.warning(f'No files returned for PR #{pr.pr_number}')
+        if repo_config.fixed_base_score is not None:
+            _apply_fixed_base_score(scored, mirror_eval, repo_config)
         return
 
     file_changes, file_contents = mirror_files_to_legacy(pr.repo_full_name, pr.pr_number, files)
@@ -153,7 +159,7 @@ async def score_mirror_pr(
     scored.leaf_score = result.leaf_score
     scored.total_nodes_scored = result.total_nodes_scored
     scored.code_density = result.code_density
-    scored.base_score = result.base_score
+    scored.base_score = repo_config.fixed_base_score if repo_config.fixed_base_score is not None else result.base_score
 
     _calculate_pr_multipliers(scored, repo_config)
 
@@ -162,6 +168,18 @@ async def score_mirror_pr(
         # Token totals are aggregated later in finalize_miner_scores (legacy parity
         # — score sets per-PR state, finalize rolls up eval-level totals across
         # both paths).
+
+
+def _apply_fixed_base_score(
+    scored: ScoredMirrorPR,
+    mirror_eval: MirrorMinerEvaluation,
+    repo_config: RepositoryConfig,
+) -> None:
+    assert repo_config.fixed_base_score is not None
+    scored.base_score = repo_config.fixed_base_score
+    _calculate_pr_multipliers(scored, repo_config)
+    if scored.pr.state == 'MERGED':
+        mirror_eval.unique_repos_contributed_to.add(scored.pr.repo_full_name)
 
 
 # ============================================================================
@@ -339,6 +357,7 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
     pr = scored.pr
     is_merged = pr.state == 'MERGED'
 
+    scored.eligibility_mode = repo_config.eligibility_mode
     scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
 
     chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -360,18 +360,29 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
         evaluation.is_eligible = is_eligible
         evaluation.credibility = credibility
 
+        merged_prs = evaluation.merged_pull_requests + evaluation.mirror_merged_prs
+        scorable_prs = merged_prs
+        credibility_multiplier = round(credibility, 2)
+
         if not is_eligible:
-            bt.logging.info(f'UID {uid} ineligible: {reason} — score set to 0')
-            continue
+            scorable_prs = [pr for pr in evaluation.mirror_merged_prs if not pr.eligibility_mode]
+            if not scorable_prs:
+                bt.logging.info(f'UID {uid} ineligible: {reason} — score set to 0')
+                continue
+
+            bt.logging.info(
+                f'UID {uid} ineligible: {reason} — scoring {len(scorable_prs)} '
+                'mirror PR(s) with eligibility_mode=false'
+            )
+            credibility_multiplier = 1.0
 
         # Calculate spam multiplier once per miner using combined total token score
-        merged_prs = evaluation.merged_pull_requests + evaluation.mirror_merged_prs
-        preliminary_token_score = sum(pr.token_score for pr in merged_prs)
+        preliminary_token_score = sum(pr.token_score for pr in scorable_prs)
         spam_multiplier = calculate_pr_spam_penalty_multiplier(evaluation.total_open_prs, preliminary_token_score)
 
-        for pr in merged_prs:
+        for pr in scorable_prs:
             pr.open_pr_spam_multiplier = spam_multiplier
-            pr.credibility_multiplier = round(credibility, 2)
+            pr.credibility_multiplier = credibility_multiplier
             pr.calculate_final_earned_score()
 
             evaluation.total_token_score += pr.token_score

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -42,7 +42,10 @@ class RepositoryConfig:
             same fnmatch wildcard syntax as ``additional_acceptable_branches``.
         default_label_multiplier: Multiplier used when no configured label
             pattern matches. Defaults to neutral scoring.
-
+        fixed_base_score: Mirror-only base score override. When set, mirror
+            scoring uses this as the PR base score before downstream multipliers.
+        eligibility_mode: Mirror-only flag. When False, merged PRs in this repo
+            may earn even if the miner fails the global eligibility gate.
     """
 
     weight: float
@@ -52,6 +55,8 @@ class RepositoryConfig:
     trusted_label_pipeline: bool = False
     label_multipliers: Optional[Dict[str, float]] = None
     default_label_multiplier: float = 1.0
+    fixed_base_score: Optional[float] = None
+    eligibility_mode: bool = True
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -59,6 +64,12 @@ def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
     if repo_config is None:
         return DEFAULT_REPO_WEIGHT
     return repo_config.weight
+
+
+def _clamp_fixed_base_score(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    return min(100.0, max(0.0, float(value)))
 
 
 @dataclass
@@ -140,6 +151,8 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                         else None
                     ),
                     default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
+                    fixed_base_score=_clamp_fixed_base_score(metadata.get('fixed_base_score')),
+                    eligibility_mode=bool(metadata.get('eligibility_mode', True)),
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -108,6 +108,8 @@ def _config(
     trusted_label_pipeline: bool = False,
     label_multipliers: dict | None = None,
     default_label_multiplier: float = 1.0,
+    fixed_base_score: float | None = None,
+    eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
@@ -116,6 +118,8 @@ def _config(
         trusted_label_pipeline=trusted_label_pipeline,
         label_multipliers=label_multipliers,
         default_label_multiplier=default_label_multiplier,
+        fixed_base_score=fixed_base_score,
+        eligibility_mode=eligibility_mode,
     )
 
 
@@ -333,10 +337,162 @@ class TestScoringDataStoredGate:
         assert scored.files is None
         assert scored.base_score == 0.0
 
+    def test_fixed_base_score_does_not_require_stored_file_data(self):
+        scored = ScoredMirrorPR(pr=_pr())
+        scored.pr.scoring_data_stored = False
+        mirror_eval = Mock(unique_repos_contributed_to=set())
+        client = Mock()
+
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=mirror_eval,
+                mirror_repos={scored.pr.repo_full_name: _config(fixed_base_score=12.5)},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        client.get_pr_files.assert_not_called()
+        assert scored.base_score == pytest.approx(12.5)
+        assert scored.repo_weight_multiplier == pytest.approx(0.5)
+        assert scored.pr.repo_full_name in mirror_eval.unique_repos_contributed_to
+
+
+class TestFixedBaseScore:
+    def test_fixed_base_score_replaces_base_only(self, monkeypatch):
+        scored = ScoredMirrorPR(pr=_pr())
+        client = Mock()
+        client.get_pr_files.return_value = Mock(files=[MirrorFile.from_dict(_file_data('src/small.py', 'x = 1\n'))])
+        monkeypatch.setattr(
+            scoring_module,
+            'calculate_base_score_for_pr_files',
+            Mock(
+                return_value=scoring_module.BaseScoreResult(
+                    base_score=0.25,
+                    token_score=9.0,
+                    structural_count=1,
+                    structural_score=2.0,
+                    leaf_count=3,
+                    leaf_score=7.0,
+                    total_nodes_scored=4,
+                    code_density=1.0,
+                )
+            ),
+        )
+
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=Mock(unique_repos_contributed_to=set()),
+                mirror_repos={scored.pr.repo_full_name: _config(fixed_base_score=1.0)},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert scored.base_score == pytest.approx(1.0)
+        assert scored.token_score == pytest.approx(9.0)
+        assert scored.total_nodes_scored == 4
+
+    def test_fixed_base_score_can_outscore_larger_non_fixed_pr_with_same_multiplier(self, monkeypatch):
+        fixed = ScoredMirrorPR(pr=_pr())
+        non_fixed = ScoredMirrorPR(pr=_pr())
+        non_fixed.pr.repo_full_name = 'entrius/other'
+
+        client = Mock()
+        client.get_pr_files.return_value = Mock(files=[MirrorFile.from_dict(_file_data('src/file.py', 'x = 1\n'))])
+        monkeypatch.setattr(
+            scoring_module,
+            'calculate_base_score_for_pr_files',
+            Mock(
+                side_effect=[
+                    scoring_module.BaseScoreResult(0.05, 1.0, 0, 0.0, 1, 1.0, 1, 1.0),
+                    scoring_module.BaseScoreResult(0.75, 100.0, 10, 50.0, 50, 50.0, 60, 1.0),
+                ]
+            ),
+        )
+
+        asyncio.run(
+            score_mirror_pr(
+                fixed,
+                mirror_eval=Mock(unique_repos_contributed_to=set()),
+                mirror_repos={fixed.pr.repo_full_name: _config(fixed_base_score=1.0)},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+        asyncio.run(
+            score_mirror_pr(
+                non_fixed,
+                mirror_eval=Mock(unique_repos_contributed_to=set()),
+                mirror_repos={non_fixed.pr.repo_full_name: _config()},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        fixed.calculate_final_earned_score()
+        non_fixed.calculate_final_earned_score()
+
+        assert fixed.earned_score > non_fixed.earned_score
+        assert fixed.base_score == pytest.approx(1.0)
+        assert non_fixed.base_score == pytest.approx(0.75)
+
+
+class TestEligibilityMode:
+    def test_low_credibility_miner_earns_only_from_eligibility_mode_false_mirror_repos(self):
+        from gittensor.classes import MinerEvaluation
+        from gittensor.validator.oss_contributions.scoring import finalize_miner_scores
+
+        bypassed = ScoredMirrorPR(pr=_pr())
+        bypassed.pr.repo_full_name = 'entrius/bypass'
+        bypassed.base_score = 10.0
+        bypassed.token_score = 0.0
+        bypassed.eligibility_mode = False
+
+        gated = ScoredMirrorPR(pr=_pr())
+        gated.pr.repo_full_name = 'entrius/gated'
+        gated.base_score = 100.0
+        gated.token_score = 0.0
+        gated.eligibility_mode = True
+
+        evaluation = MinerEvaluation(uid=1, hotkey='hk', github_id='gid')
+        evaluation.mirror_merged_prs = [bypassed, gated]
+        evaluation.mirror_closed_prs = [ScoredMirrorPR(pr=_pr(state='CLOSED')) for _ in range(100)]
+
+        finalize_miner_scores({1: evaluation})
+
+        assert evaluation.is_eligible is False
+        assert evaluation.credibility < 0.8
+        assert bypassed.earned_score == pytest.approx(10.0)
+        assert bypassed.credibility_multiplier == pytest.approx(1.0)
+        assert gated.earned_score == 0.0
+        assert evaluation.total_score == pytest.approx(10.0)
+
 
 # ============================================================================
 # File adapter
 # ============================================================================
+
+
+def _file_data(filename: str, content: str) -> dict:
+    return {
+        'filename': filename,
+        'previous_filename': None,
+        'status': 'modified',
+        'additions': 1,
+        'deletions': 0,
+        'changes': 1,
+        'is_binary': False,
+        'byte_size': len(content),
+        'head_content': content,
+        'base_content': '',
+    }
 
 
 class TestConvertMirrorFiles:

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -288,6 +288,62 @@ class TestRepositoryConfigLabelMultipliers:
         )
 
 
+class TestRepositoryConfigMirrorScoringFields:
+    """Dataclass + JSON parsing tests for mirror-only scoring config."""
+
+    def test_defaults_preserve_existing_behavior(self):
+        config = RepositoryConfig(weight=0.5)
+
+        assert config.fixed_base_score is None
+        assert config.eligibility_mode is True
+
+    def test_loader_parses_fixed_base_score_and_eligibility_mode(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/custom': {
+                        'weight': 0.5,
+                        'fixed_base_score': 42.5,
+                        'eligibility_mode': False,
+                    },
+                    'foo/defaults': {'weight': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/custom'].fixed_base_score == pytest.approx(42.5)
+        assert repos['foo/custom'].eligibility_mode is False
+        assert repos['foo/defaults'].fixed_base_score is None
+        assert repos['foo/defaults'].eligibility_mode is True
+
+    @pytest.mark.parametrize(
+        'raw,expected',
+        [
+            (-1.0, 0.0),
+            (101.0, 100.0),
+            ('25.5', 25.5),
+        ],
+    )
+    def test_loader_clamps_fixed_base_score(self, raw, expected, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps({'foo/repo': {'weight': 0.5, 'fixed_base_score': raw}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/repo'].fixed_base_score == pytest.approx(expected)
+
+
 class TestBannedOrganizations:
     """Tests ensuring banned organizations are not active in the repository list.
 


### PR DESCRIPTION
## Summary

Adds mirror-only per-repo scoring config for issue #1110:
- parse `fixed_base_score` from repository metadata, clamp it to `[0.0, 100.0]`, and use it as the mirror PR base score before existing downstream multipliers
- parse `eligibility_mode`, default it to `True`, and allow only `eligibility_mode=false` mirror PRs to earn when a miner fails the global eligibility gate
- preserve existing behavior when both fields are absent

## Related Issues

Fixes #1110

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Real behavior proof:
- `uv run --python 3.12 ruff check gittensor/validator/utils/load_weights.py gittensor/validator/oss_contributions/mirror/scored_pr.py gittensor/validator/oss_contributions/mirror/scoring.py gittensor/validator/oss_contributions/scoring.py tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_scoring.py` -> passed
- `uv run --python 3.12 pytest tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_scoring.py -q` -> `744 passed`
- `uv run --python 3.12 pytest -q` -> `1423 passed, 2 warnings`
- `git diff --check` -> passed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
