### PR TITLE
fix: remove stale All-Hands-AI/OpenHands repo entry (#1098)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -20,9 +20,6 @@
   "AgentOps-AI/agentops": {
     "weight": 0.0363
   },
-  "All-Hands-AI/OpenHands": {
-    "weight": 0.0532
-  },
   "AlphaCoreBittensor/alphacore": {
     "weight": 0.0484
   },
@@ -30,7 +27,9 @@
     "weight": 0.0372
   },
   "ant-design/ant-design": {
-    "additional_acceptable_branches": ["feature"],
+    "additional_acceptable_branches": [
+      "feature"
+    ],
     "weight": 0.0715
   },
   "antoniorodr/cronboard": {
@@ -40,17 +39,25 @@
     "weight": 0.0579
   },
   "autoppia/autoppia_iwa": {
-    "additional_acceptable_branches": ["contribution/*"],
+    "additional_acceptable_branches": [
+      "contribution/*"
+    ],
     "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1259
   },
   "autoppia/autoppia_web_agents_subnet": {
-    "additional_acceptable_branches": ["dev", "dev-gittensor"],
+    "additional_acceptable_branches": [
+      "dev",
+      "dev-gittensor"
+    ],
     "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1321
   },
   "autoppia/autoppia_webs_demo": {
-    "additional_acceptable_branches": ["feature/*", "fix/*"],
+    "additional_acceptable_branches": [
+      "feature/*",
+      "fix/*"
+    ],
     "inactive_at": "2026-04-06T00:00:00Z",
     "weight": 0.1239
   },
