### PR TITLE
fix: handle transient GitHub PAT checks

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -14,7 +14,7 @@ import requests
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.validator import pat_storage
-from gittensor.validator.utils.github_validation import validate_github_credentials
+from gittensor.validator.utils.github_validation import validate_github_credentials_result
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -49,9 +49,13 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     uid = validator.metagraph.hotkeys.index(hotkey)
 
     # 2. Validate PAT (checks it works, extracts github_id)
-    github_id, error = validate_github_credentials(uid, synapse.github_access_token)
-    if error:
-        return _reject(error)
+    validation = validate_github_credentials_result(uid, synapse.github_access_token)
+    if validation.transient_failure:
+        return _reject('GitHub API temporarily unavailable; retry the broadcast in a few minutes.')
+    if validation.error:
+        return _reject(validation.error)
+
+    github_id = validation.github_id
 
     # 3. Enforce GitHub identity pinning — same hotkey cannot switch GitHub accounts
     existing = pat_storage.get_pat_by_uid(uid)
@@ -66,7 +70,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     if test_error:
         return _reject(f'PAT test query failed: {test_error}')
 
-    # 5. Store PAT (github_id guaranteed non-None after validate_github_credentials success)
+    # 5. Store PAT (github_id guaranteed non-None after validation success)
     pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=github_id or '0')
 
     # Clear PAT from response so it isn't echoed back
@@ -117,11 +121,16 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
     synapse.has_pat = True
 
     # Re-validate the stored PAT
-    _, error = validate_github_credentials(uid, entry['pat'])
-    if error:
+    validation = validate_github_credentials_result(uid, entry['pat'], stored_github_id=entry.get('github_id'))
+    if validation.transient_failure:
+        synapse.pat_valid = None
+        synapse.rejection_reason = 'GitHub API temporarily unavailable; retry the check in a few minutes.'
+        bt.logging.warning(f'PAT check result — UID: {uid}: transient GitHub API failure')
+        return synapse
+    if validation.error:
         synapse.pat_valid = False
-        synapse.rejection_reason = error
-        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {error}')
+        synapse.rejection_reason = validation.error
+        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {validation.error}')
         return synapse
 
     test_error = _test_pat_against_repo(entry['pat'])

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -9,6 +9,7 @@ import pytest
 from bittensor.core.synapse import TerminalInfo
 
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
+from gittensor.utils.github_api_tools import GitHubIdentityResult, GitHubIdentityStatus
 from gittensor.validator import pat_storage
 from gittensor.validator.pat_handler import (
     _test_pat_against_repo,
@@ -17,6 +18,7 @@ from gittensor.validator.pat_handler import (
     handle_pat_broadcast,
     handle_pat_check,
 )
+from gittensor.validator.utils.github_validation import GitHubCredentialValidation
 
 
 def _run(coro):
@@ -57,6 +59,18 @@ def _make_check_synapse(hotkey: str) -> PatCheckSynapse:
     return synapse
 
 
+def _transient_github_identity() -> GitHubIdentityResult:
+    return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+
+
+def _github_validation(
+    github_id: str | None,
+    error: str | None = None,
+    transient_failure: bool = False,
+) -> GitHubCredentialValidation:
+    return GitHubCredentialValidation(github_id, error, transient_failure)
+
+
 # ---------------------------------------------------------------------------
 # Blacklist tests
 # ---------------------------------------------------------------------------
@@ -93,7 +107,10 @@ class TestBlacklistPatCheck:
 
 class TestHandlePatBroadcast:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation('github_42'),
+    )
     def test_valid_pat_accepted(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_valid')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -118,7 +135,10 @@ class TestHandlePatBroadcast:
         assert result.accepted is False
         assert 'not registered' in (result.rejection_reason or '')
 
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=(None, 'PAT invalid'))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation(None, 'PAT invalid'),
+    )
     def test_invalid_pat_rejected(self, mock_validate, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_bad')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -129,8 +149,22 @@ class TestHandlePatBroadcast:
         # Verify PAT was NOT stored
         assert pat_storage.get_pat_by_uid(1) is None
 
+    @patch('gittensor.validator.utils.github_validation.get_github_identity', return_value=_transient_github_identity())
+    def test_transient_github_failure_rejected_with_retry_message(self, mock_identity, mock_validator):
+        synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_transient')
+        result = _run(handle_pat_broadcast(mock_validator, synapse))
+
+        assert result.accepted is False
+        assert result.github_access_token == ''
+        assert result.rejection_reason == 'GitHub API temporarily unavailable; retry the broadcast in a few minutes.'
+        assert 'Could not validate Github id' not in (result.rejection_reason or '')
+        assert pat_storage.get_pat_by_uid(1) is None
+
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value='GitHub API returned 403')
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation('github_42'),
+    )
     def test_test_query_failure_rejected(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -139,7 +173,10 @@ class TestHandlePatBroadcast:
         assert '403' in (result.rejection_reason or '')
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation('github_99'),
+    )
     def test_github_identity_change_rejected(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey cannot switch to a different GitHub account."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_old', 'github_42')
@@ -156,7 +193,10 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation('github_42'),
+    )
     def test_pat_rotation_same_github_accepted(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey can rotate PATs if GitHub identity stays the same."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_old', 'github_42')
@@ -171,7 +211,10 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation('github_99'),
+    )
     def test_new_miner_on_uid_can_use_any_github(self, mock_validate, mock_test_query, mock_validator):
         """A new hotkey on the same UID (new miner) can register any GitHub account."""
         pat_storage.save_pat(1, 'old_hotkey', 'ghp_old', 'github_42')
@@ -188,7 +231,10 @@ class TestHandlePatBroadcast:
 
 class TestHandlePatCheck:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation('github_42'),
+    )
     def test_valid_pat(self, mock_validate, mock_test_query, mock_validator):
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_test', 'github_42')
 
@@ -214,7 +260,10 @@ class TestHandlePatCheck:
         assert result.pat_valid is False
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=(None, 'PAT expired'))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=_github_validation(None, 'PAT expired'),
+    )
     def test_stored_but_invalid_pat(self, mock_validate, mock_test_query, mock_validator):
         """PAT is stored but fails re-validation."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_expired', 'github_42')
@@ -224,6 +273,18 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is False
         assert 'PAT expired' in (result.rejection_reason or '')
+
+    @patch('gittensor.validator.utils.github_validation.get_github_identity', return_value=_transient_github_identity())
+    def test_transient_github_failure_keeps_stored_pat_inconclusive(self, mock_identity, mock_validator):
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_stored', 'github_42')
+
+        synapse = _make_check_synapse('hotkey_1')
+        result = _run(handle_pat_check(mock_validator, synapse))
+
+        assert result.has_pat is True
+        assert result.pat_valid is None
+        assert result.rejection_reason == 'GitHub API temporarily unavailable; retry the check in a few minutes.'
+        assert 'Could not validate Github id' not in (result.rejection_reason or '')
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- switch validator PAT broadcast/check handlers to `validate_github_credentials_result()`
- return retry-oriented messages when GitHub `/user` lookup fails transiently
- keep stored PAT checks inconclusive with `pat_valid=None` instead of marking them invalid

Fixes #1106

## Testing

- `pytest tests/validator/test_pat_handler.py -q`
- `pytest tests/validator/test_pat_handler.py tests/validator/test_github_identity_fallback.py tests/validator/test_pat_storage.py -q`
- `ruff check gittensor/validator/pat_handler.py tests/validator/test_pat_handler.py`
- `ruff format --check gittensor/validator/pat_handler.py tests/validator/test_pat_handler.py`
- `git diff --check`
