### PR TITLE
chore: add focused pre-push vulture guard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Re-run pre-commit to verify clean
         run: uv run pre-commit run --all-files
 
-      - name: Run pyright
+      - name: Run pre-push checks (pyright, vulture)
         run: SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push
 
   # If PR is from a fork, fail on any diff
@@ -54,5 +54,5 @@ jobs:
       - name: Run pre-commit checks
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
-      - name: Run pyright
+      - name: Run pre-push checks (pyright, vulture)
         run: SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,14 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      - id: vulture
+        name: vulture
+        entry: uv run vulture
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]
+
       - id: pytest
         name: pytest
         entry: uv run pytest tests/ -x -q

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from math import prod
-from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
@@ -112,21 +112,6 @@ class FileChange:
 
         return any(re.search(pattern, basename) for pattern in test_patterns)
 
-    @classmethod
-    def from_github_response(cls, pr_number: int, repository_full_name: str, file_diff: DefaultDict) -> 'FileChange':
-        """Create FileChange from GitHub API response"""
-        return cls(
-            pr_number=pr_number,
-            repository_full_name=repository_full_name,
-            filename=file_diff['filename'],
-            changes=file_diff['changes'],
-            additions=file_diff['additions'],
-            deletions=file_diff['deletions'],
-            status=file_diff['status'],
-            patch=file_diff.get('patch'),
-            previous_filename=file_diff.get('previous_filename'),
-        )
-
 
 @dataclass
 class Issue:
@@ -193,8 +178,6 @@ class PullRequest:
     review_quality_multiplier: float = 1.0  # Penalty for CHANGES_REQUESTED reviews from maintainers
     label_multiplier: float = 1.0  # Multiplier resolved from repository label config
     label: Optional[str] = None  # Resolved scoring label, set during scoring
-    current_labels: frozenset[str] = field(default_factory=frozenset)
-    label_timeline_order: tuple[str, ...] = field(default_factory=tuple)  # Newest current labels first
     changes_requested_count: int = 0  # Number of maintainer CHANGES_REQUESTED reviews
     earned_score: float = 0.0
     collateral_score: float = 0.0  # For OPEN PRs: potential_score * collateral_percent
@@ -219,10 +202,6 @@ class PullRequest:
     last_edited_at: Optional[datetime] = None
     head_ref_oid: Optional[str] = None
     base_ref_oid: Optional[str] = None
-
-    def set_file_changes(self, file_changes: List[FileChange]) -> None:
-        """Set the file changes for this pull request"""
-        self.file_changes = file_changes
 
     def is_pioneer_eligible(self) -> bool:
         """Check if this PR qualifies for pioneer consideration.

--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -325,7 +325,7 @@ def validate_bounty_amount(bounty: str) -> int:
             param_hint='--bounty',
         )
 
-    sign, digits, exponent = d.as_tuple()
+    _sign, _digits, exponent = d.as_tuple()
     decimal_places = max(0, -int(exponent))
     if decimal_places > ALPHA_DECIMALS:
         raise click.BadParameter(

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -25,8 +25,6 @@ GITHUB_HTTP_TIMEOUT_SECONDS = 15
 GRAPHQL_VIEWER_QUERY = '{ viewer { login } }'
 # 1MB max file size for github api file fetches. Files exceeding this get no score.
 MAX_FILE_SIZE_BYTES = 1_000_000
-# Too many object lookups in one GraphQL query can trigger 502 errors and lose all results.
-MAX_FILES_PER_GRAPHQL_BATCH = 50
 
 # =============================================================================
 # das-github-mirror (https://mirror.gittensor.io)

--- a/gittensor/utils/utils.py
+++ b/gittensor/utils/utils.py
@@ -3,16 +3,10 @@ GitTensor Utilities
 """
 
 import os
-from typing import Dict
 
 
 def backoff_seconds(attempt: int, base: int = 5, cap: int = 30) -> int:
     return min(base * (2**attempt), cap)
-
-
-def parse_repo_name(repo_data: Dict):
-    """Normalizes and converts repository name from dict"""
-    return f'{repo_data["owner"]["login"]}/{repo_data["name"]}'.lower()
 
 
 def get_contract_address() -> str:

