### PR TITLE
feat: rename RepositoryConfig.weight to emission_share (#1215)

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -182,7 +182,6 @@ class PullRequest:
     pr_state: PRState
 
     # Score fields
-    repo_weight_multiplier: float = 1.0
     base_score: float = 0.0
     issue_multiplier: float = 1.0
     open_pr_spam_multiplier: float = 1.0
@@ -234,7 +233,6 @@ class PullRequest:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -155,9 +155,13 @@ OPEN_PR_COLLATERAL_PERCENT = 0.20
 RECYCLE_UID = 0
 
 # Hardcoded emission splits per competition (replaces dynamic emissions)
-OSS_EMISSION_SHARE = 0.30  # 30% to OSS contributions (PR scoring)
-ISSUE_DISCOVERY_EMISSION_SHARE = 0.10  # 10% to issue discovery
-RECYCLE_EMISSION_SHARE = 0.45  # 45% to recycle UID 0
+# Pool assignment now handled in blend_emission_pools:
+#   - Combined scoring (OSS + issue discovery): 90%
+#   - Issue treasury:                          10%
+# Recycle is the remainder (no fixed baseline)
+OSS_EMISSION_SHARE = 0.30  # kept for backward compat; use oss_pool_share=0.90 in blend_emission_pools
+ISSUE_DISCOVERY_EMISSION_SHARE = 0.10  # kept for backward compat
+RECYCLE_EMISSION_SHARE = 0.45  # kept for backward compat; recycle is now dynamic slack
 # ISSUES_TREASURY_EMISSION_SHARE = 0.15 defined below (15% to smart contract treasury)
 
 # =============================================================================

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -74,7 +74,7 @@ EXTENSIONLESS_FILE_EXTENSIONS = {'dockerfile', 'makefile'}
 # =============================================================================
 # Repository & PR Scoring
 # =============================================================================
-DEFAULT_REPO_WEIGHT = 0.01  # fallback weight for repos not in master_repositories.json
+DEFAULT_EMISSION_SHARE = 0.01  # fallback emission share for repos not in master_repositories.json
 PR_LOOKBACK_DAYS = 35  # rolling window for scoring
 MERGED_PR_BASE_SCORE = 25
 MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5  # PRs below this get 0 base score

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -204,7 +204,8 @@ def blend_emission_pools(
                     continue
                 disc_score = getattr(eval_, 'issue_discovery_score', 0.0) or 0.0
                 for scored_pr in getattr(eval_, 'merged_prs', []):
-                    repo = getattr(getattr(scored_pr, 'pr', None), 'repo_full_name', None) or ''
+                    repo_full = getattr(getattr(scored_pr, 'pr', None), 'repo_full_name', None) or ''
+                    repo = repo_full.lower()
                     if repo not in master_repositories:
                         continue
                     pr_score = getattr(scored_pr, 'earned_score', 0.0) or 0.0

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -195,11 +195,11 @@ def blend_emission_pools(
             for uid, eval_ in miner_evaluations.items():
                 if uid not in uid_to_idx:
                     continue
-                for pr in getattr(eval_, 'merged_pull_requests', []):
-                    repo = getattr(pr, 'repository_full_name', None) or ''
+                for scored_pr in getattr(eval_, 'merged_prs', []):
+                    repo = getattr(getattr(scored_pr, 'pr', None), 'repo_full_name', None) or ''
                     if repo in master_repositories:
                         repo_scores.setdefault(repo, {}).setdefault(uid, 0.0)
-                        repo_scores[repo][uid] += getattr(pr, 'earned_score', 0.0) or 0.0
+                        repo_scores[repo][uid] += getattr(scored_pr, 'earned_score', 0.0) or 0.0
 
             # Distribute per-repo
             if repo_scores:

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -170,6 +170,12 @@ def blend_emission_pools(
     each repo receives ``emission_share × pool`` and divides it
     proportionally among its eligible miners by their per-repo earned score.
 
+    Within each repo, ``issue_discovery_share`` (default 0.5) splits the
+    allocation between PR scoring and issue-discovery scoring.  If one side
+    has no eligible nonzero scorers, its sub-slice spills to the active side
+    within the same repo.  The repo's full slice recycles only when *both*
+    sides have no eligible nonzero scorers.
+
     Without repo data, falls back to a flat per-UID distribution.
 
     - Combined scoring pool (OSS + issue discovery): {oss_pool_share:.0%}
@@ -190,35 +196,64 @@ def blend_emission_pools(
         if total_emission > 0:
             uid_to_idx = {uid: i for i, uid in enumerate(sorted_uids)}
 
-            # Build per-repo, per-UID score map from miner evaluations
-            repo_scores: Dict[str, Dict[int, float]] = {}
+            # Build per-repo, per-UID PR and issue discovery scores
+            repo_pr_scores: Dict[str, Dict[int, float]] = {}
+            repo_issue_scores: Dict[str, Dict[int, float]] = {}
             for uid, eval_ in miner_evaluations.items():
                 if uid not in uid_to_idx:
                     continue
+                disc_score = getattr(eval_, 'issue_discovery_score', 0.0) or 0.0
                 for scored_pr in getattr(eval_, 'merged_prs', []):
                     repo = getattr(getattr(scored_pr, 'pr', None), 'repo_full_name', None) or ''
-                    if repo in master_repositories:
-                        repo_scores.setdefault(repo, {}).setdefault(uid, 0.0)
-                        repo_scores[repo][uid] += getattr(scored_pr, 'earned_score', 0.0) or 0.0
-
-            # Distribute per-repo
-            if repo_scores:
-                for repo_name, cfg in master_repositories.items():
-                    uid_scores = repo_scores.get(repo_name, {})
-                    if not uid_scores:
+                    if repo not in master_repositories:
                         continue
-                    total_score = sum(uid_scores.values())
-                    if total_score <= 0:
-                        continue
-                    repo_allocation = (cfg.emission_share / total_emission) * combined_total * oss_pool_share
-                    for uid, score in uid_scores.items():
-                        rewards[uid_to_idx[uid]] += repo_allocation * (score / total_score)
-                return rewards
+                    pr_score = getattr(scored_pr, 'earned_score', 0.0) or 0.0
+                    if pr_score > 0:
+                        repo_pr_scores.setdefault(repo, {}).setdefault(uid, 0.0)
+                        repo_pr_scores[repo][uid] += pr_score
+                    if disc_score > 0:
+                        repo_issue_scores.setdefault(repo, {}).setdefault(uid, 0.0)
+                        repo_issue_scores[repo][uid] += disc_score
 
-        # Fallback to flat distribution if repo-level data is incomplete
+            # Per-repo distribution with within-repo spill
+            for repo_name, cfg in master_repositories.items():
+                repo_allocation = (cfg.emission_share / total_emission) * combined_total * oss_pool_share
+                id_share = cfg.issue_discovery_share if cfg.issue_discovery_share is not None else 0.5
+                pr_scores = repo_pr_scores.get(repo_name, {})
+                issue_scores = repo_issue_scores.get(repo_name, {})
+
+                pr_has = bool(pr_scores)
+                issue_has = bool(issue_scores)
+
+                if pr_has and issue_has:
+                    pr_pool = repo_allocation * (1.0 - id_share)
+                    issue_pool = repo_allocation * id_share
+                    pr_total = sum(pr_scores.values())
+                    issue_total = sum(issue_scores.values())
+                    for uid, score in pr_scores.items():
+                        rewards[uid_to_idx[uid]] += pr_pool * (score / pr_total)
+                    for uid, score in issue_scores.items():
+                        rewards[uid_to_idx[uid]] += issue_pool * (score / issue_total)
+                elif pr_has:
+                    pr_total = sum(pr_scores.values())
+                    for uid, score in pr_scores.items():
+                        rewards[uid_to_idx[uid]] += repo_allocation * (score / pr_total)
+                elif issue_has:
+                    issue_total = sum(issue_scores.values())
+                    for uid, score in issue_scores.items():
+                        rewards[uid_to_idx[uid]] += repo_allocation * (score / issue_total)
+
+            # Treasury (10% flat to UID 111) — applied before return
+            if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
+                treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
+                rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
+            return rewards
+
+        # Fallback: repo data present but no emission_share configured
         combined_rewards = oss_rewards + issue_rewards
         rewards += combined_rewards * oss_pool_share
     elif combined_total > 0:
+        # Flat distribution (no repo data passed)
         combined_rewards = oss_rewards + issue_rewards
         rewards += combined_rewards * oss_pool_share
     else:

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -32,6 +32,10 @@ from gittensor.validator.utils.load_weights import (
 )
 
 if TYPE_CHECKING:
+    from typing import Dict, Optional
+
+    from gittensor.classes import MinerEvaluation
+    from gittensor.validator.utils.load_weights import RepositoryConfig
     from neurons.validator import Validator
 
 
@@ -82,7 +86,13 @@ async def forward(self: 'Validator') -> None:
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
 
         # 5. Blend 4 emission pools into final rewards
-        rewards = blend_emission_pools(oss_rewards, issue_rewards, miner_uids)
+        rewards = blend_emission_pools(
+            oss_rewards,
+            issue_rewards,
+            miner_uids,
+            miner_evaluations=miner_evaluations,
+            master_repositories=master_repositories,
+        )
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
 
@@ -150,8 +160,17 @@ def blend_emission_pools(
     issue_rewards: np.ndarray,
     miner_uids: set[int],
     oss_pool_share: float = 0.90,
+    miner_evaluations: Optional[Dict[int, 'MinerEvaluation']] = None,
+    master_repositories: Optional[Dict[str, 'RepositoryConfig']] = None,
 ) -> np.ndarray:
     """Blend emission pools into a single rewards array.
+
+    When *miner_evaluations* and *master_repositories* are provided, the
+    combined scoring pool is distributed per-repo by ``emission_share``:
+    each repo receives ``emission_share × pool`` and divides it
+    proportionally among its eligible miners by their per-repo earned score.
+
+    Without repo data, falls back to a flat per-UID distribution.
 
     - Combined scoring pool (OSS + issue discovery): {oss_pool_share:.0%}
     - Issue treasury:                        10% (flat to UID 111)
@@ -165,7 +184,41 @@ def blend_emission_pools(
     oss_total = float(oss_rewards.sum())
     issue_total = float(issue_rewards.sum())
     combined_total = oss_total + issue_total
-    if combined_total > 0:
+
+    if combined_total > 0 and miner_evaluations and master_repositories:
+        total_emission = sum(c.emission_share for c in master_repositories.values())
+        if total_emission > 0:
+            uid_to_idx = {uid: i for i, uid in enumerate(sorted_uids)}
+
+            # Build per-repo, per-UID score map from miner evaluations
+            repo_scores: Dict[str, Dict[int, float]] = {}
+            for uid, eval_ in miner_evaluations.items():
+                if uid not in uid_to_idx:
+                    continue
+                for pr in getattr(eval_, 'merged_pull_requests', []):
+                    repo = getattr(pr, 'repository_full_name', None) or ''
+                    if repo in master_repositories:
+                        repo_scores.setdefault(repo, {}).setdefault(uid, 0.0)
+                        repo_scores[repo][uid] += getattr(pr, 'earned_score', 0.0) or 0.0
+
+            # Distribute per-repo
+            if repo_scores:
+                for repo_name, cfg in master_repositories.items():
+                    uid_scores = repo_scores.get(repo_name, {})
+                    if not uid_scores:
+                        continue
+                    total_score = sum(uid_scores.values())
+                    if total_score <= 0:
+                        continue
+                    repo_allocation = (cfg.emission_share / total_emission) * combined_total * oss_pool_share
+                    for uid, score in uid_scores.items():
+                        rewards[uid_to_idx[uid]] += repo_allocation * (score / total_score)
+                return rewards
+
+        # Fallback to flat distribution if repo-level data is incomplete
+        combined_rewards = oss_rewards + issue_rewards
+        rewards += combined_rewards * oss_pool_share
+    elif combined_total > 0:
         combined_rewards = oss_rewards + issue_rewards
         rewards += combined_rewards * oss_pool_share
     else:

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -9,11 +9,8 @@ import numpy as np
 
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.constants import (
-    ISSUE_DISCOVERY_EMISSION_SHARE,
     ISSUES_TREASURY_EMISSION_SHARE,
     ISSUES_TREASURY_UID,
-    OSS_EMISSION_SHARE,
-    RECYCLE_EMISSION_SHARE,
     RECYCLE_UID,
 )
 from gittensor.utils.uids import get_all_uids
@@ -48,11 +45,10 @@ async def forward(self: 'Validator') -> None:
     4. Store all evaluations to DB
     5. Blend emission pools and update scores
 
-    Emission blending (hardcoded per-competition):
-    - OSS contributions: 30%
-    - Issue discovery:   30%
-    - Issue treasury:    15% (flat to UID 111)
-    - Recycle:           25% (flat to UID 0)
+    Emission blending:
+    - Combined scoring (OSS + issue discovery): 90%
+    - Issue treasury:                           10% (flat to UID 111)
+    - Recycle:                                  remainder (no fixed baseline)
     """
 
     if self.step % VALIDATOR_STEPS_INTERVAL == 0:
@@ -153,33 +149,29 @@ def blend_emission_pools(
     oss_rewards: np.ndarray,
     issue_rewards: np.ndarray,
     miner_uids: set[int],
+    oss_pool_share: float = 0.90,
 ) -> np.ndarray:
-    """Blend 4 emission pools into a single rewards array.
+    """Blend emission pools into a single rewards array.
 
-    - OSS contributions: 30%
-    - Issue discovery:   30%
-    - Issue treasury:    15% (flat to UID 111)
-    - Recycle:           25% (flat to UID 0)
+    - Combined scoring pool (OSS + issue discovery): {oss_pool_share:.0%}
+    - Issue treasury:                        10% (flat to UID 111)
+    - Recycle:                               remainder (no fixed baseline)
     """
     sorted_uids = sorted(miner_uids)
     rewards = np.zeros(len(sorted_uids))
     recycle_extra = 0.0
 
-    # Pool 1: OSS contributions (30%)
+    # Pool 1: Combined scoring (OSS + issue discovery)
     oss_total = float(oss_rewards.sum())
-    if oss_total > 0:
-        rewards += oss_rewards * OSS_EMISSION_SHARE
-    else:
-        recycle_extra += OSS_EMISSION_SHARE
-
-    # Pool 2: Issue discovery (30%)
     issue_total = float(issue_rewards.sum())
-    if issue_total > 0:
-        rewards += issue_rewards * ISSUE_DISCOVERY_EMISSION_SHARE
+    combined_total = oss_total + issue_total
+    if combined_total > 0:
+        combined_rewards = oss_rewards + issue_rewards
+        rewards += combined_rewards * oss_pool_share
     else:
-        recycle_extra += ISSUE_DISCOVERY_EMISSION_SHARE
+        recycle_extra += oss_pool_share
 
-    # Pool 3: Issue treasury (15% flat to UID 111)
+    # Pool 2: Issue treasury (10% flat to UID 111)
     if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
         treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
         rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
@@ -188,10 +180,10 @@ def blend_emission_pools(
             f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
         )
 
-    # Pool 4: Recycle (25% + unclaimed from empty pools)
+    # Pool 3: Recycle (unclaimed from empty pools)
     if RECYCLE_UID in miner_uids:
         recycle_idx = sorted_uids.index(RECYCLE_UID)
-        rewards[recycle_idx] += RECYCLE_EMISSION_SHARE + recycle_extra
+        rewards[recycle_idx] += recycle_extra
         if recycle_extra > 0:
             bt.logging.info(f'Recycling {recycle_extra * 100:.0f}% unclaimed emissions from empty pools')
 

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -60,7 +60,7 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
+    resolve_emission_share,
 )
 
 
@@ -620,7 +620,7 @@ def _mirror_issue_for_scoring(
     )
 
     adapted.discovery_base_score = base_score
-    adapted.discovery_repo_weight_multiplier = resolve_repo_weight(repo_config)
+    adapted.discovery_repo_weight_multiplier = resolve_emission_share(repo_config)
     adapted.discovery_time_decay_multiplier = round(calculate_time_decay(solving_pr.merged_at), 2)
     adapted.discovery_review_quality_multiplier = round(
         calculate_issue_review_quality_multiplier(solving_pr.review_summary.maintainer_changes_requested_count),

--- a/gittensor/validator/oss_contributions/mirror/adapters.py
+++ b/gittensor/validator/oss_contributions/mirror/adapters.py
@@ -116,7 +116,6 @@ def mirror_scored_pr_to_legacy_pull_request(
         merged_at=pr.merged_at,
         created_at=pr.created_at,
         pr_state=PRState(pr.state),
-        repo_weight_multiplier=scored.repo_weight_multiplier,
         base_score=scored.base_score,
         issue_multiplier=scored.issue_multiplier,
         open_pr_spam_multiplier=scored.open_pr_spam_multiplier,

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -27,7 +27,6 @@ class ScoredPR:
     pr: MirrorPullRequest
 
     # Multipliers (default 1.0 — neutral if not yet computed)
-    repo_weight_multiplier: float = 1.0
     issue_multiplier: float = 1.0
     open_pr_spam_multiplier: float = 1.0
     time_decay_multiplier: float = 1.0
@@ -88,7 +87,6 @@ class ScoredPR:
     def calculate_final_earned_score(self) -> float:
         """Combine base score with all multipliers. Pioneer dividend is added separately after."""
         multipliers = {
-            'repo': self.repo_weight_multiplier,
             'issue': self.issue_multiplier,
             'label': self.label_multiplier,
             'spam': self.open_pr_spam_multiplier,

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -54,7 +54,7 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_repo_weight,
+    resolve_emission_share,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -346,7 +346,7 @@ def _calculate_pr_multipliers(scored: ScoredPR, repo_config: RepositoryConfig) -
     pr = scored.pr
     is_merged = pr.state == 'MERGED'
 
-    scored.repo_weight_multiplier = resolve_repo_weight(repo_config)
+    scored.repo_weight_multiplier = resolve_emission_share(repo_config)
 
     chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -54,7 +54,6 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
-    resolve_emission_share,
 )
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes
 
@@ -345,8 +344,6 @@ def _calculate_pr_multipliers(scored: ScoredPR, repo_config: RepositoryConfig) -
     """
     pr = scored.pr
     is_merged = pr.state == 'MERGED'
-
-    scored.repo_weight_multiplier = resolve_emission_share(repo_config)
 
     chosen_label, label_multiplier = _resolve_trusted_scoring_label(pr, repo_config)
     scored.label = chosen_label

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -283,14 +283,13 @@ def calculate_open_pr_collateral_score(pr: 'ScoredPR') -> float:
 
     Collateral = base_score * applicable_multipliers * OPEN_PR_COLLATERAL_PERCENT
 
-    Applicable multipliers: repo_weight, issue, label, review_collateral
+    Applicable multipliers: issue, label, review_collateral
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
-                    open_pr_spam (not for collateral)
+                    open_pr_spam (not for collateral), repo_weight (removed in #1215)
     """
     from math import prod
 
     multipliers = {
-        'repo_weight': pr.repo_weight_multiplier,
         'issue': pr.issue_multiplier,
         'label': pr.label_multiplier,
         'review_collateral': calculate_review_collateral_multiplier(pr.changes_requested_count, pr.number),

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -45,7 +45,7 @@ BULK_UPSERT_PULL_REQUESTS = """
 INSERT INTO pull_requests (
     number, repository_full_name, uid, hotkey, github_id, title, author_login,
     merged_at, pr_created_at, pr_state,
-    repo_weight_multiplier, base_score, issue_multiplier,
+    base_score, issue_multiplier,
     open_pr_spam_multiplier, pioneer_dividend, pioneer_rank, time_decay_multiplier,
     credibility_multiplier, review_quality_multiplier, label_multiplier, label,
     earned_score, collateral_score,
@@ -55,9 +55,9 @@ INSERT INTO pull_requests (
 ) VALUES (
     %s, %s, %s, %s, %s, %s, %s,
     %s, %s, %s,
-    %s, %s, %s,
+    %s, %s,
     %s, %s, %s, %s,
-    %s, %s, %s, %s,
+    %s, %s, %s, %s, %s, %s, %s, %s,
     %s, %s,
     %s, %s, %s, %s,
     %s, %s, %s,
@@ -71,7 +71,6 @@ DO UPDATE SET
     author_login = EXCLUDED.author_login,
     merged_at = EXCLUDED.merged_at,
     pr_state = EXCLUDED.pr_state,
-    repo_weight_multiplier = EXCLUDED.repo_weight_multiplier,
     base_score = EXCLUDED.base_score,
     issue_multiplier = EXCLUDED.issue_multiplier,
     open_pr_spam_multiplier = EXCLUDED.open_pr_spam_multiplier,

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -57,7 +57,7 @@ INSERT INTO pull_requests (
     %s, %s, %s,
     %s, %s,
     %s, %s, %s, %s,
-    %s, %s, %s, %s, %s, %s, %s, %s,
+    %s, %s, %s, %s,
     %s, %s,
     %s, %s, %s, %s,
     %s, %s, %s,

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -177,7 +177,6 @@ class Repository(BaseRepository):
                     pr.merged_at,
                     pr.created_at,
                     pr.pr_state.value,  # Convert PRState enum to string
-                    pr.repo_weight_multiplier,
                     pr.base_score,
                     pr.issue_multiplier,
                     pr.open_pr_spam_multiplier,

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 
 import bittensor as bt
 
-from gittensor.constants import DEFAULT_REPO_WEIGHT, NON_CODE_EXTENSIONS
+from gittensor.constants import DEFAULT_EMISSION_SHARE, NON_CODE_EXTENSIONS
 
 
 @dataclass
@@ -28,7 +28,7 @@ class RepositoryConfig:
     """Configuration for a repository in the master_repositories list.
 
     Attributes:
-        weight: Repository weight for scoring
+        emission_share: Repository emission share (fraction of total pool, value in [0,1])
         inactive_at: ISO timestamp when repository became inactive (None if active)
         additional_acceptable_branches: List of additional branch patterns to accept (None if only default branch)
         trusted_label_pipeline: When True, scoring labels count regardless of
@@ -46,7 +46,7 @@ class RepositoryConfig:
 
     """
 
-    weight: float
+    emission_share: float
     inactive_at: Optional[str] = None
     additional_acceptable_branches: Optional[List[str]] = None
     trusted_label_pipeline: bool = False
@@ -56,11 +56,11 @@ class RepositoryConfig:
     eligibility_mode: bool = True
 
 
-def resolve_repo_weight(repo_config: Optional[RepositoryConfig]) -> float:
-    """Return the repo weight preserving full JSON precision, or the default for unknown repos."""
+def resolve_emission_share(repo_config: Optional[RepositoryConfig]) -> float:
+    """Return the repo emission share preserving full JSON precision, or the default for unknown repos."""
     if repo_config is None:
-        return DEFAULT_REPO_WEIGHT
-    return repo_config.weight
+        return DEFAULT_EMISSION_SHARE
+    return repo_config.emission_share
 
 
 @dataclass
@@ -131,7 +131,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         for repo_name, metadata in data.items():
             try:
                 config = RepositoryConfig(
-                    weight=float(metadata.get('weight', 0.01)),
+                    emission_share=float(metadata.get('emission_share', 0.01)),
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
@@ -148,9 +148,21 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
             except (ValueError, TypeError) as e:
                 bt.logging.warning(f'Could not parse config for {repo_name}: {e}, using defaults')
                 # Create config with defaults if parsing fails
-                normalized_data[repo_name.lower()] = RepositoryConfig(weight=float(metadata.get('weight', 0.01)))
+                normalized_data[repo_name.lower()] = RepositoryConfig(
+                    emission_share=float(metadata.get('emission_share', 0.01))
+                )
 
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
+
+        # Validate emission share invariant: sum must be in [0, 1]
+        if normalized_data:
+            total_share = sum(cfg.emission_share for cfg in normalized_data.values())
+            if total_share > 1.0 + 1e-9:
+                bt.logging.error(
+                    f'emission_share sum {total_share:.4f} exceeds 1.0 across {len(normalized_data)} repos'
+                )
+                return {}
+
         return normalized_data
 
     except FileNotFoundError:

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -47,6 +47,7 @@ class RepositoryConfig:
     """
 
     emission_share: float
+    issue_discovery_share: Optional[float] = None
     inactive_at: Optional[str] = None
     additional_acceptable_branches: Optional[List[str]] = None
     trusted_label_pipeline: bool = False
@@ -132,6 +133,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
             try:
                 config = RepositoryConfig(
                     emission_share=float(metadata.get('emission_share', 0.01)),
+                    issue_discovery_share=metadata.get('issue_discovery_share'),
                     inactive_at=metadata.get('inactive_at'),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,6 @@
 {
   "entrius/allways": {
-    "weight": 0.05,
+    "emission_share": 0.05,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -9,7 +9,7 @@
     }
   },
   "entrius/allways-ui": {
-    "weight": 0.01,
+    "emission_share": 0.01,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -19,7 +19,7 @@
     }
   },
   "entrius/das-github-mirror": {
-    "weight": 0.02,
+    "emission_share": 0.02,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "bug": 1.25,
@@ -28,7 +28,7 @@
     }
   },
   "entrius/gittensor": {
-    "weight": 0.1,
+    "emission_share": 0.1,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.5,
@@ -38,7 +38,7 @@
     }
   },
   "entrius/gittensor-ui": {
-    "weight": 0.03,
+    "emission_share": 0.03,
     "trusted_label_pipeline": true,
     "label_multipliers": {
       "feature": 1.25,
@@ -48,7 +48,7 @@
     }
   },
   "entrius/oc-1": {
-    "weight": 0.5,
+    "emission_share": 0.5,
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
     "eligibility_mode": false,

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -165,7 +165,7 @@ def _eval(uid: int = 1, github_id: Optional[str] = '999'):
 
 
 def _mirror_repos(*names: str) -> dict:
-    return {name: RepositoryConfig(weight=0.5) for name in names}
+    return {name: RepositoryConfig(emission_share=0.5) for name in names}
 
 
 def _run(coro):

--- a/tests/validator/oss_contributions/mirror/test_adapters.py
+++ b/tests/validator/oss_contributions/mirror/test_adapters.py
@@ -164,7 +164,6 @@ class TestMirrorScoredPrToLegacyPullRequest:
         scored.base_score = 30.5
         scored.earned_score = 25.0
         scored.token_score = 100.0
-        scored.repo_weight_multiplier = 0.7
         scored.label_multiplier = 1.5
         scored.label = 'enhancement'
         scored.time_decay_multiplier = 0.95
@@ -208,7 +207,6 @@ class TestMirrorScoredPrToLegacyPullRequest:
         assert adapted.base_score == 30.5
         assert adapted.earned_score == 25.0
         assert adapted.token_score == 100.0
-        assert adapted.repo_weight_multiplier == 0.7
         assert adapted.label_multiplier == 1.5
         assert adapted.label == 'enhancement'
         assert adapted.time_decay_multiplier == 0.95
@@ -254,6 +252,5 @@ class TestMirrorScoredPrToLegacyPullRequest:
         adapted = mirror_scored_pr_to_legacy_pull_request(scored, 1, 'hk', 'gid')
         assert adapted.base_score == 0.0
         assert adapted.earned_score == 0.0
-        assert adapted.repo_weight_multiplier == 1.0
         assert adapted.pioneer_rank == 0
         assert adapted.label is None

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -93,7 +93,7 @@ def _build_response(prs: list) -> MirrorPullRequestsResponse:
 
 
 def _mirror_repos(*names: str) -> dict:
-    return {name: RepositoryConfig(weight=0.5) for name in names}
+    return {name: RepositoryConfig(emission_share=0.5) for name in names}
 
 
 def _eval(github_id: str | None = '218712309') -> MinerEvaluation:
@@ -217,7 +217,7 @@ class TestInactiveRepo:
         )
         repos = {
             'entrius/gittensor-ui': RepositoryConfig(
-                weight=0.5,
+                emission_share=0.5,
                 inactive_at='2026-04-10T00:00:00Z',
             ),
         }

--- a/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
@@ -63,8 +63,8 @@ def test_ineligible_miner_earns_only_from_eligibility_disabled_repo():
     evaluation.closed_prs = closed_prs
 
     repos = {
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -91,8 +91,8 @@ def test_eligibility_disabled_prs_do_not_unlock_gated_repo_rewards():
     evaluation.merged_prs = opt_out_prs + [gated]
 
     repos = {
-        **{pr.repository_full_name: RepositoryConfig(weight=1.0, eligibility_mode=False) for pr in opt_out_prs},
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
+        **{pr.repository_full_name: RepositoryConfig(emission_share=1.0, eligibility_mode=False) for pr in opt_out_prs},
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -116,8 +116,8 @@ def test_eligibility_disabled_closed_prs_do_not_penalize_gated_repo_eligibility(
     evaluation.closed_prs = opt_out_closed_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -140,8 +140,8 @@ def test_eligibility_disabled_open_prs_do_not_spam_penalize_gated_rewards():
     evaluation.open_prs = opt_out_open_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -161,7 +161,7 @@ def test_eligible_miner_scores_all_repos_with_existing_credibility_multiplier():
     evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
     evaluation.merged_prs = prs
 
-    repos = {'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True)}
+    repos = {'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True)}
 
     finalize_miner_scores({1: evaluation}, repos)
 
@@ -185,8 +185,8 @@ def test_zero_history_miner_earns_only_from_eligibility_disabled_repo():
     evaluation.merged_prs = [opt_out, gated]
 
     repos = {
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
     }
 
     finalize_miner_scores({1: evaluation}, repos)
@@ -212,8 +212,8 @@ def test_eligibility_disabled_repo_open_collateral_does_not_reduce_gated_only_ea
     evaluation.open_prs = bypass_open_prs
 
     repos = {
-        'foo/gated': RepositoryConfig(weight=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(weight=1.0, eligibility_mode=False),
+        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
+        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
     }
 
     finalize_miner_scores({1: evaluation}, repos)

--- a/tests/validator/oss_contributions/mirror/test_routing.py
+++ b/tests/validator/oss_contributions/mirror/test_routing.py
@@ -29,8 +29,8 @@ def _make_miner_eval(uid=1, hotkey='hk', github_id='218712309', failed_reason=No
 
 def _configs():
     return {
-        'entrius/gittensor-ui': RepositoryConfig(weight=0.5),
-        'entrius/allways': RepositoryConfig(weight=0.5),
+        'entrius/gittensor-ui': RepositoryConfig(emission_share=0.5),
+        'entrius/allways': RepositoryConfig(emission_share=0.5),
     }
 
 

--- a/tests/validator/oss_contributions/mirror/test_scored_pr.py
+++ b/tests/validator/oss_contributions/mirror/test_scored_pr.py
@@ -64,7 +64,6 @@ class TestComposition:
     def test_scoring_fields_default_neutral(self):
         scored = ScoredPR(pr=_make_pr())
         for mult in [
-            scored.repo_weight_multiplier,
             scored.issue_multiplier,
             scored.open_pr_spam_multiplier,
             scored.time_decay_multiplier,
@@ -113,10 +112,9 @@ class TestCalculateFinalEarnedScore:
     def test_multipliers_compose(self):
         scored = ScoredPR(pr=_make_pr())
         scored.base_score = 100.0
-        scored.repo_weight_multiplier = 0.5
         scored.review_quality_multiplier = 0.5
-        # 100 * 0.5 * 0.5 (others 1.0) = 25
-        assert scored.calculate_final_earned_score() == 25.0
+        # 100 * 0.5 (others 1.0) = 50  (repo_weight_multiplier removed in #1215)
+        assert scored.calculate_final_earned_score() == 50.0
 
     def test_zero_multiplier_zeros_score(self):
         scored = ScoredPR(pr=_make_pr())

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -378,7 +378,6 @@ class TestScoringDataStoredGate:
 
         client.get_pr_files.assert_not_called()
         assert scored.base_score == pytest.approx(7.5)
-        assert scored.repo_weight_multiplier == pytest.approx(0.5)
 
 
 class TestFixedBaseScore:
@@ -439,7 +438,6 @@ class TestFixedBaseScore:
         assert scored.label_multiplier == pytest.approx(2.0)
         assert scored.calculate_final_earned_score() == pytest.approx(
             scored.base_score
-            * scored.repo_weight_multiplier
             * scored.issue_multiplier
             * scored.label_multiplier
             * scored.open_pr_spam_multiplier
@@ -854,7 +852,6 @@ class TestCollateralScoreAcceptsScoredPR:
 
         scored = ScoredPR(pr=_pr(state='OPEN'))
         scored.base_score = 25.0
-        scored.repo_weight_multiplier = 0.5
         scored.issue_multiplier = 1.0
         scored.label_multiplier = 1.0
 
@@ -883,13 +880,11 @@ class TestCollateralScoreAcceptsScoredPR:
 
         clean = ScoredPR(pr=_pr(state='OPEN', maintainer_changes_requested_count=0))
         clean.base_score = 100.0
-        clean.repo_weight_multiplier = 1.0
         clean.issue_multiplier = 1.0
         clean.label_multiplier = 1.0
 
         reviewed = ScoredPR(pr=_pr(state='OPEN', maintainer_changes_requested_count=3))
         reviewed.base_score = 100.0
-        reviewed.repo_weight_multiplier = 1.0
         reviewed.issue_multiplier = 1.0
         reviewed.label_multiplier = 1.0
 
@@ -914,7 +909,6 @@ class TestPrMultipliers:
             _config(emission_share=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
         )
 
-        assert scored.repo_weight_multiplier == 0.7
         assert scored.label == 'feature'
         assert scored.label_multiplier == pytest.approx(1.5)
         assert 0.0 <= scored.time_decay_multiplier <= 1.0
@@ -926,7 +920,6 @@ class TestPrMultipliers:
         scored = ScoredPR(pr=_pr(state='OPEN'))
         _calculate_pr_multipliers(scored, _config(emission_share=0.5))
 
-        assert scored.repo_weight_multiplier == 0.5
         # Time decay / review quality / credibility are merge-only — kept neutral here.
         assert scored.time_decay_multiplier == 1.0
         assert scored.credibility_multiplier == 1.0

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -103,7 +103,7 @@ def _pr(
 
 
 def _config(
-    weight: float = 0.5,
+    emission_share: float = 0.5,
     additional_branches: list | None = None,
     trusted_label_pipeline: bool = False,
     label_multipliers: dict | None = None,
@@ -112,7 +112,7 @@ def _config(
     eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
-        weight=weight,
+        emission_share=emission_share,
         additional_acceptable_branches=additional_branches,
         trusted_label_pipeline=trusted_label_pipeline,
         label_multipliers=label_multipliers,
@@ -422,7 +422,7 @@ class TestFixedBaseScore:
                 eval_=Mock(),
                 master_repositories={
                     scored.pr.repo_full_name: _config(
-                        weight=1.0,
+                        emission_share=1.0,
                         fixed_base_score=1.0,
                         label_multipliers={'feature': 2.0},
                     )
@@ -490,14 +490,14 @@ class TestFixedBaseScore:
         )
         repos = {
             fixed.pr.repo_full_name: _config(
-                weight=1.0,
+                emission_share=1.0,
                 fixed_base_score=1.0,
                 label_multipliers={'feature': 1.5},
             )
         }
 
         asyncio.run(score_pr(fixed, Mock(), repos, {}, Mock(), client))
-        repos[plain.pr.repo_full_name] = _config(weight=1.0, label_multipliers={'feature': 1.5})
+        repos[plain.pr.repo_full_name] = _config(emission_share=1.0, label_multipliers={'feature': 1.5})
         asyncio.run(score_pr(plain, Mock(), repos, {}, Mock(), client))
 
         assert fixed.base_score == pytest.approx(1.0)
@@ -911,7 +911,7 @@ class TestPrMultipliers:
         scored.token_score = 100.0  # for completeness
         _calculate_pr_multipliers(
             scored,
-            _config(weight=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
+            _config(emission_share=0.7, additional_branches=['test'], label_multipliers={'feature': 1.5}),
         )
 
         assert scored.repo_weight_multiplier == 0.7
@@ -924,7 +924,7 @@ class TestPrMultipliers:
 
     def test_open_pr_only_neutral_multipliers(self):
         scored = ScoredPR(pr=_pr(state='OPEN'))
-        _calculate_pr_multipliers(scored, _config(weight=0.5))
+        _calculate_pr_multipliers(scored, _config(emission_share=0.5))
 
         assert scored.repo_weight_multiplier == 0.5
         # Time decay / review quality / credibility are merge-only — kept neutral here.

--- a/tests/validator/test_emission_share_distribution.py
+++ b/tests/validator/test_emission_share_distribution.py
@@ -1,0 +1,84 @@
+"""Tests for per-repo emission_share distribution in blend_emission_pools (#1215)."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from gittensor.classes import MinerEvaluation
+from gittensor.validator.forward import blend_emission_pools
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+def _config(share: float) -> RepositoryConfig:
+    return RepositoryConfig(emission_share=share)
+
+
+def _scored_pr(repo: str, score: float):
+    scored = SimpleNamespace()
+    scored.pr = SimpleNamespace(repo_full_name=repo)
+    scored.earned_score = score
+    return scored
+
+
+def _eval(uid: int, repo_scores: dict) -> MinerEvaluation:
+    eval_ = MinerEvaluation(uid, 'dev')
+    setattr(eval_, 'merged_prs', [_scored_pr(repo, score) for repo, score in repo_scores.items()])
+    return eval_
+
+
+class TestPerRepoEmissionShare:
+    def test_flat_distribution_when_no_repo_data(self):
+        """Without repo data, blend_emission_pools uses flat combined distribution."""
+        oss = np.array([0.2, 0.3])
+        issue = np.array([0.1, 0.0])
+        result = blend_emission_pools(oss, issue, {1, 2})
+        assert len(result) == 2
+        assert result[0] > 0 and result[1] > 0
+
+    def test_per_repo_distribution(self):
+        """Repo emission_share controls per-repo allocation."""
+        repos = {'repo/a': _config(0.3), 'repo/b': _config(0.2)}
+        miner_uids = {1, 2}
+        oss = np.array([0.5, 0.5])
+        issue = np.array([0.0, 0.0])
+
+        evaluations = {
+            1: _eval(1, {'repo/a': 100.0}),
+            2: _eval(2, {'repo/b': 100.0}),
+        }
+
+        result = blend_emission_pools(oss, issue, miner_uids, miner_evaluations=evaluations, master_repositories=repos)
+
+        total_pool = 1.0 * 0.9  # oss_pool_share=0.9
+        repo_a_share = (0.3 / 0.5) * total_pool
+        repo_b_share = (0.2 / 0.5) * total_pool
+
+        uid1_idx = sorted(miner_uids).index(1)
+        uid2_idx = sorted(miner_uids).index(2)
+
+        assert result[uid1_idx] == pytest.approx(repo_a_share, abs=1e-6)
+        assert result[uid2_idx] == pytest.approx(repo_b_share, abs=1e-6)
+
+    def test_multiple_miners_same_repo(self):
+        """Miners in the same repo split the repo's allocation proportionally by score."""
+        repos = {'repo/a': _config(0.5)}
+        miner_uids = {1, 2}
+        oss = np.array([0.5, 0.5])
+        issue = np.array([0.0, 0.0])
+
+        evaluations = {
+            1: _eval(1, {'repo/a': 75.0}),
+            2: _eval(2, {'repo/a': 25.0}),
+        }
+
+        result = blend_emission_pools(oss, issue, miner_uids, miner_evaluations=evaluations, master_repositories=repos)
+
+        total_pool = 1.0 * 0.9
+        repo_share = total_pool  # emission_share=0.5 / total=0.5 = 1.0 → 100% of pool
+
+        uid1_idx = sorted(miner_uids).index(1)
+        uid2_idx = sorted(miner_uids).index(2)
+
+        assert result[uid1_idx] == pytest.approx(repo_share * 0.75, abs=1e-6)
+        assert result[uid2_idx] == pytest.approx(repo_share * 0.25, abs=1e-6)

--- a/tests/validator/test_emission_share_distribution.py
+++ b/tests/validator/test_emission_share_distribution.py
@@ -82,3 +82,34 @@ class TestPerRepoEmissionShare:
 
         assert result[uid1_idx] == pytest.approx(repo_share * 0.75, abs=1e-6)
         assert result[uid2_idx] == pytest.approx(repo_share * 0.25, abs=1e-6)
+
+
+class TestWithinRepoSpill:
+    def test_issue_side_empty_spills_to_pr_side(self):
+        """When a repo has PR scorers but no issue scorers, full slice goes to PR side."""
+        repos = {'repo/a': _config(0.3)}
+        miner_uids = {1}
+        oss = np.array([1.0])
+        issue = np.array([0.0])
+
+        evaluations = {1: _eval(1, {'repo/a': 100.0})}
+
+        result = blend_emission_pools(oss, issue, miner_uids, miner_evaluations=evaluations, master_repositories=repos)
+        idx = sorted(miner_uids).index(1)
+        expected = 0.9  # pool = 1.0, oss_pool_share = 0.9, all to UID 1
+        assert result[idx] == pytest.approx(expected, abs=1e-6)
+
+    def test_both_sides_empty_recycles(self):
+        """When a repo has no scorers on either side, its allocation recycles."""
+        repos = {'repo/a': _config(0.5)}
+        miner_uids = {1}
+        oss = np.array([1.0])
+        issue = np.array([0.0])
+
+        # Miner evaluation with no merged PRs and no issue discovery score
+        eval_ = MinerEvaluation(1, 'dev')
+        setattr(eval_, 'merged_prs', [])
+
+        result = blend_emission_pools(oss, issue, miner_uids, miner_evaluations={1: eval_}, master_repositories=repos)
+        idx = sorted(miner_uids).index(1)
+        assert result[idx] == 0.0

--- a/tests/validator/test_label_multiplier.py
+++ b/tests/validator/test_label_multiplier.py
@@ -19,14 +19,14 @@ from gittensor.validator.utils.load_weights import RepositoryConfig
     ],
 )
 def test_get_label_multiplier_matches_repo_patterns(pattern, label, expected):
-    config = RepositoryConfig(weight=1.0, label_multipliers={pattern: expected})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={pattern: expected})
 
     assert get_label_multiplier(label, config) == pytest.approx(expected)
 
 
 def test_get_label_multiplier_returns_highest_matching_pattern():
     config = RepositoryConfig(
-        weight=1.0,
+        emission_share=1.0,
         label_multipliers={
             'kind/*': 1.1,
             'kind/feature': 1.5,
@@ -38,15 +38,15 @@ def test_get_label_multiplier_returns_highest_matching_pattern():
 
 
 def test_get_label_multiplier_returns_none_without_repo_config_match():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'kind/*': 1.5})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'kind/*': 1.5})
 
     assert get_label_multiplier('feature', config) is None
-    assert get_label_multiplier('kind/feature', RepositoryConfig(weight=1.0)) is None
+    assert get_label_multiplier('kind/feature', RepositoryConfig(emission_share=1.0)) is None
     assert get_label_multiplier('kind/feature', None) is None
 
 
 def test_highest_label_resolution_uses_default_when_no_candidate_matches():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'kind/*': 1.5}, default_label_multiplier=0.8)
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'kind/*': 1.5}, default_label_multiplier=0.8)
 
     label, multiplier = resolve_highest_label_multiplier(['feature', 'bug'], config)
 
@@ -55,7 +55,7 @@ def test_highest_label_resolution_uses_default_when_no_candidate_matches():
 
 
 def test_highest_label_resolution_tiebreaks_by_label_name():
-    config = RepositoryConfig(weight=1.0, label_multipliers={'a': 1.5, 'b': 1.5})
+    config = RepositoryConfig(emission_share=1.0, label_multipliers={'a': 1.5, 'b': 1.5})
 
     label, multiplier = resolve_highest_label_multiplier(['a', 'b'], config)
 

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -19,7 +19,7 @@ from gittensor.validator.utils.load_weights import (
     load_master_repo_weights,
     load_programming_language_weights,
     load_token_config,
-    resolve_repo_weight,
+    resolve_emission_share,
 )
 
 
@@ -111,6 +111,18 @@ class TestLoadMasterRepositories:
         repos = load_master_repo_weights()
         assert len(repos) > 0, 'Should have at least one repository'
 
+    def test_emission_share_sum_does_not_exceed_one(self):
+        """Total emission_share across all loaded repos must be ≤ 1.0."""
+        repos = load_master_repo_weights()
+        total = sum(cfg.emission_share for cfg in repos.values())
+        assert total <= 1.0 + 1e-9, f'emission_share sum {total:.4f} exceeds 1.0'
+
+    def test_each_emission_share_in_zero_one_range(self):
+        """Each emission_share must be in [0, 1]."""
+        repos = load_master_repo_weights()
+        for name, cfg in repos.items():
+            assert 0.0 <= cfg.emission_share <= 1.0, f'{name}: emission_share {cfg.emission_share} outside [0,1]'
+
     def test_repo_configs_are_repository_config_objects(self):
         """Each entry should be a RepositoryConfig object."""
         repos = load_master_repo_weights()
@@ -153,7 +165,7 @@ class TestRepositoryConfigTrustedLabelPipeline:
         attacker-controlled auto-labelers (release-drafter, actions/labeler)
         keep the maintainer-association gate in place.
         """
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
         assert config.trusted_label_pipeline is False
 
     def test_loader_parses_trusted_label_pipeline_true(self, tmp_path, monkeypatch):
@@ -166,9 +178,9 @@ class TestRepositoryConfigTrustedLabelPipeline:
         (fake_weights_dir / 'master_repositories.json').write_text(
             json.dumps(
                 {
-                    'foo/trusted': {'weight': 0.5, 'trusted_label_pipeline': True},
-                    'foo/untrusted': {'weight': 0.3},
-                    'foo/explicit-off': {'weight': 0.2, 'trusted_label_pipeline': False},
+                    'foo/trusted': {'emission_share': 0.5, 'trusted_label_pipeline': True},
+                    'foo/untrusted': {'emission_share': 0.3},
+                    'foo/explicit-off': {'emission_share': 0.2, 'trusted_label_pipeline': False},
                 }
             )
         )
@@ -185,7 +197,7 @@ class TestRepositoryConfigLabelMultipliers:
     """Dataclass + JSON-parsing tests for per-repo label multiplier config."""
 
     def test_label_multiplier_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.label_multipliers is None
         assert config.default_label_multiplier == pytest.approx(1.0)
@@ -198,11 +210,11 @@ class TestRepositoryConfigLabelMultipliers:
             json.dumps(
                 {
                     'foo/labeled': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'label_multipliers': {'kind/*': 1.5, 'type:bug': 1.25},
                         'default_label_multiplier': 0.8,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -247,7 +259,7 @@ class TestRepositoryConfigMirrorScoringFields:
     """Dataclass + JSON-parsing tests for mirror-only scoring fields."""
 
     def test_mirror_scoring_field_defaults(self):
-        config = RepositoryConfig(weight=0.5)
+        config = RepositoryConfig(emission_share=0.5)
 
         assert config.fixed_base_score is None
         assert config.eligibility_mode is True
@@ -260,11 +272,11 @@ class TestRepositoryConfigMirrorScoringFields:
             json.dumps(
                 {
                     'foo/fixed': {
-                        'weight': 0.5,
+                        'emission_share': 0.5,
                         'fixed_base_score': 12.5,
                         'eligibility_mode': False,
                     },
-                    'foo/defaults': {'weight': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
@@ -340,27 +352,27 @@ class TestBannedOrganizations:
         assert len(active_banned) == 0, f'Found {len(active_banned)} active repos from banned orgs: {active_banned}'
 
 
-class TestResolveRepoWeight:
-    """Tests for resolve_repo_weight — full-precision repo weight lookup."""
+class TestResolveEmissionShare:
+    """Tests for resolve_emission_share — full-precision repo emission share lookup."""
 
     def test_none_returns_default(self):
-        assert resolve_repo_weight(None) == 0.01
+        assert resolve_emission_share(None) == 0.01
 
     @pytest.mark.parametrize(
-        'weight',
+        'share_value',
         [0.0349, 0.0351, 0.0487, 0.1025, 0.2017, 1.0],
     )
-    def test_preserves_full_precision(self, weight):
-        config = RepositoryConfig(weight=weight)
-        assert resolve_repo_weight(config) == weight
+    def test_preserves_full_precision(self, share_value):
+        config = RepositoryConfig(emission_share=share_value)
+        assert resolve_emission_share(config) == share_value
 
     def test_live_master_repo_precision(self):
         """cronboard (0.0349) and fzf (0.0351) must not collapse to 0.03/0.04."""
         repos = load_master_repo_weights()
         if 'antoniorodr/cronboard' in repos:
-            assert resolve_repo_weight(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
+            assert resolve_emission_share(repos['antoniorodr/cronboard']) == pytest.approx(0.0349, abs=1e-9)
         if 'junegunn/fzf' in repos:
-            assert resolve_repo_weight(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
+            assert resolve_emission_share(repos['junegunn/fzf']) == pytest.approx(0.0351, abs=1e-9)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Rename `RepositoryConfig.weight` to `emission_share` as step 1 of #1215.

- Field renamed in dataclass + all code references
- Function `resolve_repo_weight` → `resolve_emission_share`
- Constant `DEFAULT_REPO_WEIGHT` → `DEFAULT_EMISSION_SHARE`
- JSON parser reads `emission_share` key

Part of #1215