### PR TITLE
fix: remove unnecessary renormalization in update_scores after blacklisting (#1177)

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -355,12 +355,6 @@ class BaseValidatorNeuron(BaseNeuron):
             self.scores[blacklisted_uids_array] = 0.0
             bt.logging.info(f'Set scores to 0 for blacklisted UIDs: {blacklisted_uids}')
 
-            # Renormalize scores to sum to 1 after blacklisting
-            total_score = np.sum(self.scores)
-            if total_score > 0:
-                self.scores = self.scores / total_score
-                bt.logging.debug(f'Renormalized scores to sum=1 after blacklisting. New sum: {np.sum(self.scores)}')
-
     def save_state(self):
         """Saves the state of the validator to a file."""
         bt.logging.info('Saving validator state.')

--- a/tests/validator/test_duplicate_penalty_propagation.py
+++ b/tests/validator/test_duplicate_penalty_propagation.py
@@ -53,4 +53,4 @@ def test_detected_duplicates_wipe_prior_ema_via_update_scores():
     assert validator.scores[1] == 0.0
     assert validator.scores[2] == 0.0
     assert validator.scores[0] > 0.0
-    assert np.isclose(validator.scores.sum(), 1.0)
+    assert validator.scores.sum() < 0.99

--- a/tests/validator/test_ema_renormalization.py
+++ b/tests/validator/test_ema_renormalization.py
@@ -1,0 +1,26 @@
+"""Tests for EMA score corruption fix (#1177)."""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+
+def _make_validator():
+    """Create a minimal validator-like object with scores for testing update_scores."""
+    from neurons.validator import Validator
+
+    v = object.__new__(Validator)
+    v.scores = np.array([0.2, 0.5, 0.3], dtype=np.float32)
+    setattr(v, 'config', SimpleNamespace(neuron=SimpleNamespace(moving_average_alpha=0.1)))
+    return v
+
+
+class TestUpdateScoresRenormalization:
+    def test_blacklist_zeros_uids_without_renormalization(self):
+        """Blacklisting zeros out UIDs but does NOT renormalize remaining scores to sum=1."""
+        v = _make_validator()
+        v.update_scores(np.array([0.1, 0.2, 0.3]), {0, 1, 2}, blacklisted_uids=[1])
+
+        assert v.scores[1] == 0.0
+        assert v.scores.sum() < 0.999
+        assert v.scores[0] > 0


### PR DESCRIPTION
## Summary

Remove the L1-renormalization step in `update_scores` that runs after zeroing blacklisted UIDs. `set_weights` already performs L1-normalization before emitting weights, so the renormalization inside `update_scores` is redundant and corrupts the EMA state.

## Validation

- `ruff check` + `ruff format` pass
- Test: blacklisted UID is zeroed but remaining scores are NOT renormalized to sum=1

Closes #1177