### PR TITLE
fix: don't count same-account solves toward MIN_VALID_SOLVED_ISSUES gate

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -463,17 +463,20 @@ async def _score_miner_issues(
             )
             continue
 
-        # Valid-solved gate: solving PR must meet the repo's token threshold.
-        if cached.token_score >= cfg.min_token_score_for_valid_issue:
-            acc.valid_solved += 1
-
-        # Same-account: discoverer == solver gets credibility only, no score
+        # Same-account: discoverer == solver gets credibility only, no score.
+        # Must run before the valid-solved increment so self-loops don't satisfy
+        # the MIN_VALID_SOLVED_ISSUES eligibility gate (see module docstring:
+        # anti-self-issue is an applied anti-gaming gate).
         if issue.author_github_id == solving_pr.author_github_id:
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): same-account '
                 f'(discoverer == solver {issue.author_github_id}) — credibility only'
             )
             continue
+
+        # Valid-solved gate: solving PR must meet the repo's token threshold.
+        if cached.token_score >= cfg.min_token_score_for_valid_issue:
+            acc.valid_solved += 1
 
         pr_key = (issue.repo_full_name, solving_pr.pr_number)
         own_marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -307,7 +307,11 @@ class TestRunMirrorIssueDiscovery:
             )
         )
         assert eval_.total_solved_issues == 1  # credibility counts
-        # But no discovery_earned_score because self-solve
+        # Self-solves must NOT contribute to the valid-solved gate — otherwise
+        # a miner could self-file + self-solve to bypass MIN_VALID_SOLVED_ISSUES
+        # without performing any discovery activity.
+        assert eval_.total_valid_solved_issues == 0
+        # And no discovery_earned_score because self-solve
         assert eval_.issue_discovery_score == 0
 
     def test_not_planned_bumps_closed_count(self):


### PR DESCRIPTION
## Summary

Moves the same-account (`discoverer == solver`) check ahead of the `valid_solved_count` increment in `_score_miner_mirror_issues` so self-filed-and-self-solved issues no longer count toward the `MIN_VALID_SOLVED_ISSUES = 7` eligibility gate. Previously the counter incremented at [mirror_scan.py:328-329](gittensor/validator/issue_discovery/mirror_scan.py#L328-L329) *before* the same-account `continue` at line 332, letting a miner satisfy the gate with self-loops despite the module docstring listing "anti-self-issue" as an applied anti-gaming gate ([mirror_scan.py:19](gittensor/validator/issue_discovery/mirror_scan.py#L19)).

After this PR: same-account solves still bump `total_solved_issues` (credibility) but do not bump `total_valid_solved_issues`, so they cannot satisfy the discovery eligibility gate.

## Related Issues

Fixes #1255

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Extended `test_self_issue_counts_credibility_but_no_score` in [tests/validator/issue_discovery/test_mirror_scan.py](tests/validator/issue_discovery/test_mirror_scan.py) with `assert eval_.total_valid_solved_issues == 0` to lock in the gate-bypass fix.

Test runs:

```
pytest tests/validator/issue_discovery/test_mirror_scan.py
42 passed in 0.22s

pytest tests/validator/test_issue_eligibility.py tests/validator/issue_discovery/
46 passed in 0.17s
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

## Notes for reviewers

- Single-function change, no protocol or abstraction changes, matches scope described in #1255.
- Added a short comment at the reordered check pointing back to the module docstring so the ordering can't silently regress.
- The other "credibility only" branches (one-issue-per-PR siblings, sub-threshold solving PRs) intentionally still fall after the increment — they're not affected by this fix and a sub-threshold solving PR can't increment `valid_solved_count` anyway since the increment is gated on the same `MIN_TOKEN_SCORE_FOR_BASE_SCORE` threshold.
