### PR TITLE
fix: reject cross-repo linked issues in mirror-path issue multiplier

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -73,7 +73,15 @@ class MirrorReviewSummary:
 
 @dataclass
 class MirrorLinkedIssue:
-    """Issue that a PR closes, as nested inside a ``MirrorPullRequest``."""
+    """Issue that a PR closes, as nested inside a ``MirrorPullRequest``.
+
+    ``repository_full_name`` is the home repo of the issue itself — distinct
+    from the home repo of the PR that closes it. GitHub's ``Closes
+    owner/other-repo#N`` syntax lets a PR reference issues in different repos;
+    without this field the validator can't reject cross-repo linked issues
+    from the issue-bonus multiplier (see ``_is_valid_linked_issue``).
+    Defaults to ``None`` for mirror snapshots predating the schema addition.
+    """
 
     number: int
     title: str
@@ -87,6 +95,7 @@ class MirrorLinkedIssue:
     is_transferred: bool
     solved_by_pr: Optional[int]
     labels: List[MirrorLabel] = field(default_factory=list)
+    repository_full_name: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict) -> 'MirrorLinkedIssue':
@@ -94,6 +103,9 @@ class MirrorLinkedIssue:
         # str-typed field so downstream `==` comparisons with author_github_id
         # from MirrorPullRequest don't silently mismatch on type.
         author_github_id = data.get('author_github_id')
+        # Lowercased to match MirrorPullRequest.repo_full_name normalization;
+        # the cross-repo guard compares the two case-insensitively.
+        repo_full_name = data.get('repository_full_name')
         return cls(
             number=data['number'],
             title=data.get('title', ''),
@@ -107,6 +119,7 @@ class MirrorLinkedIssue:
             is_transferred=bool(data.get('is_transferred', False)),
             solved_by_pr=data.get('solved_by_pr'),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
+            repository_full_name=repo_full_name.lower() if repo_full_name else None,
         )
 
 

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -432,6 +432,12 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
     - Reject transferred issues.
     - Missing author / self-issue (uses github_id for immutability).
     - Issue created after the PR.
+    - Cross-repo references: when the mirror surfaces the issue's home repo
+      and it differs from the PR's repo, reject — a ``Closes other/repo#N``
+      keyword should not pay the issue-bonus multiplier in this repo. Fails
+      open when ``repository_full_name`` is ``None`` (older mirror snapshots
+      without the field); the guard arms automatically once das-github-mirror
+      populates the field.
     - Any CLOSED issue must have state_reason=COMPLETED — NOT_PLANNED / reopened
       closures never grant a multiplier. Applies regardless of PR state, so the
       gate covers OPEN-PR collateral as well.
@@ -454,6 +460,17 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
 
     if li.created_at and li.created_at > pr.created_at:
         bt.logging.warning(f'Skipping linked issue #{li.number} - created after PR')
+        return False
+
+    # Mirror payload may omit repository identity on older snapshots; only
+    # gate when the field is populated. Both sides are normalized to lowercase
+    # at parse time (see ``MirrorLinkedIssue.from_dict`` and
+    # ``MirrorPullRequest.from_dict``), so a direct ``!=`` is case-correct.
+    if li.repository_full_name is not None and li.repository_full_name != pr.repo_full_name:
+        bt.logging.warning(
+            f'Skipping linked issue #{li.number} - cross-repo reference '
+            f'(issue in {li.repository_full_name}, PR in {pr.repo_full_name})'
+        )
         return False
 
     # state_reason check applies regardless of PR state — OPEN-PR collateral

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -706,8 +706,9 @@ def _linked_issue(
     closed_at: str | None = '2026-04-18T10:00:00Z',
     author_association: str | None = 'CONTRIBUTOR',
     number: int = 50,
+    repository_full_name: str | None = None,
 ):
