### PR TITLE
feat(cli): add miner score profiling flag

### DIFF
--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -23,7 +23,7 @@ from rich.console import Console
 from rich.table import Table
 
 from gittensor.cli.json_output import emit_json
-from gittensor.cli.miner_commands.helpers import _error
+from gittensor.cli.miner_commands.helpers import _error, err_console
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -195,6 +195,24 @@ def _apply_log_level(level: str) -> None:
     getattr(bt.logging, f'set_{level}')()
 
 
+@contextmanager
+def _profile_to(path: Optional[str]) -> Iterator[None]:
+    """Profile the wrapped block and dump cProfile pstats when path is set."""
+    if path is None:
+        yield
+        return
+
+    import cProfile
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    try:
+        yield
+    finally:
+        profiler.disable()
+        profiler.dump_stats(path)
+
+
 def _drain_logs() -> None:
     """Stop log production and wait for the async stderr writer to drain.
 
@@ -228,7 +246,14 @@ def _drain_logs() -> None:
     help="Bittensor log verbosity. 'info' surfaces the validator pipeline's per-step progress on stderr.",
 )
 @click.option('--json', 'json_mode', is_flag=True, default=False, help='Emit result as JSON on stdout.')
-def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
+@click.option(
+    '--profile',
+    'profile_path',
+    default=None,
+    metavar='PATH',
+    help='Run the scoring pipeline under cProfile and write a pstats binary to PATH.',
+)
+def score_command(pat: Optional[str], log_level: str, json_mode: bool, profile_path: Optional[str]) -> None:
     """Locally run the validator scoring pipeline end-to-end for the miner identified by --pat.
 
     No subtensor, wallet, DB, axon, or wandb is touched.
@@ -236,6 +261,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
     Example:
         gitt miner score --pat ghp_xxxxx
         gitt miner score --pat ghp_xxxxx --log-level debug
+        gitt miner score --pat ghp_xxxxx --profile run.prof
     """
     import asyncio
 
@@ -260,7 +286,9 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
     stub = cast('Validator', _StubValidator(_DEV_UID, _DEV_HOTKEY))
     miner_uids = {_DEV_UID}
 
-    if json_mode:
+    quiet_mode = json_mode or profile_path is not None
+
+    if quiet_mode:
         master_repositories = load_master_repo_weights()
         programming_languages = load_programming_language_weights()
         token_config = load_token_config()
@@ -272,7 +300,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
 
     pat_snapshot = [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': resolved_pat}]
 
-    async def _run() -> Dict[str, Any]:
+    async def _run_pipeline() -> Tuple[Any, Any, Any, Dict[int, Any]]:
         with _override_pats_file(pat_snapshot):
             oss_rewards, miner_evaluations, _, _ = await oss_contributions(
                 stub, miner_uids, master_repositories, programming_languages, token_config
@@ -281,7 +309,9 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
                 miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
             )
         rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+        return oss_rewards, issue_rewards, rewards, miner_evaluations
 
+    def _build_payload(oss_rewards, issue_rewards, rewards, miner_evaluations) -> Dict[str, Any]:
         return {
             'success': True,
             'miner_evaluation': _serialize_evaluation(miner_evaluations[_DEV_UID]),
@@ -292,11 +322,19 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
             },
         }
 
-    if not json_mode:
+    if not quiet_mode:
         console.print('[bold cyan]Running validator pipeline...[/bold cyan]')
-    payload = asyncio.run(_run())
+
+    with _profile_to(profile_path):
+        pipeline_result = asyncio.run(_run_pipeline())
 
     _drain_logs()
+
+    if profile_path is not None:
+        err_console.print(f'[bold cyan]wrote pstats binary:[/bold cyan] {profile_path}')
+        return
+
+    payload = _build_payload(*pipeline_result)
 
     if json_mode:
         emit_json(payload)

--- a/tests/cli/test_miner_score.py
+++ b/tests/cli/test_miner_score.py
@@ -132,6 +132,7 @@ class TestScoreCommand:
         result = runner.invoke(cli, ['miner', 'score', '--help'])
         assert result.exit_code == 0
         assert 'validator scoring pipeline' in result.output
+        assert '--profile PATH' in result.output
 
     def test_missing_pat_exits(self, runner, monkeypatch):
         monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
@@ -289,6 +290,45 @@ class TestScoreCommand:
         assert result.exit_code == 0, result.output
         assert 'octo/repo#42' in result.output
         assert 'Per-PR breakdown' in result.output
+
+    def test_profile_path_writes_pstats_file_and_suppresses_result_output(self, runner, miner_eval_factory, tmp_path):
+        """`--profile PATH` writes a valid cProfile pstats file without table/JSON rendering."""
+        import pstats
+
+        evaluation = miner_eval_factory(uid=_DEV_UID, is_eligible=True)
+        prof_file = tmp_path / 'run.prof'
+
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score', '--profile', str(prof_file)],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert prof_file.exists()
+        assert prof_file.stat().st_size > 0
+        pstats.Stats(str(prof_file))
+        assert f'Miner UID {_DEV_UID}' not in result.output
+        assert 'Total earned score' not in result.output
+        assert 'success' not in result.output
+        assert 'wrote pstats binary' in result.stderr
+        assert str(prof_file) in result.stderr
+
+    def test_profile_omitted_skips_profiler_message(self, runner, miner_eval_factory):
+        """Default invocation must not print profile-specific output."""
+        evaluation = miner_eval_factory(uid=_DEV_UID, is_eligible=True)
+
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation)):
+            result = runner.invoke(
+                cli,
+                ['miner', 'score'],
+                env={'GITTENSOR_MINER_PAT': 'ghp_dummy'},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert 'wrote pstats binary' not in result.output
+        assert 'wrote pstats binary' not in result.stderr
 
     def test_pat_storage_load_all_pats_is_patched(self, runner, miner_eval_factory):
         """The injected PAT snapshot must override pat_storage.load_all_pats()."""


### PR DESCRIPTION
## Summary

- Add `--profile PATH` to `gitt miner score` so contributors can capture the validator scoring pipeline with built-in `cProfile`.
- Write a loadable pstats binary while suppressing normal table/JSON result rendering in profiling mode.
- Keep default table output and `--json-output` behavior unchanged when `--profile` is omitted.

## Related Issues

Closes #1179

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Validation run:

- `UV_PROJECT_ENVIRONMENT=.venv312 uv run --python 3.12 --extra dev python -m pytest tests/cli`
- `UV_PROJECT_ENVIRONMENT=.venv312 uv run --python 3.12 --extra dev python -m ruff check gittensor/cli/miner_commands/score.py tests/cli/test_miner_score.py`
- `git diff --check`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
