### PR TITLE
fix(validator): sanitize nan scores before weights

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -221,9 +221,9 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.warning(
                 'Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions.'
             )
+            self.scores = np.nan_to_num(self.scores, nan=0.0)
 
         # Calculate the average reward for each uid across non-zero values.
-        # Replace any NaN values with 0.
         # Compute the norm of the scores
         norm = np.linalg.norm(self.scores, ord=1, axis=0, keepdims=True)
 

--- a/tests/validator/test_set_weights_nan.py
+++ b/tests/validator/test_set_weights_nan.py
@@ -1,0 +1,44 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Regression tests for validator weight emission safety."""
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from neurons.base.validator import BaseValidatorNeuron
+
+
+class _DummyValidator:
+    def __init__(self):
+        self.scores = np.array([0.2, np.nan, 0.3], dtype=np.float32)
+        self.metagraph = SimpleNamespace(uids=np.array([0, 1, 2]))
+        self.config = SimpleNamespace(netuid=74)
+        self.subtensor = MagicMock()
+        self.subtensor.set_weights.return_value = (True, '')
+        self.wallet = MagicMock()
+        self.spec_version = 1
+
+
+def test_set_weights_sanitizes_nan_scores_before_processing():
+    validator = _DummyValidator()
+    captured = {}
+
+    def _capture_processed_weights(uids, weights, **_kwargs):
+        captured['weights'] = weights.copy()
+        return uids, weights
+
+    with (
+        patch('neurons.base.validator.process_weights_for_netuid', side_effect=_capture_processed_weights),
+        patch('neurons.base.validator.convert_weights_and_uids_for_emit', return_value=([0, 2], [65535, 65535])),
+    ):
+        BaseValidatorNeuron.set_weights(cast(BaseValidatorNeuron, validator))
+
+    assert np.array_equal(validator.scores, np.array([0.2, 0.0, 0.3], dtype=np.float32))
+    assert not np.isnan(captured['weights']).any()
+    assert captured['weights'][1] == 0.0
+    assert captured['weights'].sum() == np.float32(1.0)
+    validator.subtensor.set_weights.assert_called_once()


### PR DESCRIPTION
## Summary

- Replace NaN validator EMA scores with zero inside `set_weights()` before raw weights are normalized.
- Prevent NaN values from reaching `process_weights_for_netuid()` and the on-chain weight emission path.
- Add a focused regression test that captures downstream raw weights and verifies the corrupted UID is zeroed.

## Related Issues

Fixes #1188

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

Validation run:

- `uv run pytest tests/validator/test_set_weights_nan.py`
- `uv run pytest tests/validator/test_set_weights_nan.py tests/validator/test_duplicate_penalty_propagation.py`
- `uv run ruff check neurons/base/validator.py tests/validator/test_set_weights_nan.py`
- `git diff --check`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
