### PR TITLE
fix: report PAT check as inconclusive on transient GitHub /user failures

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -14,7 +14,10 @@ import requests
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.validator import pat_storage
-from gittensor.validator.utils.github_validation import validate_github_credentials
+from gittensor.validator.utils.github_validation import (
+    validate_github_credentials,
+    validate_github_credentials_result,
+)
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -116,12 +119,17 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
 
     synapse.has_pat = True
 
-    # Re-validate the stored PAT
-    _, error = validate_github_credentials(uid, entry['pat'])
-    if error:
+    # Re-validate the stored PAT — transient GitHub failures report inconclusive, not invalid.
+    validation = validate_github_credentials_result(uid, entry['pat'])
+    if validation.transient_failure:
+        synapse.pat_valid = None
+        synapse.rejection_reason = 'GitHub API temporarily unavailable; please retry the PAT check in a few minutes.'
+        bt.logging.warning(f'PAT check result — UID: {uid}: GitHub identity lookup temporarily unavailable')
+        return synapse
+    if validation.error:
         synapse.pat_valid = False
-        synapse.rejection_reason = error
-        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {error}')
+        synapse.rejection_reason = validation.error
+        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {validation.error}')
         return synapse
 
     test_error = _test_pat_against_repo(entry['pat'])

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -3,12 +3,14 @@
 """Tests for PAT broadcast and check handlers."""
 
 import asyncio
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
 from bittensor.core.synapse import TerminalInfo
 
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
+from gittensor.utils.github_api_tools import GitHubIdentityResult, GitHubIdentityStatus
 from gittensor.validator import pat_storage
 from gittensor.validator.pat_handler import (
     _test_pat_against_repo,
@@ -17,6 +19,16 @@ from gittensor.validator.pat_handler import (
     handle_pat_broadcast,
     handle_pat_check,
 )
+from gittensor.validator.utils.github_validation import GitHubCredentialValidation
+
+
+def _validation(
+    github_id: Optional[str] = 'github_42',
+    error: Optional[str] = None,
+    transient_failure: bool = False,
+) -> GitHubCredentialValidation:
+    """Build a GitHubCredentialValidation for mocking validate_github_credentials_result."""
+    return GitHubCredentialValidation(github_id, error, transient_failure=transient_failure)
 
 
 def _run(coro):
@@ -188,7 +200,7 @@ class TestHandlePatBroadcast:
 
 class TestHandlePatCheck:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
     def test_valid_pat(self, mock_validate, mock_test_query, mock_validator):
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_test', 'github_42')
 
@@ -214,7 +226,10 @@ class TestHandlePatCheck:
         assert result.pat_valid is False
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=(None, 'PAT expired'))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_validation(None, 'PAT expired'),
+    )
     def test_stored_but_invalid_pat(self, mock_validate, mock_test_query, mock_validator):
         """PAT is stored but fails re-validation."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_expired', 'github_42')
@@ -224,6 +239,25 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is False
         assert 'PAT expired' in (result.rejection_reason or '')
+
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo')
+    @patch(
+        'gittensor.validator.utils.github_validation.get_github_identity',
+        return_value=GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE),
+    )
+    def test_transient_identity_lookup_reports_inconclusive(self, mock_get_identity, mock_test_query, mock_validator):
+        """Transient GitHub /user failures must surface as pat_valid=None, not False (issue #1106)."""
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_stored', 'github_42')
+
+        synapse = _make_check_synapse('hotkey_1')
+        result = _run(handle_pat_check(mock_validator, synapse))
+
+        assert result.has_pat is True
+        assert result.pat_valid is None
+        assert result.rejection_reason == (
+            'GitHub API temporarily unavailable; please retry the PAT check in a few minutes.'
+        )
+        mock_test_query.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When the GitHub `/user` endpoint is temporarily unreachable, `handle_pat_check` was reporting stored PATs as invalid (`pat_valid = False`), which surfaces in `gitt miner check` as a hard "PAT invalid" message. That can push miners to rotate a token that's actually fine — the validator just couldn't reach GitHub.

This PR keeps the existing failure path for permanent errors and adds a third state for transient failures: `pat_valid = None` (inconclusive) with a short "please retry in a few minutes" message. The check handler now uses `validate_github_credentials_result()` so the `transient_failure` flag introduced in #932 isn't dropped.

The broadcast handler is intentionally **not** changed — it already rejects the PAT and short-circuits the same way before and after, so swapping the rejection string there isn't worth the extra surface area.

## Related Issues

Closes #1106

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

**Added** `test_transient_identity_lookup_reports_inconclusive` — patches `get_github_identity` to return `TRANSIENT_FAILURE` end-to-end and asserts `pat_valid is None`, the inconclusive message, and that the GraphQL test query is **not** called (proves the early return).

**Updated** `test_valid_pat` and `test_stored_but_invalid_pat` to patch the new symbol (`validate_github_credentials_result`); behavior assertions are unchanged.

Local run:

```
uv run pytest tests/validator/test_pat_handler.py -v   # 22 passed
uv run pytest tests/                                   # 1450 passed
uv run ruff check  gittensor/validator/pat_handler.py tests/validator/test_pat_handler.py
uv run ruff format --check gittensor/validator/pat_handler.py tests/validator/test_pat_handler.py
uv run pyright   gittensor/validator/pat_handler.py tests/validator/test_pat_handler.py
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
