### PR TITLE
refactor: remove dead parse_github_timestamp_to_cst and its pytz dependency

### DIFF
--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -2,8 +2,6 @@ import math
 from datetime import datetime, timezone
 from typing import Optional
 
-import pytz
-
 from gittensor.constants import (
     SECONDS_PER_HOUR,
     TIME_DECAY_GRACE_PERIOD_HOURS,
@@ -11,8 +9,6 @@ from gittensor.constants import (
     TIME_DECAY_SIGMOID_MIDPOINT,
     TIME_DECAY_SIGMOID_STEEPNESS_SCALAR,
 )
-
-CHICAGO_TZ = pytz.timezone('America/Chicago')
 
 
 def parse_github_iso_to_utc(timestamp_str: str) -> datetime:
@@ -37,14 +33,6 @@ def parse_optional_github_iso_to_utc(value: Optional[str]) -> Optional[datetime]
     callers feed ``data.get(...)`` straight through without per-site None-checks.
     """
     return parse_github_iso_to_utc(value) if value else None
-
-
-def parse_github_timestamp_to_cst(timestamp_str: str) -> datetime:
-    """
-    Parse GitHub's ISO format timestamp and convert to Chicago timezone.
-    GitHub returns timestamps like: 2024-01-15T10:30:00Z
-    """
-    return parse_github_iso_to_utc(timestamp_str).astimezone(CHICAGO_TZ)
 
 
 def calculate_time_decay(merged_at: datetime) -> float:


### PR DESCRIPTION
## Summary

[`parse_github_timestamp_to_cst`](gittensor/validator/utils/datetime_utils.py) parsed GitHub ISO timestamps and converted them to the `America/Chicago` timezone. It has no remaining call sites — scoring works entirely in UTC via `parse_github_iso_to_utc` / `parse_optional_github_iso_to_utc`.

It was the **sole** consumer of the module-level `CHICAGO_TZ` constant, which in turn was the **sole** consumer of `import pytz`. So the whole chain is dead and goes together:

- `parse_github_timestamp_to_cst` function
- `CHICAGO_TZ = pytz.timezone('America/Chicago')`
- `import pytz`

`grep -rn pytz --include='*.py'` across `gittensor/` and `neurons/` confirms `pytz` appears nowhere else, so this also drops `pytz` as a runtime import. (I've left the dependency manifest untouched — whether to also drop `pytz` from project dependencies is a separate call for a maintainer, since transitive deps may still pull it.)

`grep -rn parse_github_timestamp_to_cst` across `gittensor/`, `neurons/`, and `tests/` returns only the (now removed) definition.

Net: **-12 lines**, single file. Same dead-code-chain shape as #466 and #1187.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 739 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)