### PR TITLE
fix: count ALL open issues for spam multiplier instead of lookback-bounded subset (#929)

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -167,13 +167,17 @@ async def run_mirror_issue_discovery(
             no_issues += 1
             continue
 
-        # Count this miner's currently-open issues across mirror-enabled repos
-        # (within the lookback window). Used as the spam-multiplier signal and
-        # also written to evaluation.total_open_issues so the DB row reflects
-        # mirror-scoped state (the legacy GraphQL global open-issue count was
-        # never the right signal for the gate).
-        open_issue_count = sum(1 for i in filtered if i.state == 'OPEN')
-        pending.append((evaluation, filtered, open_issue_count))
+        # Count this miner's total open issues across mirror-enabled repos
+        # without the lookback window, so old open issues correctly trigger
+        # the spam multiplier.  The lookback filter above is for scoring;
+        # the spam gate needs the miner's true open-issue load.
+        try:
+            all_response = await asyncio.to_thread(client.get_miner_issues, evaluation.github_id)
+            all_filtered = [i for i in all_response.issues if i.repo_full_name in enabled_names]
+            total_open = sum(1 for i in all_filtered if i.state == 'OPEN')
+        except MirrorRequestError:
+            total_open = sum(1 for i in filtered if i.state == 'OPEN')
+        pending.append((evaluation, filtered, total_open))
 
     canonical_pr_owners = _build_canonical_pr_owners(pending)
     for evaluation, filtered, open_issue_count in pending:


### PR DESCRIPTION
## Summary

Mirror issue discovery currently uses the same lookback-bounded `get_miner_issues(since=lookback_date)` response for both scoring (correct) and counting open issues for the spam multiplier (incorrect). Open issues created before `PR_LOOKBACK_DAYS` are omitted from `total_open_issues` and never trigger the open-issue spam gate.

This fix adds a second `get_miner_issues` call *without* the lookback window, then counts `OPEN` issues across mirror-enabled repos from that full response. The scoring path still uses the lookback-bounded list unchanged.

If the unfiltered fetch fails, the lookback-bounded count is used as a fallback approximation (previous behavior).

## Validation

- `total_open` is derived from `get_miner_issues(github_id)` (no `since`) — counts ALL open issues
- `total_open` falls back to lookback-bounded count if the unfiltered fetch raises `MirrorRequestError`
- Scoring still uses the lookback-bounded `filtered` list
- ruff check + ruff format pass

Closes #929