### PR TITLE
fix(forward): recycle treasury share when treasury UID inactive (#974)

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -176,13 +176,25 @@ def blend_emission_pools(
         recycle_extra += ISSUE_DISCOVERY_EMISSION_SHARE
 
     # Pool 3: Issue treasury (15% flat to UID 111)
-    if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
+    # Treasury is considered "active" only when its UID is set to a non-recycle
+    # neuron AND that neuron is currently in the metagraph. When inactive
+    # (disabled via ISSUES_TREASURY_UID == RECYCLE_UID, or temporarily missing
+    # because the neuron is deregistered), the share recycles like Pools 1 and
+    # 2 do — otherwise the validator emits only ~85% of weight while the
+    # docstring claims 100%.
+    treasury_active = (
+        ISSUES_TREASURY_UID != RECYCLE_UID
+        and ISSUES_TREASURY_UID in miner_uids
+    )
+    if treasury_active:
         treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
         rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
         bt.logging.info(
             f'Treasury allocation: UID {ISSUES_TREASURY_UID} receives '
             f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
         )
+    else:
+        recycle_extra += ISSUES_TREASURY_EMISSION_SHARE
 
     # Pool 4: Recycle (25% + unclaimed from empty pools)
     if RECYCLE_UID in miner_uids:


### PR DESCRIPTION
## Summary

Closes #974.

`blend_emission_pools` previously allocated Pool 3's 15% treasury share to `ISSUES_TREASURY_UID` only when `ISSUES_TREASURY_UID > 0` AND `ISSUES_TREASURY_UID in miner_uids`. When that condition was false — treasury neuron deregistered, or disabled by setting `ISSUES_TREASURY_UID = RECYCLE_UID` — the 15% share was silently dropped and the validator emitted only ~85% of weight, contradicting the function's own docstring promise of 100%.

Pools 1 (OSS, 30%) and 2 (issue discovery, 30%) already handle their unclaimed shares by accumulating into `recycle_extra` and routing them to `RECYCLE_UID`. This makes Pool 3 do the same.

## Change

```diff
+    treasury_active = (
+        ISSUES_TREASURY_UID != RECYCLE_UID
+        and ISSUES_TREASURY_UID in miner_uids
+    )
+    if treasury_active:
         treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
         rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
         bt.logging.info(...)
+    else:
+        recycle_extra += ISSUES_TREASURY_EMISSION_SHARE
```

Two narrowly-scoped fixes packed in:

1. **Primary**: the missing `else` branch — the 15% now recycles through `recycle_extra` like Pools 1 & 2 already do.
2. **Secondary** (per issue body): `ISSUES_TREASURY_UID > 0` → `ISSUES_TREASURY_UID != RECYCLE_UID`. The constants comment says treasury is disabled when set to `RECYCLE_UID`; the previous guard expressed that as `> 0` only because today `RECYCLE_UID == 0`. The new form remains correct if either constant is reassigned.

## Scope

Single function, +13/-1. No call-site changes. The `recycle_extra` accumulator and `RECYCLE_UID` distribution at Pool 4 are unchanged — the new contribution flows through the existing path.

## Test plan

- [x] AST parses cleanly: `python3 -c "import ast; ast.parse(open('gittensor/validator/forward.py').read())"`
- [x] No existing test for `blend_emission_pools`; manual review confirms `recycle_extra` is correctly summed at Pool 4 (`rewards[recycle_idx] += RECYCLE_EMISSION_SHARE + recycle_extra`).
- [x] When treasury IS active, behavior is unchanged (same `treasury_idx` allocation + same log line).
- [x] When treasury is inactive, `recycle_extra` now grows by `ISSUES_TREASURY_EMISSION_SHARE` (0.15) and routes to `RECYCLE_UID`, restoring the docstring's 100% emission contract.