### PR TITLE
fix(mirror): skip fixed-base scoring when PR file evidence is unavailable

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -140,9 +140,10 @@ async def score_mirror_pr(
             files = (await asyncio.to_thread(client.get_pr_files, pr.repo_full_name, pr.pr_number)).files
         except MirrorRequestError as e:
             bt.logging.warning(f'Mirror file fetch failed for PR #{pr.pr_number}: {e}')
-            if not has_fixed_base:
-                return
-            files = []
+            # scoring_data_stored=True means file evidence should exist for this PR.
+            # If retrieval fails this round, do not award a fresh score (including
+            # fixed-base repos) from incomplete evidence.
+            return
         scored.files = files
 
         if files:
@@ -157,7 +158,7 @@ async def score_mirror_pr(
             scored.total_nodes_scored = result.total_nodes_scored
             scored.code_density = result.code_density
             scored.base_score = result.base_score
-        elif not has_fixed_base:
+        else:
             bt.logging.warning(f'No files returned for PR #{pr.pr_number}')
             return
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -383,6 +383,44 @@ class TestScoringDataStoredGate:
 
 
 class TestFixedBaseScore:
+    def test_fixed_base_does_not_score_when_file_fetch_fails(self):
+        scored = ScoredMirrorPR(pr=_pr())
+        client = Mock()
+        client.get_pr_files.side_effect = scoring_module.MirrorRequestError('mirror unavailable')
+
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=Mock(),
+                mirror_repos={scored.pr.repo_full_name: _config(fixed_base_score=7.5)},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert scored.base_score == 0.0
+        assert scored.token_score == 0.0
+
+    def test_fixed_base_does_not_score_when_empty_files_returned(self):
+        scored = ScoredMirrorPR(pr=_pr())
+        client = Mock()
+        client.get_pr_files.return_value.files = []
+
+        asyncio.run(
+            score_mirror_pr(
+                scored,
+                mirror_eval=Mock(),
+                mirror_repos={scored.pr.repo_full_name: _config(fixed_base_score=7.5)},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert scored.base_score == 0.0
+        assert scored.token_score == 0.0
+
     def test_fixed_base_replaces_token_base_but_keeps_token_breakdown_and_multipliers(self, monkeypatch):
         scored = ScoredMirrorPR(
             pr=_pr(labels=[{'name': 'feature', 'actor_github_id': '1', 'actor_association': 'OWNER'}])


### PR DESCRIPTION
## Summary

Prevent awarding fresh mirror OSS score from `fixed_base_score` when PR file evidence is unavailable in the current round.

Before this change, `score_mirror_pr` could still apply `fixed_base_score` after:

- mirror file fetch raised `MirrorRequestError`, or
- mirror returned an empty file list for `scoring_data_stored=True`.

That allowed nonzero earned score with zero token evidence for the round.

This PR changes that behavior to skip scoring that PR for the round when file evidence is unavailable, even in fixed-base repositories.

## Related Issues

Closes #1203

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

Added regression tests in mirror scoring suite:

- fixed-base repo + `MirrorRequestError` on `get_pr_files` => no fresh score
- fixed-base repo + empty files for `scoring_data_stored=True` => no fresh score

Validation notes:

- `python3 -m py_compile` passed for modified files.
- Full pytest execution is blocked in this environment due missing runtime dependency `bittensor`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)