### PR TITLE
Feat/emission share allocation

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -236,7 +236,6 @@ class PullRequest:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,
@@ -407,6 +406,8 @@ class MinerEvaluation:
 
     # Issue discovery scoring
     issue_discovery_score: float = 0.0
+    # Per-repo sums of discovery_earned_score (repo lower-case -> total) for emission allocation
+    issue_discovery_repo_scores: Dict[str, float] = field(default_factory=dict)
     issue_token_score: float = 0.0  # sum of solving PR token_scores for scored issues
     issue_credibility: float = 0.0
     is_issue_eligible: bool = False

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -142,8 +142,6 @@ def _render_table(payload: Dict[str, Any]) -> None:
         '  solved / valid / open',
         f'{miner["total_solved_issues"]} / {miner["total_valid_solved_issues"]} / {miner["total_open_issues"]}',
     )
-    table.add_row('OSS reward (normalized)', f'{rewards["oss_normalized"]:.6f}')
-    table.add_row('Issue disc. reward (normalized)', f'{rewards["issue_discovery_normalized"]:.6f}')
     table.add_row(
         '[bold green]Final blended reward[/bold green]', f'[bold green]{rewards["blended_final"]:.6f}[/bold green]'
     )
@@ -247,7 +245,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
 
     # Deferred imports: keeps --help fast (these pull bittensor + the validator graph).
     from gittensor.validator.forward import (
-        blend_emission_pools,
+        allocate_round_emissions,
         issue_discovery,
         oss_contributions,
     )
@@ -281,20 +279,18 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
 
     async def _run() -> Dict[str, Any]:
         with _override_pats_file(pat_snapshot):
