### PR TITLE
fix: reject cross-repo linked issue references in mirror path (#1243)

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -86,6 +86,7 @@ class MirrorLinkedIssue:
     updated_at: Optional[datetime]
     is_transferred: bool
     solved_by_pr: Optional[int]
+    repository_full_name: Optional[str] = None
     labels: List[MirrorLabel] = field(default_factory=list)
 
     @classmethod
@@ -106,6 +107,7 @@ class MirrorLinkedIssue:
             updated_at=parse_optional_github_iso_to_utc(data.get('updated_at')),
             is_transferred=bool(data.get('is_transferred', False)),
             solved_by_pr=data.get('solved_by_pr'),
+            repository_full_name=data.get('repository_full_name'),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
         )
 

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -444,6 +444,13 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
         bt.logging.warning(f'Skipping linked issue #{li.number} - transferred')
         return False
 
+    if li.repository_full_name and li.repository_full_name.lower() != pr.repo_full_name.lower():
+        bt.logging.warning(
+            f'Skipping linked issue #{li.number} - cross-repo reference '
+            f'({li.repository_full_name} != {pr.repo_full_name})'
+        )
+        return False
+
     if li.author_github_id is None:
         bt.logging.warning(f'Skipping linked issue #{li.number} - missing author_github_id')
         return False


### PR DESCRIPTION
## Summary

Add `repository_full_name` field to `MirrorLinkedIssue` and a cross-repo gate in `_is_valid_linked_issue` to reject linked issues that belong to a different repo than the PR.

PR #1038 fixed this for the legacy path; this ports the same check to the mirror path. No behavior change for same-repo linked issues.

## Validation

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors / 0 warnings
- `uv run pytest tests/ -q` — existing tests pass

Closes #1243