### PR TITLE
feat: add repository emission share validation

### DIFF
--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 import json
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -8,6 +9,8 @@ from typing import Dict, List, Optional
 import bittensor as bt
 
 from gittensor.constants import DEFAULT_REPO_WEIGHT, NON_CODE_EXTENSIONS
+
+EMISSION_SHARE_SUM_TOLERANCE = 1e-9
 
 
 @dataclass
@@ -23,12 +26,12 @@ class LanguageConfig:
     language: Optional[str] = None
 
 
-@dataclass
+@dataclass(init=False)
 class RepositoryConfig:
     """Configuration for a repository in the master_repositories list.
 
     Attributes:
-        weight: Repository weight for scoring
+        emission_share: Repository share of the scoring emission pool
         inactive_at: ISO timestamp when repository became inactive (None if active)
         additional_acceptable_branches: List of additional branch patterns to accept (None if only default branch)
         trusted_label_pipeline: When True, scoring labels count regardless of
@@ -46,7 +49,7 @@ class RepositoryConfig:
 
     """
 
-    weight: float
+    emission_share: float
     inactive_at: Optional[str] = None
     additional_acceptable_branches: Optional[List[str]] = None
     trusted_label_pipeline: bool = False
@@ -55,12 +58,44 @@ class RepositoryConfig:
     fixed_base_score: Optional[float] = None
     eligibility_mode: bool = True
 
+    def __init__(
+        self,
+        emission_share: Optional[float] = None,
+        *,
+        weight: Optional[float] = None,
+        inactive_at: Optional[str] = None,
+        additional_acceptable_branches: Optional[List[str]] = None,
+        trusted_label_pipeline: bool = False,
+        label_multipliers: Optional[Dict[str, float]] = None,
+        default_label_multiplier: float = 1.0,
+        fixed_base_score: Optional[float] = None,
+        eligibility_mode: bool = True,
+    ) -> None:
+        if emission_share is None:
+            emission_share = weight
+        if emission_share is None:
+            emission_share = DEFAULT_REPO_WEIGHT
+
+        self.emission_share = float(emission_share)
+        self.inactive_at = inactive_at
+        self.additional_acceptable_branches = additional_acceptable_branches
+        self.trusted_label_pipeline = trusted_label_pipeline
+        self.label_multipliers = label_multipliers
+        self.default_label_multiplier = default_label_multiplier
+        self.fixed_base_score = fixed_base_score
+        self.eligibility_mode = eligibility_mode
+
+    @property
+    def weight(self) -> float:
+        """Compatibility alias while scoring consumers migrate off repo weights."""
+        return self.emission_share
+
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
     """Return the repo weight preserving full JSON precision, or the default for unknown repos."""
     if repo_config is None:
         return DEFAULT_REPO_WEIGHT
-    return repo_config.weight
+    return repo_config.emission_share
 
 
 @dataclass
@@ -107,14 +142,27 @@ def _get_weights_dir() -> Path:
     return Path(__file__).parent.parent / 'weights'
 
 
+def _validate_emission_share(repo_name: str, emission_share: float) -> None:
+    if not math.isfinite(emission_share):
+        raise ValueError(f'{repo_name} emission_share must be finite, got {emission_share!r}')
+    if not 0.0 <= emission_share <= 1.0:
+        raise ValueError(f'{repo_name} emission_share must be within [0, 1], got {emission_share}')
+
+
+def _validate_total_emission_share(repositories: Dict[str, RepositoryConfig]) -> None:
+    total_share = sum(config.emission_share for config in repositories.values())
+    if total_share < -EMISSION_SHARE_SUM_TOLERANCE or total_share > 1.0 + EMISSION_SHARE_SUM_TOLERANCE:
+        raise ValueError(f'Total repository emission_share must be within [0, 1], got {total_share}')
+
+
 def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
     """
-    Load repository weights from the local JSON file.
+    Load repository emission shares from the local JSON file.
     Normalizes repository names to lowercase for case-insensitive matching.
 
     Returns:
         Dictionary mapping normalized (lowercase) fullName (str) to RepositoryConfig object.
-        Returns empty dict on error.
+        Returns empty dict when the file is missing or malformed JSON.
     """
     weights_file = _get_weights_dir() / 'master_repositories.json'
 
