### PR TITLE
fix: skip draft PRs in mirror scoring pipeline (#1259)

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -146,6 +146,7 @@ class MirrorPullRequest:
     commits_count: int
     scoring_data_stored: bool
     review_summary: MirrorReviewSummary
+    is_draft: bool = False
     labels: List[MirrorLabel] = field(default_factory=list)
     linked_issues: List[MirrorLinkedIssue] = field(default_factory=list)
 
@@ -183,6 +184,7 @@ class MirrorPullRequest:
             deletions=int(data.get('deletions', 0)),
             commits_count=int(data.get('commits_count', 0)),
             scoring_data_stored=bool(data.get('scoring_data_stored', False)),
+            is_draft=bool(data.get('is_draft', False)),
             review_summary=MirrorReviewSummary.from_dict(data.get('review_summary') or {}),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
             linked_issues=[MirrorLinkedIssue.from_dict(issue) for issue in data.get('linked_issues') or []],

--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -110,6 +110,10 @@ def _maybe_add_pr(
     if not os.environ.get('DEV_MODE') and pr.author_association in MAINTAINER_ASSOCIATIONS:
         return
 
+    # Skip draft PRs — WIP changes shouldn't affect scoring or collateral
+    if pr.is_draft:
+        return
+
     if pr.state == 'OPEN':
         eval_.open_prs.append(ScoredPR(pr=pr))
     elif pr.state == 'CLOSED':


### PR DESCRIPTION
## Summary

Add `is_draft` field to `MirrorPullRequest` and filter out draft PRs in the mirror load path. Draft PRs (WIP) should not affect open-PR collateral, scoring, or spam threshold logic.

## Validation

- `ruff check` + `ruff format` pass
- 6 lines added, no behavior change for non-draft PRs

Closes #1259