### PR TITLE
feat: recycle unallocated emission slack

### DIFF
--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from gittensor.constants import RECYCLE_UID
+
+
+def recycle_unallocated_emission(
+    rewards: np.ndarray,
+    miner_uids: set[int],
+    configured_share: float,
+    pool_share: float = 1.0,
+) -> np.ndarray:
+    """Return rewards with unallocated registry slack paid to recycle UID.
+
+    ``configured_share`` is the sum of configured repo emission shares. Any
+    positive ``pool_share - configured_share`` is unallocated by the registry and
+    therefore belongs to the recycle UID.
+    """
+    slack = max(float(pool_share) - float(configured_share), 0.0)
+    if slack == 0.0 or RECYCLE_UID not in miner_uids:
+        return rewards
+
+    updated = rewards.copy()
+    updated[sorted(miner_uids).index(RECYCLE_UID)] += slack
+    return updated

--- a/tests/validator/test_recycle_emission_slack.py
+++ b/tests/validator/test_recycle_emission_slack.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from gittensor.constants import RECYCLE_UID
+from gittensor.validator.emission_allocation import recycle_unallocated_emission
+
+
+def test_unconfigured_registry_slack_goes_to_recycle_uid():
+    rewards = np.array([0.0, 0.25, 0.25])
+
+    updated = recycle_unallocated_emission(
+        rewards,
+        miner_uids={RECYCLE_UID, 1, 2},
+        configured_share=0.50,
+    )
+
+    assert updated[0] == pytest.approx(0.50)
+    assert updated[1] == pytest.approx(0.25)
+    assert updated[2] == pytest.approx(0.25)
+    assert updated.sum() == pytest.approx(1.0)
+
+
+def test_no_slack_is_added_when_registry_is_fully_allocated():
+    rewards = np.array([0.0, 0.5, 0.5])
+
+    updated = recycle_unallocated_emission(
+        rewards,
+        miner_uids={RECYCLE_UID, 1, 2},
+        configured_share=1.0,
+    )
+
+    assert updated.tolist() == pytest.approx(rewards.tolist())
+
+
+def test_missing_recycle_uid_leaves_rewards_unchanged():
+    rewards = np.array([0.25, 0.25])
+
+    updated = recycle_unallocated_emission(
+        rewards,
+        miner_uids={1, 2},
+        configured_share=0.50,
+    )
+
+    assert updated.tolist() == pytest.approx(rewards.tolist())


### PR DESCRIPTION
## Summary

- Add `recycle_unallocated_emission` for paying registry slack to UID 0
- Treat positive `pool_share - configured_share` as unallocated emission that belongs to recycle
- Leave rewards unchanged when there is no slack or UID 0 is absent
- Add focused recycle slack tests

## Related Issues

Part of #1215. Covers required deliverable 10 only.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_recycle_emission_slack.py -q`
`uv run ruff check gittensor/validator/emission_allocation.py tests/validator/test_recycle_emission_slack.py`
`uv run ruff format --check gittensor/validator/emission_allocation.py tests/validator/test_recycle_emission_slack.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally adds the recycle slack primitive only. The later #1215 integration PR can call it after repo allocation calculates configured registry share and per-repo no-scorer slack.