### PR TITLE
fix: persist cached UID issue-discovery fields to DB (#1052)

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -75,7 +75,7 @@ async def forward(self: 'Validator') -> None:
         await issue_competitions(self, miner_evaluations)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
-        await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
+        await self.bulk_store_evaluation(miner_evaluations)
 
         # 5. Blend 4 emission pools into final rewards
         rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest==9.0.0",
+    "pytest-asyncio>=0.24",
     "pyright",
     "ruff==0.14.10",
     "pre-commit>=4.0",
@@ -55,3 +56,4 @@ quote-style = "single"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/tests/validator/test_cached_uid_issue_discovery_storage.py
+++ b/tests/validator/test_cached_uid_issue_discovery_storage.py
@@ -1,6 +1,6 @@
 """Tests for cached UID issue-discovery DB storage fix (#1052)."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -10,11 +10,12 @@ async def test_cached_uid_stored_with_fresh_issue_discovery():
     """Cached UIDs should be stored with fresh issue-discovery fields."""
     from gittensor.validator.forward import forward
 
-    mock_self = AsyncMock()
+    mock_self = MagicMock()
+    mock_self.step = 0
     mock_self.bulk_store_evaluation = AsyncMock()
 
-    miner_evaluations = [
-        type(
+    miner_evaluations = {
+        1: type(
             'MockEval',
             (),
             {
@@ -25,7 +26,7 @@ async def test_cached_uid_stored_with_fresh_issue_discovery():
                 'is_issue_eligible': True,
             },
         )()
-    ]
+    }
 
     with (
         patch('gittensor.validator.forward.oss_contributions', return_value=([], miner_evaluations, {1}, set())),
@@ -34,8 +35,6 @@ async def test_cached_uid_stored_with_fresh_issue_discovery():
         patch('gittensor.validator.forward.blend_emission_pools', return_value=[]),
         patch('gittensor.validator.forward.VALIDATOR_WAIT', 0),
     ):
-        mock_self.oss_contributions = AsyncMock(return_value=([], miner_evaluations, {1}, set()))
-
         await forward(mock_self)
 
         # Verify bulk_store_evaluation was called WITHOUT skip_uids

--- a/tests/validator/test_cached_uid_issue_discovery_storage.py
+++ b/tests/validator/test_cached_uid_issue_discovery_storage.py
@@ -1,0 +1,45 @@
+"""Tests for cached UID issue-discovery DB storage fix (#1052)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cached_uid_stored_with_fresh_issue_discovery():
+    """Cached UIDs should be stored with fresh issue-discovery fields."""
+    from gittensor.validator.forward import forward
+
+    mock_self = AsyncMock()
+    mock_self.bulk_store_evaluation = AsyncMock()
+
+    miner_evaluations = [
+        type(
+            'MockEval',
+            (),
+            {
+                'uid': 1,
+                'hotkey': 'test_hotkey',
+                'github_id': '123',
+                'issue_discovery_score': 0.5,
+                'is_issue_eligible': True,
+            },
+        )()
+    ]
+
+    with (
+        patch('gittensor.validator.forward.oss_contributions', return_value=([], miner_evaluations, {1}, set())),
+        patch('gittensor.validator.forward.issue_discovery', return_value=[]),
+        patch('gittensor.validator.forward.issue_competitions'),
+        patch('gittensor.validator.forward.blend_emission_pools', return_value=[]),
+        patch('gittensor.validator.forward.VALIDATOR_WAIT', 0),
+    ):
+        mock_self.oss_contributions = AsyncMock(return_value=([], miner_evaluations, {1}, set()))
+
+        await forward(mock_self)
+
+        # Verify bulk_store_evaluation was called WITHOUT skip_uids
+        call_args = mock_self.bulk_store_evaluation.call_args
+        assert call_args is not None
+        assert len(call_args[0]) == 1
+        assert 'skip_uids' not in call_args[1]


### PR DESCRIPTION
## Summary

- Remove `skip_uids=cached_uids` from `bulk_store_evaluation` call so cached UIDs are persisted to DB
- Add minimal test to verify fix
- Add `pytest-asyncio` to dev dependencies for async test support
- Total diff: 3 files, +48/-1 lines (within 100-line PR limit)