### PR TITLE
test: guard repository share invariants

### DIFF
--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 import json
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -107,6 +108,17 @@ def _get_weights_dir() -> Path:
     return Path(__file__).parent.parent / 'weights'
 
 
+def _validate_repository_weight(repo_name: str, weight: float) -> None:
+    if not math.isfinite(weight) or not 0.0 <= weight <= 1.0:
+        raise ValueError(f'{repo_name} weight must be within [0.0, 1.0], got {weight}')
+
+
+def _validate_total_repository_weight(repositories: Dict[str, RepositoryConfig]) -> None:
+    total_weight = sum(config.weight for config in repositories.values())
+    if total_weight < 0.0 or total_weight > 1.0:
+        raise ValueError(f'Total repository weight must be within [0.0, 1.0], got {total_weight}')
+
+
 def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
     """
     Load repository weights from the local JSON file.
@@ -129,9 +141,11 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         # Parse JSON data into RepositoryConfig objects
         normalized_data: Dict[str, RepositoryConfig] = {}
         for repo_name, metadata in data.items():
+            weight = float(metadata.get('weight', 0.01))
+            _validate_repository_weight(repo_name, weight)
             try:
                 config = RepositoryConfig(
-                    weight=float(metadata.get('weight', 0.01)),
+                    weight=weight,
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
@@ -148,8 +162,9 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
             except (ValueError, TypeError) as e:
                 bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
                 # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+                normalized_data[repo_name.lower()] = RepositoryConfig(weight=weight)
 
+        _validate_total_repository_weight(normalized_data)
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data
 

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -142,6 +142,47 @@ class TestLoadMasterRepositories:
                 f'labeling worker is honored at scoring time'
             )
 
+    def test_live_repository_weights_are_in_range(self):
+        """CI guard: every configured repo share must be in [0, 1]."""
+        repos = load_master_repo_weights()
+        for repo_name, config in repos.items():
+            assert 0.0 <= config.weight <= 1.0, f'{repo_name} weight must be within [0.0, 1.0]'
+
+    def test_live_repository_weight_total_is_not_above_one(self):
+        """CI guard: configured repo shares cannot allocate more than the scoring pool."""
+        repos = load_master_repo_weights()
+        assert sum(config.weight for config in repos.values()) <= 1.0
+
+    @pytest.mark.parametrize('weight', [-0.001, 1.001])
+    def test_loader_rejects_repository_weight_outside_range(self, tmp_path, monkeypatch, weight):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(json.dumps({'foo/bad': {'weight': weight}}))
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos == {}
+
+    def test_loader_rejects_total_repository_weight_above_one(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/one': {'weight': 0.6},
+                    'foo/two': {'weight': 0.5},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos == {}
+
 
 class TestRepositoryConfigTrustedLabelPipeline:
     """Dataclass + JSON-parsing tests for trusted_label_pipeline (issue #911)."""


### PR DESCRIPTION
## Summary

- Add loader validation that every configured repository share is finite and in `[0, 1]`
- Add loader validation that the configured repository share total is at most `1.0`
- Add live registry CI guards plus explicit invalid-config tests for per-entry and total overflow cases

## Related Issues

Part of #1215. Covers required deliverable 5 only, against the current `weight` field name. The follow-up schema PR renames this field to `emission_share`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe below)

Validation / CI guard.

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_load_weights.py -q`
`uv run ruff check gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py`
`uv run ruff format --check gittensor/validator/utils/load_weights.py tests/validator/test_load_weights.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally keeps the existing `weight` JSON field so the invariant guard can be reviewed independently. The separate #1215 schema PR performs the `weight` → `emission_share` rename.