### PR TITLE
fix: remove repo weight from pr scoring

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -234,7 +234,6 @@ class PullRequest:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -88,7 +88,6 @@ class ScoredPR:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -2,7 +2,7 @@
 
 Scope:
 - Compute base_score for each PR via the existing token-scoring infra.
-- Compute per-PR multipliers: repo_weight, time_decay, review_quality, label, issue.
+- Compute per-PR multipliers: time_decay, review_quality, label, issue.
 - The merge-eligibility gate (``_should_skip_merged_mirror_pr``) is exported and
   applied at LOAD time by ``mirror.load._maybe_add_pr`` — rejected PRs never
   enter ``merged_prs``, so the merged_count used by ``check_eligibility``
@@ -54,7 +54,6 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -338,15 +337,13 @@ def calculate_base_score_for_pr_files(
 
 
 def _calculate_pr_multipliers(scored: ScoredPR, repo_config: RepositoryConfig) -> None:
-    """Compute repo_weight, time_decay, review_quality, label, issue multipliers.
+    """Compute time_decay, review_quality, label, issue multipliers.
 
     Spam and credibility multipliers are deferred to ``finalize_miner_scores``
     — they depend on per-miner aggregate counts.
     """
     pr = scored.pr
     is_merged = pr.state == 'MERGED'
-
-    scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
 
     chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -283,14 +283,13 @@ def calculate_open_pr_collateral_score(pr: 'ScoredPR') -> float:
 
     Collateral = base_score * applicable_multipliers * OPEN_PR_COLLATERAL_PERCENT
 
-    Applicable multipliers: repo_weight, issue, label, review_collateral
+    Applicable multipliers: issue, label, review_collateral
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
                     open_pr_spam (not for collateral)
     """
     from math import prod
 
     multipliers = {
-        'repo_weight': pr.repo_weight_multiplier,
         'issue': pr.issue_multiplier,
         'label': pr.label_multiplier,
         'review_collateral': calculate_review_collateral_multiplier(pr.changes_requested_count, pr.number),

--- a/tests/validator/oss_contributions/mirror/test_scored_pr.py
+++ b/tests/validator/oss_contributions/mirror/test_scored_pr.py
@@ -115,8 +115,9 @@ class TestCalculateFinalEarnedScore:
         scored.base_score = 100.0
         scored.repo_weight_multiplier = 0.5
         scored.review_quality_multiplier = 0.5
-        # 100 * 0.5 * 0.5 (others 1.0) = 25
-        assert scored.calculate_final_earned_score() == 25.0
+        # repo_weight_multiplier is persisted for compatibility but no longer
+        # participates in per-PR score composition.
+        assert scored.calculate_final_earned_score() == 50.0
 
     def test_zero_multiplier_zeros_score(self):
         scored = ScoredPR(pr=_make_pr())

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -378,7 +378,7 @@ class TestScoringDataStoredGate:
 
         client.get_pr_files.assert_not_called()
         assert scored.base_score == pytest.approx(7.5)
-        assert scored.repo_weight_multiplier == pytest.approx(0.5)
+        assert scored.repo_weight_multiplier == pytest.approx(1.0)
 
 
 class TestFixedBaseScore:
@@ -439,7 +439,6 @@ class TestFixedBaseScore:
         assert scored.label_multiplier == pytest.approx(2.0)
         assert scored.calculate_final_earned_score() == pytest.approx(
             scored.base_score
-            * scored.repo_weight_multiplier
             * scored.issue_multiplier
             * scored.label_multiplier
             * scored.open_pr_spam_multiplier
@@ -860,7 +859,7 @@ class TestCollateralScoreAcceptsScoredPR:
 
         # Must not raise AttributeError on .number
         result = calculate_open_pr_collateral_score(scored)
-        assert result >= 0.0
+        assert result == pytest.approx(5.0)
 
     def test_number_property_proxies_to_pr_pr_number(self):
         scored = ScoredPR(pr=_pr())
@@ -914,7 +913,7 @@ class TestPrMultipliers:
             _config(weight=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
         )
 
-        assert scored.repo_weight_multiplier == 0.7
+        assert scored.repo_weight_multiplier == 1.0
         assert scored.label == 'feature'
         assert scored.label_multiplier == pytest.approx(1.5)
         assert 0.0 <= scored.time_decay_multiplier <= 1.0
@@ -926,7 +925,7 @@ class TestPrMultipliers:
         scored = ScoredPR(pr=_pr(state='OPEN'))
         _calculate_pr_multipliers(scored, _config(weight=0.5))
 
-        assert scored.repo_weight_multiplier == 0.5
+        assert scored.repo_weight_multiplier == 1.0
         # Time decay / review quality / credibility are merge-only — kept neutral here.
         assert scored.time_decay_multiplier == 1.0
         assert scored.credibility_multiplier == 1.0


### PR DESCRIPTION
## Summary

- Remove `repo_weight_multiplier` from legacy and mirror per-PR earned-score composition
- Stop assigning repository weight during mirror PR multiplier calculation
- Remove repo weight from open-PR collateral score composition
- Update scoring tests so the compatibility field remains neutral/persisted but no longer affects PR-level scores

## Related Issues

Part of #1215. Covers required deliverable 4 only.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/oss_contributions/mirror/test_scoring.py tests/validator/oss_contributions/mirror/test_scored_pr.py tests/test_classes.py tests/validator/test_scoring_classes.py -q`
`uv run ruff check gittensor/classes.py gittensor/validator/oss_contributions/mirror/scored_pr.py gittensor/validator/oss_contributions/mirror/scoring.py gittensor/validator/oss_contributions/scoring.py tests/validator/oss_contributions/mirror/test_scoring.py tests/validator/oss_contributions/mirror/test_scored_pr.py`
`uv run ruff format --check gittensor/classes.py gittensor/validator/oss_contributions/mirror/scored_pr.py gittensor/validator/oss_contributions/mirror/scoring.py gittensor/validator/oss_contributions/scoring.py tests/validator/oss_contributions/mirror/test_scoring.py tests/validator/oss_contributions/mirror/test_scored_pr.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally leaves the historical `repo_weight_multiplier` field in storage/adapters for compatibility. The later #1215 consumer-migration deliverable can remove or repurpose persisted fields after aggregation is moved to `emission_share`.