### PR TITLE
feat(cli): add --profile flag to `gitt miner score`

### DIFF
--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -23,7 +23,7 @@ from rich.console import Console
 from rich.table import Table
 
 from gittensor.cli.json_output import emit_json
-from gittensor.cli.miner_commands.helpers import _error
+from gittensor.cli.miner_commands.helpers import _error, err_console
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -199,6 +199,23 @@ def _apply_log_level(level: str) -> None:
     getattr(bt.logging, f'set_{level}')()
 
 
+@contextmanager
+def _maybe_profile(path: Optional[str]) -> Iterator[None]:
+    """Profile the wrapped block and dump a pstats binary to `path`; no-op when path is None."""
+    if path is None:
+        yield
+        return
+    import cProfile
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    try:
+        yield
+    finally:
+        profiler.disable()
+        profiler.dump_stats(path)
+
+
 def _drain_logs() -> None:
     """Stop log production and wait for the async stderr writer to drain.
 
@@ -232,7 +249,14 @@ def _drain_logs() -> None:
     help="Bittensor log verbosity. 'info' surfaces the validator pipeline's per-step progress on stderr.",
 )
 @click.option('--json', 'json_mode', is_flag=True, default=False, help='Emit result as JSON on stdout.')
-def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
+@click.option(
+    '--profile',
+    'profile_path',
+    default=None,
+    metavar='PATH',
+    help='Run under cProfile and write a pstats binary to PATH.',
+)
+def score_command(pat: Optional[str], log_level: str, json_mode: bool, profile_path: Optional[str]) -> None:
     """Locally run the validator scoring pipeline end-to-end for the miner identified by --pat.
 
     No subtensor, wallet, DB, axon, or wandb is touched.
@@ -240,6 +264,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
     Example:
         gitt miner score --pat ghp_xxxxx
         gitt miner score --pat ghp_xxxxx --log-level debug
