### PR TITLE
feat: add emission share registry field

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,7 @@
 {
   "entrius/allways": {
     "weight": 0.05,
+    "emission_share": 0.05,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -10,6 +11,7 @@
   },
   "entrius/allways-ui": {
     "weight": 0.01,
+    "emission_share": 0.01,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -20,6 +22,7 @@
   },
   "entrius/das-github-mirror": {
     "weight": 0.02,
+    "emission_share": 0.02,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -29,6 +32,7 @@
   },
   "entrius/gittensor": {
     "weight": 0.1,
+    "emission_share": 0.1,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.5,
@@ -39,6 +43,7 @@
   },
   "entrius/gittensor-ui": {
     "weight": 0.03,
+    "emission_share": 0.03,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -49,6 +54,7 @@
   },
   "entrius/oc-1": {
     "weight": 0.5,
+    "emission_share": 0.5,
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
     "eligibility_mode": false,

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -142,6 +142,12 @@ class TestLoadMasterRepositories:
                 f'labeling worker is honored at scoring time'
             )
 
+    @pytest.mark.parametrize('repo_name,metadata', _live_master_repo_metadata())
+    def test_live_emission_share_matches_legacy_weight_during_migration(self, repo_name, metadata):
+        """Migration guard: emission_share preserves each current repo weight exactly."""
+        assert 'emission_share' in metadata, f'{repo_name} must declare emission_share'
+        assert float(metadata['emission_share']) == pytest.approx(float(metadata['weight']), abs=1e-12)
+
 
 class TestRepositoryConfigTrustedLabelPipeline:
     """Dataclass + JSON-parsing tests for trusted_label_pipeline (issue #911)."""


### PR DESCRIPTION
## Summary

- Add `emission_share` beside the current `weight` field for every live master repository entry
- Preserve every current relative repo value exactly during the migration
- Add a live-config guard that verifies each `emission_share` matches its legacy `weight` value while both fields exist

## Related Issues

Part of #1215. Covers required deliverable 3 only.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_load_weights.py -q`
`uv run ruff check tests/validator/test_load_weights.py`
`uv run ruff format --check tests/validator/test_load_weights.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally keeps `weight` next to `emission_share` so the current loader remains unchanged. The separate #1215 schema PR can switch the loader and remove the legacy key.