### PR TITLE
feat: add repo emission slice allocation

### DIFF
--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -1,0 +1,40 @@
+from collections.abc import Mapping
+from typing import Dict
+
+import numpy as np
+
+from gittensor.constants import RECYCLE_UID
+
+
+def allocate_repo_emission_slices(
+    repo_scores: Mapping[str, Mapping[int, float]],
+    repo_emission_shares: Mapping[str, float],
+    miner_uids: set[int],
+    pool_share: float = 1.0,
+) -> np.ndarray:
+    """Allocate each repo's fixed emission slice across that repo's scorers.
+
+    A repo with positive eligible score pays exactly
+    ``repo_emission_share * pool_share`` across its scorers, proportionally by
+    score. A repo with no positive score sends its slice to the recycle UID.
+    Registry-level slack is intentionally handled by the caller.
+    """
+    sorted_uids = sorted(miner_uids)
+    uid_to_index = {uid: idx for idx, uid in enumerate(sorted_uids)}
+    rewards = np.zeros(len(sorted_uids))
+
+    for repo_name, emission_share in repo_emission_shares.items():
+        repo_slice = float(emission_share) * pool_share
+        scores = repo_scores.get(repo_name, {})
+        positive_scores: Dict[int, float] = {
+            uid: float(score) for uid, score in scores.items() if uid in uid_to_index and float(score) > 0.0
+        }
+        score_total = sum(positive_scores.values())
+
+        if score_total > 0.0:
+            for uid, score in positive_scores.items():
+                rewards[uid_to_index[uid]] += repo_slice * (score / score_total)
+        elif RECYCLE_UID in uid_to_index:
+            rewards[uid_to_index[RECYCLE_UID]] += repo_slice
+
+    return rewards

--- a/tests/validator/test_emission_allocation.py
+++ b/tests/validator/test_emission_allocation.py
@@ -1,0 +1,55 @@
+import pytest
+
+from gittensor.constants import RECYCLE_UID
+from gittensor.validator.emission_allocation import allocate_repo_emission_slices
+
+
+def test_active_repo_with_one_scorer_pays_full_slice_to_that_scorer():
+    rewards = allocate_repo_emission_slices(
+        repo_scores={'repo/a': {1: 25.0}},
+        repo_emission_shares={'repo/a': 0.05},
+        miner_uids={RECYCLE_UID, 1},
+    )
+
+    assert rewards[0] == pytest.approx(0.0)
+    assert rewards[1] == pytest.approx(0.05)
+
+
+def test_active_repo_with_many_scorers_splits_same_slice_by_score():
+    rewards = allocate_repo_emission_slices(
+        repo_scores={'repo/a': {1: 10.0, 2: 30.0, 3: 60.0}},
+        repo_emission_shares={'repo/a': 0.05},
+        miner_uids={RECYCLE_UID, 1, 2, 3},
+    )
+
+    assert rewards[0] == pytest.approx(0.0)
+    assert rewards[1] == pytest.approx(0.005)
+    assert rewards[2] == pytest.approx(0.015)
+    assert rewards[3] == pytest.approx(0.03)
+    assert rewards.sum() == pytest.approx(0.05)
+
+
+def test_repo_with_zero_positive_score_recycles_slice():
+    rewards = allocate_repo_emission_slices(
+        repo_scores={'repo/a': {1: 0.0, 2: -5.0}},
+        repo_emission_shares={'repo/a': 0.05},
+        miner_uids={RECYCLE_UID, 1, 2},
+    )
+
+    assert rewards[0] == pytest.approx(0.05)
+    assert rewards[1] == pytest.approx(0.0)
+    assert rewards[2] == pytest.approx(0.0)
+
+
+def test_high_throughput_repo_cannot_exceed_its_slice():
+    rewards = allocate_repo_emission_slices(
+        repo_scores={
+            'repo/a': {1: 1000.0, 2: 1000.0},
+            'repo/b': {3: 1.0},
+        },
+        repo_emission_shares={'repo/a': 0.05, 'repo/b': 0.10},
+        miner_uids={RECYCLE_UID, 1, 2, 3},
+    )
+
+    assert rewards[1] + rewards[2] == pytest.approx(0.05)
+    assert rewards[3] == pytest.approx(0.10)


### PR DESCRIPTION
## Summary

- Add a pure `allocate_repo_emission_slices` helper for fixed per-repo emission allocation
- Pay each active repo exactly `repo_emission_share * pool_share`, split proportionally across positive eligible miner scores
- Recycle a repo slice when the repo has no positive eligible score
- Add tests proving a high-throughput repo cannot exceed its configured slice

## Related Issues

Part of #1215. Covers required deliverable 2 only.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_emission_allocation.py -q`
`uv run ruff check gittensor/validator/emission_allocation.py tests/validator/test_emission_allocation.py`
`uv run ruff format --check gittensor/validator/emission_allocation.py tests/validator/test_emission_allocation.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally adds the allocation primitive only. Later #1215 deliverables wire it into the forward scoring path with `emission_share`, PR/issue split handling, and registry slack recycling.