### PR TITLE
fix: count ALL open issues for spam multiplier instead of lookback-bounded subset (#929)

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -75,6 +75,10 @@ async def forward(self: 'Validator') -> None:
         await issue_competitions(self, miner_evaluations)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
+        # cached_uids may have received fresh issue discovery data — persist it
+        has_mirror_repos = any(cfg.mirror_enabled for cfg in master_repositories.values())
+        if has_mirror_repos:
+            cached_uids = set()
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
 
         # 5. Blend 4 emission pools into final rewards

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -1,8 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-import asyncio
-from typing import TYPE_CHECKING, Dict, Set, Tuple
+from typing import TYPE_CHECKING, Dict
 
 import bittensor as bt
 import numpy as np
@@ -22,10 +21,8 @@ from gittensor.validator.issue_discovery.mirror_scan import run_mirror_issue_dis
 from gittensor.validator.issue_discovery.normalize import (
     normalize_issue_discovery_rewards,
 )
-from gittensor.validator.oss_contributions.reward import get_rewards
 from gittensor.validator.utils.config import (
     VALIDATOR_STEPS_INTERVAL,
-    VALIDATOR_WAIT,
 )
 from gittensor.validator.utils.load_weights import (
     RepositoryConfig,
@@ -75,38 +72,11 @@ async def forward(self: 'Validator') -> None:
         await issue_competitions(self, miner_evaluations)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
+        # cached_uids may have received fresh issue discovery data — persist it
+        has_mirror_repos = any(cfg.mirror_enabled for cfg in master_repositories.values())
+        if has_mirror_repos:
+            cached_uids = set()
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
-
-        # 5. Blend 4 emission pools into final rewards
-        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
-
-        self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
-
-    await asyncio.sleep(VALIDATOR_WAIT)
-
-
-async def oss_contributions(
-    self: 'Validator',
-    miner_uids: set[int],
-    master_repositories: Dict[str, RepositoryConfig],
-    programming_languages: Dict,
-    token_config,
-) -> Tuple[np.ndarray, Dict[int, MinerEvaluation], Set[int], Set[int]]:
-    """Score OSS contributions and return normalized rewards + miner evaluations + cached UIDs + penalized UIDs.
-
-    Pure scoring — no DB storage or emission blending. Those are handled by forward().
-    """
-    tree_sitter_count = sum(1 for c in token_config.language_configs.values() if c.language is not None)
-
-    bt.logging.info('***** Starting scoring round *****')
-    bt.logging.info(f'Total Repositories loaded: {len(master_repositories)}')
-    bt.logging.info(f'Total Languages loaded: {len(programming_languages)}')
-    bt.logging.info(f'Token config: {tree_sitter_count} tree-sitter languages')
-    bt.logging.info(f'Neurons to evaluate: {len(miner_uids)}')
-
-    rewards, miner_evaluations, cached_uids, penalized_uids = await get_rewards(
-        self, miner_uids, master_repositories, programming_languages, token_config
-    )
 
     return rewards, miner_evaluations, cached_uids, penalized_uids
 

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -75,10 +75,6 @@ async def forward(self: 'Validator') -> None:
         await issue_competitions(self, miner_evaluations)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
-        # cached_uids may have received fresh issue discovery data — persist it
-        has_mirror_repos = any(cfg.mirror_enabled for cfg in master_repositories.values())
-        if has_mirror_repos:
-            cached_uids = set()
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
 
         # 5. Blend 4 emission pools into final rewards

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -1,7 +1,8 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-from typing import TYPE_CHECKING, Dict
+import asyncio
+from typing import TYPE_CHECKING, Dict, Set, Tuple
 
 import bittensor as bt
 import numpy as np
@@ -21,8 +22,10 @@ from gittensor.validator.issue_discovery.mirror_scan import run_mirror_issue_dis
 from gittensor.validator.issue_discovery.normalize import (
     normalize_issue_discovery_rewards,
 )
+from gittensor.validator.oss_contributions.reward import get_rewards
 from gittensor.validator.utils.config import (
     VALIDATOR_STEPS_INTERVAL,
+    VALIDATOR_WAIT,
 )
 from gittensor.validator.utils.load_weights import (
     RepositoryConfig,
@@ -72,11 +75,38 @@ async def forward(self: 'Validator') -> None:
         await issue_competitions(self, miner_evaluations)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
-        # cached_uids may have received fresh issue discovery data — persist it
-        has_mirror_repos = any(cfg.mirror_enabled for cfg in master_repositories.values())
-        if has_mirror_repos:
-            cached_uids = set()
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
+
+        # 5. Blend 4 emission pools into final rewards
+        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+
+        self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
+
+    await asyncio.sleep(VALIDATOR_WAIT)
+
+
+async def oss_contributions(
+    self: 'Validator',
+    miner_uids: set[int],
+    master_repositories: Dict[str, RepositoryConfig],
+    programming_languages: Dict,
+    token_config,
+) -> Tuple[np.ndarray, Dict[int, MinerEvaluation], Set[int], Set[int]]:
+    """Score OSS contributions and return normalized rewards + miner evaluations + cached UIDs + penalized UIDs.
+
+    Pure scoring — no DB storage or emission blending. Those are handled by forward().
+    """
+    tree_sitter_count = sum(1 for c in token_config.language_configs.values() if c.language is not None)
+
+    bt.logging.info('***** Starting scoring round *****')
+    bt.logging.info(f'Total Repositories loaded: {len(master_repositories)}')
+    bt.logging.info(f'Total Languages loaded: {len(programming_languages)}')
+    bt.logging.info(f'Token config: {tree_sitter_count} tree-sitter languages')
+    bt.logging.info(f'Neurons to evaluate: {len(miner_uids)}')
+
+    rewards, miner_evaluations, cached_uids, penalized_uids = await get_rewards(
+        self, miner_uids, master_repositories, programming_languages, token_config
+    )
 
     return rewards, miner_evaluations, cached_uids, penalized_uids
 

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -167,13 +167,17 @@ async def run_mirror_issue_discovery(
             no_issues += 1
             continue
 
-        # Count this miner's currently-open issues across mirror-enabled repos
-        # (within the lookback window). Used as the spam-multiplier signal and
-        # also written to evaluation.total_open_issues so the DB row reflects
-        # mirror-scoped state (the legacy GraphQL global open-issue count was
-        # never the right signal for the gate).
-        open_issue_count = sum(1 for i in filtered if i.state == 'OPEN')
-        pending.append((evaluation, filtered, open_issue_count))
+        # Count this miner's total open issues across mirror-enabled repos
+        # without the lookback window, so old open issues correctly trigger
+        # the spam multiplier.  The lookback filter above is for scoring;
+        # the spam gate needs the miner's true open-issue load.
+        try:
+            all_response = await asyncio.to_thread(client.get_miner_issues, evaluation.github_id)
+            all_filtered = [i for i in all_response.issues if i.repo_full_name in enabled_names]
+            total_open = sum(1 for i in all_filtered if i.state == 'OPEN')
+        except MirrorRequestError:
+            total_open = sum(1 for i in filtered if i.state == 'OPEN')
+        pending.append((evaluation, filtered, total_open))
 
     canonical_pr_owners = _build_canonical_pr_owners(pending)
     for evaluation, filtered, open_issue_count in pending:


### PR DESCRIPTION
## Summary

`run_mirror_issue_discovery` derives `open_issue_count` from the same lookback-bounded `/issues` response used for scoring. Open issues created before `PR_LOOKBACK_DAYS` (35 days) are invisible, so the `calculate_open_issue_spam_multiplier` gate never penalizes miners with many old open issues.

This fix makes a second mirror API call without the `since` filter to count ALL open issues across mirror-enabled repos for the spam multiplier, while keeping the lookback-bounded call for scoring.

## Validation

- `ruff check --fix` and `ruff format` pass
- Miners with open issues only older than the lookback window are now correctly penalized
- Falls back to lookback-bounded count if the unfiltered call fails
- Scoring remains lookback-bounded (unchanged)

Closes #929