--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -2,8 +2,6 @@ import math
 from datetime import datetime, timezone
 from typing import Optional
 
-import pytz
-
 from gittensor.constants import (
     SECONDS_PER_HOUR,
     TIME_DECAY_GRACE_PERIOD_HOURS,
@@ -11,8 +9,6 @@ from gittensor.constants import (
     TIME_DECAY_SIGMOID_MIDPOINT,
     TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
 )
-
-CHICAGO_TZ = pytz.timezone('America/Chicago')
 
 
 def parse_github_iso_to_utc(timestamp_str: str) -> datetime:
@@ -37,14 +33,6 @@ def parse_optional_github_iso_to_utc(value: Optional[str]) -> Optional[datetime]
     callers feed ``data.get(...)`` straight through without per-site None-checks.
     """
     return parse_github_iso_to_utc(value) if value else None
-
-
-def parse_github_timestamp_to_cst(timestamp_str: str) -> datetime:
-    """
-    Parse GitHub's ISO format timestamp and convert to Chicago timezone.
-    GitHub returns timestamps like: 2024-01-15T10:30:00Z
-    """
-    return parse_github_iso_to_utc(timestamp_str).astimezone(CHICAGO_TZ)
 
 
 def calculate_time_decay(merged_at: datetime) -> float:

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -77,7 +77,6 @@ class BaseValidatorNeuron(BaseNeuron):
         self.should_exit: bool = False
         self.is_running: bool = False
         self.thread: Union[threading.Thread, None] = None
-        self.lock = asyncio.Lock()
 
     def serve_axon(self):
         """Serve axon to enable external connections."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pyright",
     "ruff==0.14.10",
     "pre-commit>=4.0",
+    "vulture==2.16",
 ]
 debug = [
     "debugpy==1.8.11",
@@ -55,3 +56,65 @@ quote-style = "single"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.vulture]
+# Dead-code scanner. Run via pre-push hook (`uv run vulture`) or directly.
+# False positives live in `vulture_whitelist.py`; framework-driven names are
+# matched here so individual call sites don't need annotation.
+paths = ["gittensor", "neurons", "scripts", "tests"]
+exclude = [
+    ".venv/",
+    "smart-contracts/",
+    "assets/",
+    # Issue-bounty contract client: enum members and dataclass fields mirror
+    # the on-chain shape, so unused-name reports here are not actionable
+    "gittensor/validator/issue_competitions/contract_client.py",
+    # das-github-mirror response schema: dataclass fields mirror the upstream
+    # wire format and are kept even when no validator code reads them today
+    "gittensor/utils/mirror/models.py",
+]
+min_confidence = 60
+sort_by_size = true
+ignore_decorators = [
+    # Click command/group registration - vulture cannot see the registry calls
+    "@click.command",
+    "@click.group",
+    "@*.command",
+    "@*.group",
+    # pytest fixtures (incl. autouse) are resolved by pytest, not by import
+    "@pytest.fixture",
+]
+ignore_names = [
+    # `__exit__(self, exc_type, exc_value, traceback)` - dunder signature
+    "exc_type",
+    "exc_value",
+    "exc",
+    "tb",
+    "traceback",
+    # pytest hook functions defined in conftest.py
+    "pytest_*",
+    # Click subclass overrides invoked by the framework
+    "get_help",
+    "command_class",
+    # `lru_cache`'s synthetic cache-buster argument used by ttl_cache()
+    "ttl_hash",
+    # MagicMock attribute consumed by the mock framework, not by us
+    "side_effect",
+    # psycopg Connection attributes (autocommit setter, prepared-statement
+    # threshold) - written for side effects, read inside the driver
+    "autocommit",
+    "prepare_threshold",
+    # Required-env-var capture; kept for parity with `.env.example` even when
+    # no code reads it directly (wandb consumes WANDB_API_KEY from the env)
+    "WANDB_API_KEY",
+    # Attribute set on IssueCompetitionContractClient test doubles - the
+    # client itself is excluded above, so reads of this attribute are invisible
+    "contract_address",
+    # PRInfo TypedDict fields populated and read via `dict.get(...)`; vulture
+    # cannot link a string-keyed dict access to a typed attribute name
+    "author_id",
+    "review_count",
+    # Consumed only by `gittensor/utils/mirror/models.py`, excluded above as
+    # wire-format schema; the helper itself is otherwise invisible to vulture
+    "parse_optional_github_iso_to_utc",
+]

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -576,13 +576,6 @@ class TestCliRegisterValidation:
         """
         import gittensor.cli.issue_commands.mutations as mut
 
-        exec_was_called = {'value': False}
-
-        class _Sentinel:
-            def exec(self, *_args, **_kwargs):
-                exec_was_called['value'] = True
-                raise AssertionError('register_issue must not be submitted on a GitHub skip')
-
         with (
             patch(
                 'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
@@ -605,7 +598,6 @@ class TestCliRegisterValidation:
             )
 
         assert result.exit_code != 0
-        assert exec_was_called['value'] is False
         assert 'Could not verify' in result.output
         assert '503' in result.output
 

--- a/tests/validator/conftest.py
+++ b/tests/validator/conftest.py
@@ -3,35 +3,20 @@
 
 """
 Pytest fixtures for validator tests.
