### PR TITLE
fix: distinguish transient GitHub failures in validator PAT handlers (#1106)

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -14,7 +14,7 @@ import requests
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.validator import pat_storage
-from gittensor.validator.utils.github_validation import validate_github_credentials
+from gittensor.validator.utils.github_validation import validate_github_credentials_result
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -49,9 +49,12 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     uid = validator.metagraph.hotkeys.index(hotkey)
 
     # 2. Validate PAT (checks it works, extracts github_id)
-    github_id, error = validate_github_credentials(uid, synapse.github_access_token)
-    if error:
-        return _reject(error)
+    validation = validate_github_credentials_result(uid, synapse.github_access_token)
+    if validation.transient_failure:
+        return _reject('GitHub API temporarily unavailable; retry the broadcast in a few minutes.')
+    if validation.error:
+        return _reject(validation.error)
+    github_id = validation.github_id
 
     # 3. Enforce GitHub identity pinning — same hotkey cannot switch GitHub accounts
     existing = pat_storage.get_pat_by_uid(uid)
@@ -117,11 +120,16 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
     synapse.has_pat = True
 
     # Re-validate the stored PAT
-    _, error = validate_github_credentials(uid, entry['pat'])
-    if error:
+    validation = validate_github_credentials_result(uid, entry['pat'])
+    if validation.transient_failure:
+        synapse.pat_valid = None
+        synapse.rejection_reason = 'GitHub API temporarily unavailable; retry the check in a few minutes.'
+        bt.logging.warning(f'PAT check result — UID: {uid}: transient failure')
+        return synapse
+    if validation.error:
         synapse.pat_valid = False
-        synapse.rejection_reason = error
-        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {error}')
+        synapse.rejection_reason = validation.error
+        bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {validation.error}')
         return synapse
 
     test_error = _test_pat_against_repo(entry['pat'])

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -17,6 +17,7 @@ from gittensor.validator.pat_handler import (
     handle_pat_broadcast,
     handle_pat_check,
 )
+from gittensor.validator.utils.github_validation import GitHubCredentialValidation
 
 
 def _run(coro):
@@ -93,7 +94,10 @@ class TestBlacklistPatCheck:
 
 class TestHandlePatBroadcast:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation('github_42', None),
+    )
     def test_valid_pat_accepted(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_valid')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -118,7 +122,10 @@ class TestHandlePatBroadcast:
         assert result.accepted is False
         assert 'not registered' in (result.rejection_reason or '')
 
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=(None, 'PAT invalid'))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation(None, 'PAT invalid'),
+    )
     def test_invalid_pat_rejected(self, mock_validate, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_bad')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -130,7 +137,10 @@ class TestHandlePatBroadcast:
         assert pat_storage.get_pat_by_uid(1) is None
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value='GitHub API returned 403')
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation('github_42', None),
+    )
     def test_test_query_failure_rejected(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1')
         result = _run(handle_pat_broadcast(mock_validator, synapse))
@@ -139,7 +149,10 @@ class TestHandlePatBroadcast:
         assert '403' in (result.rejection_reason or '')
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation('github_99', None),
+    )
     def test_github_identity_change_rejected(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey cannot switch to a different GitHub account."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_old', 'github_42')
@@ -156,7 +169,10 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation('github_42', None),
+    )
     def test_pat_rotation_same_github_accepted(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey can rotate PATs if GitHub identity stays the same."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_old', 'github_42')
@@ -171,7 +187,10 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_42'
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation('github_99', None),
+    )
     def test_new_miner_on_uid_can_use_any_github(self, mock_validate, mock_test_query, mock_validator):
         """A new hotkey on the same UID (new miner) can register any GitHub account."""
         pat_storage.save_pat(1, 'old_hotkey', 'ghp_old', 'github_42')
@@ -185,10 +204,30 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_99'
         assert entry['hotkey'] == 'hotkey_1'
 
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation(None, 'GitHub /user lookup failed transiently', transient_failure=True),
+    )
+    def test_transient_failure_on_broadcast(self, mock_validate, mock_test_query, mock_validator):
+        """Transient GitHub failure should reject with retry message, not 'invalid PAT'."""
+        synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_transient')
+        result = _run(handle_pat_broadcast(mock_validator, synapse))
+
+        assert result.accepted is False
+        assert 'temporarily unavailable' in (result.rejection_reason or '').lower()
+        assert 'retry' in (result.rejection_reason or '').lower()
+
+        # PAT should NOT be stored
+        assert pat_storage.get_pat_by_uid(1) is None
+
 
 class TestHandlePatCheck:
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation('github_42', None),
+    )
     def test_valid_pat(self, mock_validate, mock_test_query, mock_validator):
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_test', 'github_42')
 
@@ -214,7 +253,10 @@ class TestHandlePatCheck:
         assert result.pat_valid is False
 
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
-    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=(None, 'PAT expired'))
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation(None, 'PAT expired'),
+    )
     def test_stored_but_invalid_pat(self, mock_validate, mock_test_query, mock_validator):
         """PAT is stored but fails re-validation."""
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_expired', 'github_42')
@@ -224,6 +266,21 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is False
         assert 'PAT expired' in (result.rejection_reason or '')
+
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch(
+        'gittensor.validator.pat_handler.validate_github_credentials_result',
+        return_value=GitHubCredentialValidation(None, 'transient', transient_failure=True),
+    )
+    def test_transient_failure_on_check_returns_inconclusive(self, mock_validate, mock_test_query, mock_validator):
+        """Transient GitHub failure should return pat_valid=None, not False."""
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_transient', 'github_42')
+
+        synapse = _make_check_synapse('hotkey_1')
+        result = _run(handle_pat_check(mock_validator, synapse))
+        assert result.has_pat is True
+        assert result.pat_valid is None
+        assert 'temporarily unavailable' in (result.rejection_reason or '').lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The validator PAT handlers (`handle_pat_broadcast`, `handle_pat_check`) use the legacy `validate_github_credentials()` wrapper that collapses the richer `GitHubCredentialValidation` result into a simple `(github_id, error)` tuple, discarding the `transient_failure` flag. When GitHub /user API fails transiently (rate limit, timeout, 5xx), the handlers treat the result as a definitive validation failure — rejecting broadcasts with "Could not validate Github id" and marking stored PATs as `pat_valid=False` — even though the result is inconclusive.

This fix replaces the legacy wrapper calls with `validate_github_credentials_result()` and branches on `transient_failure` before checking `error`. For broadcast, the transient case returns a retry-oriented message. For check, the transient case returns `pat_valid=None` (inconclusive) instead of `pat_valid=False`.
## Validation

- ruff check — clean
- ruff format --check — clean
- pyright — 0 errors
- pytest tests/validator/test_pat_handler.py -q — 14 passed
Closes #1106