### PR TITLE
Standardize --json behavior

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -20,6 +20,8 @@ import requests
 from rich.console import Console
 
 from gittensor.cli.issue_commands.tables import build_pr_table
+from gittensor.cli.json_output import emit_error_json
+from gittensor.cli.json_output import emit_json as emit_json
 from gittensor.constants import BASE_GITHUB_API_URL, MAX_ISSUE_ID, NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
     ISSUES_MAPPING_ROOT_KEY,
@@ -192,28 +194,6 @@ def print_error(message: str) -> None:
 def print_warning(message: str) -> None:
     """Print a warning message."""
     err_console.print(f'\n[yellow]{message}[/yellow]\n', highlight=True)
-
-
-def emit_error_json(message: str, error_type: str = 'cli_error') -> None:
-    """Emit a machine-readable error payload to stdout."""
-    payload = {
-        'success': False,
-        'error': {
-            'type': error_type,
-            'message': message,
-        },
-    }
-    # click.echo writes plain text to stdout without Rich styling.
-    click.echo(json.dumps(payload), err=False)
-
-
-def emit_json(payload: Any, pretty: bool = True, default: Optional[Callable] = str) -> None:
-    """Emit a machine-readable JSON payload to stdout."""
-    if pretty:
-        output = json.dumps(payload, indent=2, ensure_ascii=False, default=default)
-    else:
-        output = json.dumps(payload, separators=(',', ':'), ensure_ascii=False, default=default)
-    click.echo(output, err=False)
 
 
 def handle_exception(as_json: bool, message: str, error_type: str = 'cli_error') -> None:

--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import click
 
