### PR TITLE
feat(cli): add --profile flag to gitt miner score (#1179)

### DIFF
--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -232,7 +232,14 @@ def _drain_logs() -> None:
     help="Bittensor log verbosity. 'info' surfaces the validator pipeline's per-step progress on stderr.",
 )
 @click.option('--json-output', 'json_mode', is_flag=True, default=False, help='Emit result as JSON on stdout.')
-def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
+@click.option(
+    '--profile',
+    'profile_path',
+    default=None,
+    metavar='PATH',
+    help='Run under cProfile and write pstats binary to PATH.',
+)
+def score_command(pat: Optional[str], log_level: str, json_mode: bool, profile_path: Optional[str]) -> None:
     """Locally run the validator scoring pipeline end-to-end for the miner identified by --pat.
 
     No subtensor, wallet, DB, axon, or wandb is touched.
@@ -299,11 +306,26 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
             },
         }
 
-    if not json_mode:
+    if not json_mode and profile_path is None:
         console.print('[bold cyan]Running validator pipeline...[/bold cyan]')
-    payload = asyncio.run(_run())
+
+    if profile_path is not None:
+        import cProfile
+
+        profiler = cProfile.Profile()
+        profiler.enable()
+    try:
+        payload = asyncio.run(_run())
+    finally:
+        if profile_path is not None:
+            profiler.disable()
+            profiler.dump_stats(profile_path)
 
     _drain_logs()
+
+    if profile_path is not None:
+        console.print(f'[bold cyan]wrote pstats binary:[/bold cyan] {profile_path}')
+        return
 
     if json_mode:
         emit_json(payload)

--- a/tests/cli/test_miner_score_profile.py
+++ b/tests/cli/test_miner_score_profile.py
@@ -1,0 +1,75 @@
+"""Tests for --profile flag on `gitt miner score`."""
+
+from unittest.mock import patch
+
+import pytest
+
+from gittensor.cli.miner_commands.score import _DEV_UID
+
+
+@pytest.fixture
+def runner():
+    from click.testing import CliRunner
+
+    return CliRunner()
+
+
+def _patch_pipeline():
+    import numpy as np
+
+    from gittensor.classes import MinerEvaluation
+
+    evaluation = MinerEvaluation(uid=_DEV_UID, hotkey='dev')
+    miner_evaluations = {_DEV_UID: evaluation}
+    oss_rewards = np.array([0.5])
+    issue_rewards = np.array([0.1])
+    final_rewards = np.array([0.3])
+    return [
+        patch(
+            'gittensor.validator.forward.oss_contributions', return_value=(oss_rewards, miner_evaluations, set(), set())
+        ),
+        patch('gittensor.validator.forward.issue_discovery', return_value=issue_rewards),
+        patch('gittensor.validator.forward.blend_emission_pools', return_value=final_rewards),
+        patch('gittensor.validator.utils.load_weights.load_master_repo_weights', return_value={}),
+        patch('gittensor.validator.utils.load_weights.load_programming_language_weights', return_value={}),
+        patch('gittensor.validator.utils.load_weights.load_token_config'),
+    ]
+
+
+class TestProfileFlag:
+    def test_profile_writes_valid_pstats(self, runner, tmp_path):
+        """--profile PATH writes a valid pstats binary."""
+        import pstats
+
+        prof_file = tmp_path / 'run.prof'
+        with _multi_patch(_patch_pipeline()):
+            from gittensor.cli.main import cli
+
+            result = runner.invoke(
+                cli, ['miner', 'score', '--profile', str(prof_file)], env={'GITTENSOR_MINER_PAT': 'ghp_d'}
+            )
+
+        assert result.exit_code == 0, result.output
+        assert prof_file.exists()
+        pstats.Stats(str(prof_file))
+        assert prof_file.stat().st_size > 0
+
+    def test_default_no_profile_side_effects(self, runner):
+        """Default invocation has no profile output."""
+        with _multi_patch(_patch_pipeline()):
+            from gittensor.cli.main import cli
+
+            result = runner.invoke(cli, ['miner', 'score'], env={'GITTENSOR_MINER_PAT': 'ghp_d'})
+
+        assert result.exit_code == 0, result.output
+        assert 'pstats' not in result.output
+        assert 'pstats' not in (result.stderr or '')
+
+
+def _multi_patch(patches):
+    import contextlib
+
+    stack = contextlib.ExitStack()
+    for p in patches:
+        stack.enter_context(p)
+    return stack


### PR DESCRIPTION
## Summary

Add `--profile PATH` flag to `gitt miner score` that runs the scoring pipeline under cProfile and writes a pstats binary.

## Validation

- `--profile PATH` writes valid pstats file
- Default invocation unchanged, no profile side-effects
- ruff check + format pass

Closes #1179