### PR TITLE
fix: normalize repo name casing in dict lookups (#1214)

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -418,7 +418,7 @@ async def _score_miner_issues(
             )
             continue
 
-        repo_config = mirror_repos.get(issue.repo_full_name)
+        repo_config = mirror_repos.get(issue.repo_full_name.lower())
         if repo_config is None:
             continue
 

--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -87,7 +87,7 @@ def _maybe_add_pr(
 ) -> None:
     """Apply load-time filters and bucket pr by state if it passes."""
 
-    repo_config = master_repositories.get(pr.repo_full_name)
+    repo_config = master_repositories.get(pr.repo_full_name.lower())
     if repo_config is None:
         # Mirror tracks more repos than the scoring set; skip-noise dominates the
         # log at info level when master_repositories is small. Demoted to debug.

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -154,7 +154,7 @@ def _pr_bypasses_eligibility(
     pr: 'ScoredPR',
     master_repositories: Dict[str, RepositoryConfig],
 ) -> bool:
-    repo_config = master_repositories.get(pr.repository_full_name)
+    repo_config = master_repositories.get(pr.repository_full_name.lower())
     return repo_config is not None and not repo_config.eligibility_mode
 
 


### PR DESCRIPTION
## Summary

`master_repositories` dict keys are lowercase at load time, but lookups from legacy/mirror paths were not consistently lowercased — causing silent `None` returns and skipped scoring/eligibility/issue-discovery for repos with mixed-case names.

Fix: apply `.lower()` at the three affected call sites. Empty and already-lowercase strings are idempotent.

## Validation

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors / 0 warnings
- `uv run pytest tests/ -q` — existing tests pass

Closes #1214