+from gittensor.cli.json_output import click_error_type
+
 from .help import StyledCommand
 from .helpers import (
     emit_json,
@@ -83,7 +85,7 @@ def issues_submissions(
             as_json=as_json,
         )
     except click.ClickException as e:
-        handle_exception(as_json, str(e), 'click_exception')
+        handle_exception(as_json, str(e), click_error_type(e))
 
     if as_json:
         submissions = [

--- a/gittensor/cli/json_output.py
+++ b/gittensor/cli/json_output.py
@@ -1,0 +1,48 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Canonical JSON output helpers for the CLI (envelope shape, argv detection,
+Click-exception mapping)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Iterable, Optional
+
+import click
+
+
+def emit_json(payload: Any, pretty: bool = True, default: Optional[Callable] = str) -> None:
+    """Write a JSON payload to stdout (pretty by default; compact when `pretty=False`)"""
+    if pretty:
+        output = json.dumps(payload, indent=2, ensure_ascii=False, default=default)
+    else:
+        output = json.dumps(payload, separators=(',', ':'), ensure_ascii=False, default=default)
+    click.echo(output, err=False)
+
+
+def emit_error_json(message: str, error_type: str = 'cli_error', **extra: Any) -> None:
+    """Write `{success: false, error: {type, message}, ...extra}` to stdout.
+
+    Extra kwargs become sibling fields (e.g. `skipped=[...]`).
+    """
+    payload: dict[str, Any] = {
+        'success': False,
+        'error': {'type': error_type, 'message': message},
+        **extra,
+    }
+    click.echo(json.dumps(payload), err=False)
+
+
+def wants_json_output(argv: Iterable[str]) -> bool:
+    """True if `--json` appears anywhere in argv"""
+    return any(t == '--json' or t.startswith('--json=') for t in argv)
+
+
+def click_error_type(exc: click.ClickException) -> str:
+    """Map a Click exception class to the canonical `error_type` tag"""
+    if isinstance(exc, click.BadParameter):
+        return 'bad_parameter'
+    if isinstance(exc, click.UsageError):
+        return 'usage_error'
+    return 'cli_error'

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -40,9 +40,43 @@ from gittensor import __version__
 from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR, console, err_console
+from gittensor.cli.json_output import click_error_type, emit_error_json, wants_json_output
 
 
-@click.group(cls=StyledAliasGroup)
+class JsonAwareAliasGroup(StyledAliasGroup):
+    """Root group that rewrites Click parse errors into the canonical JSON
+    envelope when `--json` is in argv; otherwise Click's default rendering."""
+
+    def main(self, args=None, prog_name=None, complete_var=None, standalone_mode=True, **extra):
+        json_mode = wants_json_output(args if args is not None else sys.argv[1:])
+        try:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                **extra,
+            )
+        except click.ClickException as exc:
+            if not standalone_mode:
+                raise
+            if json_mode:
+                emit_error_json(exc.format_message(), error_type=click_error_type(exc))
+            else:
+                exc.show()
+            sys.exit(exc.exit_code)
+        except click.exceptions.Abort:
+            if not standalone_mode:
+                raise
+            click.echo('Aborted!', err=True)
+            sys.exit(1)
+        except click.exceptions.Exit as exc:
+            if not standalone_mode:
+                raise
+            sys.exit(exc.exit_code)
+
+
+@click.group(cls=JsonAwareAliasGroup)
 @click.version_option(version=__version__, prog_name='gittensor')
 def cli():
     """Gittensor CLI - Manage issue bounties and validator operations"""

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -55,7 +55,7 @@ _PAT_CHECK_STATUS_MARKUP = {
     show_default=True,
     help='Minimum validator stake (α) to probe.',
 )
-@click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
+@click.option('--json', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_check(wallet_name, wallet_hotkey, netuid, network, rpc_url, min_vtrust, min_stake, json_mode):
     """Check how many validators have your PAT stored.
 

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -10,10 +10,10 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-import click
 from rich.console import Console
 from rich.table import Table
 
+from gittensor.cli.json_output import emit_error_json
 from gittensor.constants import NETWORK_MAP
 
 console = Console()
@@ -104,14 +104,14 @@ def _status(message: str):
 
 
 def _print(message: str) -> None:
-    """Print a status/info message to stderr (safe under --json-output)."""
+    """Print a status/info message to stderr (safe under --json)."""
     err_console.print(message)
 
 
-def _error(msg: str, json_mode: bool) -> None:
+def _error(msg: str, json_mode: bool, error_type: str = 'cli_error') -> None:
     """Print an error message in the appropriate format."""
     if json_mode:
-        click.echo(json.dumps({'success': False, 'error': msg}))
+        emit_error_json(msg, error_type=error_type)
     else:
         err_console.print(f'[red]Error: {msg}[/red]')
 
@@ -141,7 +141,7 @@ def _require_validator_axons(
                 f'--min-stake={min_stake:,.0f} α; all {len(excluded)} candidate(s) excluded.'
             )
             if json_mode:
-                click.echo(json.dumps({'success': False, 'error': msg, 'skipped': excluded}))
+                emit_error_json(msg, error_type='no_validators_eligible', skipped=excluded)
             else:
                 _render_skipped_validators(excluded, json_mode)
                 console.print(f'[red]Error: {msg}[/red]')

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -66,7 +66,7 @@ _PAT_POST_STATUS_MARKUP = {
     show_default=True,
     help='Minimum validator stake (α) to broadcast to.',
 )
-@click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
+@click.option('--json', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
 def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, json_mode):
     """Broadcast your GitHub PAT to all validators on the network.
 

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -22,7 +22,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from gittensor.cli.issue_commands.helpers import emit_json
+from gittensor.cli.json_output import emit_json
 from gittensor.cli.miner_commands.helpers import _error
 
 if TYPE_CHECKING:
@@ -231,7 +231,7 @@ def _drain_logs() -> None:
     show_default=True,
     help="Bittensor log verbosity. 'info' surfaces the validator pipeline's per-step progress on stderr.",
 )
-@click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Emit result as JSON on stdout.')
+@click.option('--json', 'json_mode', is_flag=True, default=False, help='Emit result as JSON on stdout.')
 def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
     """Locally run the validator scoring pipeline end-to-end for the miner identified by --pat.
 

--- a/tests/cli/test_cli_json_error_output.py
+++ b/tests/cli/test_cli_json_error_output.py
@@ -82,3 +82,40 @@ def test_admin_info_human_mode_exits_non_zero_on_soft_read_failure(cli_root, run
 
     assert result.exit_code == 1
     assert 'Could not read contract configuration' in result.output
+
+
+@pytest.mark.parametrize(
+    'argv,error_type,message_fragment',
+    [
+        # Type validation by Click on a primitive --id (issue list)
+        (['issues', 'list', '--json', '--id', 'not-an-int'], 'bad_parameter', "Invalid value for '--id'"),
+        # Unknown option under any command
+        (['issues', 'list', '--json', '--no-such-flag'], 'usage_error', 'No such option'),
+        # Missing required option (issues submissions requires --id)
+        (['issues', 'submissions', '--json'], 'bad_parameter', "Missing option '--id'"),
+        # Miner command Click validation under --json
+        (['miner', 'post', '--json', '--netuid', 'not-an-int'], 'bad_parameter', "'--netuid'"),
+    ],
+)
+def test_click_parse_errors_emit_canonical_json(cli_root, runner, argv, error_type, message_fragment):
+    """Click's own arg-parsing errors must surface as the canonical JSON envelope
+    when --json appears in argv."""
+    result = runner.invoke(cli_root, argv, catch_exceptions=False)
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == error_type
+    assert message_fragment in payload['error']['message']
+
+
+def test_click_parse_errors_stay_human_without_json_flag(cli_root, runner):
+    """Without --json, Click parse errors keep their plain-text rendering"""
+    result = runner.invoke(cli_root, ['issues', 'list', '--id', 'not-an-int'], catch_exceptions=False)
+    assert result.exit_code == 2
+    # Plain text, not JSON
+    try:
+        json.loads(result.output)
+        raise AssertionError('output should not be JSON without --json flag')
+    except json.JSONDecodeError:
+        pass
+    assert 'Invalid value' in result.output

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -46,7 +46,7 @@ class TestMinerPost:
 
     def test_no_pat_json_mode_exits(self, runner, monkeypatch):
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
-        result = runner.invoke(cli, ['miner', 'post', '--json-output', '--wallet', 'test', '--hotkey', 'test'])
+        result = runner.invoke(cli, ['miner', 'post', '--json', '--wallet', 'test', '--hotkey', 'test'])
         assert result.exit_code != 0
         output = json.loads(result.stdout)
         assert output['success'] is False
@@ -110,7 +110,7 @@ class TestMinerPost:
                 [
                     'miner',
                     'post',
-                    '--json-output',
+                    '--json',
                     '--pat',
                     'ghp_test123',
                     '--wallet',
@@ -205,8 +205,9 @@ class TestRequireValidatorAxonsErrorPath:
         assert exc_info.value.code == 1
         payload = json.loads(capsys.readouterr().out.strip())
         assert payload['success'] is False
-        assert '--min-stake' in payload['error']
-        assert '--min-vtrust' in payload['error']
+        assert payload['error']['type'] == 'no_validators_eligible'
+        assert '--min-stake' in payload['error']['message']
+        assert '--min-vtrust' in payload['error']['message']
         assert len(payload['skipped']) == 3
         assert {entry['uid'] for entry in payload['skipped']} == {0, 1, 2}
         assert all(entry['reasons'] for entry in payload['skipped'])
@@ -234,7 +235,10 @@ class TestRequireValidatorAxonsErrorPath:
         payload = json.loads(capsys.readouterr().out.strip())
         assert payload == {
             'success': False,
-            'error': 'No reachable validator axons found on the network.',
+            'error': {
+                'type': 'cli_error',
+                'message': 'No reachable validator axons found on the network.',
+            },
         }
 
     def test_subvtrust_only_metagraph_keeps_generic_message(self, capsys):
@@ -245,7 +249,8 @@ class TestRequireValidatorAxonsErrorPath:
             _require_validator_axons(mg, True, min_vtrust=0.25, min_stake=15_000.0)
         assert exc_info.value.code == 1
         payload = json.loads(capsys.readouterr().out.strip())
-        assert payload['error'] == 'No reachable validator axons found on the network.'
+        assert payload['error']['type'] == 'cli_error'
+        assert payload['error']['message'] == 'No reachable validator axons found on the network.'
         assert 'skipped' not in payload
 
 

--- a/tests/cli/test_miner_score.py
+++ b/tests/cli/test_miner_score.py
@@ -173,7 +173,7 @@ class TestScoreCommand:
         ):
             result = runner.invoke(
                 cli,
-                ['miner', 'score', '--json-output'],
+                ['miner', 'score', '--json'],
                 env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
             )
         assert result.exit_code == 0, result.output
@@ -193,7 +193,7 @@ class TestScoreCommand:
         with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
             result = runner.invoke(
                 cli,
-                ['miner', 'score', '--pat', 'ghp_should_not_leak', '--json-output'],
+                ['miner', 'score', '--pat', 'ghp_should_not_leak', '--json'],
                 env={},
             )
         assert result.exit_code == 0, result.output
@@ -218,7 +218,7 @@ class TestScoreCommand:
         with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
             result = runner.invoke(
                 cli,
-                ['miner', 'score', '--json-output'],
+                ['miner', 'score', '--json'],
                 env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
             )
         assert result.exit_code == 0, result.output
@@ -252,7 +252,7 @@ class TestScoreCommand:
         with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
             result = runner.invoke(
                 cli,
-                ['miner', 'score', '--json-output'],
+                ['miner', 'score', '--json'],
                 env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
             )
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
Closes #1151

## Summary

Three CLI surface differences collapsed into one:

1. `gitt miner {post,check,score}` shipped `--json-output`; every other command uses `--json`. Renamed everything to the `--json`.
1. The miner commands emitted `{"success": false, "error": "<string>"}`; issue commands emit `{"success": false, "error": {"type": ..., "message": ...}}`. Unified everything on the nested shape.
1. Click's own parse errors (`Invalid value for '--id'`, `No such option`, `Missing option`) printed plain text to stderr regardless of `--json`. Sometimes we throw such exceptions by ourselves. Added `JsonAwareAliasGroup` at the root so parse errors surface as the canonical JSON envelope when `--json` is in argv. Without `--json` the default Click rendering is preserved.

Centralized the envelope helpers in a new `gittensor/cli/json_output.py` (`emit_json`, `emit_error_json`, `wants_json_output`, `click_error_type`). Issue commands, miner commands, and the root group now import from one source.

## Before / After

Before:
```sh
$ gitt issues list --json --id abc

Error: Invalid value for '--id': 'abc' is not a valid integer.
```

After (standardized json error handling behavior across the whole codebase):
```sh
$ gitt issues list --json --id abc

{"success": false, "error": {"type": "bad_parameter", "message": "Invalid value for '--id': 'abc' is not a valid integer."}}
```

## Testing

- `test_click_parse_errors_stay_human_without_json_flag` - asserts plain-text rendering is preserved when `--json` is absent
- `test_click_parse_errors_emit_canonical_json` - asserts that Click's own arg-parsing errors emit the canonical `{success: false, error: {type, message}}` envelope when `--json` is in argv.

Other existing tests were updated according to the new behavior.