### PR TITLE
fix(github_api): bump labels(first: 5) to labels(first: 100) (#1048)

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -138,7 +138,7 @@ QUERY = """
                   authorAssociation
                 }
               }
-              labels(first: 5) {
+              labels(first: 100) {
                 nodes { name }
               }
               timelineItems(itemTypes: [LABELED_EVENT], last: 5) {


### PR DESCRIPTION
## Summary

Closes #1048.

The legacy GraphQL PR query at `gittensor/utils/github_api_tools.py:141` fetches current PR labels with `labels(first: 5)`. After PR #1027 moved label-multiplier scoring into per-repository config, the scoring code falls back to `current_labels` when the relevant `LABELED_EVENT` is outside the `timelineItems(last: 5)` window — but `current_labels` itself was bounded to 5 entries by this same query.

So a PR with more than 5 labels can have its scoring label fall **outside both** the timeline window AND the current-labels page, causing the PR to silently receive the repository default label multiplier instead of the configured one.

## Change

```diff
-              labels(first: 5) {
+              labels(first: 100) {
                 nodes { name }
               }
```

100 is the GitHub GraphQL maximum page size for this connection — covers any realistic PR.

## Why no downstream changes

`current_labels` is consumed as a `frozenset[str]` in two sites:
- `gittensor/classes.py:194` — field default `frozenset()`
- `gittensor/validator/oss_contributions/label_resolution.py:30,48` — iterates the full set

Neither assumes bounded length, so the page-size bump propagates cleanly.

## Scope

`gittensor/utils/github_api_tools.py`: **+1 / -1**. No other files touched.

## Test plan

- [x] Single-character GraphQL parameter change; the existing `current_labels` parsing accepts any number of nodes.
- [x] No GraphQL cost concern: `labels(first: 100)` consumes 1 node-cost per label vs 1 per label at `first: 5` — total points charged are bounded by actual labels on the PR (rarely >10), not the page size.
- [x] No timeline window change — that fix is independent and tracked elsewhere if needed.