### PR TITLE
refactor: use repo emission share resolver

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -60,7 +60,7 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
+    resolve_repo_emission_share,
 )
 
 
@@ -620,7 +620,7 @@ def _mirror_issue_for_scoring(
     )
 
     adapted.discovery_base_score = base_score
-    adapted.discovery_repo_weight_multiplier = resolve_repo_weight(repo_config)
+    adapted.discovery_repo_weight_multiplier = resolve_repo_emission_share(repo_config)
     adapted.discovery_time_decay_multiplier = round(calculate_time_decay(solving_pr.merged_at), 2)
     adapted.discovery_review_quality_multiplier = round(
         calculate_issue_review_quality_multiplier(solving_pr.review_summary.maintainer_changes_requested_count),

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -54,7 +54,7 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
+    resolve_repo_emission_share,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -346,7 +346,7 @@ def _calculate_pr_multipliers(scored: ScoredPR, repo_config: RepositoryConfig) -
     pr = scored.pr
     is_merged = pr.state == 'MERGED'
 
-    scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
+    scored.repo_weight_multiplier = resolve_repo_emission_share(repo_config)
 
     chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -56,11 +56,16 @@ class RepositoryConfig:
     eligibility_mode: bool = True
 
 
-def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
-    """Return the repo weight preserving full JSON precision, or the default for unknown repos."""
+def resolve_repo_emission_share(repo_config: Optional[RepositoryConfig]) -> float:
+    """Return the repo emission share preserving full JSON precision, or the default for unknown repos."""
     if repo_config is None:
         return DEFAULT_REPO_WEIGHT
     return repo_config.weight
+
+
+def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
+    """Compatibility alias for callers not yet migrated to emission-share terminology."""
+    return resolve_repo_emission_share(repo_config)
 
 
 @dataclass

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -19,6 +19,7 @@ from gittensor.validator.utils.load_weights import (
     load_master_repo_weights,
     load_programming_language_weights,
     load_token_config,
+    resolve_repo_emission_share,
     resolve_repo_weight,
 )
 
@@ -341,10 +342,10 @@ class TestBannedOrganizations:
 
 
 class TestResolveRepoWeight:
-    """Tests for resolve_repo_weight — full-precision repo weight lookup."""
+    """Tests for repo emission-share resolution — full-precision lookup."""
 
     def test_none_returns_default(self):
-        assert resolve_repo_weight(None) == 0.01
+        assert resolve_repo_emission_share(None) == 0.01
 
     @pytest.mark.parametrize(
         'weight',
@@ -352,15 +353,20 @@ class TestResolveRepoWeight:
     )
     def test_preserves_full_precision(self, weight):
         config = RepositoryConfig(weight=weight)
-        assert resolve_repo_weight(config) == weight
+        assert resolve_repo_emission_share(config) == weight
 
     def test_live_master_repo_precision(self):
         """cronboard (0.0349) and fzf (0.0351) must not collapse to 0.03/0.04."""
         repos = load_master_repo_weights()
         if 'antoniorodr/cronboard' in repos:
-            assert resolve_repo_weight(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
+            assert resolve_repo_emission_share(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
         if 'junegunn/fzf' in repos:
-            assert resolve_repo_weight(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
+            assert resolve_repo_emission_share(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
+
+    def test_legacy_weight_resolver_aliases_emission_share_resolver(self):
+        config = RepositoryConfig(weight=0.1234)
+
+        assert resolve_repo_weight(config) == pytest.approx(resolve_repo_emission_share(config))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Add `resolve_repo_emission_share` as the active resolver name for repository allocation values
- Migrate mirror PR scoring and issue discovery callers to the emission-share resolver
- Keep `resolve_repo_weight` as a compatibility alias while older fields/tests are still being retired
- Update resolver tests to assert full-precision emission-share lookup and alias behavior

## Related Issues

Part of #1215. Covers required deliverable 7 terminology/API migration slice.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

`uv run pytest tests/validator/test_load_weights.py tests/validator/issue_discovery/test_scan.py tests/validator/oss_contributions/mirror/test_scoring.py -q`
`uv run ruff check gittensor/validator/utils/load_weights.py gittensor/validator/issue_discovery/scan.py gittensor/validator/oss_contributions/mirror/scoring.py tests/validator/test_load_weights.py`
`uv run ruff format --check gittensor/validator/utils/load_weights.py gittensor/validator/issue_discovery/scan.py gittensor/validator/oss_contributions/mirror/scoring.py tests/validator/test_load_weights.py`
`uv run pytest -q`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

Note for reviewers: this PR intentionally preserves behavior and keeps a legacy alias. It moves active callers toward `emission_share` terminology so the later schema/aggregation PRs have a smaller consumer migration surface.