### PR TITLE
fix: clear stale issue_discovery_score when fresh mirror data makes cached miner ineligible

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -455,6 +455,7 @@ async def _score_miner_issues(
             f'{solved_count} solved ({valid_solved_count} valid) | {closed_count} closed | '
             f'{open_issue_count} open'
         )
+        evaluation.issue_discovery_score = 0.0
         return not score_fetch_failed
 
     spam_mult = calculate_open_issue_spam_multiplier(open_issue_count, issue_token_score)


### PR DESCRIPTION
## Summary

When `_score_miner_issues()` determines a miner is ineligible after a successful mirror fetch, it returned early without zeroing `evaluation.issue_discovery_score`. A `MinerEvaluation` restored from a prior cycle kept its old positive score even though the current authoritative data showed ineligibility. `normalize_issue_discovery_rewards()` then read that stale score and awarded an undeserved emission share.

Fix: add `evaluation.issue_discovery_score = 0.0` in the ineligible early-return branch. All other diagnostic fields (`total_solved_issues`, `issue_credibility`, `is_issue_eligible`, counts) are already written from fresh data before this branch and are intentionally preserved for operator diagnostics.

The cache-failure restore path (`_restore_issue_discovery_from_cache`) is unaffected — it runs only on `MirrorRequestError`, not on a successful-but-ineligible result.

## Related Issues

Closes #1244

## Type of Change

- [x] Bug fix

## Testing

- [x] Tests added/updated
- [x] Manually tested

Regression test `TestStaleScoreClearedOnIneligible` (3 cases):
- Primary: stale `8.12` score zeroed to `0.0` when fresh fetch is ineligible — **FAIL before fix, PASS after**
- Normalizer: `normalize_issue_discovery_rewards` returns `0.0` instead of `1.0` — **FAIL before fix, PASS after**
- Control: mirror fetch failure still restores cached score unchanged — PASS both

Full suite: 728/728 passed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)