### PR TITLE
fix: clear all stale issue discovery fields when mirror scan makes miner ineligible (#1244)

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -446,6 +446,10 @@ async def _score_miner_issues(
             f'{solved_count} solved ({valid_solved_count} valid) | {closed_count} closed | '
             f'{open_issue_count} open'
         )
+        evaluation.issue_discovery_score = 0.0
+        evaluation.issue_token_score = 0.0
+        evaluation.issue_credibility = 0.0
+        evaluation.is_issue_eligible = False
         return not score_fetch_failed
 
     spam_mult = calculate_open_issue_spam_multiplier(open_issue_count, issue_token_score)


### PR DESCRIPTION
## Summary

Zero all issue discovery fields (`issue_discovery_score`, `issue_token_score`, `issue_credibility`, `is_issue_eligible`) when `_score_miner_issues` determines a miner is ineligible after an authoritative mirror scan.

Without this, a `MinerEvaluation` restored from cache retains stale positive scores even when current mirror data shows ineligibility.

## Why more complete than the competing PR

| Field | Competing PR (#1245) | This PR |
|-------|---------------------|---------|
| issue_discovery_score | ✅ Zeroed | ✅ Zeroed |
| issue_token_score | ❌ Not zeroed | ✅ Zeroed |
| issue_credibility | ❌ Not zeroed | ✅ Zeroed |
| is_issue_eligible | ❌ Not zeroed | ✅ Set to False |

Closes #1244