### PR TITLE
chore: rebalance emission shares (issue discovery 30→10, recycle 25→45)

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -155,8 +155,8 @@ RECYCLE_UID = 0
 
 # Hardcoded emission splits per competition (replaces dynamic emissions)
 OSS_EMISSION_SHARE = 0.30  # 30% to OSS contributions (PR scoring)
-ISSUE_DISCOVERY_EMISSION_SHARE = 0.30  # 30% to issue discovery
-RECYCLE_EMISSION_SHARE = 0.25  # 25% to recycle UID 0
+ISSUE_DISCOVERY_EMISSION_SHARE = 0.10  # 10% to issue discovery
+RECYCLE_EMISSION_SHARE = 0.45  # 45% to recycle UID 0
 # ISSUES_TREASURY_EMISSION_SHARE = 0.15 defined below (15% to smart contract treasury)
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Rebalance the hardcoded emission shares in `gittensor/constants.py`:

- `ISSUE_DISCOVERY_EMISSION_SHARE`: 0.30 → 0.10
- `RECYCLE_EMISSION_SHARE`: 0.25 → 0.45

Other shares unchanged: OSS contributions 30%, issues treasury 15%. Total still sums to 100%.

## Test plan

- [x] `ruff check`, `ruff format --check`, `pyright` clean on the touched file
- [x] `pytest tests/` — 1443 passing (one pre-existing failure on `tests/cli/test_cli_helpers.py::TestCliRegisterLogicalFailures::test_register_exits_non_zero_when_contract_metadata_missing` is unrelated to this change; reproduces on a clean tree)