-    return {
+    payload = {
         'number': number,
         'title': 't',
         'state': state,
@@ -721,6 +722,9 @@ def _linked_issue(
         'solved_by_pr': 100,
         'labels': [],
     }
+    if repository_full_name is not None:
+        payload['repository_full_name'] = repository_full_name
+    return payload
 
 
 class TestIssueMultiplier:
@@ -821,6 +825,62 @@ class TestLinkedIssueValidity:
         scored = ScoredPR(pr=_pr(state='OPEN'))
         li = MirrorLinkedIssue.from_dict(_linked_issue(state='OPEN', state_reason=None, closed_at=None))
         assert _is_valid_linked_issue(li, scored.pr) is True
+
+
+class TestLinkedIssueCrossRepo:
+    """Cross-repo `Closes owner/other-repo#N` references must not pay the issue
+    multiplier on a PR in a different repo (parity with #1019 / PR #1038 on the
+    legacy path, ported here after the mirror-only cutover #1202).
+
+    The mirror payload may omit ``repository_full_name`` on older snapshots; in
+    that case the guard fails open so existing data behaves as before. Once
+    das-github-mirror populates the field, the guard arms automatically.
+    """
+
+    def test_cross_repo_linked_issue_rejected(self):
+        """PR in `entrius/gittensor-ui` linked to issue in `outsider/throwaway`
+        — the guard must reject."""
+        scored = ScoredPR(pr=_pr())  # repo_full_name='entrius/gittensor-ui'
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name='outsider/throwaway'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+
+    def test_same_repo_linked_issue_passes(self):
+        """Same repo populated explicitly — guard does not fire."""
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name='entrius/gittensor-ui'))
+        assert _is_valid_linked_issue(li, scored.pr) is True
+
+    def test_repo_identity_missing_falls_open(self):
+        """Pre-schema mirror rows have no ``repository_full_name``; guard must
+        not fire (backwards-compat with current production mirror)."""
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue())  # field absent
+        assert li.repository_full_name is None
+        assert _is_valid_linked_issue(li, scored.pr) is True
+
+    def test_cross_repo_case_insensitive(self):
+        """Mirror normalizes repo names to lowercase at parse time; the
+        guard's direct ``!=`` comparison must remain correct against
+        mixed-case payloads."""
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name='OUTSIDER/Throwaway'))
+        # Mirror lowercased the field at parse time
+        assert li.repository_full_name == 'outsider/throwaway'
+        assert _is_valid_linked_issue(li, scored.pr) is False
+
+    def test_cross_repo_multiplier_stays_neutral(self):
+        """End-to-end: a cross-repo linked issue should not produce a
+        STANDARD/MAINTAINER multiplier from ``_calculate_issue_multiplier``."""
+        scored = ScoredPR(pr=_pr(linked_issues=[_linked_issue(repository_full_name='outsider/throwaway')]))
+        assert _calculate_issue_multiplier(scored) == 1.0
+
+    def test_same_repo_multiplier_still_applies(self):
+        """End-to-end regression guard: a known same-repo linked issue still
+        earns the standard multiplier."""
+        from gittensor.constants import STANDARD_ISSUE_MULTIPLIER
+
+        scored = ScoredPR(pr=_pr(linked_issues=[_linked_issue(repository_full_name='entrius/gittensor-ui')]))
+        assert _calculate_issue_multiplier(scored) == STANDARD_ISSUE_MULTIPLIER
 
 
 class TestIssueMultiplierPreference:


### PR DESCRIPTION
## Summary

- Add `repository_full_name: Optional[str]` to `MirrorLinkedIssue`; lowercase at parse time to match `MirrorPullRequest.repo_full_name`.
- Gate `_is_valid_linked_issue` on the same-repo invariant when the field is populated; fail open on `None` (older mirror snapshots, current production payload).
- 6 new test cases covering cross-repo / same-repo / missing / case-mismatch / end-to-end multiplier.

Closes the mirror-path half of #1019 / PR #1038. After #1202 the mirror path is the only PR scoring path; the cross-repo leak that was tolerable when legacy was authoritative is now the entire surface.

## Failure mode this closes

`_is_valid_linked_issue` walks every anti-gaming gate from the legacy path (transferred, self-issue, created-after-PR, state_reason=COMPLETED, edited_after_merge, CLOSED, close-window) **except the repository-identity gate** — because `MirrorLinkedIssue` had no repository field to gate on.

A miner can earn 1.33×–1.66× on every PR by:

