### PR TITLE
fix:ema-blacklist-no-renormalization

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -355,12 +355,6 @@ class BaseValidatorNeuron(BaseNeuron):
             self.scores[blacklisted_uids_array] = 0.0
             bt.logging.info(f'Set scores to 0 for blacklisted UIDs: {blacklisted_uids}')
 
-            # Renormalize scores to sum to 1 after blacklisting
-            total_score = np.sum(self.scores)
-            if total_score > 0:
-                self.scores = self.scores / total_score
-                bt.logging.debug(f'Renormalized scores to sum=1 after blacklisting. New sum: {np.sum(self.scores)}')
-
     def save_state(self):
         """Saves the state of the validator to a file."""
         bt.logging.info('Saving validator state.')


### PR DESCRIPTION
## Summary

Removes the post-blacklist renormalization step in `update_scores` in `neurons/base/validator.py`. After blacklisted UIDs are zeroed, scores are no longer divided by `sum(scores)` to force a total of 1.0.

That renormalization was redundant with `set_weights`, which already applies L1 normalization before emitting weights to the chain. It also broke the EMA scale invariant: `scores = alpha * new_rewards + (1 - alpha) * old_scores` assumes `old_scores` stay on the same scale as `new_rewards`. Inflating non-blacklisted miners’ scores after a blacklist round made `(1 - alpha) * old_scores` dominate later rounds, unfairly suppressing miners who were blacklisted (e.g. transient duplicate GitHub detection) and giving a persistent advantage to others.

Blacklisted UIDs are still set to `0.0` immediately; only the harmful renormalization block was removed.

## Related Issues

Fixes:#1177

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Automated tests added/updated *(none added; change is localized removal of dead/harmful logic)*
- [ ] Manual testing performed *(describe if you ran a validator or replayed scoring)*

<!-- Optional: briefly note what you did manually, e.g. “Ran validator N rounds with mock blacklist; confirmed scores scale and weights from `set_weights` unchanged in intent.” -->

## Checklist

- [x] Code style consistent with surrounding code
- [x] Self-review completed
- [ ] Documentation updated *(not required for this internal scoring fix unless you maintain operator docs)*