### PR TITLE
feat: Convert per-repo weight  from unbounded multiplier to emission_share

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -150,7 +150,6 @@ class Issue:
     discovery_base_score: float = 0.0
     discovery_earned_score: float = 0.0
     discovery_review_quality_multiplier: float = 1.0
-    discovery_repo_weight_multiplier: float = 1.0
     discovery_time_decay_multiplier: float = 1.0
     discovery_credibility_multiplier: float = 1.0
     discovery_open_issue_spam_multiplier: float = 1.0
@@ -182,7 +181,6 @@ class PullRequest:
     pr_state: PRState
 
     # Score fields
-    repo_weight_multiplier: float = 1.0
     base_score: float = 0.0
     issue_multiplier: float = 1.0
     open_pr_spam_multiplier: float = 1.0
@@ -234,7 +232,6 @@ class PullRequest:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,
@@ -289,6 +286,7 @@ class MinerEvaluation:
     total_valid_solved_issues: int = 0  # solved issues where solving PR has token_score >= 5
     total_closed_issues: int = 0
     total_open_issues: int = 0  # mirror-tracked open issues in lookback window (set by issue_discovery.scan)
+    issue_discovery_scores_by_repo: Dict[str, float] = field(default_factory=dict)
 
     @property
     def total_prs(self) -> int:

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -280,7 +280,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
             issue_rewards = await issue_discovery(
                 miner_evaluations, master_repositories, programming_languages, token_config, miner_uids
             )
