### PR TITLE
refactor: remove unused parse_repo_name and its Dict import

### DIFF
--- a/gittensor/utils/utils.py
+++ b/gittensor/utils/utils.py
@@ -3,16 +3,10 @@ GitTensor Utilities
 """
 
 import os
-from typing import Dict
 
 
 def backoff_seconds(attempt: int, base: int = 5, cap: int = 30) -> int:
     return min(base * (2**attempt), cap)
-
-
-def parse_repo_name(repo_data: Dict):
-    """Normalizes and converts repository name from dict"""
-    return f'{repo_data["owner"]["login"]}/{repo_data["name"]}'.lower()
 
 
 def get_contract_address() -> str:


### PR DESCRIPTION
## Summary

[`parse_repo_name`](gittensor/utils/utils.py#L13) was the legacy GraphQL-response parser that wrapped `repo_data['owner']['login'] + '/' + repo_data['name']` into a lowercased `'owner/repo'` string. The legacy scoring pipeline that called it was stripped in #1202, and the mirror path uses `MirrorPullRequest.repo_full_name` directly (already lowercased at parse time in `MirrorPullRequest.from_dict`).

`grep -rn parse_repo_name --include='*.py' .` across `gittensor/`, `neurons/`, and `tests/` returns only the definition line — no remaining call sites.

Dropping the function also frees the only consumer of `from typing import Dict` in this module, so the import goes with it.

Net: **-6 lines**, single file. Matches the dead-code-removal precedent from #437, #448, #466.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 725 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)