### PR TITLE
fix: duplicate-GitHub penalty wipes stale_closed_pull_requests to prevent post-penalty storage (#1006)

### DIFF
--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -73,6 +73,7 @@ def _zero_for_duplicate_penalty(eval_: MinerEvaluation, reason: str) -> None:
     eval_.mirror_merged_prs = []
     eval_.mirror_open_prs = []
     eval_.mirror_closed_prs = []
+    eval_.stale_closed_pull_requests = []
     eval_.unique_repos_contributed_to = set()
     eval_.unique_repos_count = 0
     eval_.is_eligible = False


### PR DESCRIPTION
## Description

Fix #1006 — `_zero_for_duplicate_penalty` clears score-bearing PR buckets but missed `stale_closed_pull_requests` added in PR #769. Penalized miners' stale closed PRs survive the wipe and are still written to storage.

This bucket is storage-only (not reward-counted), so no current-round score leak. But penalized miners should be fully isolated from PR persistence after the wipe.

## Changes

- Added `eval_.stale_closed_pull_requests = []` to `_zero_for_duplicate_penalty`

## Testing

- [x] Duplicate miner penalized → stale_closed_pull_requests is empty → no stale PR rows written