1. Coordinating a second GitHub account B (any access, no privileges needed in the target repo).
2. Filing trivial issue `#X` in `B/throwaway-repo`. State: OPEN.
3. Submitting PR `P_M` to a registered repo with `Closes B/throwaway-repo#X` in the body. The cross-repo `Closes` does **not** auto-close `#X` because A has no write on `B/throwaway-repo` — `#X` stays OPEN at merge.
4. Within 24 h of `P_M` merging, B manually closes `#X` as `COMPLETED`.
5. das-github-mirror surfaces `P_M.linked_issues = [MirrorLinkedIssue(number=X, state='CLOSED', state_reason='COMPLETED', author_github_id=B, ...)]` — no repository identity on the payload.
6. All other gates pass. Multiplier applied: 1.33× (STANDARD), or 1.66× (MAINTAINER) if B has OWNER/MEMBER/COLLABORATOR on `B/throwaway-repo` (trivial when B owns it).

Per-PR uplift: 1.33×–1.66× on `earned_score`. Orchestration cost per fake link: one alt GitHub account + one trivial issue. Detection: indistinguishable from a legitimate same-repo `Closes #N` in any log line.

## Layer 1 / Layer 2

This is intentionally a two-layer change:

### Layer 1 — validator-side (this PR)

- `MirrorLinkedIssue.repository_full_name: Optional[str] = None`, populated from `data.get('repository_full_name')` and lowercased to match the PR side.
- New gate in `_is_valid_linked_issue`, placed after the existing transferred / author / created-at gates and before state_reason / close-window:
  ```python
  if li.repository_full_name is not None and li.repository_full_name != pr.repo_full_name:
      bt.logging.warning(
          f'Skipping linked issue #{li.number} - cross-repo reference '
          f'(issue in {li.repository_full_name}, PR in {pr.repo_full_name})'
      )
      return False
  ```
- Fails open when `repository_full_name is None` — no behavior change for the current production mirror snapshot. No-op until Layer 2 lands.

### Layer 2 — das-github-mirror (separate / coordinated)

`das-github-mirror` populates `repository_full_name` on each `linked_issues` entry. This validator-side guard arms automatically the moment the field is served. No further validator-side change required.

A follow-up issue can later tighten the guard to fail-closed-on-unknown once the mirror is fully repopulated, but that would over-correct today and zero every issue multiplier in the system.

## Tests

`tests/validator/oss_contributions/mirror/test_scoring.py::TestLinkedIssueCrossRepo`:

- `test_cross_repo_linked_issue_rejected` — PR in `entrius/gittensor-ui`, issue payload says `outsider/throwaway`; `_is_valid_linked_issue` returns False.
- `test_same_repo_linked_issue_passes` — same-repo populated → guard does not fire.
- `test_repo_identity_missing_falls_open` — `None` (current production shape) → guard does not fire; regression guard for the no-op-today invariant.
- `test_cross_repo_case_insensitive` — mixed-case `OUTSIDER/Throwaway` is lowercased at parse time; `!=` comparison stays case-correct.
- `test_cross_repo_multiplier_stays_neutral` — end-to-end: `_calculate_issue_multiplier` returns `1.0`.
- `test_same_repo_multiplier_still_applies` — end-to-end regression guard: known same-repo still earns `STANDARD_ISSUE_MULTIPLIER`.

Existing fixture `_linked_issue(...)` gained one optional kwarg (`repository_full_name=None`); 61 prior tests unchanged.

## Test plan

- [x] `pytest tests/validator/oss_contributions/mirror/test_scoring.py` — 67/67 pass (6 new).
- [x] `pytest tests/` — 731/731 pass, no regressions.
- [x] `pyright` — 0 errors / 0 warnings.
- [x] `ruff check gittensor/ tests/` — clean.

## Related

- #1019 / PR #1038 — fixed the same shape on legacy OSS scoring; explicitly scoped out the mirror path.
- PR #1042 — fixed the analogous shape in bounty solver detection (`_PR_TIMELINE_QUERY`'s `closingIssuesReferences` got `repository { nameWithOwner }`).
- #1202 — stripped legacy scoring; made mirror the sole PR scoring path; elevates this gap from "tolerable parallel-track" to "load-bearing".

## Out of scope

- das-github-mirror schema change (Layer 2). Filed/tracked separately; this PR is the validator-side preparation.
- Tightening to fail-closed-on-unknown. Premature until Layer 2 lands and the mirror snapshot is fully repopulated.

Fixes #1243