-            oss_rewards, miner_evaluations, _, _ = await oss_contributions(
+            miner_evaluations, _, _ = await oss_contributions(
                 stub, miner_uids, master_repositories, programming_languages, token_config
             )
-            issue_rewards = await issue_discovery(
+            await issue_discovery(
                 miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
             )
-        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+        rewards = allocate_round_emissions(miner_evaluations, master_repositories, miner_uids)
 
         return {
             'success': True,
             'miner_evaluation': _serialize_evaluation(miner_evaluations[_DEV_UID]),
             'rewards': {
-                'oss_normalized': _round(float(oss_rewards[0])),
-                'issue_discovery_normalized': _round(float(issue_rewards[0])),
                 'blended_final': _round(float(rewards[0])),
             },
         }

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -74,7 +74,6 @@ EXTENSIONLESS_FILE_EXTENSIONS = {'dockerfile', 'makefile'}
 # =============================================================================
 # Repository & PR Scoring
 # =============================================================================
-DEFAULT_REPO_WEIGHT = 0.01  # fallback weight for repos not in master_repositories.json
 PR_LOOKBACK_DAYS = 35  # rolling window for scoring
 MERGED_PR_BASE_SCORE = 25
 MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5  # PRs below this get 0 base score
@@ -154,11 +153,12 @@ OPEN_PR_COLLATERAL_PERCENT = 0.20
 # =============================================================================
 RECYCLE_UID = 0
 
-# Hardcoded emission splits per competition (replaces dynamic emissions)
-OSS_EMISSION_SHARE = 0.30  # 30% to OSS contributions (PR scoring)
-ISSUE_DISCOVERY_EMISSION_SHARE = 0.10  # 10% to issue discovery
-RECYCLE_EMISSION_SHARE = 0.45  # 45% to recycle UID 0
-# ISSUES_TREASURY_EMISSION_SHARE = 0.15 defined below (15% to smart contract treasury)
+# Hardcoded emission splits: unified scoring pool + flat treasury. Recycle is no
+# longer a fixed baseline — RECYCLE_UID receives registry slack
+# ``(1 - Σ emission_share) * OSS_EMISSION_SHARE`` plus any per-repo slice with no
+# eligible nonzero-scored PR or issue activity in the round (see emission_allocation).
+OSS_EMISSION_SHARE = 0.90  # combined PR + issue-discovery scoring pool (per-repo emission_share)
+# ISSUES_TREASURY_EMISSION_SHARE defined with ISSUES_TREASURY_UID below (flat to UID 111)
 
 # =============================================================================
 # Spam & Gaming Mitigation
@@ -187,5 +187,5 @@ MAX_OPEN_PR_THRESHOLD = 30  # Maximum open PR threshold (base + bonus capped at 
 # =============================================================================
 CONTRACT_ADDRESS = '5FWNdk8YNtNcHKrAx2krqenFrFAZG7vmsd2XN2isJSew3MrD'
 ISSUES_TREASURY_UID = 111  # UID of the smart contract neuron, if set to RECYCLE_UID then it's disabled
-ISSUES_TREASURY_EMISSION_SHARE = 0.15  # % of emissions allocated to funding issues treasury
+ISSUES_TREASURY_EMISSION_SHARE = 0.10  # % of emissions allocated to funding issues treasury
 MAX_ISSUE_ID = 1_000_000  # sanity-check upper bound for any real deployment

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -1,0 +1,149 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Per-round emission allocation for the unified OSS + issue-discovery scoring pool.
+
+Replaces the legacy global normalize-then-blend pipeline with allocate-then-distribute:
+each registered repo receives ``OSS_EMISSION_SHARE * emission_share`` of the full
+round (fractions sum to at most 1.0 across the registry). Within each repo, the
+slice splits between PR and issue discovery by ``issue_discovery_share``, with
+spill to the active side when the other side has no eligible weight. Unclaimed
+repo slices and registry slack ``(1 - Σ emission_share) * OSS_EMISSION_SHARE``
+go to ``RECYCLE_UID`` in the same round.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Set, Tuple
+
+import bittensor as bt
+import numpy as np
+
+from gittensor.classes import MinerEvaluation
+from gittensor.constants import (
+    ISSUES_TREASURY_EMISSION_SHARE,
+    ISSUES_TREASURY_UID,
+    OSS_EMISSION_SHARE,
+    RECYCLE_UID,
+)
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+def _merged_scored_prs(evaluation: MinerEvaluation) -> Tuple:
+    return tuple(evaluation.merged_pull_requests) + tuple(evaluation.mirror_merged_prs)
+
+
+def _repo_pr_weights(
+    miner_evaluations: Dict[int, MinerEvaluation],
+) -> Dict[str, Tuple[float, Dict[int, float]]]:
+    """repo_lower -> (total_weight, uid -> weight) from merged PR earned_score."""
+    per_repo_uid: Dict[str, Dict[int, float]] = defaultdict(lambda: defaultdict(float))
+    for uid, ev in miner_evaluations.items():
+        for pr in _merged_scored_prs(ev):
+            repo = pr.repository_full_name.lower()
+            per_repo_uid[repo][uid] += max(0.0, float(pr.earned_score))
+
+    out: Dict[str, Tuple[float, Dict[int, float]]] = {}
+    for repo, uid_map in per_repo_uid.items():
+        total = sum(uid_map.values())
+        out[repo] = (total, dict(uid_map))
+    return out
+
+
+def _repo_issue_weights(
+    miner_evaluations: Dict[int, MinerEvaluation],
+) -> Dict[str, Tuple[float, Dict[int, float]]]:
+    """repo_lower -> (total_weight, uid -> weight) from issue discovery (eligible miners only)."""
+    per_repo_uid: Dict[str, Dict[int, float]] = defaultdict(lambda: defaultdict(float))
+    for uid, ev in miner_evaluations.items():
+        if not ev.is_issue_eligible:
+            continue
+        for repo, score in ev.issue_discovery_repo_scores.items():
+            if score > 0:
+                per_repo_uid[repo.lower()][uid] += float(score)
+
+    out: Dict[str, Tuple[float, Dict[int, float]]] = {}
+    for repo, uid_map in per_repo_uid.items():
+        total = sum(uid_map.values())
+        out[repo] = (total, dict(uid_map))
+    return out
+
+
+def allocate_round_emissions(
+    miner_evaluations: Dict[int, MinerEvaluation],
+    master_repositories: Dict[str, RepositoryConfig],
+    miner_uids: Set[int],
+) -> np.ndarray:
+    """Build the final per-UID reward vector (sums to 1.0 when treasury/recycle UIDs exist).
+
+    - ``ISSUES_TREASURY_EMISSION_SHARE`` flat to ``ISSUES_TREASURY_UID`` when present in ``miner_uids``.
+    - ``OSS_EMISSION_SHARE`` is split across repos by ``emission_share``, then within each repo by
+      PR vs issue discovery with spill; registry slack and inactive repos go to ``RECYCLE_UID``.
+    """
+    sorted_uids = sorted(miner_uids)
+    uid_index = {u: i for i, u in enumerate(sorted_uids)}
+    rewards = np.zeros(len(sorted_uids), dtype=np.float64)
+
+    if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
+        rewards[uid_index[ISSUES_TREASURY_UID]] += ISSUES_TREASURY_EMISSION_SHARE
+        bt.logging.info(
+            f'Treasury allocation: UID {ISSUES_TREASURY_UID} receives '
+            f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
+        )
+
+    sum_emission = sum(cfg.emission_share for cfg in master_repositories.values())
+    recycle_total = OSS_EMISSION_SHARE * max(0.0, 1.0 - sum_emission)
+    if recycle_total > 0 and RECYCLE_UID in miner_uids:
+        bt.logging.info(
+            f'Registry slack: {(1.0 - sum_emission) * 100:.2f}% of scoring weight → recycle '
+            f'({recycle_total * 100:.2f}% of round)'
+        )
+
+    pr_by_repo = _repo_pr_weights(miner_evaluations)
+    issue_by_repo = _repo_issue_weights(miner_evaluations)
+
+    for repo_name, cfg in master_repositories.items():
+        repo_key = repo_name.lower()
+        slice_total = OSS_EMISSION_SHARE * float(cfg.emission_share)
+        if slice_total <= 0.0:
+            continue
+
+        alpha = float(cfg.issue_discovery_share)
+        pr_budget_nominal = slice_total * (1.0 - alpha)
+        issue_budget_nominal = slice_total * alpha
+
+        wp_total, wp_uid = pr_by_repo.get(repo_key, (0.0, {}))
+        wi_total, wi_uid = issue_by_repo.get(repo_key, (0.0, {}))
+
+        if wp_total <= 0.0 and wi_total > 0.0:
+            pr_budget, issue_budget = 0.0, slice_total
+        elif wi_total <= 0.0 and wp_total > 0.0:
+            pr_budget, issue_budget = slice_total, 0.0
+        elif wp_total > 0.0 and wi_total > 0.0:
+            pr_budget, issue_budget = pr_budget_nominal, issue_budget_nominal
+        else:
+            recycle_total += slice_total
+            continue
+
+        if pr_budget > 0.0 and wp_total > 0.0:
+            for uid, w in wp_uid.items():
+                if uid in uid_index and w > 0.0:
+                    rewards[uid_index[uid]] += pr_budget * (w / wp_total)
+        elif pr_budget > 0.0:
+            recycle_total += pr_budget
+
+        if issue_budget > 0.0 and wi_total > 0.0:
+            for uid, w in wi_uid.items():
+                if uid in uid_index and w > 0.0:
+                    rewards[uid_index[uid]] += issue_budget * (w / wi_total)
+        elif issue_budget > 0.0:
+            recycle_total += issue_budget
+
+    if recycle_total > 0.0 and RECYCLE_UID in miner_uids:
+        rewards[uid_index[RECYCLE_UID]] += recycle_total
+
+    total = float(rewards.sum())
+    if abs(total - 1.0) > 1e-5:
+        bt.logging.warning(f'Emission allocation sum is {total:.6f} (expected ~1.0)')
+
+    return rewards

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -5,23 +5,12 @@ import asyncio
 from typing import TYPE_CHECKING, Dict, Set, Tuple
 
 import bittensor as bt
-import numpy as np
 
 from gittensor.classes import MinerEvaluation
-from gittensor.constants import (
-    ISSUE_DISCOVERY_EMISSION_SHARE,
-    ISSUES_TREASURY_EMISSION_SHARE,
-    ISSUES_TREASURY_UID,
-    OSS_EMISSION_SHARE,
-    RECYCLE_EMISSION_SHARE,
-    RECYCLE_UID,
-)
 from gittensor.utils.uids import get_all_uids
+from gittensor.validator.emission_allocation import allocate_round_emissions
 from gittensor.validator.issue_competitions.forward import issue_competitions
 from gittensor.validator.issue_discovery.mirror_scan import run_mirror_issue_discovery
-from gittensor.validator.issue_discovery.normalize import (
-    normalize_issue_discovery_rewards,
-)
 from gittensor.validator.oss_contributions.reward import get_rewards
 from gittensor.validator.utils.config import (
     VALIDATOR_STEPS_INTERVAL,
@@ -46,13 +35,14 @@ async def forward(self: 'Validator') -> None:
     2. Score issue discovery (mirror-only; non-mirror repos skip)
     3. Run issue bounties verification
     4. Store all evaluations to DB
-    5. Blend emission pools and update scores
+    5. Allocate emissions (per-repo ``emission_share`` + within-repo PR/issue split) and update scores
 
-    Emission blending (hardcoded per-competition):
-    - OSS contributions: 30%
-    - Issue discovery:   30%
-    - Issue treasury:    15% (flat to UID 111)
-    - Recycle:           25% (flat to UID 0)
+    Monetary policy (see ``constants`` and ``emission_allocation``):
+    - ``OSS_EMISSION_SHARE`` (90%) is the unified scoring pool: each repo receives
+      its registry ``emission_share`` slice; recycle absorbs registry slack
+      ``(1 - Σ emission_share) × OSS_EMISSION_SHARE`` plus any repo slice with no
+      eligible nonzero-scored PR or issue activity in the round.
+    - ``ISSUES_TREASURY_EMISSION_SHARE`` (10%) is flat to the treasury UID.
     """
 
     if self.step % VALIDATOR_STEPS_INTERVAL == 0:
@@ -61,24 +51,17 @@ async def forward(self: 'Validator') -> None:
         programming_languages = load_programming_language_weights()
         token_config = load_token_config()
 
-        # 1. Score OSS contributions
-        oss_rewards, miner_evaluations, cached_uids, penalized_uids = await oss_contributions(
+        miner_evaluations, cached_uids, penalized_uids = await oss_contributions(
             self, miner_uids, master_repositories, programming_languages, token_config
         )
 
-        # 2. Score issue discovery
-        issue_rewards = await issue_discovery(
-            miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
-        )
+        await issue_discovery(miner_evaluations, master_repositories, programming_languages, token_config, miner_uids)
 
-        # 3. Issue bounties verification
         await issue_competitions(self, miner_evaluations)
 
-        # 4. Store all evaluations to DB (includes issue discovery fields)
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
 
-        # 5. Blend 4 emission pools into final rewards
-        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+        rewards = allocate_round_emissions(miner_evaluations, master_repositories, miner_uids)
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
 
@@ -91,10 +74,10 @@ async def oss_contributions(
     master_repositories: Dict[str, RepositoryConfig],
     programming_languages: Dict,
     token_config,
-) -> Tuple[np.ndarray, Dict[int, MinerEvaluation], Set[int], Set[int]]:
-    """Score OSS contributions and return normalized rewards + miner evaluations + cached UIDs + penalized UIDs.
+) -> Tuple[Dict[int, MinerEvaluation], Set[int], Set[int]]:
+    """Score OSS contributions and return miner evaluations + cached UIDs + penalized UIDs.
 
-    Pure scoring — no DB storage or emission blending. Those are handled by forward().
+    Pure scoring — no DB storage or emission allocation. Those are handled by forward().
     """
     tree_sitter_count = sum(1 for c in token_config.language_configs.values() if c.language is not None)
 
@@ -104,11 +87,11 @@ async def oss_contributions(
     bt.logging.info(f'Token config: {tree_sitter_count} tree-sitter languages')
     bt.logging.info(f'Neurons to evaluate: {len(miner_uids)}')
 
-    rewards, miner_evaluations, cached_uids, penalized_uids = await get_rewards(
+    miner_evaluations, cached_uids, penalized_uids = await get_rewards(
         self, miner_uids, master_repositories, programming_languages, token_config
     )
 
-    return rewards, miner_evaluations, cached_uids, penalized_uids
+    return miner_evaluations, cached_uids, penalized_uids
 
 
 async def issue_discovery(
@@ -117,17 +100,15 @@ async def issue_discovery(
     programming_languages: Dict,
     token_config,
     miner_uids: set[int],
-) -> np.ndarray:
-    """Score issue discovery and return normalized rewards array.
+) -> None:
+    """Score issue discovery (mirror-only). Mutates ``miner_evaluations`` in place.
 
-    Mirror-only path: uses ``MirrorClient.get_miner_issues`` with authoritative
-    ``solved_by_pr`` + inline ``solving_pr`` data, and a cross-miner cache of
-    already-scored solving PRs so the base_score reflects real token scoring.
-    The legacy timeline-scraping path has been removed — it produced unreliable
-    solver attribution on busy issues, and non-mirror repos are deliberately
-    left out of issue discovery entirely until their mirror_enabled flag flips.
+    Uses ``MirrorClient.get_miner_issues`` with authoritative ``solved_by_pr`` +
+    inline ``solving_pr`` data, and a cross-miner cache of already-scored solving
+    PRs so the base_score reflects real token scoring. Non-mirror repos are skipped.
 
-    Returns numpy array of normalized issue discovery rewards (sorted by UID).
+    Per-repo discovery weights for emission allocation are accumulated on each
+    ``MinerEvaluation.issue_discovery_repo_scores`` (issue home repo).
     """
     mirror_repos: Dict[str, RepositoryConfig] = {
         name: cfg for name, cfg in master_repositories.items() if cfg.mirror_enabled
@@ -137,58 +118,3 @@ async def issue_discovery(
         await run_mirror_issue_discovery(miner_evaluations, mirror_repos, programming_languages, token_config)
     else:
         bt.logging.info('No mirror-enabled repos — issue discovery skipped for this round')
-
-    # Normalize into independent pool
-    issue_rewards_dict = normalize_issue_discovery_rewards(miner_evaluations)
-
-    sorted_uids = sorted(miner_uids)
-    return np.array([issue_rewards_dict.get(uid, 0.0) for uid in sorted_uids])
-
-
-def blend_emission_pools(
-    oss_rewards: np.ndarray,
-    issue_rewards: np.ndarray,
-    miner_uids: set[int],
-) -> np.ndarray:
-    """Blend 4 emission pools into a single rewards array.
-
-    - OSS contributions: 30%
-    - Issue discovery:   30%
-    - Issue treasury:    15% (flat to UID 111)
-    - Recycle:           25% (flat to UID 0)
-    """
-    sorted_uids = sorted(miner_uids)
-    rewards = np.zeros(len(sorted_uids))
-    recycle_extra = 0.0
-
-    # Pool 1: OSS contributions (30%)
-    oss_total = float(oss_rewards.sum())
-    if oss_total > 0:
-        rewards += oss_rewards * OSS_EMISSION_SHARE
-    else:
-        recycle_extra += OSS_EMISSION_SHARE
-
-    # Pool 2: Issue discovery (30%)
-    issue_total = float(issue_rewards.sum())
-    if issue_total > 0:
-        rewards += issue_rewards * ISSUE_DISCOVERY_EMISSION_SHARE
-    else:
-        recycle_extra += ISSUE_DISCOVERY_EMISSION_SHARE
-
-    # Pool 3: Issue treasury (15% flat to UID 111)
-    if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
-        treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
-        rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
-        bt.logging.info(
-            f'Treasury allocation: UID {ISSUES_TREASURY_UID} receives '
-            f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
-        )
-
-    # Pool 4: Recycle (25% + unclaimed from empty pools)
-    if RECYCLE_UID in miner_uids:
-        recycle_idx = sorted_uids.index(RECYCLE_UID)
-        rewards[recycle_idx] += RECYCLE_EMISSION_SHARE + recycle_extra
-        if recycle_extra > 0:
-            bt.logging.info(f'Recycling {recycle_extra * 100:.0f}% unclaimed emissions from empty pools')
-
-    return rewards

--- a/gittensor/validator/issue_discovery/mirror_scan.py
+++ b/gittensor/validator/issue_discovery/mirror_scan.py
@@ -60,7 +60,6 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
 )
 
 
@@ -275,6 +274,7 @@ async def _score_miner_mirror_issues(
     ``canonical_pr_owners`` enforces the cross-miner one-issue-per-PR rule:
     only the marker-matching issue scores, siblings count for credibility.
     """
+    evaluation.issue_discovery_repo_scores.clear()
     solved_count = 0
     valid_solved_count = 0
     closed_count = 0
@@ -397,12 +397,15 @@ async def _score_miner_mirror_issues(
         issue.discovery_open_issue_spam_multiplier = spam_mult
         issue.discovery_earned_score = round(
             issue.discovery_base_score
-            * issue.discovery_repo_weight_multiplier
             * issue.discovery_time_decay_multiplier
             * issue.discovery_review_quality_multiplier
             * issue.discovery_credibility_multiplier
             * issue.discovery_open_issue_spam_multiplier,
             2,
+        )
+        rk = issue.repository_full_name.lower()
+        evaluation.issue_discovery_repo_scores[rk] = (
+            evaluation.issue_discovery_repo_scores.get(rk, 0.0) + issue.discovery_earned_score
         )
         total_discovery_score += issue.discovery_earned_score
 
@@ -560,7 +563,7 @@ def _mirror_issue_for_scoring(
     )
 
     adapted.discovery_base_score = base_score
-    adapted.discovery_repo_weight_multiplier = resolve_repo_weight(repo_config)
+    adapted.discovery_repo_weight_multiplier = 1.0
     adapted.discovery_time_decay_multiplier = round(calculate_time_decay(solving_pr.merged_at), 2)
     adapted.discovery_review_quality_multiplier = round(
         calculate_issue_review_quality_multiplier(solving_pr.review_summary.maintainer_changes_requested_count),

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -92,7 +92,6 @@ class ScoredMirrorPR:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -2,7 +2,7 @@
 
 Mirror analogue of ``gittensor.validator.oss_contributions.scoring``. Scope:
 - Compute base_score for each PR via the existing token-scoring infra
-- Compute per-PR multipliers: repo_weight, time_decay, review_quality, label, issue
+- Compute per-PR multipliers: time_decay, review_quality, label, issue
 - The eligibility gate (``_should_skip_merged_mirror_pr``) is exported and
   used at LOAD time by ``mirror.load._maybe_add_pr`` — rejected PRs never
   enter ``mirror_merged_prs`` (matches legacy ``should_skip_merged_pr`` flow)
@@ -54,7 +54,6 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -343,7 +342,10 @@ def calculate_base_score_for_pr_files(
 
 
 def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryConfig) -> None:
-    """Compute repo_weight, time_decay, review_quality, label, issue multipliers.
+    """Compute time_decay, review_quality, label, issue multipliers.
+
+    Per-repo emission caps are enforced at round aggregation (``emission_allocation``),
+    not as a per-PR multiplier. ``repo_weight_multiplier`` stays at 1.0 for schema parity.
 
     Spam and credibility multipliers are deferred to ``finalize_miner_scores``
     — they depend on counts combined across both legacy and mirror paths.
@@ -351,7 +353,7 @@ def _calculate_pr_multipliers(scored: ScoredMirrorPR, repo_config: RepositoryCon
     pr = scored.pr
     is_merged = pr.state == 'MERGED'
 
-    scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
+    scored.repo_weight_multiplier = 1.0
 
     chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
-import numpy as np
 
 from gittensor.classes import MinerEvaluation
 from gittensor.utils.github_api_tools import load_miners_prs, session_scope
@@ -20,7 +19,6 @@ from gittensor.validator.oss_contributions.mirror.combine import combine
 from gittensor.validator.oss_contributions.mirror.evaluation import MirrorMinerEvaluation
 from gittensor.validator.oss_contributions.mirror.load import load_mirror_miner_prs
 from gittensor.validator.oss_contributions.mirror.scoring import score_mirror_miner_prs
-from gittensor.validator.oss_contributions.normalize import normalize_rewards_linear
 from gittensor.validator.oss_contributions.scoring import (
     finalize_miner_scores,
     score_miner_prs,
@@ -118,12 +116,13 @@ async def get_rewards(
     master_repositories: Dict[str, RepositoryConfig],
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
-) -> Tuple[np.ndarray, Dict[int, MinerEvaluation], Set[int], Set[int]]:
+) -> Tuple[Dict[int, MinerEvaluation], Set[int], Set[int]]:
     """Score OSS contributions for all miners.
 
     Returns:
-        Tuple of (normalized_rewards_array, miner_evaluations, cached_uids, penalized_uids).
-        DB storage and emission blending are handled by the caller (forward.py).
+        Tuple of (miner_evaluations, cached_uids, penalized_uids).
+        Per-round emission allocation is handled by the caller after issue discovery
+        (``allocate_round_emissions`` in forward.py).
     """
 
     bt.logging.info(f'UIDs: {uids}')
@@ -178,12 +177,4 @@ async def get_rewards(
     # Finalize scores: apply eligibility gate, credibility, pioneer dividends, collateral
     finalize_miner_scores(miner_evaluations, master_repositories)
 
-    # Normalize the rewards between [0,1] — single flat pool
-    normalized_rewards = normalize_rewards_linear(miner_evaluations)
-
-    return (
-        np.array([normalized_rewards.get(uid, 0.0) for uid in sorted(uids)]),
-        miner_evaluations,
-        cached_uids,
-        penalized_uids,
-    )
+    return (miner_evaluations, cached_uids, penalized_uids)

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -41,7 +41,7 @@ from gittensor.utils.github_api_tools import (
 from gittensor.validator.oss_contributions.credibility import check_eligibility
 from gittensor.validator.oss_contributions.label_resolution import resolve_legacy_label_multiplier
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
-from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig, resolve_repo_weight
+from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig
 
 
 def score_miner_prs(
@@ -209,7 +209,7 @@ def calculate_pr_multipliers(
     is_merged = pr.pr_state == PRState.MERGED
     repo_config = master_repositories.get(pr.repository_full_name)
 
-    pr.repo_weight_multiplier = resolve_repo_weight(repo_config)
+    pr.repo_weight_multiplier = 1.0
     pr.issue_multiplier = round(calculate_issue_multiplier(pr), 2)
     pr.label, pr.label_multiplier = resolve_legacy_label_multiplier(
         pr.label_timeline_order,
@@ -577,14 +577,13 @@ def calculate_open_pr_collateral_score(
 
     Collateral = base_score * applicable_multipliers * OPEN_PR_COLLATERAL_PERCENT
 
-    Applicable multipliers: repo_weight, issue, label, review_collateral
+    Applicable multipliers: issue, label, review_collateral
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
                     open_pr_spam (not for collateral)
     """
     from math import prod
 
     multipliers = {
-        'repo_weight': pr.repo_weight_multiplier,
         'issue': pr.issue_multiplier,
         'label': pr.label_multiplier,
         'review_collateral': calculate_review_collateral_multiplier(pr.changes_requested_count, pr.number),

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -7,7 +7,11 @@ from typing import Dict, List, Optional
 
 import bittensor as bt
 
-from gittensor.constants import DEFAULT_REPO_WEIGHT, NON_CODE_EXTENSIONS
+from gittensor.constants import NON_CODE_EXTENSIONS
+
+# Registry-level validation tolerances for emission_share sums and bounds checks.
+_EMISSION_SUM_UPPER_TOLERANCE = 1e-9
+_EMISSION_ENTRY_TOLERANCE = 1e-12
 
 
 @dataclass
@@ -28,7 +32,12 @@ class RepositoryConfig:
     """Configuration for a repository in the master_repositories list.
 
     Attributes:
-        weight: Repository weight for scoring
+        emission_share: This repo's allocated fraction of the unified scoring pool
+            (``OSS_EMISSION_SHARE`` of the round). Must lie in ``[0, 1]``; the sum
+            across all registered repos must not exceed 1.0. Shortfall recycles.
+        issue_discovery_share: Fraction of this repo's slice allocated to issue
+            discovery before spill rules; ``1 - issue_discovery_share`` is the PR
+            slice. Defaults to 0.5 when omitted from JSON.
         inactive_at: ISO timestamp when repository became inactive (None if active)
         additional_acceptable_branches: List of additional branch patterns to accept (None if only default branch)
         mirror_enabled: When True, fetch this repo's data from the das-github-mirror
@@ -49,7 +58,8 @@ class RepositoryConfig:
 
     """
 
-    weight: float
+    emission_share: float
+    issue_discovery_share: float = 0.5
     inactive_at: Optional[str] = None
     additional_acceptable_branches: Optional[List[str]] = None
     mirror_enabled: bool = False
@@ -60,51 +70,23 @@ class RepositoryConfig:
     eligibility_mode: bool = True
 
 
-def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
-    """Return the repo weight preserving full JSON precision, or the default for unknown repos."""
-    if repo_config is None:
-        return DEFAULT_REPO_WEIGHT
-    return repo_config.weight
-
-
-@dataclass
-class TokenConfig:
-    """Configuration for token-based scoring weights.
-
-    Attributes:
-        structural_bonus: Weights for structural AST nodes (functions, classes, etc.)
-        leaf_tokens: Weights for leaf AST nodes (identifiers, literals, etc.)
-        language_configs: Language configurations from programming_languages.json
-    """
-
-    structural_bonus: Dict[str, float] = field(default_factory=dict)
-    leaf_tokens: Dict[str, float] = field(default_factory=dict)
-    language_configs: Dict[str, LanguageConfig] = field(default_factory=dict)
-
-    def get_structural_weight(self, node_type: str) -> float:
-        """Get weight for a structural node type."""
-        return self.structural_bonus.get(node_type, 0.0)
-
-    def get_leaf_weight(self, node_type: str) -> float:
-        """Get weight for a leaf token type."""
-        return self.leaf_tokens.get(node_type, 0.0)
-
-    def get_language(self, extension: str) -> Optional[str]:
-        """Get the tree-sitter language name for a file extension."""
-        ext = extension.lstrip('.').lower()
-        config = self.language_configs.get(ext)
-        return config.language if config else None
-
-    def supports_tree_sitter(self, extension: Optional[str]) -> bool:
-        """Check if a file extension is supported by tree-sitter."""
-        if not extension:
+def _validate_registry_emission_shares(configs: Dict[str, RepositoryConfig]) -> bool:
+    """Return True if every entry is in [0, 1] and the registry sum is <= 1 (within tolerance)."""
+    total = 0.0
+    for name, cfg in configs.items():
+        es = float(cfg.emission_share)
+        if es < 0.0 - _EMISSION_ENTRY_TOLERANCE or es > 1.0 + _EMISSION_ENTRY_TOLERANCE:
+            bt.logging.error(f'Invalid emission_share for {name}: {es} (must be in [0, 1])')
             return False
-        ext = extension.lstrip('.').lower()
-        # Non-code extensions use line-count scoring, not tree-sitter
-        if ext in NON_CODE_EXTENSIONS:
+        ids = float(cfg.issue_discovery_share)
+        if ids < 0.0 - _EMISSION_ENTRY_TOLERANCE or ids > 1.0 + _EMISSION_ENTRY_TOLERANCE:
+            bt.logging.error(f'Invalid issue_discovery_share for {name}: {ids} (must be in [0, 1])')
             return False
-        config = self.language_configs.get(ext)
-        return config is not None and config.language is not None
+        total += es
+    if total > 1.0 + _EMISSION_SUM_UPPER_TOLERANCE:
+        bt.logging.error(f'Registry emission_share sum {total} exceeds 1.0 (tolerance {_EMISSION_SUM_UPPER_TOLERANCE})')
+        return False
+    return True
 
 
 def _get_weights_dir() -> Path:
@@ -113,12 +95,12 @@ def _get_weights_dir() -> Path:
 
 def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
     """
-    Load repository weights from the local JSON file.
+    Load repository configuration from the local JSON file.
     Normalizes repository names to lowercase for case-insensitive matching.
 
     Returns:
         Dictionary mapping normalized (lowercase) fullName (str) to RepositoryConfig object.
-        Returns empty dict on error.
+        Returns empty dict on error or when registry emission invariants fail.
     """
     weights_file = _get_weights_dir() / 'master_repositories.json'
 
@@ -130,12 +112,23 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
             bt.logging.error(f'Expected dict from {weights_file}, got {type(data)}')
             return {}
 
-        # Parse JSON data into RepositoryConfig objects
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
+            if not isinstance(metadata, dict):
+                bt.logging.warning(f'Expected dict metadata for {repo_name}, skipping')
+                continue
+            if 'emission_share' not in metadata:
+                bt.logging.error(f'{repo_name}: missing required field emission_share')
+                return {}
             try:
+                emission_share = float(metadata['emission_share'])
+                issue_discovery_share = (
+                    float(metadata['issue_discovery_share']) if 'issue_discovery_share' in metadata else 0.5
+                )
+
                 config = RepositoryConfig(
-                    weight=float(metadata.get('weight', 0.01)),
+                    emission_share=emission_share,
+                    issue_discovery_share=issue_discovery_share,
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     mirror_enabled=bool(metadata.get('mirror_enabled', False)),
@@ -150,10 +143,12 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     eligibility_mode=metadata.get('eligibility_mode', True),
                 )
                 normalized_data[repo_name.lower()] = config
-            except (ValueError, TypeError) as e:
-                bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
-                # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+            except (ValueError, TypeError, KeyError) as e:
+                bt.logging.warning(f'Could not parse config for {repo_name}: {e}')
+                return {}
+
+        if not _validate_registry_emission_shares(normalized_data):
+            return {}
 
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data
@@ -214,6 +209,46 @@ def load_programming_language_weights() -> Dict[str, LanguageConfig]:
     except Exception as e:
         bt.logging.error(f'Unexpected error loading language weights: {e}')
         return {}
+
+
+@dataclass
+class TokenConfig:
+    """Configuration for token-based scoring weights.
+
+    Attributes:
+        structural_bonus: Weights for structural AST nodes (functions, classes, etc.)
+        leaf_tokens: Weights for leaf AST nodes (identifiers, literals, etc.)
+        language_configs: Language configurations from programming_languages.json
+    """
+
+    structural_bonus: Dict[str, float] = field(default_factory=dict)
+    leaf_tokens: Dict[str, float] = field(default_factory=dict)
+    language_configs: Dict[str, LanguageConfig] = field(default_factory=dict)
+
+    def get_structural_weight(self, node_type: str) -> float:
+        """Get weight for a structural node type."""
+        return self.structural_bonus.get(node_type, 0.0)
+
+    def get_leaf_weight(self, node_type: str) -> float:
+        """Get weight for a leaf token type."""
+        return self.leaf_tokens.get(node_type, 0.0)
+
+    def get_language(self, extension: str) -> Optional[str]:
+        """Get the tree-sitter language name for a file extension."""
+        ext = extension.lstrip('.').lower()
+        config = self.language_configs.get(ext)
+        return config.language if config else None
+
+    def supports_tree_sitter(self, extension: Optional[str]) -> bool:
+        """Check if a file extension is supported by tree-sitter."""
+        if not extension:
+            return False
+        ext = extension.lstrip('.').lower()
+        # Non-code extensions use line-count scoring, not tree-sitter
+        if ext in NON_CODE_EXTENSIONS:
+            return False
+        config = self.language_configs.get(ext)
+        return config is not None and config.language is not None
 
 
 def load_token_config() -> TokenConfig:

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,205 +1,219 @@
 {
   "404-Repo/404-base-miner-gs": {
-    "weight": 0.0487
+    "emission_share": 0.0022412134767341805
   },
   "404-Repo/404-gen-subnet": {
-    "weight": 0.1025
+    "emission_share": 0.004717133087582207
   },
   "AffineFoundation/affine-cortex": {
-    "weight": 0.2017
+    "emission_share": 0.009282397500149572
   },
   "AffineFoundation/affinetes": {
-    "weight": 0.1957
+    "emission_share": 0.009006272636486224
   },
   "AffineFoundation/liveweb-arena": {
-    "weight": 0.1168
+    "emission_share": 0.005375230679313188
   },
   "afterpartyai/bittensor-conversation-genome-project": {
-    "weight": 0.0536
+    "emission_share": 0.0024667154487259153
   },
   "AgentOps-AI/agentops": {
-    "weight": 0.0363
+    "emission_share": 0.0016705554251632596
   },
   "agno-agi/agno": {
-    "weight": 0.0442
+    "emission_share": 0.002034119828986669
   },
   "AlphaCoreBittensor/alphacore": {
-    "weight": 0.0484
+    "emission_share": 0.002227407233551013
   },
   "ansible/ansible": {
-    "weight": 0.0372
+    "emission_share": 0.001711974154712762
   },
   "ant-design/ant-design": {
-    "additional_acceptable_branches": ["feature"],
-    "weight": 0.0715
+    "additional_acceptable_branches": [
+      "feature"
+    ],
+    "emission_share": 0.0032904879586549054
   },
   "antoniorodr/cronboard": {
-    "weight": 0.0349
+    "emission_share": 0.0016061262903084785
   },
   "appwrite/appwrite": {
-    "weight": 0.0579
+    "emission_share": 0.002664604934351315
   },
   "autoppia/autoppia_iwa": {
-    "additional_acceptable_branches": ["contribution/*"],
+    "additional_acceptable_branches": [
+      "contribution/*"
+    ],
     "inactive_at": "2026-04-06T00:00:00Z",
-    "weight": 0.1259
+    "emission_share": 0.005794020055869268
   },
   "autoppia/autoppia_web_agents_subnet": {
-    "additional_acceptable_branches": ["dev", "dev-gittensor"],
+    "additional_acceptable_branches": [
+      "dev",
+      "dev-gittensor"
+    ],
     "inactive_at": "2026-04-06T00:00:00Z",
-    "weight": 0.1321
+    "emission_share": 0.006079349081654728
   },
   "autoppia/autoppia_webs_demo": {
-    "additional_acceptable_branches": ["feature/*", "fix/*"],
+    "additional_acceptable_branches": [
+      "feature/*",
+      "fix/*"
+    ],
     "inactive_at": "2026-04-06T00:00:00Z",
-    "weight": 0.1239
+    "emission_share": 0.005701978434648151
   },
   "aws/aws-cli": {
-    "weight": 0.0978
+    "emission_share": 0.004500835277712584
   },
   "axios/axios": {
-    "weight": 0.0352
+    "emission_share": 0.001619932533491646
   },
   "backend-developers-ltd/ComputeHorde": {
-    "weight": 0.0504
+    "emission_share": 0.0023194488547721294
   },
   "backend-developers-ltd/InfiniteHash": {
-    "weight": 0.0438
+    "emission_share": 0.0020157115047424456
   },
   "Barbariandev/MANTIS": {
-    "weight": 0.0549
+    "emission_share": 0.0025265425025196406
   },
   "BerriAI/litellm": {
-    "weight": 0.0529
+    "emission_share": 0.0024345008812985246
   },
   "bevyengine/bevy": {
-    "weight": 0.0571
+    "emission_share": 0.0026277882858628684
   },
   "bitcast-network/bitcast": {
-    "weight": 0.0501
+    "emission_share": 0.002305642611588962
   },
   "bitcoin/bips": {
-    "weight": 0.3303
+    "emission_share": 0.015200673744667346
   },
   "bitcoin/bitcoin": {
-    "weight": 0.4274
+    "emission_share": 0.01966929445495254
   },
   "bitcoinj/bitcoinj": {
-    "weight": 0.3094
+    "emission_share": 0.014238838802906682
   },
   "bitcoinjs/bitcoinjs-lib": {
-    "weight": 0.2917
+    "emission_share": 0.013424270455099804
   },
   "BitMind-AI/bitmind-subnet": {
-    "additional_acceptable_branches": ["testnet"],
-    "weight": 0.1013
+    "additional_acceptable_branches": [
+      "testnet"
+    ],
+    "emission_share": 0.004661908114849537
   },
   "bitpay/bitcore": {
-    "weight": 0.0967
+    "emission_share": 0.00445021238604097
   },
   "bitrecs/bitrecs-subnet": {
-    "weight": 0.0435
+    "emission_share": 0.002001905261559278
   },
   "Bitsec-AI/subnet": {
-    "weight": 0.0481
+    "emission_share": 0.0022136009903678455
   },
   "bitwarden/server": {
-    "weight": 0.0956
+    "emission_share": 0.004399589494369357
   },
   "brave/brave-browser": {
-    "weight": 0.0946
+    "emission_share": 0.004353568683758798
   },
   "browser-use/browser-harness": {
-    "weight": 0.1
+    "emission_share": 0.004602081061055812
   },
   "browser-use/browser-use": {
-    "weight": 0.0526
+    "emission_share": 0.002420694638115357
   },
   "byteleapai/byteleap-Miner": {
-    "weight": 0.0433
+    "emission_share": 0.0019927010994371663
   },
   "calcom/cal.diy": {
-    "weight": 0.0347
+    "emission_share": 0.0015969221281863669
   },
   "chutesai/chutes": {
-    "weight": 0.0989
+    "emission_share": 0.004551458169384198
   },
   "Cinnamon/kotaemon": {
-    "weight": 0.0473
+    "emission_share": 0.002176784341879399
   },
   "cli/cli": {
-    "weight": 0.0936
+    "emission_share": 0.0043075478731482405
   },
   "ClickHouse/ClickHouse": {
-    "weight": 0.1152
+    "emission_share": 0.005301597382336295
   },
   "Comfy-Org/ComfyUI": {
-    "weight": 0.0523
+    "emission_share": 0.0024068883949321896
   },
   "commaai/openpilot": {
-    "weight": 0.0926
+    "emission_share": 0.004261527062537682
   },
   "cosmos/cosmos-sdk": {
-    "additional_acceptable_branches": ["release/v0.54.x", "release/v0.53.x"],
-    "weight": 0.0916
+    "additional_acceptable_branches": [
+      "release/v0.54.x",
+      "release/v0.53.x"
+    ],
+    "emission_share": 0.004215506251927124
   },
   "CreativeBuilds/sn77": {
-    "weight": 0.0546
+    "emission_share": 0.0025127362593364735
   },
   "crewAIInc/crewAI": {
-    "weight": 0.052
+    "emission_share": 0.002393082151749022
   },
   "curl/curl": {
-    "weight": 0.037
+    "emission_share": 0.0017027699925906503
   },
   "Datura-ai/lium-io": {
-    "weight": 0.0906
+    "emission_share": 0.0041694854413165654
   },
   "dbeaver/dbeaver": {
-    "weight": 0.2409
+    "emission_share": 0.011086413276083451
   },
   "deepset-ai/haystack": {
-    "weight": 0.0567
+    "emission_share": 0.0026093799616186456
   },
   "denoland/deno": {
-    "weight": 0.1106
+    "emission_share": 0.0050899016535277284
   },
   "Desearch-ai/linkedin-dms": {
-    "weight": 0.1221
+    "emission_share": 0.005619140975549147
   },
   "Desearch-ai/subnet-22": {
-    "weight": 0.1367
+    "emission_share": 0.0062910448104632945
   },
   "django/django": {
-    "weight": 0.0366
+    "emission_share": 0.0016843616683464271
   },
   "docker/compose": {
-    "weight": 0.0897
+    "emission_share": 0.004128066711767063
   },
   "dogecoin/dogecoin": {
-    "weight": 0.0417
+    "emission_share": 0.0019190678024602736
   },
   "dstrbtd/DistributedTraining": {
-    "weight": 0.0457
+    "emission_share": 0.002103151044902506
   },
   "EfficientFrontier-SignalPlus/EfficientFrontier": {
-    "weight": 0.0478
+    "emission_share": 0.0021997947471846784
   },
   "eigent-ai/eigent": {
-    "weight": 0.1392
+    "emission_share": 0.00640609683698969
   },
   "entrius/allways": {
-    "weight": 1.0,
     "mirror_enabled": true,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
       "enhancement": 1.0,
       "refactor": 0.25
-    }
+    },
+    "emission_share": 0.04602081061055812
   },
   "entrius/allways-ui": {
-    "weight": 0.5,
     "mirror_enabled": true,
     "trusted_label_pipeline": true,
     "label_multipliers": {
@@ -207,10 +221,10 @@
       "bug": 1.1,
       "enhancement": 1.0,
       "refactor": 0.5
-    }
+    },
+    "emission_share": 0.02301040530527906
   },
   "entrius/das-github-mirror": {
-    "weight": 0.2,
     "mirror_enabled": true,
     "trusted_label_pipeline": true,
     "label_multipliers": {
@@ -218,10 +232,10 @@
       "bug": 1.25,
       "enhancement": 1.1,
       "refactor": 0.5
-    }
+    },
+    "emission_share": 0.009204162122111625
   },
   "entrius/gittensor": {
-    "weight": 1.0,
     "mirror_enabled": true,
     "trusted_label_pipeline": true,
     "label_multipliers": {
@@ -229,10 +243,10 @@
       "bug": 1.1,
       "enhancement": 1.25,
       "refactor": 0.25
-    }
+    },
+    "emission_share": 0.04602081061055812
   },
   "entrius/gittensor-ui": {
-    "weight": 0.5,
     "mirror_enabled": true,
     "trusted_label_pipeline": true,
     "label_multipliers": {
@@ -240,477 +254,533 @@
       "bug": 1.1,
       "enhancement": 1.0,
       "refactor": 0.5
-    }
+    },
+    "emission_share": 0.02301040530527906
   },
   "espressif/arduino-esp32": {
-    "weight": 0.1444
+    "emission_share": 0.006645405052164592
   },
   "ethereum-optimism/optimism": {
-    "weight": 0.0888
+    "emission_share": 0.004086647982217561
   },
   "ethereum/EIPs": {
-    "weight": 0.0879
+    "emission_share": 0.004045229252668059
   },
   "ethereum/go-ethereum": {
-    "weight": 0.1849
+    "emission_share": 0.008509247881892197
   },
   "ethers-io/ethers.js": {
-    "weight": 0.087
+    "emission_share": 0.004003810523118556
   },
   "excalidraw/excalidraw": {
-    "weight": 0.059
+    "emission_share": 0.002715227826022929
   },
   "flowsurface-rs/flowsurface": {
-    "weight": 0.051
+    "emission_share": 0.002347061341138464
   },
   "General-Tao-Ventures/cartha-cli": {
-    "weight": 0.0476
+    "emission_share": 0.0021905905850625666
   },
   "General-Tao-Ventures/cartha-validator": {
-    "weight": 0.047
+    "emission_share": 0.0021629780986962316
   },
   "ggml-org/llama.cpp": {
-    "weight": 0.0339
+    "emission_share": 0.0015601054796979203
   },
   "git/git": {
-    "weight": 0.0862
+    "emission_share": 0.00396699387463011
   },
   "godotengine/godot": {
-    "weight": 0.0611
+    "emission_share": 0.002811871528305101
   },
   "gopher-lab/subnet-42": {
-    "weight": 0.0428
+    "emission_share": 0.0019696906941318875
   },
   "gradients-ai/G.O.D": {
-    "weight": 0.0853
+    "emission_share": 0.003925575145080608
   },
   "grafana/grafana": {
-    "additional_acceptable_branches": ["release-13.0.2"],
-    "weight": 0.1136
+    "additional_acceptable_branches": [
+      "release-13.0.2"
+    ],
+    "emission_share": 0.005227964085359403
   },
   "GraphiteAI/Graphite-Subnet": {
-    "weight": 0.0468
+    "emission_share": 0.0021537739365741202
   },
   "Homebrew/brew": {
-    "weight": 0.0342
+    "emission_share": 0.0015739117228810878
   },
   "hoppscotch/hoppscotch": {
-    "additional_acceptable_branches": ["next"],
-    "weight": 0.1801
+    "additional_acceptable_branches": [
+      "next"
+    ],
+    "emission_share": 0.008288347990961517
   },
   "huggingface/lerobot": {
-    "weight": 0.0629
+    "emission_share": 0.0028947089874041057
   },
   "huggingface/transformers": {
-    "weight": 0.0845
+    "emission_share": 0.0038887584965921615
   },
   "immich-app/immich": {
-    "weight": 0.0587
+    "emission_share": 0.0027014215828397616
   },
   "impel-intelligence/dippy-studio-bittensor-miner": {
-    "weight": 0.0426
+    "emission_share": 0.001960486532009776
   },
   "impel-intelligence/dippy-studio-bittensor-orchestrator": {
-    "weight": 0.0424
+    "emission_share": 0.0019512823698876643
   },
   "inference-labs-inc/subnet-2": {
-    "weight": 0.0422
+    "emission_share": 0.0019420782077655527
   },
   "infiniflow/ragflow": {
-    "weight": 0.1185
+    "emission_share": 0.0054534660573511366
   },
   "It-s-AI/llm-detection": {
-    "weight": 0.0465
+    "emission_share": 0.0021399676933909527
   },
   "janhq/jan": {
-    "weight": 0.0704
+    "emission_share": 0.003239865066983292
   },
   "jellyfin/jellyfin": {
-    "additional_acceptable_branches": ["release-10.11.z"],
-    "weight": 0.0607
+    "additional_acceptable_branches": [
+      "release-10.11.z"
+    ],
+    "emission_share": 0.002793463204060878
   },
   "jesseduffield/lazygit": {
-    "weight": 0.0357
+    "emission_share": 0.001642942938796925
   },
   "JetBrains/kotlin": {
-    "weight": 0.0354
+    "emission_share": 0.0016291366956137576
   },
   "junegunn/fzf": {
-    "weight": 0.0351
+    "emission_share": 0.00161533045243059
   },
   "jupyter/jupyter": {
-    "weight": 0.0837
+    "emission_share": 0.0038519418481037146
   },
   "jupyterlab/jupyterlab": {
-    "additional_acceptable_branches": ["4.5.x"],
-    "weight": 0.1755
+    "additional_acceptable_branches": [
+      "4.5.x"
+    ],
+    "emission_share": 0.008076652262152949
   },
   "keras-team/keras": {
-    "weight": 0.1091
+    "emission_share": 0.005020870437611891
   },
   "labring/FastGPT": {
-    "additional_acceptable_branches": ["v4.14.x"],
-    "weight": 0.0633
+    "additional_acceptable_branches": [
+      "v4.14.x"
+    ],
+    "emission_share": 0.002913117311648329
   },
   "langchain-ai/langchain": {
-    "weight": 0.0615
+    "emission_share": 0.0028302798525493243
   },
   "langgenius/dify": {
-    "weight": 0.0336,
-    "inactive_at": "2026-04-14T00:00:00Z"
+    "inactive_at": "2026-04-14T00:00:00Z",
+    "emission_share": 0.0015462992365147528
   },
   "laravel/framework": {
-    "weight": 0.0346
+    "emission_share": 0.001592320047125311
   },
   "latent-to/async-substrate-interface": {
-    "additional_acceptable_branches": ["staging"],
-    "weight": 0.2764
+    "additional_acceptable_branches": [
+      "staging"
+    ],
+    "emission_share": 0.012720152052758263
   },
   "latent-to/bittensor": {
-    "additional_acceptable_branches": ["staging", "SDKv10"],
-    "weight": 0.3556
+    "additional_acceptable_branches": [
+      "staging",
+      "SDKv10"
+    ],
+    "emission_share": 0.016365000253114468
   },
   "latent-to/btcli": {
-    "additional_acceptable_branches": ["staging"],
-    "weight": 0.2514
+    "additional_acceptable_branches": [
+      "staging"
+    ],
+    "emission_share": 0.011569631787494311
   },
   "latent-to/btwallet": {
-    "weight": 0.2631
+    "emission_share": 0.012108075271637842
   },
   "latent-to/taohash": {
-    "weight": 0.0575
+    "emission_share": 0.002646196610107092
   },
   "leadpoet/leadpoet": {
-    "weight": 0.0498
+    "emission_share": 0.0022918363684057944
   },
   "letta-ai/letta": {
-    "weight": 0.0829
+    "emission_share": 0.0038151251996152683
   },
   "llmsresearch/paperbanana": {
-    "weight": 0.1077
+    "emission_share": 0.00495644130275711
   },
   "macrocosm-os/apex": {
-    "weight": 0.0419
+    "emission_share": 0.0019282719645823852
   },
   "macrocosm-os/data-universe": {
-    "additional_acceptable_branches": ["dev"],
-    "weight": 0.0495
+    "additional_acceptable_branches": [
+      "dev"
+    ],
+    "emission_share": 0.002278030125222627
   },
   "macrocosm-os/iota": {
-    "weight": 0.0387
+    "emission_share": 0.0017810053706285992
   },
   "manifold-inc/hone": {
-    "weight": 0.0821
+    "emission_share": 0.003778308551126822
   },
   "manifold-inc/targon": {
-    "weight": 0.0814
+    "emission_share": 0.003746093983699431
   },
   "mark3labs/mcp-go": {
-    "weight": 0.0359
+    "emission_share": 0.0016521471009190367
   },
   "mastodon/mastodon": {
-    "weight": 0.0564
+    "emission_share": 0.002595573718435478
   },
   "medusajs/medusa": {
-    "additional_acceptable_branches": ["develop"],
-    "weight": 0.0603
+    "additional_acceptable_branches": [
+      "develop"
+    ],
+    "emission_share": 0.0027750548798166547
   },
   "mem0ai/mem0": {
-    "weight": 0.0455
+    "emission_share": 0.0020939468827803945
   },
   "MetaMask/metamask-extension": {
-    "additional_acceptable_branches": ["release/13.28.0", "release/13.29.0"],
-    "weight": 0.0806
+    "additional_acceptable_branches": [
+      "release/13.28.0",
+      "release/13.29.0"
+    ],
+    "emission_share": 0.003709277335210985
   },
   "metanova-labs/nova": {
-    "weight": 0.0799
+    "emission_share": 0.0036770627677835937
   },
   "mobiusfund/etf": {
-    "weight": 0.0415
+    "emission_share": 0.001909863640338162
   },
   "modelcontextprotocol/inspector": {
-    "weight": 0.0452
+    "emission_share": 0.002080140639597227
   },
   "modelcontextprotocol/python-sdk": {
-    "weight": 0.045
+    "emission_share": 0.0020709364774751152
   },
   "modelcontextprotocol/registry": {
-    "weight": 0.0447
+    "emission_share": 0.0020571302342919477
   },
   "modelcontextprotocol/servers": {
-    "weight": 0.0516
+    "emission_share": 0.002374673827504799
   },
   "modelcontextprotocol/typescript-sdk": {
-    "weight": 0.0445
+    "emission_share": 0.0020479260721698363
   },
   "monero-project/monero": {
-    "additional_acceptable_branches": ["release-v0.18"],
-    "weight": 0.0792
+    "additional_acceptable_branches": [
+      "release-v0.18"
+    ],
+    "emission_share": 0.0036448482003562034
   },
   "mrdoob/three.js": {
-    "weight": 0.0733
+    "emission_share": 0.0033733254177539104
   },
   "MystenLabs/sui": {
-    "weight": 0.0542
+    "emission_share": 0.00249432793509225
   },
   "neovim/neovim": {
-    "additional_acceptable_branches": ["release-0.12"],
-    "weight": 0.0785
+    "additional_acceptable_branches": [
+      "release-0.12"
+    ],
+    "emission_share": 0.0036126336329288123
   },
   "nextcloud/android": {
-    "weight": 0.0778
+    "emission_share": 0.0035804190655014216
   },
   "nextcloud/desktop": {
-    "additional_acceptable_branches": ["stable-33.0", "stable-4.0"],
-    "weight": 0.0771
+    "additional_acceptable_branches": [
+      "stable-33.0",
+      "stable-4.0"
+    ],
+    "emission_share": 0.0035482044980740314
   },
   "nextcloud/server": {
-    "additional_acceptable_branches": ["stable33", "stable32", "stable31"],
-    "weight": 0.0764
+    "additional_acceptable_branches": [
+      "stable33",
+      "stable32",
+      "stable31"
+    ],
+    "emission_share": 0.0035159899306466402
   },
   "nginx/nginx": {
-    "weight": 0.0758
+    "emission_share": 0.0034883774442803057
   },
   "nimbusdotstorage/Nimbus": {
-    "weight": 0.0333
+    "emission_share": 0.0015324929933315855
   },
   "nocodb/nocodb": {
-    "additional_acceptable_branches": ["develop"],
-    "weight": 0.0751
+    "additional_acceptable_branches": [
+      "develop"
+    ],
+    "emission_share": 0.003456162876852915
   },
   "NousResearch/hermes-agent": {
-    "weight": 0.59
+    "emission_share": 0.027152278260229288
   },
   "numinouslabs/numinous": {
-    "weight": 0.0413
+    "emission_share": 0.0019006594782160506
   },
   "ohmyzsh/ohmyzsh": {
-    "weight": 0.0721
+    "emission_share": 0.0033181004450212404
   },
   "ollama/ollama": {
-    "weight": 0.0594
+    "emission_share": 0.0027336361502671522
   },
   "omegalabsinc/omegalabs-anytoany-bittensor": {
-    "weight": 0.0411
+    "emission_share": 0.0018914553160939386
   },
   "omegalabsinc/omegalabs-bittensor-subnet": {
-    "weight": 0.0409
+    "emission_share": 0.001882251153971827
   },
   "oneoneone-io/subnet-111": {
-    "weight": 0.0407
+    "emission_share": 0.0018730469918497156
   },
   "openclaw/openclaw": {
-    "weight": 0.8
+    "emission_share": 0.0368166484884465
   },
   "OpenGradient/BitQuant-Subnet": {
-    "weight": 0.0462
+    "emission_share": 0.0021261614502077852
   },
   "OpenHands/OpenHands": {
-    "weight": 0.1532
+    "emission_share": 0.007050388185537504
   },
   "openprose/prose": {
-    "weight": 0.0492
+    "emission_share": 0.0022642238820394594
   },
   "opentensor/subtensor": {
-    "additional_acceptable_branches": ["devnet-ready"],
-    "weight": 0.387
+    "additional_acceptable_branches": [
+      "devnet-ready"
+    ],
+    "emission_share": 0.017810053706285994
   },
   "OpenZeppelin/openzeppelin-contracts": {
-    "weight": 0.0341
+    "emission_share": 0.0015693096418200319
   },
   "Orpheus-AI/Zeus": {
-    "weight": 0.0539
+    "emission_share": 0.002480521691909083
   },
   "oven-sh/bun": {
-    "weight": 0.0624
+    "emission_share": 0.0028716985820988264
   },
   "pandas-dev/pandas": {
-    "weight": 0.1121
+    "emission_share": 0.0051589328694435655
   },
   "paperclipai/paperclip": {
-    "weight": 0.2231
+    "emission_share": 0.010267242847215516
   },
   "paritytech/polkadot-sdk": {
-    "weight": 0.0745
+    "emission_share": 0.00342855039048658
   },
   "penpot/penpot": {
-    "weight": 0.1472
+    "emission_share": 0.006774263321874155
   },
   "pi-hole/web": {
-    "additional_acceptable_branches": ["development"],
-    "weight": 0.0739
+    "additional_acceptable_branches": [
+      "development"
+    ],
+    "emission_share": 0.003400937904120245
   },
   "PlatformNetwork/platform": {
-    "weight": 0.046
+    "emission_share": 0.0021169572880856734
   },
   "postgres/postgres": {
-    "weight": 0.0556
+    "emission_share": 0.0025587570699470313
   },
   "pydantic/pydantic-ai": {
-    "weight": 0.0513
+    "emission_share": 0.0023608675843216314
   },
   "qbittensor-labs/quantum": {
-    "weight": 0.0727
+    "emission_share": 0.0033457129313875754
   },
   "qwibitai/nanoclaw": {
-    "weight": 0.2153
+    "emission_share": 0.009908280524453163
   },
   "rails/rails": {
-    "weight": 0.0356
+    "emission_share": 0.0016383408577358692
   },
   "ray-project/ray": {
-    "weight": 0.1599
+    "emission_share": 0.007358727616628243
   },
   "reboot-org/reboot-subnet": {
-    "weight": 0.0405
+    "emission_share": 0.001863842829727604
   },
   "redis/redis": {
-    "weight": 0.0364
+    "emission_share": 0.0016751575062243158
   },
   "RedTeamSubnet/RedTeam": {
-    "additional_acceptable_branches": ["dev"],
-    "weight": 0.044
+    "additional_acceptable_branches": [
+      "dev"
+    ],
+    "emission_share": 0.002024915666864557
   },
   "resi-labs-ai/resi": {
-    "weight": 0.0402
+    "emission_share": 0.0018500365865444365
   },
   "ridgesai/ridges": {
-    "weight": 0.0709
+    "emission_share": 0.003262875472288571
   },
   "run-llama/llama_index": {
-    "weight": 0.1501
+    "emission_share": 0.006907723672644774
   },
   "sbt/sbt": {
     "inactive_at": "2026-04-18T00:00:00Z",
-    "weight": 0.1001
+    "emission_share": 0.004606683142116867
   },
   "score-technologies/turbovision": {
-    "weight": 0.0698
+    "emission_share": 0.003212252580616957
   },
   "sentient-agi/ROMA": {
-    "weight": 0.0507
+    "emission_share": 0.002333255097955297
   },
   "shiftlayer-llc/brainplay-subnet": {
-    "additional_acceptable_branches": ["dev"],
-    "weight": 0.04
+    "additional_acceptable_branches": [
+      "dev"
+    ],
+    "emission_share": 0.001840832424422325
   },
   "Significant-Gravitas/AutoGPT": {
-    "additional_acceptable_branches": ["dev"],
-    "weight": 0.062
+    "additional_acceptable_branches": [
+      "dev"
+    ],
+    "emission_share": 0.0028532902578546036
   },
   "smartcontractkit/chainlink": {
-    "weight": 0.0693
+    "emission_share": 0.0031892421753116776
   },
   "sportstensor/sn41": {
-    "weight": 0.0553
+    "emission_share": 0.0025449508267638642
   },
   "Stirling-Tools/Stirling-PDF": {
-    "weight": 0.0642
+    "emission_share": 0.002954536041197831
   },
   "strapi/strapi": {
-    "weight": 0.0338
+    "emission_share": 0.0015555033986368644
   },
   "supabase/supabase": {
-    "weight": 0.0687
+    "emission_share": 0.0031616296889453426
   },
   "sveltejs/svelte": {
-    "weight": 0.0652
+    "emission_share": 0.003000556851808389
   },
   "Swap-Subnet/swap-subnet": {
-    "weight": 0.0373
+    "emission_share": 0.0017165762357738178
   },
   "swarm-subnet/Langostino": {
-    "weight": 0.0383
+    "emission_share": 0.001762597046384376
   },
   "swarm-subnet/swarm": {
-    "weight": 0.049
+    "emission_share": 0.002255019719917348
   },
   "SWE-agent/SWE-agent": {
-    "weight": 0.0682
+    "emission_share": 0.0031386192836400637
   },
   "synthdataco/synth-subnet": {
-    "weight": 0.0385
+    "emission_share": 0.0017718012085064876
   },
   "taofu-labs/tpn-subnet": {
-    "additional_acceptable_branches": ["development"],
-    "weight": 0.0398
+    "additional_acceptable_branches": [
+      "development"
+    ],
+    "emission_share": 0.0018316282623002133
   },
   "taoshidev/vanta-network": {
-    "weight": 0.0396
+    "emission_share": 0.0018224241001781017
   },
   "TatsuProject/ChipForge_SN84": {
-    "weight": 0.0394
+    "emission_share": 0.00181321993805599
   },
   "tauri-apps/tauri": {
-    "additional_acceptable_branches": ["dev"],
-    "weight": 0.0583
+    "additional_acceptable_branches": [
+      "dev"
+    ],
+    "emission_share": 0.0026830132585955384
   },
   "Team-Rizzo/talisman-ai": {
-    "weight": 0.056
+    "emission_share": 0.002577165394191255
   },
   "tensorplex-labs/dojo": {
-    "weight": 0.0392
+    "emission_share": 0.0018040157759338783
   },
   "thenervelab/thebrain": {
-    "weight": 0.039
+    "emission_share": 0.0017948116138117667
   },
   "tinygrad/tinygrad": {
-    "weight": 0.0677
+    "emission_share": 0.0031156088783347844
   },
   "tmux/tmux": {
-    "weight": 0.0672
+    "emission_share": 0.0030925984730295055
   },
   "ToolJet/ToolJet": {
-    "additional_acceptable_branches": ["develop"],
-    "weight": 0.0599
+    "additional_acceptable_branches": [
+      "develop"
+    ],
+    "emission_share": 0.0027566465555724316
   },
   "TrishoolAI/trishool-subnet": {
-    "weight": 0.0388
+    "emission_share": 0.0017856074516896551
   },
   "twentyhq/twenty": {
-    "weight": 0.0662
+    "emission_share": 0.0030465776624189474
   },
   "unarbos/agcli": {
-    "weight": 0.2083
+    "emission_share": 0.009586134850179256
   },
   "Uniswap/v4-core": {
-    "weight": 0.0667
+    "emission_share": 0.0030695880677242262
   },
   "Unstructured-IO/unstructured": {
-    "weight": 0.1344
+    "emission_share": 0.006185196946059011
   },
   "v0idai/SN106": {
-    "weight": 0.0381
+    "emission_share": 0.0017533928842622644
   },
   "vercel/next.js": {
-    "weight": 0.0657
+    "emission_share": 0.003023567257113668
   },
   "vidAio-subnet/vidaio-subnet": {
-    "weight": 0.0379
+    "emission_share": 0.0017441887221401528
   },
   "virattt/dexter": {
-    "weight": 0.13
+    "emission_share": 0.0059827053793725556
   },
   "vitejs/vite": {
-    "weight": 0.0647
+    "emission_share": 0.0029775464465031103
   },
   "vllm-project/vllm": {
-    "weight": 0.0377
+    "emission_share": 0.001734984560018041
   },
   "vuejs/core": {
-    "weight": 0.0335
+    "emission_share": 0.001541697155453697
   },
   "we-promise/sure": {
-    "weight": 0.1279
+    "emission_share": 0.005886061677090384
   },
   "yanez-compliance/MIID-subnet": {
-    "weight": 0.0375
+    "emission_share": 0.0017257803978959294
   },
   "zcash/zcash": {
-    "weight": 0.0638
+    "emission_share": 0.0029361277169536078
   },
   "zed-industries/zed": {
-    "additional_acceptable_branches": ["v0.234.x"],
-    "weight": 0.1564
+    "additional_acceptable_branches": [
+      "v0.234.x"
+    ],
+    "emission_share": 0.0071976547794912905
   }
 }

--- a/tests/cli/test_miner_score.py
+++ b/tests/cli/test_miner_score.py
@@ -38,17 +38,13 @@ def miner_eval_factory():
 def _patch_pipeline(
     uid: int,
     miner_evaluation,
-    oss_value: float = 0.4,
-    issue_value: float = 0.1,
     blended: float = 0.3,
     oss_side_effect=None,
     master_repos: Optional[Dict] = None,
 ):
-    """Mock the three forward entry points; `oss_side_effect` captures call args, `master_repos` exercises the mirror_enabled filter."""
+    """Mock forward scoring + allocation; `oss_side_effect` captures call args, `master_repos` exercises the mirror_enabled filter."""
     miner_evaluations = {uid: miner_evaluation}
 
-    oss_rewards = np.array([oss_value])
-    issue_rewards = np.array([issue_value])
     final_rewards = np.array([blended])
 
     if oss_side_effect is not None:
@@ -56,13 +52,13 @@ def _patch_pipeline(
     else:
         oss_patch = patch(
             'gittensor.validator.forward.oss_contributions',
-            new=AsyncMock(return_value=(oss_rewards, miner_evaluations, set(), set())),
+            new=AsyncMock(return_value=(miner_evaluations, set(), set())),
         )
 
     return [
         oss_patch,
-        patch('gittensor.validator.forward.issue_discovery', new=AsyncMock(return_value=issue_rewards)),
-        patch('gittensor.validator.forward.blend_emission_pools', return_value=final_rewards),
+        patch('gittensor.validator.forward.issue_discovery', new=AsyncMock(return_value=None)),
+        patch('gittensor.validator.forward.allocate_round_emissions', return_value=final_rewards),
         patch('gittensor.validator.utils.load_weights.load_master_repo_weights', return_value=master_repos or {}),
         patch('gittensor.validator.utils.load_weights.load_programming_language_weights', return_value={}),
         patch('gittensor.validator.utils.load_weights.load_token_config', return_value=_stub_token_config()),
@@ -168,9 +164,7 @@ class TestScoreCommand:
             base_total_score=20.0,
             total_score=18.0,
         )
-        with _multi_patch(
-            _patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation, oss_value=0.4, issue_value=0.1, blended=0.3)
-        ):
+        with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation, blended=0.3)):
             result = runner.invoke(
                 cli,
                 ['miner', 'score', '--json-output'],
@@ -182,8 +176,6 @@ class TestScoreCommand:
         assert payload['miner_evaluation']['uid'] == _DEV_UID
         assert payload['miner_evaluation']['is_eligible'] is True
         assert payload['miner_evaluation']['credibility'] == 0.85
-        assert payload['rewards']['oss_normalized'] == 0.4
-        assert payload['rewards']['issue_discovery_normalized'] == 0.1
         assert payload['rewards']['blended_final'] == 0.3
 
     def test_pat_never_appears_in_json(self, runner, miner_eval_factory):
@@ -233,7 +225,7 @@ class TestScoreCommand:
         async def _capture_oss(self, miner_uids, *args, **kwargs):
             captured['hotkey_at_uid'] = self.metagraph.hotkeys[_DEV_UID]
             captured['miner_uids'] = miner_uids
-            return np.array([0.0]), {_DEV_UID: evaluation}, set(), set()
+            return {_DEV_UID: evaluation}, set(), set()
 
         with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation, oss_side_effect=_capture_oss)):
             result = runner.invoke(cli, ['miner', 'score'], env={'GITTENSOR_MINER_PAT': 'ghp_dummy'})
@@ -299,11 +291,11 @@ class TestScoreCommand:
 
         async def _capture_oss(self, miner_uids, master_repositories, *args, **kwargs):
             captured['repos'] = dict(master_repositories)
-            return np.array([0.0]), {_DEV_UID: evaluation}, set(), set()
+            return {_DEV_UID: evaluation}, set(), set()
 
         unfiltered = {
-            'legacy/repo': RepositoryConfig(weight=1.0, mirror_enabled=False),
-            'mirror/repo': RepositoryConfig(weight=1.0, mirror_enabled=True),
+            'legacy/repo': RepositoryConfig(emission_share=1.0, mirror_enabled=False),
+            'mirror/repo': RepositoryConfig(emission_share=1.0, mirror_enabled=True),
         }
         with _multi_patch(
             _patch_pipeline(
@@ -326,7 +318,7 @@ class TestScoreCommand:
             from gittensor.validator.oss_contributions.reward import pat_storage
 
             captured['pats'] = pat_storage.load_all_pats()
-            return np.array([0.0]), {_DEV_UID: evaluation}, set(), set()
+            return {_DEV_UID: evaluation}, set(), set()
 
         with _multi_patch(_patch_pipeline(uid=_DEV_UID, miner_evaluation=evaluation, oss_side_effect=_capture_oss)):
             result = runner.invoke(cli, ['miner', 'score', '--pat', 'ghp_injected'], env={})

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -1287,8 +1287,8 @@ class TestLoadMinersPrsErrorResilience:
         mock_graphql_query.return_value = _make_graphql_response([good_pr_before, bad_pr, good_pr_after])
 
         master_repos = {
-            'goodorg/goodrepo': RepositoryConfig(weight=1.0),
-            'affinefoundation/affinetes': RepositoryConfig(weight=1.0),
+            'goodorg/goodrepo': RepositoryConfig(emission_share=1.0),
+            'affinefoundation/affinetes': RepositoryConfig(emission_share=1.0),
         }
         miner_eval = MinerEvaluation(uid=74, hotkey='test_hotkey', github_id='12345', github_pat='fake_pat')
 

--- a/tests/validator/issue_discovery/test_mirror_scan.py
+++ b/tests/validator/issue_discovery/test_mirror_scan.py
@@ -164,7 +164,7 @@ def _eval(uid: int = 1, github_id: Optional[str] = '999'):
 
 
 def _mirror_repos(*names: str) -> dict:
-    return {name: RepositoryConfig(weight=0.5, mirror_enabled=True) for name in names}
+    return {name: RepositoryConfig(emission_share=0.5, mirror_enabled=True) for name in names}
 
 
 def _run(coro):

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -217,7 +217,7 @@ class TestInactiveRepo:
         )
         repos = {
             'entrius/gittensor-ui': RepositoryConfig(
-                weight=0.5,
+                emission_share=0.5,
                 mirror_enabled=True,
                 inactive_at='2026-04-10T00:00:00Z',
             ),

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -93,7 +93,7 @@ def _build_response(prs: list) -> MirrorPullRequestsResponse:
 
 
 def _mirror_repos(*names: str) -> dict:
-    return {name: RepositoryConfig(weight=0.5, mirror_enabled=True) for name in names}
+    return {name: RepositoryConfig(emission_share=0.5, mirror_enabled=True) for name in names}
 
 
 def _eval(github_id: str | None = '218712309') -> MirrorMinerEvaluation:

--- a/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
@@ -63,8 +63,8 @@ def test_ineligible_miner_earns_only_from_eligibility_disabled_repo():
     evaluation.mirror_closed_prs = closed_prs
 
     repos = {
-        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -92,10 +92,10 @@ def test_eligibility_disabled_prs_do_not_unlock_gated_repo_rewards():
 
     repos = {
         **{
-            pr.repository_full_name: RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False)
+            pr.repository_full_name: RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=False)
             for pr in opt_out_prs
         },
-        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/gated': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -119,8 +119,8 @@ def test_eligibility_disabled_closed_prs_do_not_penalize_gated_repo_eligibility(
     evaluation.mirror_closed_prs = opt_out_closed_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -143,8 +143,8 @@ def test_eligibility_disabled_open_prs_do_not_spam_penalize_gated_rewards():
     evaluation.mirror_open_prs = opt_out_open_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -164,7 +164,7 @@ def test_eligible_miner_scores_all_repos_with_existing_credibility_multiplier():
     evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
     evaluation.mirror_merged_prs = prs
 
-    repos = {'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True)}
+    repos = {'foo/gated': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=True)}
 
     finalize_miner_scores({1: evaluation}, repos)
 
@@ -188,8 +188,8 @@ def test_zero_history_miner_earns_only_from_eligibility_disabled_repo():
     evaluation.mirror_merged_prs = [opt_out, gated]
 
     repos = {
-        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -215,8 +215,8 @@ def test_eligibility_disabled_repo_open_collateral_does_not_reduce_gated_only_ea
     evaluation.mirror_open_prs = bypass_open_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, mirror_enabled=True, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, mirror_enabled=True, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)

--- a/tests/validator/oss_contributions/mirror/test_routing.py
+++ b/tests/validator/oss_contributions/mirror/test_routing.py
@@ -30,10 +30,10 @@ def _make_miner_eval(uid=1, hotkey='hk', github_id='218712309', failed_reason=No
 
 def _configs():
     return {
-        'entrius/gittensor-ui': RepositoryConfig(weight=0.5, mirror_enabled=True),
-        'entrius/allways': RepositoryConfig(weight=0.5, mirror_enabled=True),
-        'other/legacy-repo': RepositoryConfig(weight=0.3, mirror_enabled=False),
-        'third/legacy-repo': RepositoryConfig(weight=0.2),  # default False
+        'entrius/gittensor-ui': RepositoryConfig(emission_share=0.5, mirror_enabled=True),
+        'entrius/allways': RepositoryConfig(emission_share=0.5, mirror_enabled=True),
+        'other/legacy-repo': RepositoryConfig(emission_share=0.3, mirror_enabled=False),
+        'third/legacy-repo': RepositoryConfig(emission_share=0.2),  # default False
     }
 
 
@@ -82,8 +82,8 @@ def test_partitions_and_calls_both_paths():
 def test_all_legacy_repos_skips_mirror_path():
     """If no repos are mirror_enabled, mirror load/score/combine are never called."""
     configs = {
-        'a/legacy': RepositoryConfig(weight=0.5, mirror_enabled=False),
-        'b/legacy': RepositoryConfig(weight=0.3),
+        'a/legacy': RepositoryConfig(emission_share=0.5, mirror_enabled=False),
+        'b/legacy': RepositoryConfig(emission_share=0.3),
     }
 
     with (
@@ -116,8 +116,8 @@ def test_all_legacy_repos_skips_mirror_path():
 def test_all_mirror_repos_skips_legacy_path():
     """If every repo is mirror_enabled, legacy load/score are never called."""
     configs = {
-        'entrius/a': RepositoryConfig(weight=0.5, mirror_enabled=True),
-        'entrius/b': RepositoryConfig(weight=0.5, mirror_enabled=True),
+        'entrius/a': RepositoryConfig(emission_share=0.5, mirror_enabled=True),
+        'entrius/b': RepositoryConfig(emission_share=0.5, mirror_enabled=True),
     }
 
     with (

--- a/tests/validator/oss_contributions/mirror/test_scored_pr.py
+++ b/tests/validator/oss_contributions/mirror/test_scored_pr.py
@@ -115,8 +115,8 @@ class TestCalculateFinalEarnedScore:
         scored.base_score = 100.0
         scored.repo_weight_multiplier = 0.5
         scored.review_quality_multiplier = 0.5
-        # 100 * 0.5 * 0.5 (others 1.0) = 25
-        assert scored.calculate_final_earned_score() == 25.0
+        # 100 * 0.5 (others 1.0) = 50 — repo multiplier is not applied to earned score
+        assert scored.calculate_final_earned_score() == 50.0
 
     def test_zero_multiplier_zeros_score(self):
         scored = ScoredMirrorPR(pr=_make_pr())

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -103,7 +103,7 @@ def _pr(
 
 
 def _config(
-    weight: float = 0.5,
+    emission_share: float = 0.5,
     additional_branches: list | None = None,
     trusted_label_pipeline: bool = False,
     label_multipliers: dict | None = None,
@@ -112,7 +112,7 @@ def _config(
     eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
-        weight=weight,
+        emission_share=emission_share,
         mirror_enabled=True,
         additional_acceptable_branches=additional_branches,
         trusted_label_pipeline=trusted_label_pipeline,
@@ -379,7 +379,7 @@ class TestScoringDataStoredGate:
 
         client.get_pr_files.assert_not_called()
         assert scored.base_score == pytest.approx(7.5)
-        assert scored.repo_weight_multiplier == pytest.approx(0.5)
+        assert scored.repo_weight_multiplier == pytest.approx(1.0)
 
 
 class TestFixedBaseScore:
@@ -425,7 +425,7 @@ class TestFixedBaseScore:
                 mirror_eval=Mock(),
                 mirror_repos={
                     scored.pr.repo_full_name: _config(
-                        weight=1.0,
+                        emission_share=1.0,
                         fixed_base_score=1.0,
                         label_multipliers={'feature': 2.0},
                     )
@@ -442,7 +442,6 @@ class TestFixedBaseScore:
         assert scored.label_multiplier == pytest.approx(2.0)
         assert scored.calculate_final_earned_score() == pytest.approx(
             scored.base_score
-            * scored.repo_weight_multiplier
             * scored.issue_multiplier
             * scored.label_multiplier
             * scored.open_pr_spam_multiplier
@@ -497,14 +496,14 @@ class TestFixedBaseScore:
         )
         repos = {
             fixed.pr.repo_full_name: _config(
-                weight=1.0,
+                emission_share=1.0,
                 fixed_base_score=1.0,
                 label_multipliers={'feature': 1.5},
             )
         }
 
         asyncio.run(score_mirror_pr(fixed, Mock(), repos, {}, Mock(), client))
-        repos[plain.pr.repo_full_name] = _config(weight=1.0, label_multipliers={'feature': 1.5})
+        repos[plain.pr.repo_full_name] = _config(emission_share=1.0, label_multipliers={'feature': 1.5})
         asyncio.run(score_mirror_pr(plain, Mock(), repos, {}, Mock(), client))
 
         assert fixed.base_score == pytest.approx(1.0)
@@ -918,10 +917,10 @@ class TestPrMultipliers:
         scored.token_score = 100.0  # for completeness
         _calculate_pr_multipliers(
             scored,
-            _config(weight=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
+            _config(emission_share=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
         )
 
-        assert scored.repo_weight_multiplier == 0.7
+        assert scored.repo_weight_multiplier == 1.0
         assert scored.label == 'feature'
         assert scored.label_multiplier == pytest.approx(1.5)
         assert 0.0 <= scored.time_decay_multiplier <= 1.0
@@ -931,9 +930,9 @@ class TestPrMultipliers:
 
     def test_open_pr_only_neutral_multipliers(self):
         scored = ScoredMirrorPR(pr=_pr(state='OPEN'))
-        _calculate_pr_multipliers(scored, _config(weight=0.5))
+        _calculate_pr_multipliers(scored, _config(emission_share=0.5))
 
-        assert scored.repo_weight_multiplier == 0.5
+        assert scored.repo_weight_multiplier == 1.0
         # Time decay / review quality / credibility are merge-only — kept neutral here.
         assert scored.time_decay_multiplier == 1.0
         assert scored.credibility_multiplier == 1.0

--- a/tests/validator/test_emission_allocation.py
+++ b/tests/validator/test_emission_allocation.py
@@ -1,0 +1,131 @@
+"""Unit tests for per-repo emission_share allocation (``allocate_round_emissions``)."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from gittensor.classes import MinerEvaluation, PRState, PullRequest
+from gittensor.constants import (
+    ISSUES_TREASURY_EMISSION_SHARE,
+    ISSUES_TREASURY_UID,
+    OSS_EMISSION_SHARE,
+    RECYCLE_UID,
+)
+from gittensor.validator.emission_allocation import allocate_round_emissions
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+def _pr(repo: str, uid: int, earned: float) -> PullRequest:
+    now = datetime.now(timezone.utc)
+    return PullRequest(
+        number=1,
+        repository_full_name=repo,
+        uid=uid,
+        hotkey=f'hk{uid}',
+        github_id=str(uid),
+        title='t',
+        author_login='a',
+        merged_at=now,
+        created_at=now,
+        pr_state=PRState.MERGED,
+        earned_score=earned,
+        token_score=10.0,
+    )
+
+
+def _uids() -> set[int]:
+    return {1, RECYCLE_UID, ISSUES_TREASURY_UID}
+
+
+def test_full_activity_registry_sum_one_zero_recycle():
+    """Active repo with one PR: miner receives the full OSS pool share; recycle gets 0 from slack."""
+    ev = MinerEvaluation(uid=1, hotkey='hk', github_id='9')
+    ev.is_eligible = True
+    ev.merged_pull_requests = [_pr('acme/repo', 1, 100.0)]
+
+    repos = {'acme/repo': RepositoryConfig(emission_share=1.0, issue_discovery_share=0.0)}
+    rewards = allocate_round_emissions({1: ev}, repos, _uids())
+    idx = {u: i for i, u in enumerate(sorted(_uids()))}
+    assert rewards.sum() == pytest.approx(1.0)
+    assert rewards[idx[ISSUES_TREASURY_UID]] == pytest.approx(ISSUES_TREASURY_EMISSION_SHARE)
+    assert rewards[idx[RECYCLE_UID]] == pytest.approx(0.0, abs=1e-9)
+    assert rewards[idx[1]] == pytest.approx(OSS_EMISSION_SHARE)
+
+
+def test_no_pr_activity_recycles_repo_slice():
+    """Repo slice with zero PR weight and zero issue weight goes to recycle."""
+    ev = MinerEvaluation(uid=1, hotkey='hk', github_id='9')
+    ev.is_eligible = True
+    ev.merged_pull_requests = []
+
+    repos = {'acme/repo': RepositoryConfig(emission_share=1.0, issue_discovery_share=0.5)}
+    rewards = allocate_round_emissions({1: ev}, repos, _uids())
+    idx = {u: i for i, u in enumerate(sorted(_uids()))}
+    assert rewards[idx[RECYCLE_UID]] == pytest.approx(OSS_EMISSION_SHARE)
+    assert rewards[idx[1]] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_registry_slack_routes_to_recycle():
+    """When Σ emission_share < 1, (1 - sum) × OSS pool goes to recycle alongside any unclaimed repo slice."""
+    ev = MinerEvaluation(uid=1, hotkey='hk', github_id='9')
+    ev.is_eligible = True
+    ev.merged_pull_requests = [_pr('acme/a', 1, 10.0)]
+    ev.is_issue_eligible = True
+    ev.issue_discovery_repo_scores = {'acme/a': 5.0}
+
+    repos = {
+        'acme/a': RepositoryConfig(emission_share=0.8, issue_discovery_share=0.5),
+    }
+    rewards = allocate_round_emissions({1: ev}, repos, _uids())
+    idx = {u: i for i, u in enumerate(sorted(_uids()))}
+    # Treasury flat
+    assert rewards[idx[ISSUES_TREASURY_UID]] == pytest.approx(ISSUES_TREASURY_EMISSION_SHARE)
+    # Registry slack: 0.2 * OSS_EMISSION_SHARE
+    slack = 0.2 * OSS_EMISSION_SHARE
+    # Repo slice 0.8 * OSS split half/half by weight 10 vs 5 → PR gets 2/3 of 0.8*OSS, issue 1/3
+    repo_total = 0.8 * OSS_EMISSION_SHARE
+    pr_part = repo_total * (10.0 / 15.0)
+    iss_part = repo_total * (5.0 / 15.0)
+    assert rewards[idx[1]] == pytest.approx(pr_part + iss_part)
+    assert rewards[idx[RECYCLE_UID]] == pytest.approx(slack, abs=1e-6)
+    assert rewards.sum() == pytest.approx(1.0, abs=1e-5)
+
+
+def test_pr_count_does_not_change_repo_slice_total():
+    """Same repo slice is split across PRs by relative earned_score (two PRs vs one)."""
+    repos = {'acme/r': RepositoryConfig(emission_share=0.5, issue_discovery_share=0.0)}
+
+    ev1 = MinerEvaluation(uid=1, hotkey='a', github_id='1')
+    ev1.is_eligible = True
+    ev1.merged_pull_requests = [_pr('acme/r', 1, 10.0)]
+
+    ev2 = MinerEvaluation(uid=2, hotkey='b', github_id='2')
+    ev2.is_eligible = True
+    ev2.merged_pull_requests = [
+        _pr('acme/r', 2, 10.0),
+        _pr('acme/r', 2, 10.0),
+    ]
+
+    slice_amt = 0.5 * OSS_EMISSION_SHARE
+    uids = {1, 2, RECYCLE_UID, ISSUES_TREASURY_UID}
+    idx = {u: i for i, u in enumerate(sorted(uids))}
+
+    r1 = allocate_round_emissions({1: ev1}, repos, uids)
+    r2 = allocate_round_emissions({2: ev2}, repos, uids)
+    assert r1[idx[1]] == pytest.approx(slice_amt)
+    assert r2[idx[2]] == pytest.approx(slice_amt)
+
+
+def test_issue_discovery_share_spills_pr_subslice_to_issues():
+    """PR nominal sub-slice with no PR weight but positive issue weight → full repo slice to issues."""
+    ev = MinerEvaluation(uid=1, hotkey='hk', github_id='9')
+    ev.is_eligible = True
+    ev.merged_pull_requests = []
+    ev.is_issue_eligible = True
+    ev.issue_discovery_repo_scores = {'acme/r': 3.0}
+
+    repos = {'acme/r': RepositoryConfig(emission_share=1.0, issue_discovery_share=0.3)}
+    rewards = allocate_round_emissions({1: ev}, repos, _uids())
+    idx = {u: i for i, u in enumerate(sorted(_uids()))}
+    assert rewards[idx[1]] == pytest.approx(OSS_EMISSION_SHARE)
+    assert rewards[idx[RECYCLE_UID]] == pytest.approx(0.0, abs=1e-9)

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -57,7 +57,7 @@ def _score(current, timeline, repo_config):
     ],
 )
 def test_get_label_multiplier_matches_repo_patterns(pattern, label, expected):
-    config = RepositoryConfig(weight=1.0, label_multipliers={pattern: expected})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={pattern: expected})
 
     assert get_label_multiplier(label, config) == pytest.approx(expected)
 
@@ -76,15 +76,15 @@ def test_get_label_multiplier_returns_highest_matching_pattern():
 
 
 def test_get_label_multiplier_returns_none_without_repo_config_match():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'kind/*': 1.5})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'kind/*': 1.5})
 
     assert get_label_multiplier('feature', config) is None
-    assert get_label_multiplier('kind/feature', RepositoryConfig(weight=1.0)) is None
+    assert get_label_multiplier('kind/feature', RepositoryConfig(emission_share=1.0)) is None
     assert get_label_multiplier('kind/feature', None) is None
 
 
 def test_highest_label_resolution_uses_default_when_no_candidate_matches():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'kind/*': 1.5}, default_label_multiplier=0.8)
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'kind/*': 1.5}, default_label_multiplier=0.8)
 
     label, multiplier = resolve_highest_label_multiplier(['feature', 'bug'], config)
 
@@ -93,7 +93,7 @@ def test_highest_label_resolution_uses_default_when_no_candidate_matches():
 
 
 def test_highest_label_resolution_tiebreaks_by_label_name():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'a': 1.5, 'b': 1.5})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'a': 1.5, 'b': 1.5})
 
     label, multiplier = resolve_highest_label_multiplier(['a', 'b'], config)
 
