### PR TITLE
fix(validator): bound tree-sitter parse to prevent scoring-round DoS

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -100,6 +100,11 @@ TIME_DECAY_SIGMOID_MIDPOINT = 10  # days until 50% score loss
 TIME_DECAY_SIGMOID_STEEPNESS_SCALAR = 0.4
 TIME_DECAY_MIN_MULTIPLIER = 0.05  # 5% of score will retain through lookback window
 
+# Per-parse CPU budget for tree-sitter. The parser polls this flag in its
+# error-recovery loops; without it, adversarial inputs can spin forever in C
+# while holding the GIL. 2s is well above the millisecond cost of real files.
+TREE_SITTER_PARSE_TIMEOUT_MICROS = 2_000_000
+
 # comment nodes for token scoring
 COMMENT_NODE_TYPES = frozenset(
     {

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -97,7 +97,12 @@ async def score_miner_prs(
             bt.logging.info(
                 f'\n[{i}/{len(scored_prs)}] {label} PR #{scored.pr.pr_number} in {scored.pr.repo_full_name}'
             )
-            await score_pr(scored, eval_, master_repositories, programming_languages, token_config, client)
+            try:
+                await score_pr(scored, eval_, master_repositories, programming_languages, token_config, client)
+            except Exception as e:
+                bt.logging.warning(
+                    f'UID {eval_.uid}: scoring failed for PR #{scored.pr.pr_number} in {scored.pr.repo_full_name}: {e}'
+                )
 
 
 # ============================================================================

--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -21,6 +21,7 @@ from gittensor.constants import (
     MAX_LINES_SCORED_FOR_NON_CODE_EXT,
     NON_CODE_EXTENSIONS,
     TEST_FILE_CONTRIBUTION_WEIGHT,
+    TREE_SITTER_PARSE_TIMEOUT_MICROS,
 )
 from gittensor.utils.github_api_tools import FileContentPair
 from gittensor.utils.logging import log_scoring_results
@@ -51,6 +52,8 @@ def get_parser(language: str) -> Optional[Parser]:
         from tree_sitter_language_pack import get_parser as get_ts_parser
 
         parser = get_ts_parser(language)  # type: ignore[arg-type]
+        # Bound the C-level parse so adversarial inputs cannot hang the round.
+        parser.timeout_micros = TREE_SITTER_PARSE_TIMEOUT_MICROS
         _parser_cache[language] = parser
         return parser
     except Exception as e:


### PR DESCRIPTION
## Summary

- Sets `parser.timeout_micros = 2_000_000` on every cached tree-sitter parser so adversarial PR file contents cannot hang the scoring round in C.
- Wraps each PR in `score_miner_prs` with a `try/except` so one bad PR cannot abort the rest of a UID's scoring loop.

## Why

`gittensor/validator/utils/tree_sitter_scoring.py` calls `parser.parse(content.encode('utf-8'))` with no timeout. Several bundled grammars in `tree-sitter-language-pack==0.7.2` have error-recovery loops that, on adversarial input, spin forever in C while holding the GIL — including a known 16-byte TSX payload (tree-sitter-typescript#323). The `try/except Exception` already inside `parse_code` does not help here because a C-level hang never raises a Python exception.

The unguarded path runs synchronously inside the validator's scoring round:

```
get_rewards → evaluate_miners_pull_requests → score_miner_prs → score_pr
  → calculate_base_score_for_pr_files → calculate_token_score_from_file_changes
  → score_tree_diff → parse_code → parser.parse(...)   # hang point
```

A miner can open a PR (no merge required — `OPEN` PRs are scored) containing a single pathological file in any `master_repositories.json` repo. Every validator re-fetches that PR each round for ~`PR_LOOKBACK_DAYS=35` and hangs, blocking weight setting.

## What this PR does (and doesn't)

Setting `parser.timeout_micros` makes the C code raise `ValueError('Parsing failed')` back into Python after 2s. The existing wrapper in `parse_code` already catches `Exception` and returns `None`, which `score_tree_diff` already handles (the file degrades to a `tree-diff` with empty signatures, score 0). 2s is well above the millisecond cost of real files.

The per-PR `try/except` in `score_miner_prs` is defense-in-depth: any future exception in PR scoring degrades that PR to score 0 instead of aborting the rest of the loop.

Scope intentionally minimal — does **not** include subprocess isolation. One known timeout-immune class remains (`ts_subtree_balance` hangs, tree-sitter#4019, one known input on `.scala`); that requires an external wall-clock and can be addressed in a follow-up if it appears in the wild.

## Test plan

- [x] Existing test suite passes (`uv run pytest tests/` → 753 passed).
- [x] Pre-commit (ruff, ruff-format, pyright) clean on touched files.
- [x] Smoke-tested the 16-byte TSX payload from tree-sitter-typescript#323:
      `parse_code('<a {{b:>c:d(e f)', 'tsx')` returns `None` in **2.00s** (previously: infinite hang).
- [x] Verified `parser.timeout_micros = 2000000` is set on cached parsers.