### PR TITLE
fix(issue_competitions): exclude duplicate github_ids from bounty voting (#895)

### DIFF
--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -3,6 +3,7 @@
 
 """Issue bounties forward pass — harvest, verify, and vote on active issues."""
 
+from collections import Counter
 from typing import TYPE_CHECKING, Dict
 
 import bittensor as bt
@@ -61,11 +62,32 @@ async def issue_competitions(
         if harvest_result and harvest_result.get('status') == 'success':
             bt.logging.success(f'Harvested emissions! Extrinsic: {harvest_result.get("tx_hash", "")}')
 
-        # Build mapping of github_id->hotkey for eligible miners only
-        eligible_miners = {
-            eval.github_id: eval.hotkey
+        # Build mapping of github_id->hotkey for eligible miners only.
+        # Defensive (#895): if two MinerEvaluation entries share the same
+        # github_id (upstream duplicate-account penalty may not fire within
+        # a single round, leaving multiple eligible entries with the same
+        # identity), the prior dict comprehension silently kept whichever
+        # hotkey iterated last and the validator could vote-pay the wrong
+        # miner. Detect the collision and exclude every colliding github_id
+        # from this round so the bounty falls through to vote_cancel rather
+        # than mis-pay.
+        eligible_pairs = [
+            (eval.github_id, eval.hotkey)
             for eval in miner_evaluations.values()
             if eval.github_id and eval.github_id != '0' and eval.is_eligible
+        ]
+        github_id_counts = Counter(gid for gid, _ in eligible_pairs)
+        duplicate_github_ids = {gid for gid, count in github_id_counts.items() if count > 1}
+        if duplicate_github_ids:
+            bt.logging.warning(
+                f'Issue bounties: {len(duplicate_github_ids)} github_id(s) have multiple eligible miners '
+                f'this round; excluding them from bounty voting to avoid mis-pay. '
+                f'Affected github_ids: {sorted(duplicate_github_ids)}'
+            )
+        eligible_miners = {
+            github_id: hotkey
+            for github_id, hotkey in eligible_pairs
+            if github_id not in duplicate_github_ids
         }
         bt.logging.info(f'Issue bounties: {len(eligible_miners)} eligible miners out of {len(miner_evaluations)} total')
         for github_id, hotkey in eligible_miners.items():


### PR DESCRIPTION
## Summary

Closes #895.

`eligible_miners` in `gittensor/validator/issue_competitions/forward.py` was built via a dict comprehension keyed by `github_id`. When two eligible `MinerEvaluation` entries shared the same `github_id` (race between PAT broadcast and the duplicate-account penalty pass, or a divergent DB/in-memory state from past bugs like #533/#596), Python dict construction silently kept whichever hotkey iterated last with no log, no warning, and a non-deterministic winner across rounds.

Downstream lookup at line ~126:
```python
miner_hotkey = eligible_miners.get(str(solver_github_id))
```
voted to pay the surviving hotkey — even when that wasn't the actual PR author. Or fell into the cancel branch when `get_miner_coldkey()` failed on the surviving hotkey. The code path silently propagated upstream-penalty bugs into bounty mis-payments instead of failing loudly.

## Change

```diff
+from collections import Counter
 ...
-        # Build mapping of github_id->hotkey for eligible miners only
-        eligible_miners = {
-            eval.github_id: eval.hotkey
+        # Defensive (#895): detect collisions instead of silently overwriting
+        eligible_pairs = [
+            (eval.github_id, eval.hotkey)
             for eval in miner_evaluations.values()
             if eval.github_id and eval.github_id != '0' and eval.is_eligible
+        ]
+        github_id_counts = Counter(gid for gid, _ in eligible_pairs)
+        duplicate_github_ids = {gid for gid, count in github_id_counts.items() if count > 1}
+        if duplicate_github_ids:
+            bt.logging.warning(...)
+        eligible_miners = {
+            github_id: hotkey
+            for github_id, hotkey in eligible_pairs
+            if github_id not in duplicate_github_ids
         }
```

## Behaviour matrix

| Scenario | Behaviour |
|---|---|
| 0 duplicates | Identical to prior — `Counter` + filter is a no-op, all eligible miners pass through. |
| 1+ duplicates | Affected `github_id`(s) excluded from `eligible_miners`. `bt.logging.warning` logs the affected ids. Downstream lookup at ~126 returns `None`, so the bounty falls through to the existing `vote_cancel_issue` branch (with the existing `'not in eligible miners'` reason). |

The downstream `vote_cancel_issue` path is what runs **today** for any unrecognized `solver_github_id` — colliding ids now reach that path instead of mis-paying the wrong hotkey.

## Scope

`gittensor/validator/issue_competitions/forward.py`: **+25 / -3**. Adds one stdlib import (`Counter` from `collections`); no new deps. The `eligible_miners` dict shape and the downstream consumer at line ~126 are unchanged.

## Test plan

- [x] AST parses cleanly: `python3 -c "import ast; ast.parse(open('gittensor/validator/issue_competitions/forward.py').read())"`
- [x] Smoke test of fix logic in isolation:
  - `[(111,a),(222,b),(111,c),(333,d)]` → duplicates `{111}`, eligible_miners = `{222:b, 333:d}`
  - `[(111,a),(222,b)]` → duplicates `{}`, eligible_miners = `{111:a, 222:b}` (unchanged)
- [x] Manual trace through the file: downstream `eligible_miners.get(str(solver_github_id))` correctly hits the existing `'not in eligible miners'` cancel branch when collided ids are excluded.
