### PR TITLE
fix: update renamed repository URLs (#1098)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -20,9 +20,6 @@
   "AgentOps-AI/agentops": {
     "weight": 0.0363
   },
-  "All-Hands-AI/OpenHands": {
-    "weight": 0.0532
-  },
   "AlphaCoreBittensor/alphacore": {
     "weight": 0.0484
   },
@@ -118,7 +115,7 @@
   "byteleapai/byteleap-Miner": {
     "weight": 0.0433
   },
-  "calcom/cal.com": {
+  "calcom/cal.diy": {
     "weight": 0.0347
   },
   "ChutesAI/chutes": {


### PR DESCRIPTION
## Summary

Two repository URLs changed upstream: All-Hands-AI/OpenHands was renamed (already exists as OpenHands/OpenHands), and calcom/cal.com moved to calcom/cal.diy. master_repositories.json still used old names, so miners couldn't get credit for PRs to correctly-named repos. Remove the stale All-Hands-AI/OpenHands entry (dedup) and rename calcom/cal.com to calcom/cal.diy.
## Validation

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors
- `uv run pytest tests/validator/test_repository_list.py::test_renamed_repos -q` — 1 passed
Closes #1098