@@ -91,7 +98,9 @@
     "weight": 0.2917
   },
   "BitMind-AI/bitmind-subnet": {
-    "additional_acceptable_branches": ["testnet"],
+    "additional_acceptable_branches": [
+      "testnet"
+    ],
     "weight": 0.1013
   },
   "bitpay/bitcore": {
@@ -140,7 +149,10 @@
     "weight": 0.0926
   },
   "cosmos/cosmos-sdk": {
-    "additional_acceptable_branches": ["release/v0.54.x", "release/v0.53.x"],
+    "additional_acceptable_branches": [
+      "release/v0.54.x",
+      "release/v0.53.x"
+    ],
     "weight": 0.0916
   },
   "CreativeBuilds/sn77": {
@@ -285,7 +297,9 @@
     "weight": 0.0853
   },
   "grafana/grafana": {
-    "additional_acceptable_branches": ["release-13.0.2"],
+    "additional_acceptable_branches": [
+      "release-13.0.2"
+    ],
     "weight": 0.1136
   },
   "GraphiteAI/Graphite-Subnet": {
@@ -295,7 +309,9 @@
     "weight": 0.0342
   },
   "hoppscotch/hoppscotch": {
-    "additional_acceptable_branches": ["next"],
+    "additional_acceptable_branches": [
+      "next"
+    ],
     "weight": 0.1801
   },
   "huggingface/lerobot": {
@@ -326,7 +342,9 @@
     "weight": 0.0704
   },
   "jellyfin/jellyfin": {
-    "additional_acceptable_branches": ["release-10.11.z"],
+    "additional_acceptable_branches": [
+      "release-10.11.z"
+    ],
     "weight": 0.0607
   },
   "jesseduffield/lazygit": {
@@ -342,14 +360,18 @@
     "weight": 0.0837
   },
   "jupyterlab/jupyterlab": {
-    "additional_acceptable_branches": ["4.5.x"],
+    "additional_acceptable_branches": [
+      "4.5.x"
+    ],
     "weight": 0.1755
   },
   "keras-team/keras": {
     "weight": 0.1091
   },
   "labring/FastGPT": {
-    "additional_acceptable_branches": ["v4.14.x"],
+    "additional_acceptable_branches": [
+      "v4.14.x"
+    ],
     "weight": 0.0633
   },
   "langchain-ai/langchain": {
@@ -363,15 +385,22 @@
     "weight": 0.0346
   },
   "latent-to/async-substrate-interface": {
-    "additional_acceptable_branches": ["staging"],
+    "additional_acceptable_branches": [
+      "staging"
+    ],
     "weight": 0.2764
   },
   "latent-to/bittensor": {
-    "additional_acceptable_branches": ["staging", "SDKv10"],
+    "additional_acceptable_branches": [
+      "staging",
+      "SDKv10"
+    ],
     "weight": 0.3556
   },
   "latent-to/btcli": {
-    "additional_acceptable_branches": ["staging"],
+    "additional_acceptable_branches": [
+      "staging"
+    ],
     "weight": 0.2514
   },
   "latent-to/btwallet": {
@@ -393,7 +422,9 @@
     "weight": 0.0419
   },
   "macrocosm-os/data-universe": {
-    "additional_acceptable_branches": ["dev"],
+    "additional_acceptable_branches": [
+      "dev"
+    ],
     "weight": 0.0495
   },
   "macrocosm-os/iota": {
@@ -412,14 +443,19 @@
     "weight": 0.0564
   },
   "medusajs/medusa": {
-    "additional_acceptable_branches": ["develop"],
+    "additional_acceptable_branches": [
+      "develop"
+    ],
     "weight": 0.0603
   },
   "mem0ai/mem0": {
     "weight": 0.0455
   },
   "MetaMask/metamask-extension": {
-    "additional_acceptable_branches": ["release/13.28.0", "release/13.29.0"],
+    "additional_acceptable_branches": [
+      "release/13.28.0",
+      "release/13.29.0"
+    ],
     "weight": 0.0806
   },
   "metanova-labs/nova": {
@@ -447,7 +483,9 @@
     "weight": 0.0445
   },
   "monero-project/monero": {
-    "additional_acceptable_branches": ["release-v0.18"],
+    "additional_acceptable_branches": [
+      "release-v0.18"
+    ],
     "weight": 0.0792
   },
   "mrdoob/three.js": {
@@ -457,18 +495,27 @@
     "weight": 0.0542
   },
   "neovim/neovim": {
-    "additional_acceptable_branches": ["release-0.12"],
+    "additional_acceptable_branches": [
+      "release-0.12"
+    ],
     "weight": 0.0785
   },
   "nextcloud/android": {
     "weight": 0.0778
   },
   "nextcloud/desktop": {
-    "additional_acceptable_branches": ["stable-33.0", "stable-4.0"],
+    "additional_acceptable_branches": [
+      "stable-33.0",
+      "stable-4.0"
+    ],
     "weight": 0.0771
   },
   "nextcloud/server": {
-    "additional_acceptable_branches": ["stable33", "stable32", "stable31"],
+    "additional_acceptable_branches": [
+      "stable33",
+      "stable32",
+      "stable31"
+    ],
     "weight": 0.0764
   },
   "nginx/nginx": {
@@ -478,7 +525,9 @@
     "weight": 0.0333
   },
   "nocodb/nocodb": {
-    "additional_acceptable_branches": ["develop"],
+    "additional_acceptable_branches": [
+      "develop"
+    ],
     "weight": 0.0751
   },
   "nousresearch/hermes-agent": {
@@ -515,7 +564,9 @@
     "weight": 0.0492
   },
   "opentensor/subtensor": {
-    "additional_acceptable_branches": ["devnet-ready"],
+    "additional_acceptable_branches": [
+      "devnet-ready"
+    ],
     "weight": 0.387
   },
   "OpenZeppelin/openzeppelin-contracts": {
@@ -543,7 +594,9 @@
     "weight": 0.0442
   },
   "pi-hole/web": {
-    "additional_acceptable_branches": ["development"],
+    "additional_acceptable_branches": [
+      "development"
+    ],
     "weight": 0.0739
   },
   "PlatformNetwork/platform": {
@@ -574,7 +627,9 @@
     "weight": 0.0364
   },
   "RedTeamSubnet/RedTeam": {
-    "additional_acceptable_branches": ["dev"],
+    "additional_acceptable_branches": [
+      "dev"
+    ],
     "weight": 0.044
   },
   "resi-labs-ai/resi": {
@@ -597,11 +652,15 @@
     "weight": 0.0507
   },
   "shiftlayer-llc/brainplay-subnet": {
-    "additional_acceptable_branches": ["dev"],
+    "additional_acceptable_branches": [
+      "dev"
+    ],
     "weight": 0.04
   },
   "Significant-Gravitas/AutoGPT": {
-    "additional_acceptable_branches": ["dev"],
+    "additional_acceptable_branches": [
+      "dev"
+    ],
     "weight": 0.062
   },
   "smartcontractkit/chainlink": {
@@ -635,7 +694,9 @@
     "weight": 0.0682
   },
   "taofu-labs/tpn-subnet": {
-    "additional_acceptable_branches": ["development"],
+    "additional_acceptable_branches": [
+      "development"
+    ],
     "weight": 0.0398
   },
   "taoshidev/vanta-network": {
@@ -645,7 +706,9 @@
     "weight": 0.0394
   },
   "tauri-apps/tauri": {
-    "additional_acceptable_branches": ["dev"],
+    "additional_acceptable_branches": [
+      "dev"
+    ],
     "weight": 0.0583
   },
   "Team-Rizzo/talisman-ai": {
@@ -664,7 +727,9 @@
     "weight": 0.0672
   },
   "ToolJet/ToolJet": {
-    "additional_acceptable_branches": ["develop"],
+    "additional_acceptable_branches": [
+      "develop"
+    ],
     "weight": 0.0599
   },
   "trishoolai/trishool-subnet": {
@@ -716,7 +781,9 @@
     "weight": 0.0638
   },
   "zed-industries/zed": {
-    "additional_acceptable_branches": ["v0.234.x"],
+    "additional_acceptable_branches": [
+      "v0.234.x"
+    ],
     "weight": 0.1564
   }
 }


### PR DESCRIPTION
## Summary

master_repositories.json contains an entry for All-Hands-AI/OpenHands that no longer exists. The scoring code hits 404 every cycle, wasting a GraphQL query slot under rate limits. Remove the stale entry.
## Validation

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors
Closes #1098