### PR TITLE
feat: add repo pr issue split allocation

### DIFF
--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -1,0 +1,60 @@
+from collections.abc import Mapping
+
+import numpy as np
+
+from gittensor.constants import RECYCLE_UID
+
+
+def allocate_split_repo_emission_slices(
+    pr_scores: Mapping[str, Mapping[int, float]],
+    issue_scores: Mapping[str, Mapping[int, float]],
+    repo_emission_shares: Mapping[str, float],
+    repo_issue_discovery_shares: Mapping[str, float],
+    miner_uids: set[int],
+    pool_share: float = 1.0,
+) -> np.ndarray:
+    """Allocate repo slices across PR and issue-discovery scorers.
+
+    Each repo gets a fixed slice of the scoring pool. ``issue_discovery_share``
+    splits that slice between issue discovery and PR scoring. If one side has no
+    positive eligible scorer, its slice spills to the other side in the same
+    repo. If neither side has positive score, the full repo slice recycles.
+    """
+    sorted_uids = sorted(miner_uids)
+    uid_to_index = {uid: idx for idx, uid in enumerate(sorted_uids)}
+    rewards = np.zeros(len(sorted_uids))
+
+    for repo_name, emission_share in repo_emission_shares.items():
+        repo_slice = float(emission_share) * pool_share
+        issue_share = float(repo_issue_discovery_shares.get(repo_name, 0.5))
+        issue_slice = repo_slice * issue_share
+        pr_slice = repo_slice - issue_slice
+
+        pr_total = _allocate_subpool(rewards, uid_to_index, pr_scores.get(repo_name, {}), pr_slice)
+        issue_total = _allocate_subpool(rewards, uid_to_index, issue_scores.get(repo_name, {}), issue_slice)
+
+        if pr_total == 0.0 and issue_total > 0.0:
+            _allocate_subpool(rewards, uid_to_index, issue_scores.get(repo_name, {}), pr_slice)
+        elif issue_total == 0.0 and pr_total > 0.0:
+            _allocate_subpool(rewards, uid_to_index, pr_scores.get(repo_name, {}), issue_slice)
+        elif pr_total == 0.0 and issue_total == 0.0 and RECYCLE_UID in uid_to_index:
+            rewards[uid_to_index[RECYCLE_UID]] += repo_slice
+
+    return rewards
+
+
+def _allocate_subpool(
+    rewards: np.ndarray,
+    uid_to_index: dict[int, int],
+    scores: Mapping[int, float],
+    subpool: float,
+) -> float:
+    positive_scores = {uid: float(score) for uid, score in scores.items() if uid in uid_to_index and float(score) > 0.0}
+    score_total = sum(positive_scores.values())
+    if score_total == 0.0 or subpool == 0.0:
+        return score_total
+
+    for uid, score in positive_scores.items():
+        rewards[uid_to_index[uid]] += subpool * (score / score_total)
+
+    return score_total

--- a/tests/validator/test_split_emission_allocation.py
+++ b/tests/validator/test_split_emission_allocation.py
@@ -1,0 +1,62 @@
+import pytest
+
+from gittensor.constants import RECYCLE_UID
+from gittensor.validator.emission_allocation import allocate_split_repo_emission_slices
+
+
+def test_repo_slice_splits_between_pr_and_issue_scorers():
+    rewards = allocate_split_repo_emission_slices(
+        pr_scores={'repo/a': {1: 1.0}},
+        issue_scores={'repo/a': {2: 1.0}},
+        repo_emission_shares={'repo/a': 0.10},
+        repo_issue_discovery_shares={'repo/a': 0.30},
+        miner_uids={RECYCLE_UID, 1, 2},
+    )
+
+    assert rewards[0] == pytest.approx(0.0)
+    assert rewards[1] == pytest.approx(0.07)
+    assert rewards[2] == pytest.approx(0.03)
+
+
+def test_empty_issue_side_spills_to_pr_side_in_same_repo():
+    rewards = allocate_split_repo_emission_slices(
+        pr_scores={'repo/a': {1: 1.0, 2: 3.0}},
+        issue_scores={'repo/a': {}},
+        repo_emission_shares={'repo/a': 0.10},
+        repo_issue_discovery_shares={'repo/a': 0.30},
+        miner_uids={RECYCLE_UID, 1, 2},
+    )
+
+    assert rewards[0] == pytest.approx(0.0)
+    assert rewards[1] == pytest.approx(0.025)
+    assert rewards[2] == pytest.approx(0.075)
+    assert rewards.sum() == pytest.approx(0.10)
+
+
+def test_empty_pr_side_spills_to_issue_side_in_same_repo():
+    rewards = allocate_split_repo_emission_slices(
+        pr_scores={'repo/a': {}},
+        issue_scores={'repo/a': {1: 2.0, 2: 2.0}},
+        repo_emission_shares={'repo/a': 0.10},
+        repo_issue_discovery_shares={'repo/a': 0.30},
+        miner_uids={RECYCLE_UID, 1, 2},
+    )
+
+    assert rewards[0] == pytest.approx(0.0)
+    assert rewards[1] == pytest.approx(0.05)
+    assert rewards[2] == pytest.approx(0.05)
+    assert rewards.sum() == pytest.approx(0.10)
+
+
+def test_empty_repo_recycles_full_repo_slice():
+    rewards = allocate_split_repo_emission_slices(
+        pr_scores={'repo/a': {1: 0.0}},
+        issue_scores={'repo/a': {2: 0.0}},
+        repo_emission_shares={'repo/a': 0.10},
+        repo_issue_discovery_shares={'repo/a': 0.30},
+        miner_uids={RECYCLE_UID, 1, 2},
+    )
+
+    assert rewards[0] == pytest.approx(0.10)
+    assert rewards[1] == pytest.approx(0.0)
+    assert rewards[2] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- Add a pure `allocate_split_repo_emission_slices` helper for within-repo PR/issue allocation
- Split each repo slice by `issue_discovery_share`, defaulting the caller-provided share to the repo map value
- Spill an empty PR side to issue scorers in the same repo
- Spill an empty issue side to PR scorers in the same repo
- Recycle the full repo slice when neither side has positive eligible score

## Related Issues

Part of #1215. Covers required deliverable 11 only.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_split_emission_allocation.py -q`
`uv run ruff check gittensor/validator/emission_allocation.py tests/validator/test_split_emission_allocation.py`
`uv run ruff format --check gittensor/validator/emission_allocation.py tests/validator/test_split_emission_allocation.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally adds the split-allocation primitive only. Later #1215 deliverables can wire it into `forward.py` after the config schema and repo score aggregation PRs land.