+        gitt miner score --pat ghp_xxxxx --profile run.prof
     """
     import asyncio
 
@@ -264,7 +289,9 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
     stub = cast('Validator', _StubValidator(_DEV_UID, _DEV_HOTKEY))
     miner_uids = {_DEV_UID}
 
-    if json_mode:
+    quiet = json_mode or profile_path is not None
+
+    if quiet:
         master_repositories = load_master_repo_weights()
         programming_languages = load_programming_language_weights()
         token_config = load_token_config()
@@ -289,6 +316,11 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
             )
         rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
 
+        # Profiling discards `payload`, so skip serialization to keep the profile
+        # focused on the scoring pipeline itself.
+        if profile_path is not None:
+            return {}
+
         return {
             'success': True,
             'miner_evaluation': _serialize_evaluation(miner_evaluations[_DEV_UID]),
@@ -299,11 +331,17 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
             },
         }
 
-    if not json_mode:
+    if not quiet:
         console.print('[bold cyan]Running validator pipeline...[/bold cyan]')
-    payload = asyncio.run(_run())
+
+    with _maybe_profile(profile_path):
+        payload = asyncio.run(_run())
 
     _drain_logs()
+
+    if profile_path is not None:
+        err_console.print(f'[bold cyan]wrote pstats binary:[/bold cyan] {profile_path}')
+        return
 
     if json_mode:
         emit_json(payload)

--- a/tests/cli/test_miner_score.py
+++ b/tests/cli/test_miner_score.py
@@ -317,6 +317,40 @@ class TestScoreCommand:
         assert result.exit_code == 0, result.output
         assert set(captured['repos'].keys()) == {'mirror/repo'}
 
+    def test_profile_path_writes_pstats_file_and_suppresses_table(self, runner, miner_eval_factory, tmp_path):
+        """`--profile PATH` writes a binary pstats file and emits only a path notification (no table/JSON)."""
+        import pstats
+
+        evaluation = miner_eval_factory(uid=_DEV_UID, is_eligible=True)
+        prof_file = tmp_path / 'run.prof'
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score', '--profile', str(prof_file)],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        assert prof_file.exists()
+        # File must be a valid pstats binary, not just a touched empty file.
+        pstats.Stats(str(prof_file))
+        assert prof_file.stat().st_size > 0
+        # No table or JSON payload on stdout; just the path notification on stderr.
+        assert f'Miner UID {_DEV_UID}' not in result.output
+        assert str(prof_file) in result.stderr
+
+    def test_profile_omitted_skips_profiler(self, runner, miner_eval_factory):
+        """Default invocation must not enable cProfile or print any profile banner."""
+        evaluation = miner_eval_factory(uid=_DEV_UID, is_eligible=True)
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+        assert result.exit_code == 0, result.output
+        assert 'wrote pstats binary' not in result.output
+        assert 'wrote pstats binary' not in result.stderr
+
     def test_pat_storage_load_all_pats_is_patched(self, runner, miner_eval_factory):
         """The injected PAT snapshot must override pat_storage.load_all_pats()."""
         evaluation = miner_eval_factory(uid=_DEV_UID)


### PR DESCRIPTION
Closes #1179 

## Summary

`--profile PATH` runs the scoring pipeline under cProfile and writes a pstats binary to the given path. Output is loadable with `snakeviz` or `python -m pstats`, but better just to give it for analysis to your LLM. Useful for finding hot spots in `oss_contributions` / `issue_discovery` / `blend_emission_pools` without wiring profilers into the validator entry point.

When the flag is set, table/JSON output is suppressed and the `Loading weights` spinner + "Running validator pipeline..." banner are skipped, so stderr only carries bittensor logs plus one final `wrote pstats binary: <path>` line. The payload-serialization step inside `_run` is also short-circuited so it doesn't pollute the captured profile.

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Before / After

Before: no way to profile the scoring pipeline without editing the source. Running `gitt miner score` always renders the result table (or JSON).

After: `gitt miner score --pat ... --profile run.prof` dumps a pstats binary and prints one line on stderr (`wrote pstats binary: run.prof`); no table, no JSON. Default invocation is unchanged.

## (bonus) Profiling results

On my PAT results are following:

```
run.prof analysis

Total runtime: 12.53s wall, 2.46M function calls. Captured Tue May 12 12:36:53 2026.

┌────────────────────────┬────────┬─────┬─────────────────────────────────────────────┐
│         Bucket         │  Time  │  %  │                    Notes                    │
├────────────────────────┼────────┼─────┼─────────────────────────────────────────────┤
│ GitHub HTTP (TLS read) │ 10.96s │ 87% │ _ssl._SSLSocket.read x676                   │
├────────────────────────┼────────┼─────┼─────────────────────────────────────────────┤
│ TLS handshake          │ 0.68s  │ 5%  │ 3 handshakes                                │
├────────────────────────┼────────┼─────┼─────────────────────────────────────────────┤
│ Tree-sitter scoring    │ 0.53s  │ 4%  │ collect_node_signatures x170 + 0.15s parser │
├────────────────────────┼────────┼─────┼─────────────────────────────────────────────┤
│ Everything else        │ ~0.4s  │ 3%  │ JSON decode, zlib, etc                      │
└────────────────────────┴────────┴─────┴─────────────────────────────────────────────┘

HTTP breakdown

- 26 requests.Session.get calls totaling 11.75s (avg 452ms/req)
- 25 calls via client.py:113 _get
- 23 of them are client.py:96 get_pr_files (9.37s cumulative, avg 407ms each)
- 1 call to get_miner_issues took 0.97s
- They run on threads (thread.py:54 run, 9.64s cumulative), so there's some parallelism, but the wall total still dominates

get_pr_files is the hot path - 23 PR-file fetches account for ~75% of runtime. Targets if you want to speed this up:
1. Cache PR file lists keyed by PR head SHA (cheap win on reruns)
2. Higher concurrency on the thread pool used for _get (currently looks bounded - sequential thread waits visible)
3. Conditional requests (If-None-Match / ETag) to make repeated runs return 304s
```

Previously I did an attempt on introducing cache, but it was scoped to the legacy path and was declined. Seems like we still can benefit from cache, this time at mirror path. As we now control the backend code, I think some tweaks can be implemented there to speed-up things significantly. We can also do it at client path too, but I guess it's better to try tweak mirror / CF side first.