@@ -128,14 +128,14 @@ def test_wildcard_label_resolves_through_legacy_scoring(current, timeline, expec
 
 
 def test_repo_without_label_multipliers_ignores_old_global_label():
-    pr = _score(['feature'], ['feature'], RepositoryConfig(weight=1.0))
+    pr = _score(['feature'], ['feature'], RepositoryConfig(emission_share=1.0))
 
     assert pr.label is None
     assert pr.label_multiplier == pytest.approx(1.0)
 
 
 def test_repo_default_label_multiplier_applies_without_label_map():
-    config = RepositoryConfig(weight=1.0, default_label_multiplier=0.8)
+    config = RepositoryConfig(emission_share=1.0, default_label_multiplier=0.8)
 
     labeled = _score(['feature'], ['feature'], config)
     unlabeled = _score([], [], config)
@@ -147,7 +147,7 @@ def test_repo_default_label_multiplier_applies_without_label_map():
 
 
 def test_legacy_timeline_order_preserved_for_matching_labels():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'feature': 1.5, 'bug': 1.25})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'feature': 1.5, 'bug': 1.25})
 
     pr = _score(['feature', 'bug'], ['feature', 'bug'], config)
 
@@ -156,7 +156,7 @@ def test_legacy_timeline_order_preserved_for_matching_labels():
 
 
 def test_legacy_timeline_skips_unmatched_labels():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'bug': 1.25})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'bug': 1.25})
 
     pr = _score(['lgtm', 'bug'], ['bug', 'lgtm'], config)
 