@@ -129,9 +177,15 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         # Parse JSON data into RepositoryConfig objects
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
+            if not isinstance(metadata, dict):
+                raise ValueError(f'Expected dict metadata for {repo_name}, got {type(metadata)}')
+
+            emission_share = float(metadata.get('emission_share', metadata.get('weight', DEFAULT_REPO_WEIGHT)))
+            _validate_emission_share(repo_name, emission_share)
+
             try:
                 config = RepositoryConfig(
-                    weight=float(metadata.get('weight', 0.01)),
+                    emission_share=emission_share,
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
@@ -146,10 +200,9 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:
-                bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
-                # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+                raise ValueError(f'Could not parse config for {repo_name}: {e}') from e
 
+        _validate_total_emission_share(normalized_data)
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data
 
@@ -158,9 +211,6 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         return {}
     except json.JSONDecodeError as e:
         bt.logging.error(f'Failed to parse JSON from {weights_file}: {e}')
-        return {}
-    except Exception as e:
-        bt.logging.error(f'Unexpected error loading repository weights: {e}')
         return {}
 
 

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,6 @@
 {
   "entrius/allways": {
-    "weight": 0.05,
+    "emission_share": 0.05,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -9,7 +9,7 @@
     }
   },
   "entrius/allways-ui": {
-    "weight": 0.01,
+    "emission_share": 0.01,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -19,7 +19,7 @@
     }
   },
   "entrius/das-github-mirror": {
-    "weight": 0.02,
+    "emission_share": 0.02,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -28,7 +28,7 @@
     }
   },
   "entrius/gittensor": {
-    "weight": 0.1,
+    "emission_share": 0.1,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.5,
@@ -38,7 +38,7 @@
     }
   },
   "entrius/gittensor-ui": {
-    "weight": 0.03,
+    "emission_share": 0.03,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -48,7 +48,7 @@
     }
   },
   "entrius/oc-1": {
-    "weight": 0.5,
+    "emission_share": 0.5,
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
     "eligibility_mode": false,

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -13,6 +13,7 @@ import json
 import pytest
 
 from gittensor.validator.utils.load_weights import (
+    EMISSION_SHARE_SUM_TOLERANCE,
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
@@ -142,6 +143,74 @@ class TestLoadMasterRepositories:
                 f'labeling worker is honored at scoring time'
             )
 
+    def test_live_master_repository_entries_use_emission_share(self):
+        """Live registry entries should use the renamed emission_share field."""
+        for repo_name, metadata in _live_master_repo_metadata():
+            assert 'emission_share' in metadata, f'{repo_name} must declare emission_share'
+            assert 'weight' not in metadata, f'{repo_name} must not use legacy weight'
+
+    def test_live_emission_shares_are_in_range(self):
+        """CI guard for per-entry emission_share bounds."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            assert 0.0 <= config.emission_share <= 1.0, f'{repo_name} emission_share must be within [0, 1]'
+
+    def test_live_total_emission_share_is_not_above_one(self):
+        """CI guard for the registry-level sum invariant."""
+        repos = load_master_repo_weights()
+        total_share = sum(config.emission_share for config in repos.values())
+        assert 0.0 <= total_share <= 1.0 + EMISSION_SHARE_SUM_TOLERANCE
+
+    def test_loader_accepts_sum_less_than_one(self, tmp_path, monkeypatch):
+        """Registry slack is valid; aggregation will route it to recycle."""
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/one': {'emission_share': 0.2},
+                    'foo/two': {'emission_share': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/one'].emission_share == pytest.approx(0.2)
+        assert repos['foo/two'].emission_share == pytest.approx(0.3)
+
+    @pytest.mark.parametrize('emission_share', [-0.001, 1.001])
+    def test_loader_rejects_emission_share_outside_range(self, tmp_path, monkeypatch, emission_share):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps({'foo/bad': {'emission_share': emission_share}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        with pytest.raises(ValueError, match='emission_share must be within'):
+            lw.load_master_repo_weights()
+
+    def test_loader_rejects_total_emission_share_above_one(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/one': {'emission_share': 0.6},
+                    'foo/two': {'emission_share': 0.5},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        with pytest.raises(ValueError, match='Total repository emission_share'):
+            lw.load_master_repo_weights()
+
 
 class TestRepositoryConfigTrustedLabelPipeline:
     """Dataclass + JSON-parsing tests for trusted_label_pipeline (issue #911)."""
@@ -153,7 +222,7 @@ class TestRepositoryConfigTrustedLabelPipeline:
         attacker-controlled auto-labelers (release-drafter, actions/labeler)
         keep the maintainer-association gate in place.
         """
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
         assert config.trusted_label_pipeline is False
 
     def test_loader_parses_trusted_label_pipeline_true(self, tmp_path, monkeypatch):
@@ -166,9 +235,9 @@ class TestRepositoryConfigTrustedLabelPipeline:
         (fake_weights_dir / 'master_repositories.json').write_text(
             json.dumps(
                 {
-                    'foo/trusted': {'weight': 0.5, 'trusted_label_pipeline': True},
-                    'foo/untrusted': {'weight': 0.3},
-                    'foo/explicit-off': {'weight': 0.2, 'trusted_label_pipeline': False},
+                    'foo/trusted': {'emission_share': 0.5, 'trusted_label_pipeline': True},
+                    'foo/untrusted': {'emission_share': 0.3},
+                    'foo/explicit-off': {'emission_share': 0.2, 'trusted_label_pipeline': False},
                 }
             )
         )
@@ -185,7 +254,7 @@ class TestRepositoryConfigLabelMultipliers:
     """Dataclass + JSON-parsing tests for per-repo label multiplier config."""
 
     def test_label_multiplier_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.label_multipliers is None
         assert config.default_label_multiplier == pytest.approx(1.0)
@@ -198,11 +267,11 @@ class TestRepositoryConfigLabelMultipliers:
             json.dumps(
                 {
                     'foo/labeled': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'label_multipliers': {'kind/*': 1.5, 'type:bug': 1.25},
                         'default_label_multiplier': 0.8,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -247,7 +316,7 @@ class TestRepositoryConfigMirrorScoringFields:
     """Dataclass + JSON-parsing tests for mirror-only scoring fields."""
 
     def test_mirror_scoring_field_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.fixed_base_score is None
         assert config.eligibility_mode is True
@@ -260,11 +329,11 @@ class TestRepositoryConfigMirrorScoringFields:
             json.dumps(
                 {
                     'foo/fixed': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'fixed_base_score': 12.5,
                         'eligibility_mode': False,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -351,7 +420,7 @@ class TestResolveRepoWeight:
         [0.0349, 0.0351, 0.0487, 0.1025, 0.2017, 1.0],
     )
     def test_preserves_full_precision(self, weight):
-        config = RepositoryConfig(weight=weight)
+        config = RepositoryConfig(emission_share=weight)
         assert resolve_repo_weight(config) == weight
 
     def test_live_master_repo_precision(self):


### PR DESCRIPTION
## Summary

- Rename the live repository registry field from `weight` to `emission_share`
- Add load-time validation that each repo share is in `[0, 1]` and the registry total does not exceed `1.0`
- Add focused CI coverage for valid slack, invalid per-entry shares, invalid registry totals, and live registry drift

## Related Issues

Part of #1215

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_load_weights.py -q`
`uv run pytest tests/validator/test_label_multiplier.py tests/validator/oss_contributions/mirror/test_repo_config_fields.py tests/validator/issue_discovery/test_scan.py -q`
`uv run ruff check gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py`
`uv run ruff format --check gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Notes for reviewers: this PR intentionally keeps a temporary `weight` compatibility alias and JSON read fallback so existing scoring consumers can be migrated in the follow-up #1215 slices without bundling aggregation behavior into this registry-validation PR.