### PR TITLE
refactor: remove unused MAX_FILES_PER_GRAPHQL_BATCH constant

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -25,8 +25,6 @@ GITHUB_HTTP_TIMEOUT_SECONDS = 15
 GRAPHQL_VIEWER_QUERY = '{ viewer { login } }'
 # 1MB max file size for github api file fetches. Files exceeding this get no score.
 MAX_FILE_SIZE_BYTES = 1_000_000
-# Too many object lookups in one GraphQL query can trigger 502 errors and lose all results.
-MAX_FILES_PER_GRAPHQL_BATCH = 50
 
 # =============================================================================
 # das-github-mirror (https://mirror.gittensor.io)


### PR DESCRIPTION
## Summary

`MAX_FILES_PER_GRAPHQL_BATCH = 50` in [`gittensor/constants.py:29`](gittensor/constants.py#L29) gated the legacy GraphQL file-content batched fetch — files were split into batches of 50 to avoid 502 errors on large PRs (see #331's reasoning, preserved in the inline comment).

That fetch path was removed in #1202 when the legacy scoring pipeline was stripped. Mirror-only scoring pulls file contents one PR at a time via [`MirrorClient.get_pr_files`](gittensor/utils/mirror/client.py), which doesn't batch — the mirror itself handles the size limit on the response side.

`grep -rn MAX_FILES_PER_GRAPHQL_BATCH --include='*.py' .` across `gittensor/`, `neurons/`, and `tests/` returns only the definition line — no remaining call sites.

Dropping the constant also drops the explanatory comment that only made sense in the context of the removed batching code.

Net: **-2 lines**, single file. Same shape as #1187 (drop orphaned `get_github_id`), #437, #448, #466.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 753 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)