### PR TITLE
refactor: remove withastro/astro from master_repositories.json (#1002)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -706,9 +706,6 @@
   "we-promise/sure": {
     "weight": 0.1279
   },
-  "withastro/astro": {
-    "weight": 0.1064
-  },
   "yanez-compliance/MIID-subnet": {
     "weight": 0.0375
   },


### PR DESCRIPTION
## Summary

Remove `withastro/astro` entry from `master_repositories.json` as per issue #1002 — this repo no longer needs to be tracked and its inclusion wastes a GraphQL query slot under rate limits.
## Validation

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run python3 -m json.tool gittensor/master_repositories.json` — valid JSON
Closes #1002