@@ -165,7 +165,7 @@ def test_legacy_timeline_skips_unmatched_labels():
 
 
 def test_legacy_truncated_timeline_uses_highest_current_match():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'feature': 1.5, 'bug': 1.25})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'feature': 1.5, 'bug': 1.25})
 
     pr = _score(['feature', 'bug'], [], config)
 
@@ -188,7 +188,7 @@ def test_legacy_truncated_timeline_uses_highest_current_match():
     ],
 )
 def test_legacy_current_and_timeline_compatibility(current, timeline, expected_label, expected_multiplier):
-    config = RepositoryConfig(weight=1.0, label_multipliers={'feature': 1.5, 'bug': 1.25})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'feature': 1.5, 'bug': 1.25})
 
     pr = _score(current, timeline, config)
 
@@ -202,7 +202,7 @@ def test_missing_labels_key_does_not_crash():
 
     pr = PullRequest.from_graphql_response(payload, uid=0, hotkey='hk', github_id='gh')
     label, multiplier = resolve_legacy_label_multiplier(
-        pr.label_timeline_order, pr.current_labels, RepositoryConfig(1.0)
+        pr.label_timeline_order, pr.current_labels, RepositoryConfig(emission_share=1.0)
     )
 
     assert pr.current_labels == frozenset()

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -64,7 +64,7 @@ def test_get_label_multiplier_matches_repo_patterns(pattern, label, expected):
 
 def test_get_label_multiplier_returns_highest_matching_pattern():
     config = RepositoryConfig(
-        weight=1.0,
+        emission_share=1.0,
         label_multipliers={
             'kind/*': 1.1,
             'kind/feature': 1.5,
@@ -112,7 +112,7 @@ def test_highest_label_resolution_tiebreaks_by_label_name():
 )
 def test_wildcard_label_resolves_through_legacy_scoring(current, timeline, expected_label, expected_multiplier):
     config = RepositoryConfig(
-        weight=1.0,
+        emission_share=1.0,
         label_multipliers={
             'kind/*': 1.5,
             'type:*': 1.1,

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -19,7 +19,6 @@ from gittensor.validator.utils.load_weights import (
     load_master_repo_weights,
     load_programming_language_weights,
     load_token_config,
-    resolve_repo_weight,
 )
 
 
@@ -156,12 +155,12 @@ class TestRepositoryConfigMirrorFlag:
 
     def test_mirror_enabled_default_false(self):
         """RepositoryConfig constructor defaults mirror_enabled to False."""
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
         assert config.mirror_enabled is False
 
     def test_mirror_enabled_explicit_true(self):
         """RepositoryConfig accepts mirror_enabled=True."""
-        config = RepositoryConfig(weight=0.5, mirror_enabled=True)
+        config = RepositoryConfig(emission_share=0.5, mirror_enabled=True)
         assert config.mirror_enabled is True
 
     def test_loader_parses_mirror_enabled_true(self, tmp_path, monkeypatch):
@@ -174,9 +173,9 @@ class TestRepositoryConfigMirrorFlag:
         (fake_weights_dir / 'master_repositories.json').write_text(
             json.dumps(
                 {
-                    'foo/mirror-repo': {'weight': 0.5, 'mirror_enabled': True},
-                    'foo/legacy-repo': {'weight': 0.3},
-                    'foo/explicit-off': {'weight': 0.2, 'mirror_enabled': False},
+                    'foo/mirror-repo': {'emission_share': 0.5, 'mirror_enabled': True},
+                    'foo/legacy-repo': {'emission_share': 0.3},
+                    'foo/explicit-off': {'emission_share': 0.2, 'mirror_enabled': False},
                 }
             )
         )
@@ -199,7 +198,7 @@ class TestRepositoryConfigTrustedLabelPipeline:
         attacker-controlled auto-labelers (release-drafter, actions/labeler)
         keep the maintainer-association gate in place.
         """
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
         assert config.trusted_label_pipeline is False
 
     def test_loader_parses_trusted_label_pipeline_true(self, tmp_path, monkeypatch):
@@ -212,9 +211,9 @@ class TestRepositoryConfigTrustedLabelPipeline:
         (fake_weights_dir / 'master_repositories.json').write_text(
             json.dumps(
                 {
-                    'foo/trusted': {'weight': 0.5, 'trusted_label_pipeline': True},
-                    'foo/untrusted': {'weight': 0.3},
-                    'foo/explicit-off': {'weight': 0.2, 'trusted_label_pipeline': False},
+                    'foo/trusted': {'emission_share': 0.5, 'trusted_label_pipeline': True},
+                    'foo/untrusted': {'emission_share': 0.3},
+                    'foo/explicit-off': {'emission_share': 0.2, 'trusted_label_pipeline': False},
                 }
             )
         )
@@ -231,7 +230,7 @@ class TestRepositoryConfigLabelMultipliers:
     """Dataclass + JSON-parsing tests for per-repo label multiplier config."""
 
     def test_label_multiplier_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.label_multipliers is None
         assert config.default_label_multiplier == pytest.approx(1.0)
@@ -244,11 +243,11 @@ class TestRepositoryConfigLabelMultipliers:
             json.dumps(
                 {
                     'foo/labeled': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'label_multipliers': {'kind/*': 1.5, 'type:bug': 1.25},
                         'default_label_multiplier': 0.8,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -293,7 +292,7 @@ class TestRepositoryConfigMirrorScoringFields:
     """Dataclass + JSON-parsing tests for mirror-only scoring fields."""
 
     def test_mirror_scoring_field_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.fixed_base_score is None
         assert config.eligibility_mode is True
@@ -306,11 +305,11 @@ class TestRepositoryConfigMirrorScoringFields:
             json.dumps(
                 {
                     'foo/fixed': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'fixed_base_score': 12.5,
                         'eligibility_mode': False,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -386,27 +385,78 @@ class TestBannedOrganizations:
         assert len(active_banned) == 0, f'Found {len(active_banned)} active repos from banned orgs: {active_banned}'
 
 
-class TestResolveRepoWeight:
-    """Tests for resolve_repo_weight — full-precision repo weight lookup."""
+class TestRegistryEmissionShares:
+    """Invariant tests for emission_share across the loaded registry."""
 
-    def test_none_returns_default(self):
-        assert resolve_repo_weight(None) == 0.01
-
-    @pytest.mark.parametrize(
-        'weight',
-        [0.0349, 0.0351, 0.0487, 0.1025, 0.2017, 1.0],
-    )
-    def test_preserves_full_precision(self, weight):
-        config = RepositoryConfig(weight=weight)
-        assert resolve_repo_weight(config) == weight
-
-    def test_live_master_repo_precision(self):
-        """cronboard (0.0349) and fzf (0.0351) must not collapse to 0.03/0.04."""
+    def test_live_registry_sum_not_greater_than_one(self):
         repos = load_master_repo_weights()
-        if 'antoniorodr/cronboard' in repos:
-            assert resolve_repo_weight(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
-        if 'junegunn/fzf' in repos:
-            assert resolve_repo_weight(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
+        assert repos
+        total = sum(c.emission_share for c in repos.values())
+        assert total <= 1.0 + 1e-8, f'sum emission_share {total} must be <= 1'
+
+    def test_live_each_emission_share_in_unit_interval(self):
+        repos = load_master_repo_weights()
+        for name, cfg in repos.items():
+            assert 0.0 <= cfg.emission_share <= 1.0, name
+            assert 0.0 <= cfg.issue_discovery_share <= 1.0, name
+
+    def test_rejects_registry_sum_strictly_above_one(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'a/x': {'emission_share': 0.6},
+                    'b/y': {'emission_share': 0.5},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+        assert lw.load_master_repo_weights() == {}
+
+    def test_accepts_registry_sum_below_one(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'a/x': {'emission_share': 0.3},
+                    'b/y': {'emission_share': 0.4},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+        repos = lw.load_master_repo_weights()
+        assert len(repos) == 2
+        assert repos['a/x'].emission_share == pytest.approx(0.3)
+        assert repos['b/y'].emission_share == pytest.approx(0.4)
+
+    def test_rejects_emission_share_outside_unit_interval(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(json.dumps({'a/x': {'emission_share': 1.01}}))
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+        assert lw.load_master_repo_weights() == {}
+
+    def test_loader_parses_issue_discovery_share(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'a/x': {'emission_share': 0.2, 'issue_discovery_share': 0.25},
+                    'b/y': {'emission_share': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+        repos = lw.load_master_repo_weights()
+        assert repos['a/x'].issue_discovery_share == pytest.approx(0.25)
+        assert repos['b/y'].issue_discovery_share == pytest.approx(0.5)
 
 
 if __name__ == '__main__':

--- a/tests/validator/test_review_quality_multiplier.py
+++ b/tests/validator/test_review_quality_multiplier.py
@@ -249,7 +249,7 @@ class TestReviewCollateralMultiplierOnOpenPRCollateral:
 
 
 def _make_repo_config() -> dict:
-    return {'test/repo': RepositoryConfig(weight=1.0, label_multipliers={'fix': 1.25})}
+    return {'test/repo': RepositoryConfig(emission_share=1.0, label_multipliers={'fix': 1.25})}
 
 
 def _make_eval() -> MinerEvaluation:
@@ -270,7 +270,6 @@ class TestReviewCollateralThroughScoringPipeline:
 
         collateral_projection = (
             pr.base_score
-            * pr.repo_weight_multiplier
             * pr.issue_multiplier
             * pr.label_multiplier
             * calculate_review_collateral_multiplier(pr.changes_requested_count)

--- a/tests/validator/test_validator_cache_fallback.py
+++ b/tests/validator/test_validator_cache_fallback.py
@@ -161,7 +161,7 @@ class TestStoreOrUseCachedEvaluation:
                 new=AsyncMock(side_effect=evaluate),
             ),
         ):
-            _, _, cached_uids, penalized_uids = asyncio.run(
+            _, cached_uids, penalized_uids = asyncio.run(
                 get_rewards(
                     cast(Validator, validator),
                     {1, 2},


### PR DESCRIPTION
## Summary

- Replaces registry **`weight`** (used as a per-PR multiplier) with **`emission_share`**: each repo’s share of the unified **90%** scoring pool (`OSS_EMISSION_SHARE`), enforced at **round allocation** in `allocate_round_emissions`, not in the per-PR multiplier chain.
- Adds **`issue_discovery_share`** on `RepositoryConfig` (default **0.5**): splits each repo’s slice between PR scoring and issue discovery, with **same-repo spill** when one side has no eligible weight; **recycle** only when **both** sides are empty.
- **Removes** `repo_weight` from earned-score math (legacy + mirror PRs + issue discovery); **`repo_weight_multiplier` / `discovery_repo_weight_multiplier` stay 1.0** for DB/schema compatibility where needed.
- **Monetary policy:** Drops the fixed **45%** recycle floor. **`RECYCLE_UID`** only receives **registry slack** `(1 − Σ emission_share) × OSS_EMISSION_SHARE` and **unclaimed per-repo slices** (no redistribution to other repos). **Treasury** is a flat **10%** to UID **111** (`ISSUES_TREASURY_EMISSION_SHARE` trimmed from 15%).
- Migrates **`master_repositories.json`**: `weight` → **`emission_share`**, preserving relative weights and normalizing so **Σ emission_share = 1.0**. Loader validates **`[0, 1]`** per entry and **Σ ≤ 1** (strict `> 1` → empty registry).
- Pipeline: **`get_rewards`** returns evaluations only (no global OSS normalize); **`allocate_round_emissions`** runs after issue discovery. CLI **`gitt miner score`** uses the same path; rewards JSON highlights **`blended_final`**.
- Test fixes: remaining **`RepositoryConfig(weight=...)`** in `test_label_multiplier.py` and `test_load.py` updated to **`emission_share`** for pyright/pytest.

## Related Issues

- Closes #1215

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [x] Other *(emission / monetary policy — recycle no longer a fixed baseline)*

## Testing

- [x] **`tests/validator/test_emission_allocation.py`** — allocation, slack, spill, slice vs PR count.
- [x] **`tests/validator/test_load_weights.py`** — `emission_share` invariants + JSON fixtures.
- [x] Mirror/legacy scoring, label, review-quality, CLI miner-score, **`test_load`** / **`test_label_multiplier`** updated for `RepositoryConfig(emission_share=...)`.
- [ ] Full **`pytest`** + **`pyright`** in CI / local *(dev env: `uv pip install -e ".[dev]"` for pre-commit hooks)*.
- [ ] Manual: one validator round — **`rewards.sum() ≈ 1.0`** when treasury + recycle UIDs exist on metagraph.

## Checklist

- [x] Code style / **ruff** / **pre-commit** (after dev install).
- [x] Self-review; focused diff (no accidental lockfile churn unless intentional).
- [ ] Maintainer-facing **docs / changelog** if required for emission policy.
- [x] PR text calls out **recycle baseline removal** and **90/10** split explicitly.