### PR TITLE
fix: increase CHANGES_REQUESTED review cap from 7 to 100 (#1053)

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -37,7 +37,7 @@ from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
 # Beyond this many CHANGES_REQUESTED reviews the quality multiplier is already 0
-_MAX_CHANGES_REQUESTED_REVIEWS = ceil(1 / REVIEW_PENALTY_RATE)
+_MAX_CHANGES_REQUESTED_REVIEWS = 100
 
 
 class GitHubIdentityStatus(Enum):

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from math import ceil
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
 from gittensor.utils.utils import backoff_seconds, parse_repo_name
@@ -30,7 +29,6 @@ from gittensor.constants import (
     MAX_FILE_SIZE_BYTES,
     MAX_FILES_PER_GRAPHQL_BATCH,
     PR_LOOKBACK_DAYS,
-    REVIEW_PENALTY_RATE,
 )
 from gittensor.utils.models import PRInfo
 from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc

--- a/tests/validator/test_review_quality_multiplier.py
+++ b/tests/validator/test_review_quality_multiplier.py
@@ -10,8 +10,6 @@ Covers:
 - review_quality_multiplier field on PullRequest and its effect on earned_score
 """
 
-from math import ceil
-
 import pytest
 
 from gittensor.classes import MinerEvaluation, PRState, PullRequest
@@ -281,11 +279,9 @@ class TestReviewCollateralThroughScoringPipeline:
 
 
 def test_max_changes_requested_reviews_covers_review_multipliers():
-    # Tripwire: the GraphQL fetch cap must stay aligned with every review-count-based multiplier.
-    penalty_cap = ceil(1 / REVIEW_PENALTY_RATE)
-    collateral_cap = ceil((MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER - 1.0) / REVIEW_PENALTY_RATE)
-
-    assert _MAX_CHANGES_REQUESTED_REVIEWS == max(penalty_cap, collateral_cap)
+    # Tripwire: the GraphQL fetch cap must be large enough that non-maintainer
+    # CHANGES_REQUESTED reviews cannot shadow maintainer reviews.
+    assert _MAX_CHANGES_REQUESTED_REVIEWS >= 100
     assert calculate_review_quality_multiplier(_MAX_CHANGES_REQUESTED_REVIEWS) == 0.0
     assert calculate_review_collateral_multiplier(_MAX_CHANGES_REQUESTED_REVIEWS) == pytest.approx(
         MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER


### PR DESCRIPTION
## Summary

Increase `_MAX_CHANGES_REQUESTED_REVIEWS` from `ceil(1 / REVIEW_PENALTY_RATE) = 7` to `100` so maintainer `CHANGES_REQUESTED` reviews are never shadowed by non-maintainer reviews in the capped GraphQL review window. Previously, if 7 non-maintainer `CHANGES_REQUESTED` reviews filled the window, later maintainer reviews were invisible and the review quality penalty was incorrectly skipped.

## Validation

- Single constant change, no behavioral side effects for PRs with fewer than 100 `CHANGES_REQUESTED` reviews
- The review quality multiplier correctly applies the penalty when maintainer reviews exist past the old cap

Closes #1053