### PR TITLE
fix(neuron): exit non-zero on unregistered hotkey (#1011)

### DIFF
--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -136,7 +136,7 @@ class BaseNeuron(ABC):
                         f'Wallet: {self.wallet} is not registered on netuid {self.config.netuid}.'
                         f' Please register the hotkey using `btcli subnets register` before trying again'
                     )
-                    exit()
+                    raise SystemExit(1)
                 return  # Success
             except ConnectionClosedError as e:
                 bt.logging.warning(


### PR DESCRIPTION
## Summary

Closes #1011.

`BaseNeuron.check_registered` (neurons/base/neuron.py:139) called bare `exit()` on the unregistered-hotkey branch. Bare `exit()` is `sys.exit(None)` which yields process exit code **0** — supervisors (systemd, docker, k8s, `set -e` shells) interpret a misconfigured wallet as a graceful shutdown and don't restart or alert.

The companion `bt.logging.error(...)` call already describes this as a fatal failure; the exit code now matches.

## Change

```diff
-                    exit()
+                    raise SystemExit(1)
```

`raise SystemExit(1)` is preferred over `sys.exit(1)` here per the issue's suggestion — same observable behavior, no new import needed.

## Scope

Only the unregistered-hotkey branch. The other failure path (`raise` after `max_retries` `ConnectionClosedError`s) already propagates a real exception so its exit code is already non-zero.

## Test plan

- [x] `python -c "raise SystemExit(1)"; echo $?` → `1` (vs bare `exit()` → `0`)
- [x] No other call sites or tests reference `check_registered`'s exit behavior; the only test impact is on operators running supervised neurons with misconfigured hotkeys, who will now see the failure surface correctly.