### PR TITLE
refactor(cli): validate inputs with Click types at parse time

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -18,6 +18,8 @@ from rich.panel import Panel
 
 from .help import StyledGroup
 from .helpers import (
+    ONCHAIN_ISSUE_ID_TYPE,
+    Ss58AddressParam,
     _handle_command_error,
     _make_contract_client,
     _resolve_contract_and_network,
@@ -27,8 +29,6 @@ from .helpers import (
     print_error,
     print_network_header,
     print_success,
-    require_valid_issue_id,
-    require_valid_ss58,
     with_cli_behavior_options,
     with_network_contract_options,
     with_wallet_options,
@@ -45,7 +45,7 @@ def admin():
 
 
 @admin.command('cancel-issue')
-@click.argument('issue_id', type=int)
+@click.argument('issue_id', type=ONCHAIN_ISSUE_ID_TYPE)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
 @with_cli_behavior_options(include_yes=True)
@@ -66,8 +66,6 @@ def admin_cancel(
     [/dim]
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
-
-    require_valid_issue_id(issue_id)
 
     print_network_header(network_name, contract_addr)
 
@@ -106,7 +104,7 @@ def admin_cancel(
 
 
 @admin.command('payout-issue')
-@click.argument('issue_id', type=int)
+@click.argument('issue_id', type=ONCHAIN_ISSUE_ID_TYPE)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
 @with_cli_behavior_options(include_yes=True)
@@ -128,8 +126,6 @@ def admin_payout(
     [/dim]
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
-
-    require_valid_issue_id(issue_id)
 
     print_network_header(network_name, contract_addr)
 
@@ -168,7 +164,7 @@ def admin_payout(
 
 
 @admin.command('set-owner')
-@click.argument('new_owner', type=str)
+@click.argument('new_owner', type=Ss58AddressParam('new_owner'))
 @with_wallet_options()
 @with_network_contract_options('Contract address')
 @with_cli_behavior_options(include_yes=True)
@@ -186,8 +182,6 @@ def admin_set_owner(
     [/dim]
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
-
-    require_valid_ss58(new_owner, 'new_owner')
 
     print_network_header(network_name, contract_addr)
 
@@ -218,7 +212,7 @@ def admin_set_owner(
 
 
 @admin.command('set-treasury')
-@click.argument('new_treasury', type=str)
+@click.argument('new_treasury', type=Ss58AddressParam('new_treasury'))
 @with_wallet_options()
 @with_network_contract_options('Contract address')
 @with_cli_behavior_options(include_yes=True)
@@ -239,8 +233,6 @@ def admin_set_treasury(
     [/dim]
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
-
-    require_valid_ss58(new_treasury, 'new_treasury')
 
     print_network_header(network_name, contract_addr)
 
@@ -275,7 +267,7 @@ def admin_set_treasury(
 
 
 @admin.command('add-vali')
-@click.argument('hotkey', type=str)
+@click.argument('hotkey', type=Ss58AddressParam('hotkey'))
 @with_wallet_options()
 @with_network_contract_options('Contract address')
 @with_cli_behavior_options(include_yes=True)
@@ -296,8 +288,6 @@ def admin_add_validator(
     [/dim]
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
-
-    require_valid_ss58(hotkey, 'hotkey')
 
     print_network_header(network_name, contract_addr)
 
@@ -330,7 +320,7 @@ def admin_add_validator(
 
 
 @admin.command('remove-vali')
-@click.argument('hotkey', type=str)
+@click.argument('hotkey', type=Ss58AddressParam('hotkey'))
 @with_wallet_options()
 @with_network_contract_options('Contract address')
 @with_cli_behavior_options(include_yes=True)
@@ -350,8 +340,6 @@ def admin_remove_validator(
     [/dim]
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
-
-    require_valid_ss58(hotkey, 'hotkey')
 
     print_network_header(network_name, contract_addr)
 

--- a/gittensor/cli/issue_commands/help.py
+++ b/gittensor/cli/issue_commands/help.py
@@ -119,6 +119,35 @@ def _options_panel(rows: list[tuple[str, str]]) -> Panel:
 class StyledCommand(click.Command):
     """Click command with styled help output."""
 
+    def make_context(
+        self,
+        info_name: str | None,
+        args: list[str],
+        parent: click.Context | None = None,
+        **extra: object,
+    ) -> click.Context:
+        json_mode = '--json' in args
+        try:
+            return super().make_context(info_name, args, parent=parent, **extra)
+        except click.BadParameter as e:
+            if json_mode:
+                from gittensor.cli.issue_commands.helpers import emit_error_json
+
+                emit_error_json(str(e), error_type='bad_parameter')
+                raise SystemExit(1) from None
+            raise
+
+    def invoke(self, ctx: click.Context):
+        try:
+            return super().invoke(ctx)
+        except click.BadParameter as e:
+            if ctx.params.get('as_json'):
+                from gittensor.cli.issue_commands.helpers import emit_error_json
+
+                emit_error_json(str(e), error_type='bad_parameter')
+                ctx.exit(1)
+            raise
+
     def _help_options_rows(self, ctx: click.Context) -> list[tuple[str, str]]:
         return _collect_help_rows(self.get_params(ctx), ctx)
 

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -20,7 +20,7 @@ import requests
 from rich.console import Console
 
 from gittensor.cli.issue_commands.tables import build_pr_table
-from gittensor.constants import BASE_GITHUB_API_URL, MAX_ISSUE_ID, NETWORK_MAP
+from gittensor.constants import BASE_GITHUB_API_URL, CLI_NETWORK_NAMES, MAX_ISSUE_ID, NETWORK_MAP
 from gittensor.validator.issue_competitions.storage_utils import (
     ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
@@ -56,7 +56,38 @@ console = Console()
 err_console = Console(stderr=True)
 
 CommandFunc = TypeVar('CommandFunc', bound=Callable[..., Any])
-NETWORK_CHOICE = click.Choice(['finney', 'test', 'local'], case_sensitive=False)
+NETWORK_CHOICE = click.Choice(CLI_NETWORK_NAMES, case_sensitive=False)
+
+# On-chain issue IDs accepted by the contract layer (1 .. MAX_ISSUE_ID-1).
+ONCHAIN_ISSUE_ID_TYPE = click.IntRange(1, MAX_ISSUE_ID - 1)
+# GitHub issue numbers (u32).
+GITHUB_ISSUE_NUMBER_TYPE = click.IntRange(1, MAX_ISSUE_NUMBER)
+
+
+class BountyAlphaParam(click.ParamType):
+    """Parse `--bounty` as decimal ALPHA and return raw integer units (parse-time)."""
+
+    name = 'ALPHA'
+
+    def convert(self, value: Any, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> int:
+        if not isinstance(value, str):
+            raise click.BadParameter('Bounty must be passed as text', param=param, ctx=ctx)
+        return validate_bounty_amount(value)
+
+
+class Ss58AddressParam(click.ParamType):
+    """SS58 account address validated via substrate ss58_decode (parse-time)."""
+
+    name = 'SS58'
+
+    def __init__(self, field: str) -> None:
+        super().__init__()
+        self.field = field
+
+    def convert(self, value: Any, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> str:
+        if not isinstance(value, str):
+            raise click.BadParameter('Expected text', param=param, ctx=ctx)
+        return validate_ss58_address(value, self.field)
 
 
 def apply_click_options(*decorators: Callable[[CommandFunc], CommandFunc]) -> Callable[[CommandFunc], CommandFunc]:
@@ -542,30 +573,6 @@ def validate_ss58_address(address: str, param_name: str = 'address') -> str:
         )
 
     return address
-
-
-def require_valid_issue_id(value: int, param_name: str = 'issue_id') -> int:
-    """Validate an issue ID, raising ClickException on failure.
-
-    Returns:
-        The validated issue ID.
-    """
-    try:
-        return validate_issue_id(value, param_name)
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
-
-
-def require_valid_ss58(address: str, param_name: str = 'address') -> str:
-    """Validate an SS58 address, raising ClickException on failure.
-
-    Returns:
-        The validated SS58 address string.
-    """
-    try:
-        return validate_ss58_address(address, param_name)
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
 
 
 def load_config() -> Dict[str, Any]:

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -16,7 +16,8 @@ from rich.panel import Panel
 
 from .help import StyledCommand
 from .helpers import (
-    MAX_ISSUE_NUMBER,
+    BountyAlphaParam,
+    GITHUB_ISSUE_NUMBER_TYPE,
     NETWORK_CHOICE,
     _is_interactive,
     _resolve_contract_and_network,
@@ -27,7 +28,6 @@ from .helpers import (
     print_error,
     print_network_header,
     print_success,
-    validate_bounty_amount,
     validate_github_issue,
     validate_repository,
 )
@@ -51,13 +51,13 @@ def _print_register_revert_hints() -> None:
     '--issue',
     'issue_number',
     required=True,
-    type=int,
-    help='GitHub issue number',
+    type=GITHUB_ISSUE_NUMBER_TYPE,
+    help='GitHub issue number (1–4294967295)',
 )
 @click.option(
     '--bounty',
     required=True,
-    type=str,
+    type=BountyAlphaParam(),
     help='Bounty amount in ALPHA (e.g. 10 or 10.5)',
 )
 @click.option(
@@ -100,7 +100,7 @@ def _print_register_revert_hints() -> None:
 def issue_register(
     repo: str,
     issue_number: int,
-    bounty: str,
+    bounty: int,
     network: str,
     rpc_url: str,
     contract: str,
@@ -128,6 +128,15 @@ def issue_register(
     """
     err_console.print('\n[bold cyan]Register Issue for Bounty[/bold cyan]\n')
 
+    # Validate inputs before touching chain config. Bounty and GitHub issue
+    # number are already checked at Click parse time; repo/issue still need
+    # strict GitHub verification before any RPC work.
+    try:
+        owner, repo_name = validate_repository(repo, require_verified_exists=True)
+        validate_github_issue(owner, repo_name, issue_number, require_verified_exists=True)
+    except click.BadParameter as e:
+        raise click.ClickException(str(e))
+
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(
         contract,
         network,
@@ -136,23 +145,6 @@ def issue_register(
     )
     config = load_config()
 
-    # Validate inputs before showing summary. The register path is owner-only
-    # and spends real ALPHA, so both GitHub probes run in strict mode: any
-    # warn-and-skip branch (network error, 5xx, 403, rate-limit) is promoted
-    # to a click.BadParameter abort so we never submit register_issue on-chain
-    # against a repository or issue we failed to verify.
-    try:
-        owner, repo_name = validate_repository(repo, require_verified_exists=True)
-        bounty_amount = validate_bounty_amount(bounty)
-        if issue_number < 1 or issue_number > MAX_ISSUE_NUMBER:
-            raise click.BadParameter(
-                f'Issue number must be between 1 and {MAX_ISSUE_NUMBER} (got {issue_number})',
-                param_hint='--issue',
-            )
-        validate_github_issue(owner, repo_name, issue_number, require_verified_exists=True)
-    except click.BadParameter as e:
-        raise click.ClickException(str(e))
-
     github_url = f'https://github.com/{repo}/issues/{issue_number}'
 
     err_console.print(
@@ -160,7 +152,7 @@ def issue_register(
             f'[cyan]Repository:[/cyan] {repo}\n'
             f'[cyan]Issue Number:[/cyan] #{issue_number}\n'
             f'[cyan]GitHub URL:[/cyan] {github_url}\n'
-            f'[cyan]Target Bounty:[/cyan] {format_alpha(bounty_amount, 2)} ALPHA\n'
+            f'[cyan]Target Bounty:[/cyan] {format_alpha(bounty, 2)} ALPHA\n'
             f'[cyan]Network:[/cyan] {network_name}\n'
             f'[cyan]RPC Endpoint:[/cyan] {ws_endpoint}\n'
             f'[cyan]Contract:[/cyan] {contract_addr}',
@@ -227,7 +219,7 @@ def issue_register(
                 'github_url': github_url,
                 'repository_full_name': repo,
                 'issue_number': issue_number,
-                'target_bounty': bounty_amount,
+                'target_bounty': bounty,
             },
             gas_limit={'ref_time': 10_000_000_000, 'proof_size': 1_000_000},
         )

--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -9,6 +9,7 @@ import click
 
 from .help import StyledCommand
 from .helpers import (
+    ONCHAIN_ISSUE_ID_TYPE,
     emit_json,
     fetch_issue_from_contract,
     fetch_open_issue_pull_requests,
@@ -19,7 +20,6 @@ from .helpers import (
     print_network_header,
     print_warning,
     resolve_network,
-    validate_issue_id,
     with_cli_behavior_options,
     with_network_contract_options,
 )
@@ -30,8 +30,8 @@ from .helpers import (
     '--id',
     'issue_id',
     required=True,
-    type=int,
-    help='On-chain issue ID',
+    type=ONCHAIN_ISSUE_ID_TYPE,
+    help='On-chain issue ID (1–999999)',
 )
 @with_cli_behavior_options(include_verbose=True, include_json=True)
 @with_network_contract_options('Contract address (uses default if empty)')
@@ -54,11 +54,6 @@ def issues_submissions(
         $ gitt i submissions --id 42 --json
     [/dim]
     """
-    try:
-        validate_issue_id(issue_id, 'id')
-    except click.BadParameter as e:
-        handle_exception(as_json, str(e), 'bad_parameter')
-
     contract_addr = get_contract_address(contract)
     ws_endpoint, network_name = resolve_network(network, rpc_url)
 

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -19,6 +19,7 @@ from rich.table import Table
 
 from .help import StyledCommand
 from .helpers import (
+    ONCHAIN_ISSUE_ID_TYPE,
     _read_contract_packed_storage,
     _read_issues_from_child_storage,
     _resolve_contract_and_network,
@@ -31,7 +32,6 @@ from .helpers import (
     loading_context,
     print_network_header,
     read_issues_from_contract,
-    validate_issue_id,
     with_cli_behavior_options,
     with_network_contract_options,
 )
@@ -54,8 +54,8 @@ def _fill_percent(bounty: int, target: int) -> float:
     '--id',
     'issue_id',
     default=None,
-    type=int,
-    help='View a specific issue by ID',
+    type=ONCHAIN_ISSUE_ID_TYPE,
+    help='View a specific on-chain issue ID (1–999999)',
 )
 @click.option(
     '--repo',
@@ -71,7 +71,7 @@ def _fill_percent(bounty: int, target: int) -> float:
 )
 @with_network_contract_options('Contract address (uses default if empty)')
 def issues_list(
-    issue_id: int, repo_filter: str, network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool
+    issue_id: int | None, repo_filter: str | None, network: str, rpc_url: str, contract: str, verbose: bool, as_json: bool
 ):
     """List issues or view a specific issue.
 
@@ -82,12 +82,6 @@ def issues_list(
         $ gitt i list --json
     [/dim]
     """
-    if issue_id is not None:
-        try:
-            validate_issue_id(issue_id, 'id')
-        except click.BadParameter as e:
-            handle_exception(as_json, str(e), 'bad_parameter')
-
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(
         contract,
         network,

--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -11,6 +11,7 @@ Commands:
 """
 
 import re
+from typing import Any, Optional
 
 import click
 from rich.panel import Panel
@@ -18,6 +19,8 @@ from rich.table import Table
 
 from .help import StyledGroup
 from .helpers import (
+    ONCHAIN_ISSUE_ID_TYPE,
+    Ss58AddressParam,
     _handle_command_error,
     _make_contract_client,
     _resolve_contract_and_network,
@@ -30,9 +33,6 @@ from .helpers import (
     print_error,
     print_network_header,
     print_success,
-    require_valid_issue_id,
-    validate_issue_id,
-    validate_ss58_address,
     with_cli_behavior_options,
     with_network_contract_options,
     with_wallet_options,
@@ -66,6 +66,23 @@ def parse_pr_number(pr_input: str) -> int:
     raise ValueError(f'Cannot parse PR number from: {pr_input}')
 
 
+class _PrNumberOrUrlParam(click.ParamType):
+    """GitHub PR number or repository PR URL (parse-time)."""
+
+    name = 'PR'
+
+    def convert(self, value: Any, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> int:
+        if not isinstance(value, str):
+            raise click.BadParameter('Expected text', param=param, ctx=ctx)
+        try:
+            n = parse_pr_number(value)
+        except ValueError as e:
+            raise click.BadParameter(str(e), param=param, ctx=ctx) from e
+        if n < 1:
+            raise click.BadParameter(f'PR number must be positive (got {n})', param=param, ctx=ctx)
+        return n
+
+
 @click.group(name='vote', cls=StyledGroup)
 def vote():
     """Validator consensus operations.
@@ -76,10 +93,10 @@ def vote():
 
 
 @vote.command('solution')
-@click.argument('issue_id', type=int)
-@click.argument('solver_hotkey', type=str)
-@click.argument('solver_coldkey', type=str)
-@click.argument('pr_number_or_url', type=str)
+@click.argument('issue_id', type=ONCHAIN_ISSUE_ID_TYPE)
+@click.argument('solver_hotkey', type=Ss58AddressParam('solver_hotkey'))
+@click.argument('solver_coldkey', type=Ss58AddressParam('solver_coldkey'))
+@click.argument('pr_number_or_url', type=_PrNumberOrUrlParam())
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
 @with_cli_behavior_options(include_yes=True)
@@ -87,7 +104,7 @@ def val_vote_solution(
     issue_id: int,
     solver_hotkey: str,
     solver_coldkey: str,
-    pr_number_or_url: str,
+    pr_number_or_url: int,
     wallet_name: str,
     wallet_hotkey: str,
     network: str,
@@ -111,20 +128,7 @@ def val_vote_solution(
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
 
-    try:
-        validate_issue_id(issue_id)
-        validate_ss58_address(solver_hotkey, 'solver_hotkey')
-        validate_ss58_address(solver_coldkey, 'solver_coldkey')
-        pr_number = parse_pr_number(pr_number_or_url)
-        if pr_number < 1:
-            raise click.BadParameter(
-                f'PR number must be positive (got {pr_number})',
-                param_hint='pr_number_or_url',
-            )
-    except click.BadParameter:
-        raise
-    except ValueError as e:
-        raise click.BadParameter(str(e), param_hint='pr_number_or_url')
+    pr_number = pr_number_or_url
 
     print_network_header(network_name, contract_addr)
 
@@ -157,7 +161,7 @@ def val_vote_solution(
 
 
 @vote.command('cancel')
-@click.argument('issue_id', type=int)
+@click.argument('issue_id', type=ONCHAIN_ISSUE_ID_TYPE)
 @click.argument('reason', type=str)
 @with_wallet_options()
 @with_network_contract_options('Contract address (uses config if empty)')
@@ -185,8 +189,6 @@ def val_vote_cancel_issue(
     [/dim]
     """
     contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
-
-    require_valid_issue_id(issue_id)
 
     print_network_header(network_name, contract_addr)
 

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -40,6 +40,7 @@ from gittensor import __version__
 from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR, console, err_console
+from gittensor.constants import NETWORK_MAP
 
 
 @click.group(cls=StyledAliasGroup)
@@ -119,6 +120,12 @@ def config_set(key: str, value: str):
     [/dim]
     """
     key = key.lower()
+    if key == 'network' and value.lower() not in NETWORK_MAP:
+        raise click.BadParameter(
+            f'Network must be one of {", ".join(NETWORK_MAP)} (got {value!r})',
+            param_hint='VALUE',
+        )
+
     # Ensure config directory exists
     GITTENSOR_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/gittensor/cli/miner_commands/check.py
+++ b/gittensor/cli/miner_commands/check.py
@@ -9,6 +9,8 @@ import sys
 import click
 from rich.table import Table
 
+from gittensor.constants import CLI_NETWORK_NAMES
+
 from .helpers import (
     DEFAULT_MIN_VALIDATOR_STAKE,
     DEFAULT_MIN_VALIDATOR_VTRUST,
@@ -39,7 +41,12 @@ _PAT_CHECK_STATUS_MARKUP = {
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
-@click.option('--network', default=None, help='Network name (local, test, finney).')
+@click.option(
+    '--network',
+    default=None,
+    type=click.Choice(CLI_NETWORK_NAMES, case_sensitive=False),
+    help='Network (finney/test/local).',
+)
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
 @click.option(
     '--min-vtrust',

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -31,7 +31,12 @@ from gittensor.cli.miner_commands.helpers import (
     console,
     err_console,
 )
-from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
+from gittensor.constants import (
+    BASE_GITHUB_API_URL,
+    CLI_NETWORK_NAMES,
+    GITHUB_HTTP_TIMEOUT_SECONDS,
+    GRAPHQL_VIEWER_QUERY,
+)
 from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
 
 _PAT_POST_STATUS_MARKUP = {
@@ -45,7 +50,12 @@ _PAT_POST_STATUS_MARKUP = {
 @click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
 @click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
 @click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
-@click.option('--network', default=None, help='Network name (local, test, finney).')
+@click.option(
+    '--network',
+    default=None,
+    type=click.Choice(CLI_NETWORK_NAMES, case_sensitive=False),
+    help='Network (finney/test/local).',
+)
 @click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
 @click.option(
     '--pat',

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -17,6 +17,9 @@ NETWORK_MAP = {
     'local': 'ws://127.0.0.1:9944',
 }
 
+# Keys of NETWORK_MAP; used for CLI `--network` validation and help.
+CLI_NETWORK_NAMES = tuple(NETWORK_MAP.keys())
+
 # =============================================================================
 # GitHub API
 # =============================================================================

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -9,6 +9,7 @@ validate_issue_id, validate_ss58_address, colorize_status, and CLI
 invocation with validation (no live network).
 """
 
+import importlib
 import json
 from decimal import Decimal
 from typing import Any, Dict, Optional
@@ -17,6 +18,9 @@ from unittest.mock import patch
 import click
 import pytest
 from click.testing import CliRunner
+
+_ISSUE_VOTE_MOD = importlib.import_module('gittensor.cli.issue_commands.vote')
+_ISSUE_ADMIN_MOD = importlib.import_module('gittensor.cli.issue_commands.admin')
 
 from gittensor.cli.issue_commands.helpers import (
     ALPHA_DECIMALS,
@@ -543,7 +547,8 @@ class TestCliRegisterValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'Minimum' in result.output or '5' in result.output
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'Minimum' in combined or '5' in combined
 
     def test_register_rejects_bad_repo_format(self, cli_root, runner):
         with patch(
@@ -577,7 +582,8 @@ class TestCliRegisterValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'between' in result.output or '0' in result.output or 'issue' in result.output.lower()
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'range' in combined.lower() or '0' in combined or 'issue' in combined.lower()
 
     def test_register_rejects_issue_number_over_max(self, cli_root, runner):
         over_max = str(MAX_ISSUE_NUMBER + 1)
@@ -599,7 +605,8 @@ class TestCliRegisterValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'between' in result.output or over_max in result.output or 'issue' in result.output.lower()
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'range' in combined.lower() or over_max in combined or 'issue' in combined.lower()
 
     def test_register_aborts_on_github_503_before_contract_call(self, cli_root, runner):
         """A 5xx from GitHub during register must abort with a non-zero exit
@@ -678,8 +685,9 @@ class TestCliVoteValidation:
     """Ensure vote solution rejects invalid issue_id / PR (validators wired)."""
 
     def test_vote_solution_rejects_issue_id_zero(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_VOTE_MOD,
+            '_resolve_contract_and_network',
             return_value=(
                 '0x1234567890123456789012345678901234567890',
                 'wss://entrypoint-finney.opentensor.ai:443',
@@ -699,11 +707,13 @@ class TestCliVoteValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'between' in result.output or '1' in result.output or 'issue' in result.output.lower()
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'range' in combined.lower() or '<=' in combined
 
     def test_vote_solution_rejects_pr_zero(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_VOTE_MOD,
+            '_resolve_contract_and_network',
             return_value=(
                 '0x1234567890123456789012345678901234567890',
                 'wss://entrypoint-finney.opentensor.ai:443',
@@ -723,11 +733,13 @@ class TestCliVoteValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'PR' in result.output or 'positive' in result.output
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'PR' in combined or 'positive' in combined or 'range' in combined.lower()
 
     def test_vote_solution_rejects_invalid_pr(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_VOTE_MOD,
+            '_resolve_contract_and_network',
             return_value=(
                 '0x1234567890123456789012345678901234567890',
                 'wss://entrypoint-finney.opentensor.ai:443',
@@ -747,15 +759,17 @@ class TestCliVoteValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'Cannot parse' in result.output or 'not-a-pr' in result.output or 'pr_number' in result.output.lower()
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'Cannot parse' in combined or 'not-a-pr' in combined or 'pr_number' in combined.lower()
 
 
 class TestCliAdminValidation:
     """Ensure admin cancel and payout reject invalid issue_id (validator wired)."""
 
     def test_admin_cancel_rejects_issue_id_zero(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_ADMIN_MOD,
+            '_resolve_contract_and_network',
             return_value=(
                 '0x1234567890123456789012345678901234567890',
                 'wss://entrypoint-finney.opentensor.ai:443',
@@ -768,11 +782,13 @@ class TestCliAdminValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'between' in result.output or '1' in result.output
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'range' in combined.lower() or '1' in combined
 
     def test_admin_payout_rejects_issue_id_zero(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_ADMIN_MOD,
+            '_resolve_contract_and_network',
             return_value=(
                 '0x1234567890123456789012345678901234567890',
                 'wss://entrypoint-finney.opentensor.ai:443',
@@ -785,15 +801,17 @@ class TestCliAdminValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'between' in result.output or '1' in result.output
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'range' in combined.lower() or '1' in combined
 
 
 class TestCliVoteCancelValidation:
     """Ensure vote cancel rejects invalid issue_id."""
 
     def test_vote_cancel_rejects_issue_id_zero(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_VOTE_MOD,
+            '_resolve_contract_and_network',
             return_value=(
                 '0x1234567890123456789012345678901234567890',
                 'wss://entrypoint-finney.opentensor.ai:443',
@@ -806,16 +824,21 @@ class TestCliVoteCancelValidation:
                 catch_exceptions=False,
             )
         assert result.exit_code != 0
-        assert 'between' in result.output or '1' in result.output
+        combined = (result.stdout or '') + (result.stderr or '')
+        assert 'range' in combined.lower() or '1' in combined
 
 
 class TestCliMissingContractConfig:
     """Ensure missing contract config exits non-zero."""
 
     def test_register_missing_contract_fails(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
-            side_effect=click.ClickException('Contract address not configured.'),
+        with (
+            patch('gittensor.cli.issue_commands.mutations.validate_repository', return_value=('a', 'b')),
+            patch('gittensor.cli.issue_commands.mutations.validate_github_issue', return_value={}),
+            patch(
+                'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
+                side_effect=click.ClickException('Contract address not configured.'),
+            ),
         ):
             result = runner.invoke(
                 cli_root,
@@ -826,8 +849,9 @@ class TestCliMissingContractConfig:
         assert 'Contract address not configured' in result.output
 
     def test_vote_missing_contract_fails(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_VOTE_MOD,
+            '_resolve_contract_and_network',
             side_effect=click.ClickException('Contract address not configured.'),
         ):
             result = runner.invoke(
@@ -846,8 +870,9 @@ class TestCliMissingContractConfig:
         assert 'Contract address not configured' in result.output
 
     def test_admin_missing_contract_fails(self, cli_root, runner):
-        with patch(
-            'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+        with patch.object(
+            _ISSUE_ADMIN_MOD,
+            '_resolve_contract_and_network',
             side_effect=click.ClickException('Contract address not configured.'),
         ):
             result = runner.invoke(
@@ -876,6 +901,7 @@ class TestCliRegisterLogicalFailures:
     """Ensure logical failure branches in `issues register` exit non-zero."""
 
     def test_register_exits_non_zero_when_contract_metadata_missing(self, cli_root, runner):
+        pytest.importorskip('substrateinterface')
         with (
             patch(
                 'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
@@ -904,16 +930,18 @@ class TestCliRuntimeExceptions:
 
     def test_admin_cancel_runtime_exception_exits_non_zero(self, cli_root, runner):
         with (
-            patch(
-                'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+            patch.object(
+                _ISSUE_ADMIN_MOD,
+                '_resolve_contract_and_network',
                 return_value=(
                     '0x1234567890123456789012345678901234567890',
                     'wss://entrypoint-finney.opentensor.ai:443',
                     'finney',
                 ),
             ),
-            patch(
-                'gittensor.cli.issue_commands.admin._make_contract_client',
+            patch.object(
+                _ISSUE_ADMIN_MOD,
+                '_make_contract_client',
                 side_effect=RuntimeError('boom-admin'),
             ),
         ):
@@ -927,16 +955,18 @@ class TestCliRuntimeExceptions:
 
     def test_vote_solution_import_error_exits_non_zero(self, cli_root, runner):
         with (
-            patch(
-                'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+            patch.object(
+                _ISSUE_VOTE_MOD,
+                '_resolve_contract_and_network',
                 return_value=(
                     '0x1234567890123456789012345678901234567890',
                     'wss://entrypoint-finney.opentensor.ai:443',
                     'finney',
                 ),
             ),
-            patch(
-                'gittensor.cli.issue_commands.vote._make_contract_client',
+            patch.object(
+                _ISSUE_VOTE_MOD,
+                '_make_contract_client',
                 side_effect=ImportError('missing-dep'),
             ),
         ):
@@ -956,6 +986,7 @@ class TestCliRuntimeExceptions:
         assert 'Missing dependency' in result.output
 
     def test_harvest_runtime_exception_exits_non_zero(self, cli_root, runner):
+        pytest.importorskip('substrateinterface')
         with (
             patch(
                 'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',

--- a/tests/cli/test_cli_json_error_output.py
+++ b/tests/cli/test_cli_json_error_output.py
@@ -6,10 +6,14 @@
 Covers `issues bounty-pool`, `issues pending-harvest`, `admin info`, and `vote list`.
 """
 
+import importlib
 import json
 from unittest.mock import patch
 
 import pytest
+
+_ISSUE_VIEW_MOD = importlib.import_module('gittensor.cli.issue_commands.view')
+_ISSUE_VOTE_MOD = importlib.import_module('gittensor.cli.issue_commands.vote')
 
 FORCED_MESSAGE = 'forced test failure for json-error assertion'
 
@@ -25,12 +29,14 @@ FORCED_MESSAGE = 'forced test failure for json-error assertion'
 )
 def test_cli_commands_emit_json_on_exception(cli_root, runner, argv):
     with (
-        patch(
-            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+        patch.object(
+            _ISSUE_VIEW_MOD,
+            '_resolve_contract_and_network',
             return_value=('5Fakeaddr', 'ws://x', 'test'),
         ),
-        patch(
-            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+        patch.object(
+            _ISSUE_VOTE_MOD,
+            '_resolve_contract_and_network',
             return_value=('5Fakeaddr', 'ws://x', 'test'),
         ),
         patch(

--- a/tests/cli/test_config_set.py
+++ b/tests/cli/test_config_set.py
@@ -13,10 +13,13 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import importlib
 import pytest
 from click.testing import CliRunner
 
 from gittensor.cli.main import CONFIG_KEYS, config_group
+
+_MAIN = importlib.import_module('gittensor.cli.main')
 
 
 @pytest.fixture
@@ -25,8 +28,8 @@ def temp_config_dir(tmp_path: Path):
     config_dir = tmp_path / '.gittensor'
     config_file = config_dir / 'config.json'
     with (
-        patch('gittensor.cli.main.GITTENSOR_DIR', config_dir),
-        patch('gittensor.cli.main.CONFIG_FILE', config_file),
+        patch.object(_MAIN, 'GITTENSOR_DIR', config_dir),
+        patch.object(_MAIN, 'CONFIG_FILE', config_file),
     ):
         yield config_dir, config_file
 
@@ -73,10 +76,11 @@ class TestConfigSetWhitelist:
     def test_every_recognised_key_round_trips(self, temp_config_dir, key):
         _, config_file = temp_config_dir
         runner = CliRunner()
-        result = runner.invoke(config_group, ['set', key, 'value-for-' + key])
+        value = 'test' if key == 'network' else f'value-for-{key}'
+        result = runner.invoke(config_group, ['set', key, value])
 
         assert result.exit_code == 0, result.output
-        assert _read(config_file)[key] == 'value-for-' + key
+        assert _read(config_file)[key] == value
 
     def test_uppercase_key_normalised_to_lowercase(self, temp_config_dir):
         """`click.Choice(case_sensitive=False)` matches mixed case; we persist the canonical lowercase form."""

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -62,7 +62,9 @@ def test_issues_list_rejects_invalid_id_human(cli_root, runner, bad_id):
         result = runner.invoke(cli_root, ['issues', 'list', '--id', bad_id], catch_exceptions=False)
 
     assert result.exit_code != 0
-    assert 'between 1 and 999999' in result.output
+    combined = (result.stdout or '') + (result.stderr or '')
+    assert '999999' in combined
+    assert 'range' in combined.lower()
     mock_read.assert_not_called()
 
 
@@ -73,8 +75,9 @@ def test_issues_list_rejects_invalid_id_json(cli_root, runner, bad_id):
         result = runner.invoke(cli_root, ['issues', 'list', '--json', '--id', bad_id], catch_exceptions=False)
 
     assert result.exit_code != 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload['success'] is False
     assert payload['error']['type'] == 'bad_parameter'
-    assert 'between 1 and 999999' in payload['error']['message']
+    assert '999999' in payload['error']['message']
+    assert 'range' in payload['error']['message'].lower()
     mock_read.assert_not_called()


### PR DESCRIPTION
## Summary
Refactors issue/admin/vote/miner CLI validation to use Click’s built-in types (IntRange, Choice, custom ParamType for bounty/SS58) so bounds and allowed values are enforced at parse time and show correctly in --help. Removes require_valid_issue_id / require_valid_ss58. StyledCommand maps parse-time BadParameter to JSON when --json is present in the subcommand args. issues register runs strict GitHub checks before RPC/config resolution. Adds CLI_NETWORK_NAMES from NETWORK_MAP, validates gitt config set network, and tightens gitt miner check/post --network with Choice.

## Related issues

Closes #1154

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests updated (tests/cli/test_cli_helpers.py, test_config_set.py, test_issues_list_json.py, test_cli_json_error_output.py)
- [x] pytest tests/cli/ (excluding test_miner_score / test_cli_json_error_output where substrateinterface is absent): 135 passed, 2 skipped
- [ ] Manual: gitt issues list --help, gitt admin set-owner --help, bad --id / --bounty / --network with and without --json

## Checklist

- [x] Code style consistent with project
- [x] Self-review done
- [ ] Documentation updated where needed