### PR TITLE
fix: route --json CLI commands through loading_context to suppress spinner

### DIFF
--- a/tests/cli/test_loading_context_json_safety.py
+++ b/tests/cli/test_loading_context_json_safety.py
@@ -1,0 +1,57 @@
+"""Tests for loading_context JSON safety — spinner must not run in --json mode."""
+
+import io
+import sys
+
+import pytest
+
+from gittensor.cli.issue_commands.helpers import loading_context
+
+
+def test_loading_context_json_mode_is_noop():
+    """loading_context with as_json=True must be a no-op context manager."""
+    with loading_context('Test message', as_json=True):
+        pass  # must not raise
+
+
+def test_loading_context_json_mode_no_stdout():
+    """loading_context with as_json=True must not write anything to stdout."""
+    buf = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        with loading_context('Test message', as_json=True):
+            pass
+    finally:
+        sys.stdout = old_stdout
+    assert buf.getvalue() == ''
+
+
+def test_loading_context_json_mode_no_stderr():
+    """loading_context with as_json=True must not write anything to stderr."""
+    buf = io.StringIO()
+    old_stderr = sys.stderr
+    sys.stderr = buf
+    try:
+        with loading_context('Test message', as_json=True):
+            pass
+    finally:
+        sys.stderr = old_stderr
+    assert buf.getvalue() == ''
+
+
+def test_loading_context_human_mode_does_not_raise():
+    """loading_context with as_json=False must not raise."""
+    try:
+        with loading_context('Test message', as_json=False):
+            pass
+    except Exception as e:
+        pytest.fail(f'loading_context raised in human mode: {e}')
+
+
+def test_loading_context_json_mode_body_executes():
+    """loading_context with as_json=True must still execute the body."""
+    executed = []
+    with loading_context('Test message', as_json=True):
+        executed.append(True)
+    assert executed == [True]


### PR DESCRIPTION
## Summary

Five CLI commands accept `--json` but called `console.status()` directly,
running the Rich spinner even in JSON mode. This causes two problems:

1. **Crash on non-UTF-8 terminals** — the spinner uses Braille Unicode
   characters that cause `UnicodeEncodeError` on latin-1/Windows-1252 stdout
2. **Spinner frames in piped output** — ANSI/Unicode frames leak into
   the JSON stream on TTY-then-copy and pty-based subprocesses

`loading_context(msg, as_json)` already exists in `helpers.py` and is a
no-op when `as_json=True`. The callers just weren't using it.

## Fix

Route all five offending call sites through `loading_context`:

- `gitt issues list` — `view.py`
- `gitt issues bounty-pool` — `view.py`
- `gitt issues pending-harvest` — `view.py`
- `gitt admin info` — `view.py`
- `gitt vote list` — `vote.py`

## Tests

Added 5 cases in `tests/cli/test_loading_context_json_safety.py`:

- `loading_context` with `as_json=True` is a no-op context
- no stdout output in JSON mode
- no stderr output in JSON mode
- body still executes in JSON mode
- human mode does not raise

1419 tests passing (1414 existing + 5 new).

Fixes #898