### PR TITLE
fix:issue-discovery-fixed-base-cache-miss

### DIFF
--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -301,6 +301,9 @@ async def _score_miner_mirror_issues(
         # classification == 'solved'
         assert issue.solving_pr is not None  # _classify_issue guarantees
         solving_pr = issue.solving_pr
+        repo_config = mirror_repos.get(issue.repo_full_name)
+        if repo_config is None:
+            continue
 
         solved_count += 1
 
@@ -308,6 +311,7 @@ async def _score_miner_mirror_issues(
         cached = await _resolve_solving_pr_score(
             issue,
             solving_pr,
+            repo_config,
             solving_pr_cache,
             cache_stats,
             client,
@@ -343,10 +347,6 @@ async def _score_miner_mirror_issues(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): one-issue-per-PR '
                 f'(PR #{solving_pr.pr_number} canonical owner is a different issue) — credibility only'
             )
-            continue
-
-        repo_config = mirror_repos.get(issue.repo_full_name)
-        if repo_config is None:
             continue
 
         # Quality gate — matches legacy issue-discovery behavior: below-threshold
@@ -419,6 +419,7 @@ async def _score_miner_mirror_issues(
 async def _resolve_solving_pr_score(
     issue: MirrorIssue,
     solving_pr: MirrorSolvingPR,
+    repo_config: Optional[RepositoryConfig],
     cache: Dict[Tuple[str, int], CachedSolvingPR],
     cache_stats: _CacheStats,
     client: MirrorClient,
@@ -428,8 +429,9 @@ async def _resolve_solving_pr_score(
     """Return base_score + token_score for the solving PR.
 
     Cache hit: returns immediately (case 1 = miner's own PR, case 2 = another
-    miner's PR). Cache miss: fetches ``/pulls/:o/:r/:n/files`` and tokenizes;
-    writes the result back into the cache. Returns None on fetch failure.
+    miner's PR). Cache miss: fetches ``/pulls/:o/:r/:n/files`` and tokenizes.
+    If the repo has ``fixed_base_score`` configured, that override is applied
+    before writing the result into cache. Returns None on fetch failure.
     """
     key = (issue.repo_full_name, solving_pr.pr_number)
     if key in cache:
@@ -460,7 +462,12 @@ async def _resolve_solving_pr_score(
         issue.repo_full_name, solving_pr.pr_number, files_response.files
     )
     result = calculate_base_score_for_pr_files(file_changes, file_contents, programming_languages, token_config)
-    cached = CachedSolvingPR(base_score=result.base_score, token_score=result.token_score)
+    base_score = (
+        repo_config.fixed_base_score
+        if repo_config is not None and repo_config.fixed_base_score is not None
+        else result.base_score
+    )
+    cached = CachedSolvingPR(base_score=base_score, token_score=result.token_score)
     cache[key] = cached
     return cached
 

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -575,8 +575,11 @@ class TestCacheStats:
 
         issue = MirrorIssue.from_dict(_issue_dict())
         assert issue.solving_pr is not None
+        repo_config = RepositoryConfig(weight=0.5, mirror_enabled=True)
         result = asyncio.run(
-            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
+            _resolve_solving_pr_score(
+                issue, issue.solving_pr, repo_config, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+            )
         )
 
         assert result is not None
@@ -597,8 +600,11 @@ class TestCacheStats:
         stats = _CacheStats()
 
         issue = MirrorIssue.from_dict(_issue_dict())
+        repo_config = RepositoryConfig(weight=0.5, mirror_enabled=True)
         asyncio.run(
-            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
+            _resolve_solving_pr_score(
+                issue, issue.solving_pr, repo_config, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+            )
         )
 
         assert stats.hits == 0
@@ -619,8 +625,11 @@ class TestCacheStats:
         stats = _CacheStats()
 
         issue = MirrorIssue.from_dict(_issue_dict())
+        repo_config = RepositoryConfig(weight=0.5, mirror_enabled=True)
         result = asyncio.run(
-            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
+            _resolve_solving_pr_score(
+                issue, issue.solving_pr, repo_config, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+            )
         )
 
         assert result is None
@@ -656,8 +665,11 @@ class TestCacheStats:
         stats = _CacheStats()
 
         issue = MirrorIssue.from_dict(_issue_dict())
+        repo_config = RepositoryConfig(weight=0.5, mirror_enabled=True)
         result = asyncio.run(
-            _resolve_solving_pr_score(issue, issue.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG)
+            _resolve_solving_pr_score(
+                issue, issue.solving_pr, repo_config, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+            )
         )
 
         assert result is None
@@ -697,12 +709,26 @@ class TestCacheStats:
 
         result_a = asyncio.run(
             _resolve_solving_pr_score(
-                issue_a, issue_a.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+                issue_a,
+                issue_a.solving_pr,
+                RepositoryConfig(weight=0.5, mirror_enabled=True),
+                cache,
+                stats,
+                client,
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
             )
         )
         result_b = asyncio.run(
             _resolve_solving_pr_score(
-                issue_b, issue_b.solving_pr, cache, stats, client, _EMPTY_LANGS, _EMPTY_TOKEN_CONFIG
+                issue_b,
+                issue_b.solving_pr,
+                RepositoryConfig(weight=0.5, mirror_enabled=True),
+                cache,
+                stats,
+                client,
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
             )
         )
 
@@ -713,6 +739,65 @@ class TestCacheStats:
         assert stats.fetch_failures == 2
         assert cache == {}
         assert client.get_pr_files.call_count == 2
+
+    def test_fixed_base_score_is_applied_on_cache_miss_and_cache_hit(self, monkeypatch):
+        from gittensor.validator.issue_discovery.mirror_scan import (
+            _CacheStats,
+            _resolve_solving_pr_score,
+        )
+
+        repo_config = RepositoryConfig(weight=0.5, mirror_enabled=True, fixed_base_score=25.0)
+        client = Mock()
+        client.get_pr_files.return_value = _empty_files_response('entrius/gittensor-ui', 100)
+        cache = {}
+        stats = _CacheStats()
+        issue = MirrorIssue.from_dict(_issue_dict())
+
+        monkeypatch.setattr(
+            mirror_scan_module,
+            'calculate_base_score_for_pr_files',
+            Mock(
+                return_value=Mock(
+                    base_score=91.0,
+                    token_score=77.0,
+                )
+            ),
+        )
+
+        miss_result = asyncio.run(
+            _resolve_solving_pr_score(
+                issue,
+                issue.solving_pr,
+                repo_config,
+                cache,
+                stats,
+                client,
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+            )
+        )
+        hit_result = asyncio.run(
+            _resolve_solving_pr_score(
+                issue,
+                issue.solving_pr,
+                repo_config,
+                cache,
+                stats,
+                client,
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+            )
+        )
+
+        assert miss_result is not None
+        assert hit_result is not None
+        assert miss_result.base_score == 25.0
+        assert hit_result.base_score == 25.0
+        assert miss_result.token_score == 77.0
+        assert hit_result.token_score == 77.0
+        assert stats.misses == 1
+        assert stats.hits == 1
+        assert client.get_pr_files.call_count == 1
 
 
 class TestOpenIssueSpamSourceIsMirror:


### PR DESCRIPTION
## Summary
Apply `RepositoryConfig.fixed_base_score` consistently in mirror issue-discovery solving PR scoring, including the cache-miss path.

- Thread `repo_config` into `_resolve_solving_pr_score` in `mirror_scan`.
- On cache miss, compute token fields as before, but override only `base_score` when `repo_config.fixed_base_score` is set.
- Keep token-derived fields unchanged to preserve eligibility/pioneer/reporting behavior.
- Add regression coverage to ensure fixed-base behavior is identical across cache hit and cache miss for the same repo config.

## Related Issues
Fixes #1172

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing
- Updated unit tests in `tests/validator/issue_discovery/test_mirror_scan.py`.
- Added test coverage for:
  - fixed-base override applied on cache miss
  - subsequent cache hit returns the same fixed base
  - token score remains token-derived in both paths
- Local run in this environment:
  - `pytest -q tests/validator/issue_discovery/test_mirror_scan.py` (module skipped due to optional import guards in this environment)

## Checklist
- [x] Code follows project style/conventions
- [x] Self-reviewed changes
- [x] Tests added/updated for changed behavior
- [x] No unintended behavior changes to token-derived gates/signals
- [x] Documentation/comments updated where helpful