### PR TITLE
docs: correct stale emission split percentages in validator forward

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -50,9 +50,9 @@ async def forward(self: 'Validator') -> None:
 
     Emission blending (hardcoded per-competition):
     - OSS contributions: 30%
-    - Issue discovery:   30%
+    - Issue discovery:   10%
     - Issue treasury:    15% (flat to UID 111)
-    - Recycle:           25% (flat to UID 0)
+    - Recycle:           45% (flat to UID 0)
     """
 
     if self.step % VALIDATOR_STEPS_INTERVAL == 0:
@@ -168,9 +168,9 @@ def blend_emission_pools(
     """Blend 4 emission pools into a single rewards array.
 
     - OSS contributions: 30%
-    - Issue discovery:   30%
+    - Issue discovery:   10%
     - Issue treasury:    15% (flat to UID 111)
-    - Recycle:           25% (flat to UID 0)
+    - Recycle:           45% (flat to UID 0)
     """
     sorted_uids = sorted(miner_uids)
     rewards = np.zeros(len(sorted_uids))
@@ -183,7 +183,7 @@ def blend_emission_pools(
     else:
         recycle_extra += OSS_EMISSION_SHARE
 
-    # Pool 2: Issue discovery (30%)
+    # Pool 2: Issue discovery (10%)
     issue_total = float(issue_rewards.sum())
     if issue_total > 0:
         rewards += issue_rewards * ISSUE_DISCOVERY_EMISSION_SHARE
@@ -199,7 +199,7 @@ def blend_emission_pools(
             f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
         )
 
-    # Pool 4: Recycle (25% + unclaimed from empty pools)
+    # Pool 4: Recycle (45% + unclaimed from empty pools)
     if RECYCLE_UID in miner_uids:
         recycle_idx = sorted_uids.index(RECYCLE_UID)
         rewards[recycle_idx] += RECYCLE_EMISSION_SHARE + recycle_extra


### PR DESCRIPTION
## Summary

The `forward()` and `blend_emission_pools()` docstrings in [gittensor/validator/forward.py](gittensor/validator/forward.py), plus the inline pool comments, still described the pre-#1119 emission split (Issue discovery 30%, Recycle 25%). The constants in [gittensor/constants.py:158-160](gittensor/constants.py#L158-L160) have been `ISSUE_DISCOVERY_EMISSION_SHARE = 0.10` and `RECYCLE_EMISSION_SHARE = 0.45` for a while, so the docs were misleading operators reading the validator source.

This PR updates the docstrings and the two inline pool comments so they match the constants. The runtime behavior is unchanged because `blend_emission_pools()` already reads directly from the constants.

Updated values:

- OSS contributions: 30%
- Issue discovery: 10%
- Issue treasury: 15%
- Recycle: 45%

## Related Issues

Fixes #1209

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

Docs only change. Verified that all four percentages in the updated docstrings and inline comments match the current constants in [gittensor/constants.py:158-160](gittensor/constants.py#L158-L160) and [gittensor/constants.py:190](gittensor/constants.py#L190), and that they sum to 100%.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
