### PR TITLE
feat: add issue discovery share config

### DIFF
--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 import json
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -43,6 +44,8 @@ class RepositoryConfig:
             to be within [0.0, 100.0]; range is enforced by the live-config test.
         eligibility_mode: Flag controlling whether the global miner
             eligibility gate applies to PRs in this repo.
+        issue_discovery_share: Fraction of the repo emission slice allocated
+            to issue-discovery scoring before same-repo spill. Defaults to 0.5.
 
     """
 
@@ -54,6 +57,12 @@ class RepositoryConfig:
     default_label_multiplier: float = 1.0
     fixed_base_score: Optional[float] = None
     eligibility_mode: bool = True
+    issue_discovery_share: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.issue_discovery_share = float(self.issue_discovery_share)
+        if not math.isfinite(self.issue_discovery_share) or not 0.0 <= self.issue_discovery_share <= 1.0:
+            raise ValueError(f'issue_discovery_share must be within [0.0, 1.0], got {self.issue_discovery_share}')
 
 
 def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
@@ -129,6 +138,11 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         # Parse JSON data into RepositoryConfig objects
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
+            issue_discovery_share = float(metadata.get('issue_discovery_share', 0.5))
+            if not math.isfinite(issue_discovery_share) or not 0.0 <= issue_discovery_share <= 1.0:
+                raise ValueError(
+                    f'{repo_name} issue_discovery_share must be within [0.0, 1.0], got {issue_discovery_share}'
+                )
             try:
                 config = RepositoryConfig(
                     weight=float(metadata.get('weight', 0.01)),
@@ -143,6 +157,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
                     fixed_base_score=metadata.get('fixed_base_score'),
                     eligibility_mode=metadata.get('eligibility_mode', True),
+                    issue_discovery_share=issue_discovery_share,
                 )
                 normalized_data[repo_name.lower()] = config
             except (ValueError, TypeError) as e:

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -52,6 +52,7 @@
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
     "eligibility_mode": false,
+    "issue_discovery_share": 0.0,
     "default_label_multiplier": 0.0,
     "label_multipliers": {
       "benchmark-improvement": 1.0

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -292,6 +292,61 @@ class TestRepositoryConfigMirrorScoringFields:
             assert isinstance(config.eligibility_mode, bool), (
                 f'{repo_name} eligibility_mode must be bool, got {type(config.eligibility_mode)}'
             )
+            assert isinstance(config.issue_discovery_share, (int, float)) and not isinstance(
+                config.issue_discovery_share, bool
+            ), f'{repo_name} issue_discovery_share must be numeric, got {type(config.issue_discovery_share)}'
+            assert 0.0 <= float(config.issue_discovery_share) <= 1.0, (
+                f'{repo_name} issue_discovery_share must be within [0.0, 1.0]'
+            )
+
+
+class TestRepositoryConfigIssueDiscoveryShare:
+    """Dataclass + JSON-parsing tests for per-repo issue discovery allocation."""
+
+    def test_issue_discovery_share_defaults_to_even_split(self):
+        config = RepositoryConfig(weight=0.5)
+
+        assert config.issue_discovery_share == pytest.approx(0.5)
+
+    def test_loader_parses_issue_discovery_share(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/pr-only': {'weight': 0.5, 'issue_discovery_share': 0.0},
+                    'foo/issue-only': {'weight': 0.3, 'issue_discovery_share': 1.0},
+                    'foo/defaults': {'weight': 0.2},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/pr-only'].issue_discovery_share == pytest.approx(0.0)
+        assert repos['foo/issue-only'].issue_discovery_share == pytest.approx(1.0)
+        assert repos['foo/defaults'].issue_discovery_share == pytest.approx(0.5)
+
+    @pytest.mark.parametrize('share', [-0.001, 1.001])
+    def test_loader_rejects_issue_discovery_share_outside_range(self, tmp_path, monkeypatch, share):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps({'foo/bad': {'weight': 0.5, 'issue_discovery_share': share}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos == {}
+
+    def test_oc_1_opts_out_of_issue_discovery_rewards(self):
+        repos = load_master_repo_weights()
+
+        assert repos['entrius/oc-1'].issue_discovery_share == pytest.approx(0.0)
 
 
 class TestBannedOrganizations:


### PR DESCRIPTION
## Summary

- Add `issue_discovery_share` to `RepositoryConfig` with the required default of `0.5`
- Parse and validate `issue_discovery_share` from `master_repositories.json` as a finite float in `[0, 1]`
- Configure `entrius/oc-1` with `issue_discovery_share: 0.0` because that optimization track should not allocate rewards to issue discovery
- Add loader and live-config tests for defaults, explicit parsing, bounds rejection, and the `oc-1` opt-out

## Related Issues

Part of #1215. Covers required deliverable 8 only.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_load_weights.py -q`
`uv run ruff check gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py`
`uv run ruff format --check gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally adds only the config surface. The allocation/spill behavior that consumes `issue_discovery_share` is left to separate #1215 deliverable PRs.