### PR TITLE
fix: move same-account check before valid_solved_count increment (#1255)

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -386,10 +386,6 @@ async def _score_miner_issues(
             )
             continue
 
-        # Valid-solved gate: solving PR must meet the token threshold.
-        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
-            valid_solved_count += 1
-
         # Same-account: discoverer == solver gets credibility only, no score
         if issue.author_github_id == solving_pr.author_github_id:
             bt.logging.debug(
@@ -397,6 +393,10 @@ async def _score_miner_issues(
                 f'(discoverer == solver {issue.author_github_id}) — credibility only'
             )
             continue
+
+        # Valid-solved gate: solving PR must meet the token threshold.
+        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+            valid_solved_count += 1
 
         pr_key = (issue.repo_full_name, solving_pr.pr_number)
         own_marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)


### PR DESCRIPTION
## Summary

Reorder the same-account check (`issue.author_github_id == solving_pr.author_github_id`) to happen *before* `valid_solved_count` is incremented. Previously a miner who filed an issue and solved it with their own PR had that issue counted toward `valid_solved_count`, bypassing `MIN_VALID_SOLVED_ISSUES` eligibility gate.

4 lines moved, no logic change other than order.

## Validation

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors / 0 warnings
- `uv run pytest tests/ -q` — existing tests pass

Closes #1255