### PR TITLE
fix: score configured extensionless files

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -21,6 +21,11 @@ from gittensor.constants import (
 )
 from gittensor.utils.utils import parse_repo_name
 
+CONFIGURED_EXTENSIONLESS_FILENAMES = {
+    'dockerfile': 'dockerfile',
+    'makefile': 'makefile',
+}
+
 
 def _apply_score_multipliers(base_score: float, multipliers: Dict[str, float], pr_label: str) -> float:
     """Compute earned score and emit the standard scoring log lines."""
@@ -77,7 +82,9 @@ class FileChange:
 
     def _calculate_file_extension(self) -> str:
         basename = self.filename.split('/')[-1]
-        return basename.split('.')[-1].lower() if '.' in basename else ''
+        if '.' in basename:
+            return basename.split('.')[-1].lower()
+        return CONFIGURED_EXTENSIONLESS_FILENAMES.get(basename.lower(), '')
 
     def is_test_file(self) -> bool:
         filename_lower = self.filename.lower()

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -96,6 +96,22 @@ def test_is_test_file_detects_conftest_at_any_depth(filename):
     assert _file_change(filename).is_test_file() is True
 
 
+@pytest.mark.parametrize(
+    ('filename', 'expected_extension'),
+    [
+        ('Dockerfile', 'dockerfile'),
+        ('dockerfile', 'dockerfile'),
+        ('services/api/Dockerfile', 'dockerfile'),
+        ('Makefile', 'makefile'),
+        ('makefile', 'makefile'),
+        ('build.mk', 'mk'),
+        ('README', ''),
+    ],
+)
+def test_file_extension_normalizes_configured_extensionless_filenames(filename, expected_extension):
+    assert _file_change(filename).file_extension == expected_extension
+
+
 def test_pull_request_handles_deleted_label_event():
     pr_data = {
         'number': 42,


### PR DESCRIPTION
Summary
- Normalize configured extensionless basenames like Dockerfile and Makefile to their configured language keys.
- Preserve existing dotted-extension behavior and leave unrelated extensionless files unsupported.
- Add regression coverage for Dockerfile, Makefile, dotted build.mk, and unrelated README.

Related Issues
- Fixes #985

Testing
- pytest tests/test_classes.py -q (38 passed, run with a lightweight local bittensor logging stub because full bittensor deps are not installed in this Codex runtime)
- ruff check gittensor/classes.py tests/test_classes.py
- ruff format --check gittensor/classes.py tests/test_classes.py
- git diff --check