### PR TITLE
Fix(rewards): apply collateral in repo allocation

### DIFF
--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -118,11 +118,17 @@ def _collect_repo_pr_scores(
         if not _is_scoring_evaluation(uid, evaluation, miner_uids):
             continue
 
-        score = sum(
+        earned_score = sum(
             pr.earned_score
             for pr in evaluation.merged_prs
             if pr.repository_full_name.lower() == repo_name and pr.earned_score > 0
         )
+        collateral_score = sum(
+            pr.collateral_score
+            for pr in evaluation.open_prs
+            if pr.repository_full_name.lower() == repo_name and pr.collateral_score > 0
+        )
+        score = max(0.0, earned_score - collateral_score)
         if score > 0:
             scores[uid] = score
 

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -118,17 +118,11 @@ def _collect_repo_pr_scores(
         if not _is_scoring_evaluation(uid, evaluation, miner_uids):
             continue
 
-        earned_score = sum(
-            pr.earned_score
-            for pr in evaluation.merged_prs
-            if pr.repository_full_name.lower() == repo_name and pr.earned_score > 0
-        )
-        collateral_score = sum(
-            pr.collateral_score
-            for pr in evaluation.open_prs
-            if pr.repository_full_name.lower() == repo_name and pr.collateral_score > 0
-        )
-        score = max(0.0, earned_score - collateral_score)
+        repo_eval = evaluation.repo_evaluations.get(repo_name)
+        if repo_eval is None:
+            continue
+
+        score = repo_eval.total_score
         if score > 0:
             scores[uid] = score
 

--- a/tests/validator/test_blend_emission_pools.py
+++ b/tests/validator/test_blend_emission_pools.py
@@ -34,9 +34,10 @@ def _idx(uids: set[int], uid: int) -> int:
     return sorted(uids).index(uid)
 
 
-def _evaluation(uid: int, prs=None, issues=None) -> MinerEvaluation:
+def _evaluation(uid: int, prs=None, issues=None, open_prs=None) -> MinerEvaluation:
     evaluation = MinerEvaluation(uid=uid, hotkey=f'hk-{uid}', github_id=str(uid))
     evaluation.merged_prs = list(prs or [])
+    evaluation.open_prs = list(open_prs or [])
     evaluation.issue_discovery_issues = list(issues or [])
     return evaluation
 
@@ -73,6 +74,12 @@ def _scored_pr(repo: str, number: int, earned_score: float) -> ScoredPR:
         review_summary=MirrorReviewSummary(),
     )
     return ScoredPR(pr=pr, earned_score=earned_score)
+
+
+def _open_pr(repo: str, number: int, collateral_score: float) -> ScoredPR:
+    pr = _scored_pr(repo, number, earned_score=0.0)
+    pr.collateral_score = collateral_score
+    return pr
 
 
 def _discovered_issue(repo: str, number: int, earned_score: float) -> Issue:
@@ -121,6 +128,57 @@ class TestAllocationInvarianceToPrVolume:
         assert rewards[_idx(miner_uids, 1)] == pytest.approx(repo_slice * 0.6)
         assert rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice * 0.4)
         assert rewards[_idx(miner_uids, 1)] + rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice)
+
+
+class TestOpenPrCollateralAllocation:
+    def test_repo_pr_allocation_uses_collateral_adjusted_scores(self):
+        repos = {'r/collateral': _config(emission_share=0.2, issue_discovery_share=0.0)}
+        miner_uids = _uids(1, 2)
+        evaluations = {
+            1: _evaluation(1, prs=[_scored_pr('r/collateral', 100, earned_score=120.0)]),
+            2: _evaluation(
+                2,
+                prs=[_scored_pr('r/collateral', 200, earned_score=80.0)],
+                open_prs=[_open_pr('r/collateral', 201, collateral_score=20.0)],
+            ),
+        }
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids)
+
+        repo_slice = 0.2 * OSS_EMISSION_SHARE
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(repo_slice * (120.0 / 180.0))
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice * (60.0 / 180.0))
+
+    def test_repo_pr_allocation_remains_raw_ratio_without_collateral(self):
+        repos = {'r/no-collateral': _config(emission_share=0.2, issue_discovery_share=0.0)}
+        miner_uids = _uids(1, 2)
+        evaluations = {
+            1: _evaluation(1, prs=[_scored_pr('r/no-collateral', 100, earned_score=120.0)]),
+            2: _evaluation(2, prs=[_scored_pr('r/no-collateral', 200, earned_score=80.0)]),
+        }
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids)
+
+        repo_slice = 0.2 * OSS_EMISSION_SHARE
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(repo_slice * 0.6)
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice * 0.4)
+
+    def test_repo_pr_allocation_clamps_collateral_adjusted_score_at_zero(self):
+        repos = {'r/clamp': _config(emission_share=0.2, issue_discovery_share=0.0)}
+        miner_uids = _uids(1, 2)
+        evaluations = {
+            1: _evaluation(1, prs=[_scored_pr('r/clamp', 100, earned_score=50.0)]),
+            2: _evaluation(
+                2,
+                prs=[_scored_pr('r/clamp', 200, earned_score=10.0)],
+                open_prs=[_open_pr('r/clamp', 201, collateral_score=20.0)],
+            ),
+        }
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids)
+
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(0.2 * OSS_EMISSION_SHARE)
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(0.0)
 
 
 class TestCrossRepoIsolation:

