### PR TITLE
chore(weights): adjust master repo emission shares

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,61 +1,66 @@
 {
   "entrius/allways": {
-    "emission_share": 0.07042253521126761,
-    "trusted_label_pipeline": true,
+    "emission_share": 0.05017719,
+    "issue_discovery_share": 1.0,
     "label_multipliers": {
       "bug": 1.25,
       "enhancement": 1.0,
       "refactor": 0.25
-    }
+    },
+    "trusted_label_pipeline": true
   },
   "entrius/allways-ui": {
-    "emission_share": 0.014084507042253521,
-    "trusted_label_pipeline": true,
+    "emission_share": 0.01106825,
+    "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "feature": 1.25,
       "bug": 1.1,
       "enhancement": 1.0,
+      "feature": 1.25,
       "refactor": 0.5
-    }
+    },
+    "trusted_label_pipeline": true
   },
   "entrius/das-github-mirror": {
-    "emission_share": 0.028169014084507043,
-    "trusted_label_pipeline": true,
+    "emission_share": 0.0200651,
+    "issue_discovery_share": 0.5,
     "label_multipliers": {
       "bug": 1.25,
       "enhancement": 1.1,
       "refactor": 0.1
-    }
+    },
+    "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.14084507042253522,
-    "trusted_label_pipeline": true,
+    "emission_share": 0.101274,
+    "issue_discovery_share": 0.25,
     "label_multipliers": {
-      "feature": 1.5,
       "bug": 1.1,
       "enhancement": 1.25,
+      "feature": 1.5,
       "refactor": 0.25
-    }
+    },
+    "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
-    "emission_share": 0.04225352112676056,
-    "trusted_label_pipeline": true,
+    "emission_share": 0.03017,
+    "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "feature": 1.25,
       "bug": 1.1,
       "enhancement": 1.0,
+      "feature": 1.25,
       "refactor": 0.5
-    }
+    },
+    "trusted_label_pipeline": true
   },
   "entrius/oc-1": {
-    "emission_share": 0.7042253521126761,
-    "issue_discovery_share": 0.0,
-    "trusted_label_pipeline": true,
-    "fixed_base_score": 1.0,
-    "eligibility_mode": false,
     "default_label_multiplier": 0.0,
+    "eligibility_mode": false,
+    "emission_share": 0.52782093,
+    "fixed_base_score": 1.0,
+    "issue_discovery_share": 0.0,
     "label_multipliers": {
       "benchmark-improvement": 1.0
-    }
+    },
+    "trusted_label_pipeline": true
   }
 }


### PR DESCRIPTION
## Summary
- Adjust per-repo `emission_share` values in `master_repositories.json`
- Add per-repo `issue_discovery_share` splits
- Total `emission_share` ≈ 0.7406 (within the `<= 1.0` invariant)

## Test plan
- [x] `pytest tests/validator/test_load_weights.py` (60 passed)
- [ ] Confirm desired shares on `test`