-
-Provides reusable fixtures for testing credibility, eligibility,
-scoring, and other validator functionality.
 """
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Optional
 
-import pytest
-
-from gittensor.classes import Issue, PRState, PullRequest
-
-# ============================================================================
-# PR Factory Fixture
-# ============================================================================
+from gittensor.classes import PRState, PullRequest
 
 
 @dataclass
 class PRBuilder:
-    """
-    Builder for creating mock PullRequests with sensible defaults.
+    """Builder for creating mock PullRequests with sensible defaults.
 
-    Usage:
-        pr = pr_factory.merged()
-        pr = pr_factory.closed(number=5)
-        pr = pr_factory.open()
-        pr = pr_factory.merged(token_score=50.0)
-        prs = pr_factory.merged_batch(count=5, unique_repos=True)
+    Tests instantiate ``PRBuilder()`` directly and call ``.create(...)``.
     """
 
     _counter: int = 0
@@ -82,194 +67,3 @@ class PRBuilder:
             collateral_score=collateral_score,
             token_score=token_score,
         )
-
-    def merged(self, **kwargs) -> PullRequest:
-        """Create a merged PR."""
-        return self.create(state=PRState.MERGED, **kwargs)
-
-    def closed(self, **kwargs) -> PullRequest:
-        """Create a closed PR."""
-        return self.create(state=PRState.CLOSED, **kwargs)
-
-    def open(self, **kwargs) -> PullRequest:
-        """Create an open PR."""
-        return self.create(state=PRState.OPEN, **kwargs)
-
-    def merged_batch(self, count: int, unique_repos: bool = False, **kwargs) -> List[PullRequest]:
-        """Create multiple merged PRs."""
-        return [self.merged(unique_repo=unique_repos, **kwargs) for _ in range(count)]
-
-    def closed_batch(self, count: int, unique_repos: bool = False, **kwargs) -> List[PullRequest]:
-        """Create multiple closed PRs."""
-        return [self.closed(unique_repo=unique_repos, **kwargs) for _ in range(count)]
-
-    def open_batch(self, count: int, unique_repos: bool = False, **kwargs) -> List[PullRequest]:
-        """Create multiple open PRs."""
-        return [self.open(unique_repo=unique_repos, **kwargs) for _ in range(count)]
-
-    def reset(self):
-        """Reset the counters (useful between tests)."""
-        self._counter = 0
-        self._repo_counter = 0
-
-
-@pytest.fixture
-def pr_factory() -> PRBuilder:
-    """Factory fixture for creating mock PRs."""
-    return PRBuilder()
-
-
-# ============================================================================
-# Issue Factory Fixture
-# ============================================================================
-
-
-@dataclass
-class IssueBuilder:
-    """Builder for creating mock Issues with sensible defaults."""
-
-    _counter: int = 0
-
-    def create(
-        self,
-        number: Optional[int] = None,
-        repository_full_name: str = 'test/repo',
-        author_github_id: Optional[str] = '1001',
-        author_login: str = 'alice',
-        state: str = 'CLOSED',
-        state_reason: Optional[str] = 'COMPLETED',
-        pr_number: int = 1,
-        created_at: Optional[datetime] = None,
-        closed_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> Issue:
-        """Create a mock Issue with the given parameters. Defaults to COMPLETED (solved)."""
-        if number is None:
-            self._counter += 1
-            number = self._counter
-        if created_at is None:
-            created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        if closed_at is None:
-            closed_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
-
-        return Issue(
-            number=number,
-            pr_number=pr_number,
-            repository_full_name=repository_full_name,
-            title=f'Test issue #{number}',
-            created_at=created_at,
-            closed_at=closed_at,
-            author_login=author_login,
-            author_github_id=author_github_id,
-            state=state,
-            state_reason=state_reason,
-            updated_at=updated_at,
-        )
-
-    def completed(self, **kwargs) -> Issue:
-        """Create a COMPLETED issue (solved)."""
-        return self.create(state_reason='COMPLETED', **kwargs)
-
-    def transferred(self, **kwargs) -> Issue:
-        """Create a TRANSFERRED issue (counts as closed)."""
-        return self.create(state_reason='TRANSFERRED', **kwargs)
-
-    def not_planned(self, **kwargs) -> Issue:
-        """Create a NOT_PLANNED issue (counts as closed)."""
-        return self.create(state_reason='NOT_PLANNED', **kwargs)
-
-    def no_reason(self, **kwargs) -> Issue:
-        """Create an issue with no state_reason (legacy data — counts as closed)."""
-        return self.create(state_reason=None, **kwargs)
-
-
-@pytest.fixture
-def issue_factory() -> IssueBuilder:
-    """Factory fixture for creating mock Issues."""
-    return IssueBuilder()
-
-
-# ============================================================================
-# Pre-built Miner Scenario Fixtures
-# ============================================================================
-
-
-@dataclass
-class MinerScenario:
-    """Represents a miner's PR history for testing."""
-
-    merged: List[PullRequest]
-    closed: List[PullRequest]
-    open: List[PullRequest]
-    description: str = ''
-
-    @property
-    def all_prs(self) -> List[PullRequest]:
-        return self.merged + self.closed + self.open
-
-
-@pytest.fixture
-def new_miner(pr_factory) -> MinerScenario:
-    """Brand new miner with no PRs."""
-    pr_factory.reset()
-    return MinerScenario(merged=[], closed=[], open=[], description='New miner with no history')
-
-
-@pytest.fixture
-def eligible_miner(pr_factory) -> MinerScenario:
-    """Miner who passes the eligibility gate (5+ valid PRs, 100% credibility)."""
-    pr_factory.reset()
-    return MinerScenario(
-        merged=pr_factory.merged_batch(count=6, unique_repos=True, token_score=10.0),
-        closed=[],
-        open=[],
-        description='Eligible miner: 6 valid merged PRs, 100% credibility',
-    )
-
-
-@pytest.fixture
-def ineligible_low_prs(pr_factory) -> MinerScenario:
-    """Miner with too few valid PRs (below MIN_VALID_MERGED_PRS)."""
-    pr_factory.reset()
-    return MinerScenario(
-        merged=pr_factory.merged_batch(count=3, unique_repos=True, token_score=10.0),
-        closed=[],
-        open=[],
-        description='Ineligible: only 3 valid merged PRs',
-    )
-
-
-@pytest.fixture
-def ineligible_low_credibility(pr_factory) -> MinerScenario:
-    """Miner with enough PRs but credibility below 75%."""
-    pr_factory.reset()
-    return MinerScenario(
-        merged=pr_factory.merged_batch(count=5, unique_repos=True, token_score=10.0),
-        closed=pr_factory.closed_batch(count=4, unique_repos=True),
-        open=[],
-        description='Ineligible: 5/9 = 55.6% credibility (after mulligan: 5/8 = 62.5%)',
-    )
-
-
-@pytest.fixture
-def miner_with_mulligan(pr_factory) -> MinerScenario:
-    """Miner who benefits from the mulligan (1 closed PR forgiven)."""
-    pr_factory.reset()
-    return MinerScenario(
-        merged=pr_factory.merged_batch(count=5, unique_repos=True, token_score=10.0),
-        closed=pr_factory.closed_batch(count=1, unique_repos=True),
-        open=[],
-        description='Miner with mulligan: 5/5 = 100% credibility (1 closed forgiven)',
-    )
-
-
-@pytest.fixture
-def miner_with_open_prs(pr_factory) -> MinerScenario:
-    """Miner with open PRs (for collateral testing)."""
-    pr_factory.reset()
-    return MinerScenario(
-        merged=pr_factory.merged_batch(count=5, unique_repos=True, token_score=10.0),
-        closed=[],
-        open=pr_factory.open_batch(count=3, unique_repos=True),
-        description='Miner with 3 open PRs',
-    )

--- a/tests/validator/test_contract_client_transactions.py
+++ b/tests/validator/test_contract_client_transactions.py
@@ -56,7 +56,7 @@ _IDS = [row[0] for row in METHOD_TABLE]
 
 @pytest.fixture()
 def client():
-    with patch.object(IssueCompetitionContractClient, '__init__', lambda self, *a, **kw: None):
+    with patch.object(IssueCompetitionContractClient, '__init__', lambda self, *_args, **_kwargs: None):
         c = IssueCompetitionContractClient.__new__(IssueCompetitionContractClient)
         c.contract_address = '5FakeContract'
         c.subtensor = MagicMock()

--- a/tests/validator/utils/test_storage_mirror.py
+++ b/tests/validator/utils/test_storage_mirror.py
@@ -135,7 +135,7 @@ def test_cleanup_stale_called_with_commit_false():
 
     with patch(
         'gittensor.validator.oss_contributions.mirror.adapters.mirror_scored_pr_to_legacy_pull_request',
-        side_effect=lambda s, *a, **kw: s,
+        side_effect=lambda s, *_args, **_kwargs: s,
     ):
         storage.store_evaluation(eval_obj)
 
@@ -154,7 +154,7 @@ def test_failure_after_cleanup_triggers_rollback():
 
     with patch(
         'gittensor.validator.oss_contributions.mirror.adapters.mirror_scored_pr_to_legacy_pull_request',
-        side_effect=lambda s, *a, **kw: s,
+        side_effect=lambda s, *_args, **_kwargs: s,
     ):
         result = storage.store_evaluation(eval_obj)
 

--- a/uv.lock
+++ b/uv.lock
@@ -906,6 +906,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -930,6 +931,7 @@ requires-dist = [
     { name = "tree-sitter", specifier = "==0.24.0" },
     { name = "tree-sitter-language-pack", specifier = "==0.7.2" },
     { name = "uvicorn", marker = "extra == 'debug'", specifier = "==0.32.0" },
+    { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "wandb", specifier = "==0.21.3" },
 ]
 provides-extras = ["dev", "debug"]
@@ -2537,6 +2539,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #1250

Adds `vulture` as a pre-push dead-code guard and wires it into the existing CI pre-push lane. The goal is to keep unused Python helpers, stale test fixtures, and framework leftovers from accumulating after one-off cleanup PRs.

## Changes

- Add `vulture==2.16` to the dev dependency set and `uv.lock`.
- Add a local pre-push `vulture` hook in `.pre-commit-config.yaml`.
- Update CI lint step labels so the pre-push lane describes both pyright and vulture.
- Add `[tool.vulture]` configuration with project paths, excludes, and framework-specific ignores.
- Remove confirmed dead helpers, stale validator test fixtures, unused fields, and unused test-only sentinels.

## Out of scope

- No scoring, validator emission, or CLI behavior changes.
- No production-only vulture policy change.
- No broad API/storage cleanup beyond confirmed dead-code cleanup in this PR's scanner scope.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Other: developer tooling / CI validation

## Testing

- [x] Tests added/updated
- [x] Manually tested

Validation:

```bash
uv sync --extra dev
uv run vulture
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -q
git diff --cached --check && git diff --check
```

Results:

- `pytest`: `725 passed`
- `pyright`: `0 errors, 0 warnings, 0 informations`
- `vulture`, `ruff`, pre-commit, and whitespace checks: passed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented, if applicable
