### PR TITLE
feat:Add more per-repo config field

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -34,6 +34,8 @@ class ScoredMirrorPR:
     review_quality_multiplier: float = 1.0
     label_multiplier: float = 1.0
     label: Optional[str] = None
+    eligibility_mode: bool = True
+    reward_eligible: bool = True
 
     # Pioneer attribution (per-repo, populated post per-PR scoring)
     pioneer_dividend: float = 0.0

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -120,6 +120,7 @@ async def score_mirror_pr(
     if not repo_config:
         bt.logging.warning(f'{pr.repo_full_name} not in mirror_repos. Skipping...')
         return
+    scored.eligibility_mode = repo_config.eligibility_mode
 
     # Eligibility gate for MERGED PRs already ran at LOAD time (see
     # load_mirror_miner_prs → _should_skip_merged_mirror_pr). By this point
@@ -153,7 +154,14 @@ async def score_mirror_pr(
     scored.leaf_score = result.leaf_score
     scored.total_nodes_scored = result.total_nodes_scored
     scored.code_density = result.code_density
-    scored.base_score = result.base_score
+    if repo_config.fixed_base_score is not None:
+        bt.logging.info(
+            f'Fixed base score override: {repo_config.fixed_base_score:.2f} '
+            f'(replacing token-derived {result.base_score:.2f})'
+        )
+        scored.base_score = repo_config.fixed_base_score
+    else:
+        scored.base_score = result.base_score
 
     _calculate_pr_multipliers(scored, repo_config)
 

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -273,6 +273,8 @@ def calculate_pioneer_dividends(
 
     for uid, evaluation in miner_evaluations.items():
         for pr in evaluation.merged_pull_requests + evaluation.mirror_merged_prs:
+            if getattr(pr, 'reward_eligible', True) is False:
+                continue
             if not pr.is_pioneer_eligible():
                 continue
             assert pr.merged_at is not None
@@ -325,6 +327,84 @@ def calculate_pioneer_dividends(
         )
 
 
+def _split_mirror_prs_by_eligibility_mode(prs):
+    """Partition mirror PRs into gated vs ungated repo buckets."""
+    gated = []
+    ungated = []
+    for pr in prs:
+        if getattr(pr, 'eligibility_mode', True):
+            gated.append(pr)
+        else:
+            ungated.append(pr)
+    return gated, ungated
+
+
+def _has_ungated_mirror_override(evaluation: MinerEvaluation) -> bool:
+    """True when any mirror repo in this eval opts out of the global eligibility gate."""
+    mirror_prs = evaluation.mirror_merged_prs + evaluation.mirror_open_prs + evaluation.mirror_closed_prs
+    return any(not getattr(pr, 'eligibility_mode', True) for pr in mirror_prs)
+
+
+def _accumulate_scored_pr_totals(evaluation: MinerEvaluation, prs) -> None:
+    """Accumulate token/structure totals for PRs that actually participate in reward."""
+    for pr in prs:
+        evaluation.total_token_score += pr.token_score
+        evaluation.total_structural_count += pr.structural_count
+        evaluation.total_structural_score += pr.structural_score
+        evaluation.total_leaf_count += pr.leaf_count
+        evaluation.total_leaf_score += pr.leaf_score
+
+
+def _finalize_with_mirror_eligibility_mode(uid: int, evaluation: MinerEvaluation) -> None:
+    """Finalize an evaluation containing mirror repos with eligibility_mode=False.
+
+    Gated repos keep the legacy behavior, but they are evaluated only against
+    the gated subset of the miner's portfolio so ungated repos cannot unlock
+    score on gated repos in the same round. Ungated mirror repos still use the
+    normal multiplier pipeline, except they bypass the global credibility gate.
+    """
+    gated_mirror_merged, ungated_mirror_merged = _split_mirror_prs_by_eligibility_mode(evaluation.mirror_merged_prs)
+    gated_mirror_closed, _ = _split_mirror_prs_by_eligibility_mode(evaluation.mirror_closed_prs)
+    gated_mirror_open, ungated_mirror_open = _split_mirror_prs_by_eligibility_mode(evaluation.mirror_open_prs)
+
+    for pr in evaluation.open_pull_requests + evaluation.mirror_open_prs:
+        pr.collateral_score = calculate_open_pr_collateral_score(pr)
+
+    gated_merged_prs = evaluation.merged_pull_requests + gated_mirror_merged
+    gated_closed_prs = evaluation.closed_pull_requests + gated_mirror_closed
+    gated_open_prs = evaluation.open_pull_requests + gated_mirror_open
+
+    is_eligible, credibility, reason = check_eligibility(gated_merged_prs, gated_closed_prs)
+    evaluation.is_eligible = is_eligible
+    evaluation.credibility = credibility
+
+    for pr in gated_merged_prs:
+        setattr(pr, 'reward_eligible', is_eligible)
+    for pr in ungated_mirror_merged:
+        pr.reward_eligible = True
+
+    if not is_eligible:
+        bt.logging.info(f'UID {uid} gated repos ineligible: {reason}')
+
+    if is_eligible and gated_merged_prs:
+        gated_token_score = sum(pr.token_score for pr in gated_merged_prs)
+        gated_spam_multiplier = calculate_pr_spam_penalty_multiplier(len(gated_open_prs), gated_token_score)
+        for pr in gated_merged_prs:
+            pr.open_pr_spam_multiplier = gated_spam_multiplier
+            pr.credibility_multiplier = round(credibility, 2)
+            pr.calculate_final_earned_score()
+        _accumulate_scored_pr_totals(evaluation, gated_merged_prs)
+
+    if ungated_mirror_merged:
+        ungated_token_score = sum(pr.token_score for pr in ungated_mirror_merged)
+        ungated_spam_multiplier = calculate_pr_spam_penalty_multiplier(len(ungated_mirror_open), ungated_token_score)
+        for pr in ungated_mirror_merged:
+            pr.open_pr_spam_multiplier = ungated_spam_multiplier
+            pr.credibility_multiplier = 1.0
+            pr.calculate_final_earned_score()
+        _accumulate_scored_pr_totals(evaluation, ungated_mirror_merged)
+
+
 def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None:
     """Finalize all miner scores: compute earned_scores, then apply pioneer dividends, then collateral."""
     bt.logging.info('**Finalizing miner scores**')
@@ -339,16 +419,20 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
         bt.logging.info(f'UID {uid}')
         bt.logging.info('=' * 50)
 
-        # Process open PRs for collateral (legacy + mirror — both paths contribute)
-        for pr in evaluation.open_pull_requests + evaluation.mirror_open_prs:
-            pr.collateral_score = calculate_open_pr_collateral_score(pr)
-            evaluation.total_collateral_score += pr.collateral_score
-
         has_contributions = evaluation.total_merged_prs > 0 or evaluation.total_closed_prs > 0
 
         if not has_contributions:
             bt.logging.info('No merged or closed PRs - skipping evaluation')
             continue
+
+        if _has_ungated_mirror_override(evaluation):
+            _finalize_with_mirror_eligibility_mode(uid, evaluation)
+            continue
+
+        # Process open PRs for collateral (legacy + mirror — both paths contribute)
+        for pr in evaluation.open_pull_requests + evaluation.mirror_open_prs:
+            pr.collateral_score = calculate_open_pr_collateral_score(pr)
+            evaluation.total_collateral_score += pr.collateral_score
 
         # Check eligibility gate across both paths. check_eligibility only touches
         # token_score on each PR; ScoredMirrorPR has the same field, so combining
@@ -391,6 +475,40 @@ def finalize_miner_scores(miner_evaluations: Dict[int, MinerEvaluation]) -> None
 
         has_contributions = evaluation.total_merged_prs > 0 or evaluation.total_closed_prs > 0
         if not has_contributions:
+            continue
+
+        if _has_ungated_mirror_override(evaluation):
+            gated_mirror_merged, ungated_mirror_merged = _split_mirror_prs_by_eligibility_mode(
+                evaluation.mirror_merged_prs
+            )
+            gated_mirror_open, ungated_mirror_open = _split_mirror_prs_by_eligibility_mode(evaluation.mirror_open_prs)
+
+            gated_merged_prs = evaluation.merged_pull_requests + gated_mirror_merged
+            for pr in gated_merged_prs + ungated_mirror_merged:
+                evaluation.base_total_score += pr.base_score
+                evaluation.total_nodes_scored += pr.total_nodes_scored
+
+            gated_earned_score = sum(pr.earned_score for pr in gated_merged_prs)
+            ungated_earned_score = sum(pr.earned_score for pr in ungated_mirror_merged)
+            gated_collateral = sum(pr.collateral_score for pr in evaluation.open_pull_requests + gated_mirror_open)
+            ungated_collateral = sum(pr.collateral_score for pr in ungated_mirror_open)
+
+            gross_score = gated_earned_score + ungated_earned_score
+            evaluation.total_collateral_score = gated_collateral + ungated_collateral
+            evaluation.total_score = max(0.0, gated_earned_score - gated_collateral) + max(
+                0.0, ungated_earned_score - ungated_collateral
+            )
+            evaluation.unique_repos_count = len(evaluation.unique_repos_contributed_to)
+
+            bt.logging.info('')
+            bt.logging.info('Summary:')
+            bt.logging.info(
+                f'├─ Score: {gross_score:.2f} - {evaluation.total_collateral_score:.2f} collateral = {evaluation.total_score:.2f}'
+            )
+            bt.logging.info(
+                f'├─ PRs: {evaluation.total_merged_prs} merged | {evaluation.total_open_prs} open | {evaluation.total_closed_prs} closed'
+            )
+            bt.logging.info(f'└─ Eligible: {evaluation.is_eligible} | Credibility: {evaluation.credibility:.2f}')
             continue
 
         # Aggregate scores (earned_score now includes pioneer_dividend from Phase 2).

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -42,6 +42,12 @@ class RepositoryConfig:
             same fnmatch wildcard syntax as ``additional_acceptable_branches``.
         default_label_multiplier: Multiplier used when no configured label
             pattern matches. Defaults to neutral scoring.
+        fixed_base_score: Optional fixed base score override for mirror-scored
+            PRs in this repo. When set, replaces the token-derived base score
+            after clamping into ``[0.0, 100.0]``.
+        eligibility_mode: Mirror-only eligibility toggle. ``True`` keeps the
+            global miner eligibility gate; ``False`` lets this repo's merged
+            PRs earn without passing that gate.
 
     """
 
@@ -52,6 +58,27 @@ class RepositoryConfig:
     trusted_label_pipeline: bool = False
     label_multipliers: Optional[Dict[str, float]] = None
     default_label_multiplier: float = 1.0
+    fixed_base_score: Optional[float] = None
+    eligibility_mode: bool = True
+
+
+def _parse_optional_fixed_base_score(raw_value: object) -> Optional[float]:
+    """Parse and clamp a per-repo fixed base score override."""
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, bool):
+        raise TypeError('fixed_base_score must be numeric, not bool')
+    return min(100.0, max(0.0, float(raw_value)))
+
+
+def _parse_bool_config(metadata: dict, key: str, default: bool) -> bool:
+    """Parse a strict bool config field, preserving the default when absent."""
+    if key not in metadata:
+        return default
+    raw_value = metadata[key]
+    if isinstance(raw_value, bool):
+        return raw_value
+    raise TypeError(f'{key} must be bool, got {type(raw_value).__name__}')
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -140,6 +167,8 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                         else None
                     ),
                     default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
+                    fixed_base_score=_parse_optional_fixed_base_score(metadata.get('fixed_base_score')),
+                    eligibility_mode=_parse_bool_config(metadata, 'eligibility_mode', True),
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/tests/validator/oss_contributions/mirror/test_repo_overrides.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_overrides.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from gittensor.classes import MinerEvaluation
+from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredMirrorPR
+from gittensor.validator.oss_contributions.scoring import finalize_miner_scores
+from gittensor.utils.mirror.models import MirrorPullRequest
+
+
+def _mirror_pr(repo_full_name: str, pr_number: int) -> MirrorPullRequest:
+    return MirrorPullRequest.from_dict(
+        {
+            'repo_full_name': repo_full_name,
+            'pr_number': pr_number,
+            'title': 't',
+            'body': 'b',
+            'state': 'MERGED',
+            'author_github_id': '1',
+            'author_login': 'alice',
+            'author_association': 'CONTRIBUTOR',
+            'created_at': '2026-04-01T00:00:00Z',
+            'closed_at': '2026-04-18T10:00:00Z',
+            'merged_at': '2026-04-18T10:00:00Z',
+            'last_edited_at': None,
+            'edited_after_merge': False,
+            'hours_since_merge': 1.0,
+            'merged_by_login': 'maintainer',
+            'base_ref': 'main',
+            'head_ref': 'feature/pr',
+            'head_repo_full_name': repo_full_name,
+            'default_branch': 'main',
+            'head_sha': 'h',
+            'base_sha': 'b',
+            'merge_base_sha': 'mb',
+            'additions': 10,
+            'deletions': 0,
+            'commits_count': 1,
+            'scoring_data_stored': True,
+            'review_summary': {
+                'maintainer_changes_requested_count': 0,
+                'changes_requested_count': 0,
+                'approved_count': 1,
+                'commented_count': 0,
+            },
+            'labels': [],
+            'linked_issues': [],
+        }
+    )
+
+
+def _scored_pr(repo_full_name: str, pr_number: int, *, base_score: float, eligibility_mode: bool) -> ScoredMirrorPR:
+    scored = ScoredMirrorPR(pr=_mirror_pr(repo_full_name, pr_number))
+    scored.base_score = base_score
+    scored.token_score = 10.0
+    scored.eligibility_mode = eligibility_mode
+    return scored
+
+
+def test_ungated_mirror_repo_does_not_unlock_gated_repos_in_same_round():
+    evaluation = MinerEvaluation(uid=7, hotkey='hk', github_id='gh')
+    evaluation.mirror_merged_prs = [
+        _scored_pr('gated/repo', 1, base_score=5.0, eligibility_mode=True),
+        _scored_pr('gated/repo', 2, base_score=5.0, eligibility_mode=True),
+        _scored_pr('gated/repo', 3, base_score=5.0, eligibility_mode=True),
+        _scored_pr('gated/repo', 4, base_score=5.0, eligibility_mode=True),
+        _scored_pr('ungated/repo', 5, base_score=7.0, eligibility_mode=False),
+    ]
+
+    finalize_miner_scores({evaluation.uid: evaluation})
+
+    gated_scores = [pr.earned_score for pr in evaluation.mirror_merged_prs if pr.eligibility_mode]
+    ungated_scores = [pr.earned_score for pr in evaluation.mirror_merged_prs if not pr.eligibility_mode]
+
+    assert evaluation.is_eligible is False
+    assert evaluation.total_score == 7.0
+    assert gated_scores == [0.0, 0.0, 0.0, 0.0]
+    assert ungated_scores == [7.0]

--- a/tests/validator/oss_contributions/mirror/test_scored_pr.py
+++ b/tests/validator/oss_contributions/mirror/test_scored_pr.py
@@ -76,6 +76,8 @@ class TestComposition:
         assert scored.base_score == 0.0
         assert scored.earned_score == 0.0
         assert scored.token_score == 0.0
+        assert scored.eligibility_mode is True
+        assert scored.reward_eligible is True
         assert scored.pioneer_rank == 0
         assert scored.files is None
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -39,6 +39,7 @@ _resolve_trusted_scoring_label = scoring_module._resolve_trusted_scoring_label
 _calculate_issue_multiplier = scoring_module._calculate_issue_multiplier
 _is_valid_linked_issue = scoring_module._is_valid_linked_issue
 score_mirror_pr = scoring_module.score_mirror_pr
+BaseScoreResult = scoring_module.BaseScoreResult
 
 ScoredMirrorPR = scored_pr_module.ScoredMirrorPR
 MirrorPullRequest = mirror_models.MirrorPullRequest
@@ -108,6 +109,8 @@ def _config(
     trusted_label_pipeline: bool = False,
     label_multipliers: dict | None = None,
     default_label_multiplier: float = 1.0,
+    fixed_base_score: float | None = None,
+    eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
         weight=weight,
@@ -116,6 +119,8 @@ def _config(
         trusted_label_pipeline=trusted_label_pipeline,
         label_multipliers=label_multipliers,
         default_label_multiplier=default_label_multiplier,
+        fixed_base_score=fixed_base_score,
+        eligibility_mode=eligibility_mode,
     )
 
 
@@ -332,6 +337,147 @@ class TestScoringDataStoredGate:
         client.get_pr_files.assert_not_called()
         assert scored.files is None
         assert scored.base_score == 0.0
+
+
+# ============================================================================
+# Per-repo mirror overrides
+# ============================================================================
+
+
+class TestRepoOverrides:
+    def test_fixed_base_score_replaces_computed_base_and_can_outscore_non_fixed_repo(self, monkeypatch):
+        fixed_scored = ScoredMirrorPR(
+            pr=_pr(labels=[{'name': 'feature', 'actor_association': 'MEMBER'}]),
+        )
+        dynamic_scored = ScoredMirrorPR(
+            pr=_pr(labels=[{'name': 'feature', 'actor_association': 'MEMBER'}]),
+        )
+        fake_client = Mock()
+        fake_client.get_pr_files.return_value = Mock(files=['stub'])
+
+        monkeypatch.setattr(scoring_module, 'mirror_files_to_legacy', lambda *_args, **_kwargs: ([], {}))
+        monkeypatch.setattr(
+            scoring_module,
+            'calculate_base_score_for_pr_files',
+            Mock(
+                side_effect=[
+                    BaseScoreResult(
+                        base_score=0.25,
+                        token_score=6.0,
+                        structural_count=0,
+                        structural_score=0.0,
+                        leaf_count=0,
+                        leaf_score=0.0,
+                        total_nodes_scored=0,
+                        code_density=0.1,
+                    ),
+                    BaseScoreResult(
+                        base_score=0.9,
+                        token_score=60.0,
+                        structural_count=0,
+                        structural_score=0.0,
+                        leaf_count=0,
+                        leaf_score=0.0,
+                        total_nodes_scored=0,
+                        code_density=1.5,
+                    ),
+                ]
+            ),
+        )
+
+        asyncio.run(
+            score_mirror_pr(
+                fixed_scored,
+                mirror_eval=Mock(),
+                mirror_repos={fixed_scored.pr.repo_full_name: _config(fixed_base_score=1.0, label_multipliers={'feature': 1.5})},
+                programming_languages={},
+                token_config=Mock(),
+                client=fake_client,
+            )
+        )
+        asyncio.run(
+            score_mirror_pr(
+                dynamic_scored,
+                mirror_eval=Mock(),
+                mirror_repos={dynamic_scored.pr.repo_full_name: _config(label_multipliers={'feature': 1.5})},
+                programming_languages={},
+                token_config=Mock(),
+                client=fake_client,
+            )
+        )
+
+        fixed_scored.calculate_final_earned_score()
+        dynamic_scored.calculate_final_earned_score()
+
+        assert fixed_scored.base_score == pytest.approx(1.0)
+        assert dynamic_scored.base_score == pytest.approx(0.9)
+        assert fixed_scored.earned_score > dynamic_scored.earned_score
+
+    def test_absent_override_fields_match_explicit_defaults(self, monkeypatch):
+        implicit = ScoredMirrorPR(pr=_pr())
+        explicit = ScoredMirrorPR(pr=_pr())
+        fake_client = Mock()
+        fake_client.get_pr_files.return_value = Mock(files=['stub'])
+
+        monkeypatch.setattr(scoring_module, 'mirror_files_to_legacy', lambda *_args, **_kwargs: ([], {}))
+        monkeypatch.setattr(
+            scoring_module,
+            'calculate_base_score_for_pr_files',
+            Mock(
+                side_effect=[
+                    BaseScoreResult(
+                        base_score=0.75,
+                        token_score=10.0,
+                        structural_count=1,
+                        structural_score=1.0,
+                        leaf_count=1,
+                        leaf_score=1.0,
+                        total_nodes_scored=2,
+                        code_density=0.2,
+                    ),
+                    BaseScoreResult(
+                        base_score=0.75,
+                        token_score=10.0,
+                        structural_count=1,
+                        structural_score=1.0,
+                        leaf_count=1,
+                        leaf_score=1.0,
+                        total_nodes_scored=2,
+                        code_density=0.2,
+                    ),
+                ]
+            ),
+        )
+
+        asyncio.run(
+            score_mirror_pr(
+                implicit,
+                mirror_eval=Mock(),
+                mirror_repos={implicit.pr.repo_full_name: _config()},
+                programming_languages={},
+                token_config=Mock(),
+                client=fake_client,
+            )
+        )
+        asyncio.run(
+            score_mirror_pr(
+                explicit,
+                mirror_eval=Mock(),
+                mirror_repos={explicit.pr.repo_full_name: _config(fixed_base_score=None, eligibility_mode=True)},
+                programming_languages={},
+                token_config=Mock(),
+                client=fake_client,
+            )
+        )
+
+        assert implicit.base_score == explicit.base_score
+        assert implicit.repo_weight_multiplier == explicit.repo_weight_multiplier
+        assert implicit.label_multiplier == explicit.label_multiplier
+        assert implicit.issue_multiplier == explicit.issue_multiplier
+        assert implicit.time_decay_multiplier == explicit.time_decay_multiplier
+        assert implicit.review_quality_multiplier == explicit.review_quality_multiplier
+        assert implicit.eligibility_mode is True
+        assert explicit.eligibility_mode is True
 
 
 # ============================================================================

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -139,6 +139,22 @@ class TestLoadMasterRepositories:
                 f'{repo_name} trusted_label_pipeline should be bool, got {type(config.trusted_label_pipeline)}'
             )
 
+    def test_fixed_base_score_field_defaults_on_live_configs(self):
+        """Live configs without fixed_base_score keep the legacy token-derived base path."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            assert config.fixed_base_score is None, (
+                f'{repo_name} fixed_base_score should default to None when absent from JSON'
+            )
+
+    def test_eligibility_mode_field_defaults_on_live_configs(self):
+        """Live configs without eligibility_mode keep the existing global gate."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            assert config.eligibility_mode is True, (
+                f'{repo_name} eligibility_mode should default to True when absent from JSON'
+            )
+
     def test_entrius_repos_have_trusted_label_pipeline(self):
         """All entrius/* entries opt into trusted_label_pipeline (issue #911)."""
         repos = load_master_repo_weights()
@@ -260,6 +276,62 @@ class TestRepositoryConfigLabelMultipliers:
         assert repos['foo/labeled'].default_label_multiplier == pytest.approx(0.8)
         assert repos['foo/defaults'].label_multipliers is None
         assert repos['foo/defaults'].default_label_multiplier == pytest.approx(1.0)
+
+
+class TestRepositoryConfigMirrorOverrides:
+    """Dataclass + JSON parsing tests for fixed_base_score and eligibility_mode."""
+
+    def test_override_defaults_preserve_existing_behavior(self):
+        config = RepositoryConfig(weight=0.5)
+
+        assert config.fixed_base_score is None
+        assert config.eligibility_mode is True
+
+    def test_loader_parses_override_fields(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/overrides': {
+                        'weight': 0.5,
+                        'fixed_base_score': 1.25,
+                        'eligibility_mode': False,
+                    },
+                    'foo/defaults': {'weight': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/overrides'].fixed_base_score == pytest.approx(1.25)
+        assert repos['foo/overrides'].eligibility_mode is False
+        assert repos['foo/defaults'].fixed_base_score is None
+        assert repos['foo/defaults'].eligibility_mode is True
+
+    @pytest.mark.parametrize(
+        ('raw_value', 'expected'),
+        [
+            (-5.0, 0.0),
+            (0.5, 0.5),
+            (125.0, 100.0),
+        ],
+    )
+    def test_loader_clamps_fixed_base_score(self, tmp_path, monkeypatch, raw_value, expected):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps({'foo/clamped': {'weight': 0.5, 'fixed_base_score': raw_value}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/clamped'].fixed_base_score == pytest.approx(expected)
 
     @pytest.mark.parametrize('repo_name,metadata', _live_master_repo_metadata())
     def test_live_label_multiplier_maps_are_bounded(self, repo_name, metadata):


### PR DESCRIPTION
## Summary
This update adds two new **per-repository mirror-scoring controls** to `RepositoryConfig`:
- `fixed_base_score: Optional[float]`
- `eligibility_mode: bool`
These fields let a mirror-enabled repository override two behaviors that were previously global:
1. whether PR `base_score` comes from token-scored diff size or a fixed repo-configured value
2. whether merged PR reward remains blocked by the miner-wide global eligibility gate
Defaults preserve current behavior for repositories that do not set either field.
## Related Issue
Closes: #1110
## Change Type
- [x] Feature
- [x] Scoring logic update
- [x] Configuration schema update
- [x] Validation improvement
- [x] Test coverage update
- [x] Mirror-path-only behavior change
- [ ] Database schema change
- [ ] API contract change
- [ ] Legacy scoring path change
## Real Behavior Proof

### 1. Config loader now parses and validates the new fields

In `gittensor/validator/utils/load_weights.py`:

- `RepositoryConfig` now includes:
  - `fixed_base_score: Optional[float] = None`
  - `eligibility_mode: bool = True`
- `fixed_base_score` is parsed through a clamp helper
- `eligibility_mode` is parsed through strict bool validation

That means absent fields preserve the current behavior, while malformed or unexpected values are caught at load time.

### 2. Mirror per-PR scoring now honors `fixed_base_score`

In `gittensor/validator/oss_contributions/mirror/scoring.py`:

the mirror PR scoring flow still computes token metrics, but now does:

```python
if repo_config.fixed_base_score is not None:
    scored.base_score = repo_config.fixed_base_score
else:
    scored.base_score = result.base_score
```