-        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+        rewards = blend_emission_pools(miner_evaluations, miner_uids, master_repositories)
 
         return {
             'success': True,

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -74,7 +74,7 @@ EXTENSIONLESS_FILE_EXTENSIONS = {'dockerfile', 'makefile'}
 # =============================================================================
 # Repository & PR Scoring
 # =============================================================================
-DEFAULT_REPO_WEIGHT = 0.01  # fallback weight for repos not in master_repositories.json
+DEFAULT_REPO_EMISSION_SHARE = 0.01  # fallback share for repos not in master_repositories.json
 PR_LOOKBACK_DAYS = 35  # rolling window for scoring
 MERGED_PR_BASE_SCORE = 25
 MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5  # PRs below this get 0 base score
@@ -155,10 +155,8 @@ OPEN_PR_COLLATERAL_PERCENT = 0.20
 RECYCLE_UID = 0
 
 # Hardcoded emission splits per competition (replaces dynamic emissions)
-OSS_EMISSION_SHARE = 0.30  # 30% to OSS contributions (PR scoring)
-ISSUE_DISCOVERY_EMISSION_SHARE = 0.10  # 10% to issue discovery
-RECYCLE_EMISSION_SHARE = 0.45  # 45% to recycle UID 0
-# ISSUES_TREASURY_EMISSION_SHARE = 0.15 defined below (15% to smart contract treasury)
+OSS_EMISSION_SHARE = 0.90  # 90% scoring pool allocated by per-repo emission_share
+# ISSUES_TREASURY_EMISSION_SHARE = 0.10 defined below (10% to smart contract treasury)
 
 # =============================================================================
 # Spam & Gaming Mitigation
@@ -187,5 +185,5 @@ MAX_OPEN_PR_THRESHOLD = 30  # Maximum open PR threshold (base + bonus capped at 
 # =============================================================================
 CONTRACT_ADDRESS = '5FWNdk8YNtNcHKrAx2krqenFrFAZG7vmsd2XN2isJSew3MrD'
 ISSUES_TREASURY_UID = 111  # UID of the smart contract neuron, if set to RECYCLE_UID then it's disabled
-ISSUES_TREASURY_EMISSION_SHARE = 0.15  # % of emissions allocated to funding issues treasury
+ISSUES_TREASURY_EMISSION_SHARE = 0.10  # % of emissions allocated to funding issues treasury
 MAX_ISSUE_ID = 1_000_000  # sanity-check upper bound for any real deployment

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -9,11 +9,9 @@ import numpy as np
 
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.constants import (
-    ISSUE_DISCOVERY_EMISSION_SHARE,
     ISSUES_TREASURY_EMISSION_SHARE,
     ISSUES_TREASURY_UID,
     OSS_EMISSION_SHARE,
-    RECYCLE_EMISSION_SHARE,
     RECYCLE_UID,
 )
 from gittensor.utils.uids import get_all_uids
@@ -62,12 +60,12 @@ async def forward(self: 'Validator') -> None:
         token_config = load_token_config()
 
         # 1. Score OSS contributions
-        oss_rewards, miner_evaluations, cached_uids, penalized_uids = await oss_contributions(
+        _, miner_evaluations, cached_uids, penalized_uids = await oss_contributions(
             self, miner_uids, master_repositories, programming_languages, token_config
         )
 
         # 2. Score issue discovery
-        issue_rewards = await issue_discovery(
+        _ = await issue_discovery(
             miner_evaluations,
             master_repositories,
             programming_languages,
@@ -86,7 +84,7 @@ async def forward(self: 'Validator') -> None:
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
 
         # 5. Blend 4 emission pools into final rewards
-        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+        rewards = blend_emission_pools(miner_evaluations, miner_uids, master_repositories)
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
 
@@ -150,49 +148,84 @@ async def issue_discovery(
 
 
 def blend_emission_pools(
-    oss_rewards: np.ndarray,
-    issue_rewards: np.ndarray,
+    miner_evaluations: Dict[int, MinerEvaluation],
     miner_uids: set[int],
+    master_repositories: Dict[str, RepositoryConfig],
 ) -> np.ndarray:
-    """Blend 4 emission pools into a single rewards array.
+    """Blend the round emission pools using per-repo emission shares.
 
-    - OSS contributions: 30%
-    - Issue discovery:   30%
-    - Issue treasury:    15% (flat to UID 111)
-    - Recycle:           25% (flat to UID 0)
+    - OSS scoring pool: 90% distributed by repo emission_share
+    - Treasury: 10% flat to UID 111
+    - Recycle: natural slack from unallocated registry share + unclaimed repo slices
     """
     sorted_uids = sorted(miner_uids)
     rewards = np.zeros(len(sorted_uids))
+    uid_to_index = {uid: idx for idx, uid in enumerate(sorted_uids)}
     recycle_extra = 0.0
 
-    # Pool 1: OSS contributions (30%)
-    oss_total = float(oss_rewards.sum())
-    if oss_total > 0:
-        rewards += oss_rewards * OSS_EMISSION_SHARE
-    else:
-        recycle_extra += OSS_EMISSION_SHARE
+    total_registry_share = sum(repo.emission_share for repo in master_repositories.values())
+    if total_registry_share < 1.0:
+        recycle_extra += OSS_EMISSION_SHARE * (1.0 - total_registry_share)
 
-    # Pool 2: Issue discovery (30%)
-    issue_total = float(issue_rewards.sum())
-    if issue_total > 0:
-        rewards += issue_rewards * ISSUE_DISCOVERY_EMISSION_SHARE
-    else:
-        recycle_extra += ISSUE_DISCOVERY_EMISSION_SHARE
+    for repo_name, repo_config in master_repositories.items():
+        repo_slice = OSS_EMISSION_SHARE * repo_config.emission_share
+        if repo_slice <= 0.0:
+            continue
 
-    # Pool 3: Issue treasury (15% flat to UID 111)
+        pr_scores: Dict[int, float] = {}
+        issue_scores: Dict[int, float] = {}
+        for uid, evaluation in miner_evaluations.items():
+            pr_score = sum(
+                pr.earned_score
+                for pr in evaluation.merged_prs
+                if pr.repository_full_name == repo_name and pr.earned_score > 0
+            )
+            if pr_score > 0:
+                pr_scores[uid] = pr_score
+
+            issue_score = evaluation.issue_discovery_scores_by_repo.get(repo_name, 0.0)
+            if issue_score > 0:
+                issue_scores[uid] = issue_score
+
+        pr_total = sum(pr_scores.values())
+        issue_total = sum(issue_scores.values())
+
+        if pr_total <= 0.0 and issue_total <= 0.0:
+            recycle_extra += repo_slice
+            continue
+
+        issue_subslice = repo_slice * repo_config.issue_discovery_share
+        pr_subslice = repo_slice * (1.0 - repo_config.issue_discovery_share)
+
+        if pr_total <= 0.0:
+            issue_subslice += pr_subslice
+            pr_subslice = 0.0
+        elif issue_total <= 0.0:
+            pr_subslice += issue_subslice
+            issue_subslice = 0.0
+
+        if pr_subslice > 0.0 and pr_total > 0.0:
+            for uid, score in pr_scores.items():
+                idx = uid_to_index.get(uid)
+                if idx is not None:
+                    rewards[idx] += pr_subslice * (score / pr_total)
+
+        if issue_subslice > 0.0 and issue_total > 0.0:
+            for uid, score in issue_scores.items():
+                idx = uid_to_index.get(uid)
+                if idx is not None:
+                    rewards[idx] += issue_subslice * (score / issue_total)
+
+    # Treasury pool (10% flat to UID 111)
     if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
         treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
         rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
-        bt.logging.info(
-            f'Treasury allocation: UID {ISSUES_TREASURY_UID} receives '
-            f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
-        )
+    else:
+        recycle_extra += ISSUES_TREASURY_EMISSION_SHARE
 
-    # Pool 4: Recycle (25% + unclaimed from empty pools)
+    # Recycle pool: unclaimed repo slices + registry slack (+ treasury fallback)
     if RECYCLE_UID in miner_uids:
         recycle_idx = sorted_uids.index(RECYCLE_UID)
-        rewards[recycle_idx] += RECYCLE_EMISSION_SHARE + recycle_extra
-        if recycle_extra > 0:
-            bt.logging.info(f'Recycling {recycle_extra * 100:.0f}% unclaimed emissions from empty pools')
+        rewards[recycle_idx] += recycle_extra
 
     return rewards

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -60,7 +60,6 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
 )
 
 
@@ -224,6 +223,7 @@ def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
     evaluation.total_valid_solved_issues = 0
     evaluation.total_closed_issues = 0
     evaluation.total_open_issues = 0
+    evaluation.issue_discovery_scores_by_repo = {}
 
 
 def _copy_issue_discovery_fields(target: MinerEvaluation, source: MinerEvaluation) -> None:
@@ -235,6 +235,7 @@ def _copy_issue_discovery_fields(target: MinerEvaluation, source: MinerEvaluatio
     target.total_valid_solved_issues = source.total_valid_solved_issues
     target.total_closed_issues = source.total_closed_issues
     target.total_open_issues = source.total_open_issues
+    target.issue_discovery_scores_by_repo = dict(source.issue_discovery_scores_by_repo)
 
 
 def _restore_issue_discovery_from_cache(
@@ -339,6 +340,7 @@ async def _score_miner_issues(
     valid_solved_count = 0
     closed_count = 0
     issue_token_score = 0.0
+    repo_issue_scores: Dict[str, float] = {}
     score_fetch_failed = False
     scored_issues: List[Issue] = []
 
@@ -421,7 +423,7 @@ async def _score_miner_issues(
             )
             continue
 
-        adapted = _mirror_issue_for_scoring(issue, solving_pr, repo_config, base_score=cached.base_score)
+        adapted = _mirror_issue_for_scoring(issue, solving_pr, base_score=cached.base_score)
         if adapted is None:
             continue
 
@@ -456,7 +458,6 @@ async def _score_miner_issues(
         issue.discovery_open_issue_spam_multiplier = spam_mult
         issue.discovery_earned_score = round(
             issue.discovery_base_score
-            * issue.discovery_repo_weight_multiplier
             * issue.discovery_time_decay_multiplier
             * issue.discovery_review_quality_multiplier
             * issue.discovery_credibility_multiplier
@@ -464,8 +465,13 @@ async def _score_miner_issues(
             2,
         )
         total_discovery_score += issue.discovery_earned_score
+        if issue.discovery_earned_score > 0:
+            repo_issue_scores[issue.repository_full_name] = (
+                repo_issue_scores.get(issue.repository_full_name, 0.0) + issue.discovery_earned_score
+            )
 
     evaluation.issue_discovery_score = round(total_discovery_score, 2)
+    evaluation.issue_discovery_scores_by_repo = repo_issue_scores
 
     bt.logging.info(
         f'├─ UID {evaluation.uid}: {solved_count} solved ({valid_solved_count} valid) | '
@@ -590,7 +596,6 @@ def _classify_issue(issue: MirrorIssue) -> str:
 def _mirror_issue_for_scoring(
     issue: MirrorIssue,
     solving_pr: MirrorSolvingPR,
-    repo_config: RepositoryConfig,
     base_score: float,
 ) -> Optional[Issue]:
     """Build a legacy ``Issue`` with discovery_* fields populated.
@@ -620,7 +625,6 @@ def _mirror_issue_for_scoring(
     )
 
     adapted.discovery_base_score = base_score
-    adapted.discovery_repo_weight_multiplier = resolve_repo_weight(repo_config)
     adapted.discovery_time_decay_multiplier = round(calculate_time_decay(solving_pr.merged_at), 2)
     adapted.discovery_review_quality_multiplier = round(
         calculate_issue_review_quality_multiplier(solving_pr.review_summary.maintainer_changes_requested_count),

--- a/gittensor/validator/oss_contributions/mirror/adapters.py
+++ b/gittensor/validator/oss_contributions/mirror/adapters.py
@@ -116,7 +116,6 @@ def mirror_scored_pr_to_legacy_pull_request(
         merged_at=pr.merged_at,
         created_at=pr.created_at,
         pr_state=PRState(pr.state),
-        repo_weight_multiplier=scored.repo_weight_multiplier,
         base_score=scored.base_score,
         issue_multiplier=scored.issue_multiplier,
         open_pr_spam_multiplier=scored.open_pr_spam_multiplier,

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -27,7 +27,6 @@ class ScoredPR:
     pr: MirrorPullRequest
 
     # Multipliers (default 1.0 — neutral if not yet computed)
-    repo_weight_multiplier: float = 1.0
     issue_multiplier: float = 1.0
     open_pr_spam_multiplier: float = 1.0
     time_decay_multiplier: float = 1.0
@@ -88,7 +87,6 @@ class ScoredPR:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -54,7 +54,6 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -338,15 +337,13 @@ def calculate_base_score_for_pr_files(
 
 
 def _calculate_pr_multipliers(scored: ScoredPR, repo_config: RepositoryConfig) -> None:
-    """Compute repo_weight, time_decay, review_quality, label, issue multipliers.
+    """Compute time_decay, review_quality, label, issue multipliers.
 
     Spam and credibility multipliers are deferred to ``finalize_miner_scores``
     — they depend on per-miner aggregate counts.
     """
     pr = scored.pr
     is_merged = pr.state == 'MERGED'
-
-    scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
 
     chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -283,14 +283,13 @@ def calculate_open_pr_collateral_score(pr: 'ScoredPR') -> float:
 
     Collateral = base_score * applicable_multipliers * OPEN_PR_COLLATERAL_PERCENT
 
-    Applicable multipliers: repo_weight, issue, label, review_collateral
+    Applicable multipliers: issue, label, review_collateral
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
                     open_pr_spam (not for collateral)
     """
     from math import prod
 
     multipliers = {
-        'repo_weight': pr.repo_weight_multiplier,
         'issue': pr.issue_multiplier,
         'label': pr.label_multiplier,
         'review_collateral': calculate_review_collateral_multiplier(pr.changes_requested_count, pr.number),

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -45,7 +45,7 @@ BULK_UPSERT_PULL_REQUESTS = """
 INSERT INTO pull_requests (
     number, repository_full_name, uid, hotkey, github_id, title, author_login,
     merged_at, pr_created_at, pr_state,
-    repo_weight_multiplier, base_score, issue_multiplier,
+    base_score, issue_multiplier,
     open_pr_spam_multiplier, pioneer_dividend, pioneer_rank, time_decay_multiplier,
     credibility_multiplier, review_quality_multiplier, label_multiplier, label,
     earned_score, collateral_score,
@@ -54,7 +54,7 @@ INSERT INTO pull_requests (
     code_density, token_score, structural_count, structural_score, leaf_count, leaf_score
 ) VALUES (
     %s, %s, %s, %s, %s, %s, %s,
-    %s, %s, %s,
+    %s, %s,
     %s, %s, %s,
     %s, %s, %s, %s,
     %s, %s, %s, %s,
@@ -71,7 +71,6 @@ DO UPDATE SET
     author_login = EXCLUDED.author_login,
     merged_at = EXCLUDED.merged_at,
     pr_state = EXCLUDED.pr_state,
-    repo_weight_multiplier = EXCLUDED.repo_weight_multiplier,
     base_score = EXCLUDED.base_score,
     issue_multiplier = EXCLUDED.issue_multiplier,
     open_pr_spam_multiplier = EXCLUDED.open_pr_spam_multiplier,
@@ -117,14 +116,14 @@ INSERT INTO issues (
     author_login, state, author_association,
     author_github_id, is_transferred, updated_at,
     discovery_base_score, discovery_earned_score,
-    discovery_review_quality_multiplier, discovery_repo_weight_multiplier,
+    discovery_review_quality_multiplier,
     discovery_time_decay_multiplier, discovery_credibility_multiplier,
     discovery_open_issue_spam_multiplier
 ) VALUES (
     %s, %s, %s, %s, %s, %s,
     %s, %s, %s,
     %s, %s, %s,
-    %s, %s,
+    %s,
     %s, %s,
     %s, %s,
     %s
@@ -142,7 +141,6 @@ DO UPDATE SET
     discovery_base_score = EXCLUDED.discovery_base_score,
     discovery_earned_score = EXCLUDED.discovery_earned_score,
     discovery_review_quality_multiplier = EXCLUDED.discovery_review_quality_multiplier,
-    discovery_repo_weight_multiplier = EXCLUDED.discovery_repo_weight_multiplier,
     discovery_time_decay_multiplier = EXCLUDED.discovery_time_decay_multiplier,
     discovery_credibility_multiplier = EXCLUDED.discovery_credibility_multiplier,
     discovery_open_issue_spam_multiplier = EXCLUDED.discovery_open_issue_spam_multiplier

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -177,7 +177,6 @@ class Repository(BaseRepository):
                     pr.merged_at,
                     pr.created_at,
                     pr.pr_state.value,  # Convert PRState enum to string
-                    pr.repo_weight_multiplier,
                     pr.base_score,
                     pr.issue_multiplier,
                     pr.open_pr_spam_multiplier,
@@ -274,7 +273,6 @@ class Repository(BaseRepository):
                     issue.discovery_base_score,
                     issue.discovery_earned_score,
                     issue.discovery_review_quality_multiplier,
-                    issue.discovery_repo_weight_multiplier,
                     issue.discovery_time_decay_multiplier,
                     issue.discovery_credibility_multiplier,
                     issue.discovery_open_issue_spam_multiplier,

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 
 import bittensor as bt
 
-from gittensor.constants import DEFAULT_REPO_WEIGHT, NON_CODE_EXTENSIONS
+from gittensor.constants import DEFAULT_REPO_EMISSION_SHARE, NON_CODE_EXTENSIONS
 
 
 @dataclass
@@ -28,7 +28,8 @@ class RepositoryConfig:
     """Configuration for a repository in the master_repositories list.
 
     Attributes:
-        weight: Repository weight for scoring
+        emission_share: Repository share of the OSS scoring pool
+        issue_discovery_share: Share of this repo allocation routed to issue-discovery scoring
         inactive_at: ISO timestamp when repository became inactive (None if active)
         additional_acceptable_branches: List of additional branch patterns to accept (None if only default branch)
         trusted_label_pipeline: When True, scoring labels count regardless of
@@ -46,7 +47,8 @@ class RepositoryConfig:
 
     """
 
-    weight: float
+    emission_share: float
+    issue_discovery_share: float = 0.5
     inactive_at: Optional[str] = None
     additional_acceptable_branches: Optional[List[str]] = None
     trusted_label_pipeline: bool = False
@@ -56,11 +58,11 @@ class RepositoryConfig:
     eligibility_mode: bool = True
 
 
-def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
-    """Return the repo weight preserving full JSON precision, or the default for unknown repos."""
+def resolve_repo_emission_share(repo_config: Optional[RepositoryConfig]) -> float:
+    """Return the repo emission share preserving full JSON precision, or the default for unknown repos."""
     if repo_config is None:
-        return DEFAULT_REPO_WEIGHT
-    return repo_config.weight
+        return DEFAULT_REPO_EMISSION_SHARE
+    return repo_config.emission_share
 
 
 @dataclass
@@ -128,10 +130,20 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
 
         # Parse JSON data into RepositoryConfig objects
         normalized_data: Dict[str, RepositoryConfig] = {}
+        total_emission_share = 0.0
+        tolerance = 1e-9
         for repo_name, metadata in data.items():
             try:
+                emission_share = float(metadata.get('emission_share', metadata.get('weight', DEFAULT_REPO_EMISSION_SHARE)))
+                issue_discovery_share = float(metadata.get('issue_discovery_share', 0.5))
+                if emission_share < 0.0 or emission_share > 1.0:
+                    raise ValueError(f'emission_share out of bounds [0,1]: {emission_share}')
+                if issue_discovery_share < 0.0 or issue_discovery_share > 1.0:
+                    raise ValueError(f'issue_discovery_share out of bounds [0,1]: {issue_discovery_share}')
+
                 config = RepositoryConfig(
-                    weight=float(metadata.get('weight', 0.01)),
+                    emission_share=emission_share,
+                    issue_discovery_share=issue_discovery_share,
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
@@ -145,10 +157,14 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     eligibility_mode=metadata.get('eligibility_mode', True),
                 )
                 normalized_data[repo_name.lower()] = config
+                total_emission_share += emission_share
             except (ValueError, TypeError) as e:
-                bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
-                # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+                raise ValueError(f'Could not parse config for {repo_name}: {e}') from e
+
+        if total_emission_share < -tolerance or total_emission_share > 1.0 + tolerance:
+            raise ValueError(
+                f'Total emission_share across repositories must be within [0,1], got {total_emission_share:.12f}'
+            )
 
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,6 @@
 {
   "entrius/allways": {
-    "weight": 0.05,
+    "emission_share": 0.05,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -9,7 +9,7 @@
     }
   },
   "entrius/allways-ui": {
-    "weight": 0.01,
+    "emission_share": 0.01,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -19,7 +19,7 @@
     }
   },
   "entrius/das-github-mirror": {
-    "weight": 0.02,
+    "emission_share": 0.02,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -28,7 +28,7 @@
     }
   },
   "entrius/gittensor": {
-    "weight": 0.1,
+    "emission_share": 0.1,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.5,
@@ -38,7 +38,7 @@
     }
   },
   "entrius/gittensor-ui": {
-    "weight": 0.03,
+    "emission_share": 0.03,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -48,7 +48,8 @@
     }
   },
   "entrius/oc-1": {
-    "weight": 0.5,
+    "emission_share": 0.5,
+    "issue_discovery_share": 0.0,
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
     "eligibility_mode": false,

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -165,7 +165,7 @@ def _eval(uid: int = 1, github_id: Optional[str] = '999'):
 
 
 def _mirror_repos(*names: str) -> dict:
-    return {name: RepositoryConfig(weight=0.5) for name in names}
+    return {name: RepositoryConfig(emission_share=0.5) for name in names}
 
 
 def _run(coro):

--- a/tests/validator/oss_contributions/mirror/test_adapters.py
+++ b/tests/validator/oss_contributions/mirror/test_adapters.py
@@ -164,7 +164,6 @@ class TestMirrorScoredPrToLegacyPullRequest:
         scored.base_score = 30.5
         scored.earned_score = 25.0
         scored.token_score = 100.0
-        scored.repo_weight_multiplier = 0.7
         scored.label_multiplier = 1.5
         scored.label = 'enhancement'
         scored.time_decay_multiplier = 0.95
@@ -208,7 +207,6 @@ class TestMirrorScoredPrToLegacyPullRequest:
         assert adapted.base_score == 30.5
         assert adapted.earned_score == 25.0
         assert adapted.token_score == 100.0
-        assert adapted.repo_weight_multiplier == 0.7
         assert adapted.label_multiplier == 1.5
         assert adapted.label == 'enhancement'
         assert adapted.time_decay_multiplier == 0.95
@@ -254,6 +252,5 @@ class TestMirrorScoredPrToLegacyPullRequest:
         adapted = mirror_scored_pr_to_legacy_pull_request(scored, 1, 'hk', 'gid')
         assert adapted.base_score == 0.0
         assert adapted.earned_score == 0.0
-        assert adapted.repo_weight_multiplier == 1.0
         assert adapted.pioneer_rank == 0
         assert adapted.label is None

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -93,7 +93,7 @@ def _build_response(prs: list) -> MirrorPullRequestsResponse:
 
 
 def _mirror_repos(*names: str) -> dict:
-    return {name: RepositoryConfig(weight=0.5) for name in names}
+    return {name: RepositoryConfig(emission_share=0.5) for name in names}
 
 
 def _eval(github_id: str | None = '218712309') -> MinerEvaluation:

--- a/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
@@ -63,8 +63,8 @@ def test_ineligible_miner_earns_only_from_eligibility_disabled_repo():
     evaluation.closed_prs = closed_prs
 
     repos = {
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -91,8 +91,8 @@ def test_eligibility_disabled_prs_do_not_unlock_gated_repo_rewards():
     evaluation.merged_prs = opt_out_prs + [gated]
 
     repos = {
-        **{pr.repository_full_name: RepositoryConfig(weight=1.0, eligibility_mode=False) for pr in opt_out_prs},
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
+        **{pr.repository_full_name: RepositoryConfig(emission_share=1.0, eligibility_mode=False) for pr in opt_out_prs},
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -116,8 +116,8 @@ def test_eligibility_disabled_closed_prs_do_not_penalize_gated_repo_eligibility(
     evaluation.closed_prs = opt_out_closed_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -140,8 +140,8 @@ def test_eligibility_disabled_open_prs_do_not_spam_penalize_gated_rewards():
     evaluation.open_prs = opt_out_open_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -161,7 +161,7 @@ def test_eligible_miner_scores_all_repos_with_existing_credibility_multiplier():
     evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
     evaluation.merged_prs = prs
 
-    repos = {'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True)}
+    repos = {'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True)}
 
     finalize_miner_scores({1: evaluation}, repos)
 
@@ -185,8 +185,8 @@ def test_zero_history_miner_earns_only_from_eligibility_disabled_repo():
     evaluation.merged_prs = [opt_out, gated]
 
     repos = {
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -212,8 +212,8 @@ def test_eligibility_disabled_repo_open_collateral_does_not_reduce_gated_only_ea
     evaluation.open_prs = bypass_open_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)

--- a/tests/validator/oss_contributions/mirror/test_routing.py
+++ b/tests/validator/oss_contributions/mirror/test_routing.py
@@ -29,8 +29,8 @@ def _make_miner_eval(uid=1, hotkey='hk', github_id='218712309', failed_reason=No
 
 def _configs():
     return {
-        'entrius/gittensor-ui': RepositoryConfig(weight=0.5),
-        'entrius/allways': RepositoryConfig(weight=0.5),
+        'entrius/gittensor-ui': RepositoryConfig(emission_share=0.5),
+        'entrius/allways': RepositoryConfig(emission_share=0.5),
     }
 
 

--- a/tests/validator/oss_contributions/mirror/test_scored_pr.py
+++ b/tests/validator/oss_contributions/mirror/test_scored_pr.py
@@ -64,7 +64,6 @@ class TestComposition:
     def test_scoring_fields_default_neutral(self):
         scored = ScoredPR(pr=_make_pr())
         for mult in [
-            scored.repo_weight_multiplier,
             scored.issue_multiplier,
             scored.open_pr_spam_multiplier,
             scored.time_decay_multiplier,
@@ -113,10 +112,8 @@ class TestCalculateFinalEarnedScore:
     def test_multipliers_compose(self):
         scored = ScoredPR(pr=_make_pr())
         scored.base_score = 100.0
-        scored.repo_weight_multiplier = 0.5
         scored.review_quality_multiplier = 0.5
-        # 100 * 0.5 * 0.5 (others 1.0) = 25
-        assert scored.calculate_final_earned_score() == 25.0
+        assert scored.calculate_final_earned_score() == 50.0
 
     def test_zero_multiplier_zeros_score(self):
         scored = ScoredPR(pr=_make_pr())

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -103,7 +103,7 @@ def _pr(
 
 
 def _config(
-    weight: float = 0.5,
+    emission_share: float = 0.5,
     additional_branches: list | None = None,
     trusted_label_pipeline: bool = False,
     label_multipliers: dict | None = None,
@@ -112,7 +112,7 @@ def _config(
     eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
-        weight=weight,
+        emission_share=emission_share,
         additional_acceptable_branches=additional_branches,
         trusted_label_pipeline=trusted_label_pipeline,
         label_multipliers=label_multipliers,
@@ -378,8 +378,7 @@ class TestScoringDataStoredGate:
 
         client.get_pr_files.assert_not_called()
         assert scored.base_score == pytest.approx(7.5)
-        assert scored.repo_weight_multiplier == pytest.approx(0.5)
-
+        
 
 class TestFixedBaseScore:
     def test_fixed_base_replaces_token_base_but_keeps_token_breakdown_and_multipliers(self, monkeypatch):
@@ -439,7 +438,6 @@ class TestFixedBaseScore:
         assert scored.label_multiplier == pytest.approx(2.0)
         assert scored.calculate_final_earned_score() == pytest.approx(
             scored.base_score
-            * scored.repo_weight_multiplier
             * scored.issue_multiplier
             * scored.label_multiplier
             * scored.open_pr_spam_multiplier
@@ -497,7 +495,7 @@ class TestFixedBaseScore:
         }
 
         asyncio.run(score_pr(fixed, Mock(), repos, {}, Mock(), client))
-        repos[plain.pr.repo_full_name] = _config(weight=1.0, label_multipliers={'feature': 1.5})
+        repos[plain.pr.repo_full_name] = _config(emission_share=1.0, label_multipliers={'feature': 1.5})
         asyncio.run(score_pr(plain, Mock(), repos, {}, Mock(), client))
 
         assert fixed.base_score == pytest.approx(1.0)
@@ -854,7 +852,6 @@ class TestCollateralScoreAcceptsScoredPR:
 
         scored = ScoredPR(pr=_pr(state='OPEN'))
         scored.base_score = 25.0
-        scored.repo_weight_multiplier = 0.5
         scored.issue_multiplier = 1.0
         scored.label_multiplier = 1.0
 
@@ -883,13 +880,11 @@ class TestCollateralScoreAcceptsScoredPR:
 
         clean = ScoredPR(pr=_pr(state='OPEN', maintainer_changes_requested_count=0))
         clean.base_score = 100.0
-        clean.repo_weight_multiplier = 1.0
         clean.issue_multiplier = 1.0
         clean.label_multiplier = 1.0
 
         reviewed = ScoredPR(pr=_pr(state='OPEN', maintainer_changes_requested_count=3))
         reviewed.base_score = 100.0
-        reviewed.repo_weight_multiplier = 1.0
         reviewed.issue_multiplier = 1.0
         reviewed.label_multiplier = 1.0
 
@@ -911,10 +906,9 @@ class TestPrMultipliers:
         scored.token_score = 100.0  # for completeness
         _calculate_pr_multipliers(
             scored,
-            _config(weight=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
+            _config(emission_share=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
         )
 
-        assert scored.repo_weight_multiplier == 0.7
         assert scored.label == 'feature'
         assert scored.label_multiplier == pytest.approx(1.5)
         assert 0.0 <= scored.time_decay_multiplier <= 1.0
@@ -924,9 +918,8 @@ class TestPrMultipliers:
 
     def test_open_pr_only_neutral_multipliers(self):
         scored = ScoredPR(pr=_pr(state='OPEN'))
-        _calculate_pr_multipliers(scored, _config(weight=0.5))
+        _calculate_pr_multipliers(scored, _config(emission_share=0.5))
 
-        assert scored.repo_weight_multiplier == 0.5
         # Time decay / review quality / credibility are merge-only — kept neutral here.
         assert scored.time_decay_multiplier == 1.0
         assert scored.credibility_multiplier == 1.0

--- a/tests/validator/test_emission_allocation.py
+++ b/tests/validator/test_emission_allocation.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gittensor.constants import ISSUES_TREASURY_UID, RECYCLE_UID
+from gittensor.validator.forward import blend_emission_pools
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+def _eval(uid: int, pr_scores_by_repo: dict[str, list[float]] | None = None, issue_scores_by_repo: dict[str, float] | None = None):
+    merged_prs = []
+    for repo, scores in (pr_scores_by_repo or {}).items():
+        for score in scores:
+            merged_prs.append(SimpleNamespace(repository_full_name=repo, earned_score=score))
+    return SimpleNamespace(uid=uid, merged_prs=merged_prs, issue_discovery_scores_by_repo=issue_scores_by_repo or {})
+
+
+def _idx(uids: list[int], uid: int) -> int:
+    return sorted(uids).index(uid)
+
+
+def test_sum_one_with_activity_sends_zero_to_recycle():
+    uids = [RECYCLE_UID, 1, ISSUES_TREASURY_UID]
+    repos = {"r/a": RepositoryConfig(emission_share=1.0, issue_discovery_share=0.0)}
+    evals = {1: _eval(1, pr_scores_by_repo={"r/a": [10.0]})}
+    rewards = blend_emission_pools(evals, set(uids), repos)
+    assert rewards[_idx(uids, 1)] == pytest.approx(0.9)
+    assert rewards[_idx(uids, ISSUES_TREASURY_UID)] == pytest.approx(0.1)
+    assert rewards[_idx(uids, RECYCLE_UID)] == pytest.approx(0.0)
+
+
+def test_no_activity_sends_oss_pool_to_recycle():
+    uids = [RECYCLE_UID, 1, ISSUES_TREASURY_UID]
+    repos = {"r/a": RepositoryConfig(emission_share=1.0, issue_discovery_share=0.5)}
+    evals = {1: _eval(1)}
+    rewards = blend_emission_pools(evals, set(uids), repos)
+    assert rewards[_idx(uids, ISSUES_TREASURY_UID)] == pytest.approx(0.1)
+    assert rewards[_idx(uids, RECYCLE_UID)] == pytest.approx(0.9)
+
+
+def test_registry_slack_recycles_same_round():
+    uids = [RECYCLE_UID, 1, ISSUES_TREASURY_UID]
+    repos = {"r/a": RepositoryConfig(emission_share=0.8, issue_discovery_share=0.0)}
+    evals = {1: _eval(1, pr_scores_by_repo={"r/a": [1.0]})}
+    rewards = blend_emission_pools(evals, set(uids), repos)
+    assert rewards[_idx(uids, 1)] == pytest.approx(0.72)
+    assert rewards[_idx(uids, RECYCLE_UID)] == pytest.approx(0.18)
+    assert rewards[_idx(uids, ISSUES_TREASURY_UID)] == pytest.approx(0.1)
+
+
+def test_within_repo_spill_pr_active_issue_empty():
+    uids = [RECYCLE_UID, 1, ISSUES_TREASURY_UID]
+    repos = {"r/a": RepositoryConfig(emission_share=1.0, issue_discovery_share=0.3)}
+    evals = {1: _eval(1, pr_scores_by_repo={"r/a": [5.0]})}
+    rewards = blend_emission_pools(evals, set(uids), repos)
+    assert rewards[_idx(uids, 1)] == pytest.approx(0.9)
+    assert rewards[_idx(uids, RECYCLE_UID)] == pytest.approx(0.0)
+
+
+def test_repo_slice_constant_across_pr_count():
+    uids = [RECYCLE_UID, 1, 2, ISSUES_TREASURY_UID]
+    repos = {"r/a": RepositoryConfig(emission_share=0.05, issue_discovery_share=0.0)}
+
+    one_pr = blend_emission_pools({1: _eval(1, pr_scores_by_repo={"r/a": [1.0]})}, set(uids), repos)
+    many_pr = blend_emission_pools(
+        {
+            1: _eval(1, pr_scores_by_repo={"r/a": [1.0] * 25}),
+            2: _eval(2, pr_scores_by_repo={"r/a": [1.0] * 25}),
+        },
+        set(uids),
+        repos,
+    )
+    assert one_pr[_idx(uids, 1)] == pytest.approx(0.045)
+    assert many_pr[_idx(uids, 1)] + many_pr[_idx(uids, 2)] == pytest.approx(0.045)

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -19,7 +19,7 @@ from gittensor.validator.utils.load_weights import RepositoryConfig
     ],
 )
 def test_get_label_multiplier_matches_repo_patterns(pattern, label, expected):
-    config = RepositoryConfig(weight=1.0, label_multipliers={pattern: expected})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={pattern: expected})
 
     assert get_label_multiplier(label, config) == pytest.approx(expected)
 
@@ -38,15 +38,15 @@ def test_get_label_multiplier_returns_highest_matching_pattern():
 
 
 def test_get_label_multiplier_returns_none_without_repo_config_match():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'kind/*': 1.5})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'kind/*': 1.5})
 
     assert get_label_multiplier('feature', config) is None
-    assert get_label_multiplier('kind/feature', RepositoryConfig(weight=1.0)) is None
+    assert get_label_multiplier('kind/feature', RepositoryConfig(emission_share=1.0)) is None
     assert get_label_multiplier('kind/feature', None) is None
 
 
 def test_highest_label_resolution_uses_default_when_no_candidate_matches():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'kind/*': 1.5}, default_label_multiplier=0.8)
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'kind/*': 1.5}, default_label_multiplier=0.8)
 
     label, multiplier = resolve_highest_label_multiplier(['feature', 'bug'], config)
 
@@ -55,7 +55,7 @@ def test_highest_label_resolution_uses_default_when_no_candidate_matches():
 
 
 def test_highest_label_resolution_tiebreaks_by_label_name():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'a': 1.5, 'b': 1.5})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'a': 1.5, 'b': 1.5})
 
     label, multiplier = resolve_highest_label_multiplier(['a', 'b'], config)
 

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -19,7 +19,7 @@ from gittensor.validator.utils.load_weights import (
     load_master_repo_weights,
     load_programming_language_weights,
     load_token_config,
-    resolve_repo_weight,
+    resolve_repo_emission_share,
 )
 
 
@@ -153,7 +153,7 @@ class TestRepositoryConfigTrustedLabelPipeline:
         attacker-controlled auto-labelers (release-drafter, actions/labeler)
         keep the maintainer-association gate in place.
         """
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
         assert config.trusted_label_pipeline is False
 
     def test_loader_parses_trusted_label_pipeline_true(self, tmp_path, monkeypatch):
@@ -166,9 +166,9 @@ class TestRepositoryConfigTrustedLabelPipeline:
         (fake_weights_dir / 'master_repositories.json').write_text(
             json.dumps(
                 {
-                    'foo/trusted': {'weight': 0.5, 'trusted_label_pipeline': True},
-                    'foo/untrusted': {'weight': 0.3},
-                    'foo/explicit-off': {'weight': 0.2, 'trusted_label_pipeline': False},
+                    'foo/trusted': {'emission_share': 0.5, 'trusted_label_pipeline': True},
+                    'foo/untrusted': {'emission_share': 0.3},
+                    'foo/explicit-off': {'emission_share': 0.2, 'trusted_label_pipeline': False},
                 }
             )
         )
@@ -185,7 +185,7 @@ class TestRepositoryConfigLabelMultipliers:
     """Dataclass + JSON-parsing tests for per-repo label multiplier config."""
 
     def test_label_multiplier_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.label_multipliers is None
         assert config.default_label_multiplier == pytest.approx(1.0)
@@ -198,11 +198,11 @@ class TestRepositoryConfigLabelMultipliers:
             json.dumps(
                 {
                     'foo/labeled': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'label_multipliers': {'kind/*': 1.5, 'type:bug': 1.25},
                         'default_label_multiplier': 0.8,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -247,7 +247,7 @@ class TestRepositoryConfigMirrorScoringFields:
     """Dataclass + JSON-parsing tests for mirror-only scoring fields."""
 
     def test_mirror_scoring_field_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.fixed_base_score is None
         assert config.eligibility_mode is True
@@ -260,11 +260,11 @@ class TestRepositoryConfigMirrorScoringFields:
             json.dumps(
                 {
                     'foo/fixed': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'fixed_base_score': 12.5,
                         'eligibility_mode': False,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -340,27 +340,72 @@ class TestBannedOrganizations:
         assert len(active_banned) == 0, f'Found {len(active_banned)} active repos from banned orgs: {active_banned}'
 
 
-class TestResolveRepoWeight:
-    """Tests for resolve_repo_weight — full-precision repo weight lookup."""
+class TestResolveRepoEmissionShare:
+    """Tests for resolve_repo_emission_share — full-precision repo share lookup."""
 
     def test_none_returns_default(self):
-        assert resolve_repo_weight(None) == 0.01
+        assert resolve_repo_emission_share(None) == 0.01
 
     @pytest.mark.parametrize(
         'weight',
         [0.0349, 0.0351, 0.0487, 0.1025, 0.2017, 1.0],
     )
     def test_preserves_full_precision(self, weight):
-        config = RepositoryConfig(weight=weight)
-        assert resolve_repo_weight(config) == weight
+        config = RepositoryConfig(emission_share=weight)
+        assert resolve_repo_emission_share(config) == weight
 
     def test_live_master_repo_precision(self):
         """cronboard (0.0349) and fzf (0.0351) must not collapse to 0.03/0.04."""
         repos = load_master_repo_weights()
         if 'antoniorodr/cronboard' in repos:
-            assert resolve_repo_weight(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
+            assert resolve_repo_emission_share(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
         if 'junegunn/fzf' in repos:
-            assert resolve_repo_weight(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
+            assert resolve_repo_emission_share(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
+
+
+class TestEmissionShareInvariants:
+    def test_live_registry_emission_share_sum_in_unit_interval(self):
+        repos = load_master_repo_weights()
+        total = sum(repo.emission_share for repo in repos.values())
+        assert 0.0 <= total <= 1.0
+
+    def test_live_registry_individual_emission_shares_in_bounds(self):
+        repos = load_master_repo_weights()
+        for repo_name, repo in repos.items():
+            assert 0.0 <= repo.emission_share <= 1.0, f'{repo_name} emission_share must be within [0, 1]'
+
+    def test_rejects_registry_sum_greater_than_one(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/a': {'emission_share': 0.6},
+                    'foo/b': {'emission_share': 0.5},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        with pytest.raises(ValueError):
+            lw.load_master_repo_weights()
+
+    def test_accepts_registry_sum_less_than_one(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/a': {'emission_share': 0.4},
+                    'foo/b': {'emission_share': 0.2},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+        repos = lw.load_master_repo_weights()
+        assert sum(r.emission_share for r in repos.values()) == pytest.approx(0.6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
This update changes repository allocation from **per-PR `weight` multiplier** to **per-repo `emission_share` pool slicing**.
- `RepositoryConfig.weight` → `RepositoryConfig.emission_share` (`[0,1]`)
- Added `RepositoryConfig.issue_discovery_share` (`[0,1]`, default `0.5`)
- Enforced registry invariant: `sum(emission_share) <= 1.0`
- Removed repo-weight factor from per-PR/per-issue multiplier chains
- Moved allocation control to round aggregation (`allocate-then-distribute`)
- Recycle now comes from:
  - unclaimed repo slices (repo inactive on both PR + issue sides)
  - registry slack (`1 - sum(emission_share)`)
- Top-level emissions collapsed to:
  - `OSS_EMISSION_SHARE = 0.90`
  - `ISSUES_TREASURY_EMISSION_SHARE = 0.10`
  - removed fixed `RECYCLE_EMISSION_SHARE` baseline
## Related Issue
Closes: #1215 
## Change Type (select all)
- [x] Feature
- [x] Behavior change
- [x] Refactor
- [x] Config schema change
- [x] Validation/invariant hardening
- [x] Monetary policy update
- [x] Test coverage update
- [ ] Breaking API change (external)
- [ ] Security fix
- [ ] Performance optimization only
## Real Behavior Proof
Use these expected outcomes as acceptance checks:
1. **All repos active, `sum(emission_share)=1.0`**  
   - OSS scoring: `90%`  
   - Treasury: `10%`  
   - Recycle: `0%`
2. **No activity on any repo, `sum(emission_share)=1.0`**  
   - OSS scoring: `0%`  
   - Treasury: `10%`  
   - Recycle: `90%`
3. **All repos active, `sum(emission_share)=0.8`**  
   - OSS scoring: `72%` (`0.9 * 0.8`)  
   - Treasury: `10%`  
   - Recycle: `18%` (registry slack)

4. **Repo with `issue_discovery_share=0.3`, PR active, issue inactive**  
   - Full repo slice stays in repo and spills to PR side  
   - No recycle for that repo

5. **Repo has no eligible nonzero scorers on both sides**  
   - Entire repo slice goes to recycle in same round  
   - No rollover, no redistribution to other repos