--- a/tests/validator/test_blend_emission_pools.py
+++ b/tests/validator/test_blend_emission_pools.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from gittensor.classes import Issue, MinerEvaluation
+from gittensor.classes import Issue, MinerEvaluation, RepoEvaluation
 from gittensor.constants import (
     ISSUES_TREASURY_EMISSION_SHARE,
     ISSUES_TREASURY_UID,
@@ -39,7 +39,23 @@ def _evaluation(uid: int, prs=None, issues=None, open_prs=None) -> MinerEvaluati
     evaluation.merged_prs = list(prs or [])
     evaluation.open_prs = list(open_prs or [])
     evaluation.issue_discovery_issues = list(issues or [])
+    _populate_repo_evaluations(evaluation)
     return evaluation
+
+
+def _populate_repo_evaluations(evaluation: MinerEvaluation) -> None:
+    repos = {pr.repository_full_name.lower() for pr in evaluation.merged_prs + evaluation.open_prs}
+    for repo_name in repos:
+        merged = [pr for pr in evaluation.merged_prs if pr.repository_full_name.lower() == repo_name]
+
+            total_score=max(
+                0.0,
+                sum(pr.earned_score for pr in merged) - sum(pr.collateral_score for pr in open_prs),
+            ),
+            total_collateral_score=sum(pr.collateral_score for pr in open_prs),
+            total_merged_prs=len(merged),
+            total_open_prs=len(open_prs),
+        )
 
 
 def _scored_pr(repo: str, number: int, earned_score: float) -> ScoredPR:
@@ -131,6 +147,11 @@ class TestAllocationInvarianceToPrVolume:
 
 
 class TestOpenPrCollateralAllocation:
+    def test_repo_pr_allocation_reads_finalized_repo_score(self):
+
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(repo_slice * 0.3)
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice * 0.7)
+
     def test_repo_pr_allocation_uses_collateral_adjusted_scores(self):
         repos = {'r/collateral': _config(emission_share=0.2, issue_discovery_share=0.0)}
         miner_uids = _uids(1, 2)

--- a/tests/validator/test_blend_emission_pools.py
+++ b/tests/validator/test_blend_emission_pools.py
@@ -47,7 +47,9 @@ def _populate_repo_evaluations(evaluation: MinerEvaluation) -> None:
     repos = {pr.repository_full_name.lower() for pr in evaluation.merged_prs + evaluation.open_prs}
     for repo_name in repos:
         merged = [pr for pr in evaluation.merged_prs if pr.repository_full_name.lower() == repo_name]
-
+        open_prs = [pr for pr in evaluation.open_prs if pr.repository_full_name.lower() == repo_name]
+        evaluation.repo_evaluations[repo_name] = RepoEvaluation(
+            repository_full_name=repo_name,
             total_score=max(
                 0.0,
                 sum(pr.earned_score for pr in merged) - sum(pr.collateral_score for pr in open_prs),
@@ -148,7 +150,18 @@ class TestAllocationInvarianceToPrVolume:
 
 class TestOpenPrCollateralAllocation:
     def test_repo_pr_allocation_reads_finalized_repo_score(self):
+        repos = {'r/finalized': _config(emission_share=0.2, issue_discovery_share=0.0)}
+        miner_uids = _uids(1, 2)
+        evaluations = {
+            1: _evaluation(1, prs=[_scored_pr('r/finalized', 100, earned_score=1_000.0)]),
+            2: _evaluation(2, prs=[_scored_pr('r/finalized', 200, earned_score=1_000.0)]),
+        }
+        evaluations[1].repo_evaluations['r/finalized'].total_score = 30.0
+        evaluations[2].repo_evaluations['r/finalized'].total_score = 70.0
 
+        rewards = blend_emission_pools(evaluations, repos, miner_uids)
+
+        repo_slice = 0.2 * OSS_EMISSION_SHARE
         assert rewards[_idx(miner_uids, 1)] == pytest.approx(repo_slice * 0.3)
         assert rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice * 0.7)
 


### PR DESCRIPTION
## Summary

Applies finalized open-PR collateral when collecting repo-local PR allocation scores, so contributors with collateral are allocated from `merged earned_score - same-repo collateral_score` clamped at zero.

This keeps no-collateral allocation proportional to merged PR scores while making repo-bounded emission allocation agree with the collateral-adjusted scoring output.

## Related Issues

Fixes #1266

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

```
uv run pytest tests/validator/test_blend_emission_pools.py -q
uv run ruff check gittensor/validator/emission_allocation.py tests/validator/test_blend_emission_pools.py
uv run ruff format --check gittensor/validator/emission_allocation.py tests/validator/test_blend_emission_pools.py
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
