### PR TITLE
feat(validator): add maintainer_cut emission carve-out

### DIFF
--- a/gittensor/utils/mirror/client.py
+++ b/gittensor/utils/mirror/client.py
@@ -21,6 +21,7 @@ from gittensor.utils.mirror.models import (
     MirrorIssuesResponse,
     MirrorPullRequestFilesResponse,
     MirrorPullRequestsResponse,
+    MirrorRepoMaintainersResponse,
 )
 from gittensor.utils.utils import backoff_seconds
 
@@ -107,6 +108,20 @@ class MirrorClient:
         data = self._get(path)
         try:
             return MirrorPullRequestFilesResponse.from_dict(data)
+        except Exception as e:
+            raise MirrorRequestError(f'Mirror GET {path} returned invalid mirror response: {e}') from e
+
+    def get_repo_maintainers(self, repo_full_name: str) -> MirrorRepoMaintainersResponse:
+        """Fetch users whose latest known GitHub association for
+        ``repo_full_name`` (``owner/repo``) is OWNER/MEMBER/COLLABORATOR.
+
+        Used to route the per-repo ``maintainer_cut`` emission carve-out. An
+        unknown repo returns an empty maintainer list rather than an error.
+        """
+        path = f'/api/v1/repos/{repo_full_name}/maintainers'
+        data = self._get(path)
+        try:
+            return MirrorRepoMaintainersResponse.from_dict(data)
         except Exception as e:
             raise MirrorRequestError(f'Mirror GET {path} returned invalid mirror response: {e}') from e
 

--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -396,3 +396,49 @@ class MirrorPullRequestFilesResponse:
             scoring_data_stored=bool(data.get('scoring_data_stored', False)),
             files=files,
         )
+
+
+@dataclass
+class MirrorMaintainer:
+    """One maintainer-role contributor from
+    ``GET /api/v1/repos/:owner/:repo/maintainers`` — a user whose latest known
+    association for the repo is OWNER/MEMBER/COLLABORATOR.
+    """
+
+    github_id: str
+    login: str
+    association: str
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'MirrorMaintainer':
+        # Mirror may serialize github_id as int; coerce to str so comparisons
+        # with MinerEvaluation.github_id are type-correct.
+        return cls(
+            github_id=str(data['github_id']),
+            login=data.get('login') or '',
+            association=data['association'],
+        )
+
+
+@dataclass
+class MirrorRepoMaintainersResponse:
+    """Top-level wrapper for ``GET /api/v1/repos/:owner/:repo/maintainers``."""
+
+    repo_full_name: str
+    generated_at: Optional[datetime]
+    maintainers: List[MirrorMaintainer] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'MirrorRepoMaintainersResponse':
+        maintainers: List[MirrorMaintainer] = []
+        for raw in data.get('maintainers') or []:
+            try:
+                maintainers.append(MirrorMaintainer.from_dict(raw))
+            except Exception as e:
+                identifier = raw.get('github_id', '?') if isinstance(raw, dict) else '?'
+                bt.logging.warning(f'Skipping malformed mirror maintainer {identifier}: {e}')
+        return cls(
+            repo_full_name=data['repo_full_name'].lower(),
+            generated_at=parse_optional_github_iso_to_utc(data.get('generated_at')),
+            maintainers=maintainers,
+        )

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -3,7 +3,7 @@
 
 """Round-level emission allocation by repository emission shares."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 import bittensor as bt
 import numpy as np
@@ -23,6 +23,7 @@ def blend_emission_pools(
     miner_evaluations: Dict[int, MinerEvaluation],
     master_repositories: Dict[str, RepositoryConfig],
     miner_uids: set[int],
+    maintainer_uids_by_repo: Optional[Dict[str, list[int]]] = None,
 ) -> np.ndarray:
     """Allocate the combined scoring pool by bounded repository emission_share.
 
@@ -31,6 +32,11 @@ def blend_emission_pools(
     repo's ``issue_discovery_share`` and spill only inside the same repo when
     exactly one side has eligible non-zero scorers. Empty repo slices and
     registry slack recycle to UID 0.
+
+    When a repo sets ``maintainer_cut`` and ``maintainer_uids_by_repo`` lists
+    registered maintainer miners for it, ``maintainer_cut`` of that repo's slice
+    is carved off the top and split evenly among those maintainers; the
+    remainder scores normally. Repos with no listed maintainers are unaffected.
     """
     sorted_uids = sorted(miner_uids)
     uid_index = {uid: idx for idx, uid in enumerate(sorted_uids)}
@@ -43,6 +49,19 @@ def blend_emission_pools(
         repo_slice = repo_config.emission_share * OSS_EMISSION_SHARE
         if repo_slice <= 0:
             continue
+
+        # Maintainer carve-out: route maintainer_cut of the repo slice evenly to
+        # the repo's registered maintainer miners, off the top before the
+        # PR/issue split. Skipped when no maintainer miner is present.
+        maintainer_uids = (maintainer_uids_by_repo or {}).get(repo_name) or []
+        if repo_config.maintainer_cut > 0.0 and maintainer_uids:
+            carve_out = repo_config.maintainer_cut * repo_slice
+            per_maintainer = carve_out / len(maintainer_uids)
+            for uid in maintainer_uids:
+                idx = uid_index.get(uid)
+                if idx is not None:
+                    rewards[idx] += per_maintainer
+            repo_slice -= carve_out
 
         issue_share = repo_config.issue_discovery_share
         pr_scores = _collect_repo_pr_scores(miner_evaluations, repo_name, miner_uids) if issue_share < 1.0 else {}

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
+from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
 from gittensor.utils.uids import get_all_uids
 from gittensor.validator.emission_allocation import blend_emission_pools
 from gittensor.validator.issue_competitions.forward import issue_competitions
@@ -39,6 +40,7 @@ async def forward(self: 'Validator') -> None:
 
     Emission blending:
     - Combined scoring pool: 90%, allocated by repository emission_share
+    - Maintainer cut:        per-repo carve-out routed to maintainer miner neurons
     - Issue treasury:       10%, flat to UID 111
     - Recycle:              registry slack and inactive repo slices to UID 0
     """
@@ -73,7 +75,8 @@ async def forward(self: 'Validator') -> None:
         await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
 
         # 5. Allocate repo-bounded emission shares into final rewards
-        rewards = blend_emission_pools(miner_evaluations, master_repositories, miner_uids)
+        maintainer_uids_by_repo = _build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
+        rewards = blend_emission_pools(miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo)
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
 
@@ -126,3 +129,53 @@ async def issue_discovery(
         token_config,
         evaluation_cache=evaluation_cache,
     )
+
+
+def _build_maintainer_uids_by_repo(
+    miner_evaluations: Dict[int, MinerEvaluation],
+    master_repositories: Dict[str, RepositoryConfig],
+    miner_uids: set[int],
+) -> Dict[str, list[int]]:
+    """Map repo name -> sorted registered maintainer-miner UIDs for the
+    ``maintainer_cut`` carve-out.
+
+    The mirror is queried only for repos with ``maintainer_cut > 0``. A repo
+    whose lookup fails, or that has no registered maintainer miners, is omitted
+    so ``blend_emission_pools`` skips the carve-out and scores the slice
+    normally. Must run after ``miner_evaluations`` is fully populated so every
+    UID's ``github_id`` is known.
+    """
+    repos_needing = {name: cfg for name, cfg in master_repositories.items() if cfg.maintainer_cut > 0.0}
+    if not repos_needing:
+        return {}
+
+    github_id_to_uid: Dict[str, int] = {}
+    for uid, evaluation in miner_evaluations.items():
+        if uid not in miner_uids:
+            continue
+        github_id = evaluation.github_id
+        if github_id and github_id != '0':
+            github_id_to_uid[str(github_id)] = uid
+
+    result: Dict[str, list[int]] = {}
+    with MirrorClient() as client:
+        for repo_name in repos_needing:
+            try:
+                response = client.get_repo_maintainers(repo_name)
+            except MirrorRequestError as e:
+                bt.logging.warning(
+                    f'maintainer_cut: mirror maintainer lookup failed for {repo_name} ({e}); '
+                    f'skipping carve-out, slice scores normally'
+                )
+                continue
+            uids = sorted(
+                {github_id_to_uid[m.github_id] for m in response.maintainers if m.github_id in github_id_to_uid}
+            )
+            if uids:
+                result[repo_name] = uids
+            else:
+                bt.logging.info(
+                    f'maintainer_cut: no registered maintainer miners for {repo_name}; '
+                    f'carve-out skipped, slice scores normally'
+                )
+    return result

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -33,6 +33,7 @@ to the cache so sibling discoveries benefit.
 """
 
 import asyncio
+import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Set, Tuple
@@ -41,6 +42,7 @@ import bittensor as bt
 
 from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache
 from gittensor.constants import (
+    MAINTAINER_ASSOCIATIONS,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     PR_LOOKBACK_DAYS,
 )
@@ -98,6 +100,16 @@ class _CacheStats:
 
 
 _FAR_FUTURE = datetime.max.replace(tzinfo=timezone.utc)
+
+
+def _should_include_issue(issue: MirrorIssue) -> bool:
+    """Drop maintainer-discovered issues so repo maintainers cannot earn issue-
+    discovery rewards in repos they maintain — mirrors the PR-side maintainer
+    skip in ``oss_contributions/mirror/load.py``. Bypassed under DEV_MODE.
+    """
+    if not os.environ.get('DEV_MODE') and issue.author_association in MAINTAINER_ASSOCIATIONS:
+        return False
+    return True
 
 
 async def run_issue_discovery(
@@ -172,7 +184,7 @@ async def run_issue_discovery(
             continue
 
         open_issue_count = _count_open_issues(current_response.issues, enabled_names)
-        filtered = [i for i in response.issues if i.repo_full_name in enabled_names]
+        filtered = [i for i in response.issues if i.repo_full_name in enabled_names and _should_include_issue(i)]
         if not filtered:
             _clear_issue_discovery_fields(evaluation)
             evaluation.total_open_issues = open_issue_count

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -43,6 +43,9 @@ class RepositoryConfig:
             to be within [0.0, 100.0]; range is enforced by the live-config test.
         eligibility_mode: Flag controlling whether the global miner
             eligibility gate applies to PRs in this repo.
+        maintainer_cut: Fraction [0.0, 1.0] of this repo's emission slice
+            routed directly to its maintainer miner neurons, split evenly,
+            before normal scoring. Defaults to 0.0 (no carve-out).
 
     """
 
@@ -54,6 +57,7 @@ class RepositoryConfig:
     default_label_multiplier: float = 1.0
     fixed_base_score: Optional[float] = None
     eligibility_mode: bool = True
+    maintainer_cut: float = 0.0
 
 
 @dataclass
@@ -121,6 +125,10 @@ def _validate_emission_shares(configs: Dict[str, RepositoryConfig]) -> None:
             raise RepositoryRegistryError(
                 f'{repo_name} issue_discovery_share must be within [0, 1], got {config.issue_discovery_share}'
             )
+        if not 0.0 <= config.maintainer_cut <= 1.0:
+            raise RepositoryRegistryError(
+                f'{repo_name} maintainer_cut must be within [0, 1], got {config.maintainer_cut}'
+            )
         total_share += config.emission_share
 
     if total_share > 1.0 + EMISSION_SHARE_TOLERANCE:
@@ -170,6 +178,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
                     fixed_base_score=metadata.get('fixed_base_score'),
                     eligibility_mode=metadata.get('eligibility_mode', True),
+                    maintainer_cut=_coerce_share(repo_name, 'maintainer_cut', metadata.get('maintainer_cut', 0.0)),
                 )
                 normalized_data[repo_name.lower()] = config
             except RepositoryRegistryError:

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,6 +7,7 @@
       "enhancement": 1.0,
       "refactor": 0.25
     },
+    "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
   "entrius/allways-ui": {
@@ -18,6 +19,7 @@
       "feature": 1.25,
       "refactor": 0.5
     },
+    "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
   "entrius/das-github-mirror": {
@@ -28,6 +30,7 @@
       "enhancement": 1.1,
       "refactor": 0.1
     },
+    "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
@@ -39,6 +42,7 @@
       "feature": 1.5,
       "refactor": 0.25
     },
+    "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
@@ -50,6 +54,7 @@
       "feature": 1.25,
       "refactor": 0.5
     },
+    "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
   "entrius/oc-1": {
@@ -61,6 +66,7 @@
     "label_multipliers": {
       "benchmark-improvement": 1.0
     },
+    "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
   "Geniepod/genie-claw": {

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -111,6 +111,7 @@ def _issue_dict(
     last_edited_at: Optional[str] = None,
     repo: str = 'entrius/gittensor-ui',
     created_at: str = '2026-04-01T00:00:00Z',
+    author_association: str = 'CONTRIBUTOR',
 ) -> dict:
     sp = None
     if solved_by_pr:
@@ -135,7 +136,7 @@ def _issue_dict(
         'state_reason': state_reason,
         'author_github_id': author_github_id,
         'author_login': 'discoverer',
-        'author_association': 'CONTRIBUTOR',
+        'author_association': author_association,
         'created_at': created_at,
         'closed_at': '2026-04-18T10:00:00Z' if state == 'CLOSED' else None,
         'updated_at': '2026-04-18T10:00:00Z',
@@ -1349,3 +1350,88 @@ class TestCrossMinerOneIssuePerPr:
             return evaluation.issue_discovery_score
 
         assert _score_with_emission_share(0.1) == pytest.approx(_score_with_emission_share(0.9))
+
+
+def _issues_by_github_id(mapping: dict):
+    """Mock get_miner_issues side effect: each miner's github_id maps to its own
+    issue list, others get none. Keeps a seed miner from re-discovering the
+    target miner's issues and competing for the same solving PR."""
+
+    def _side_effect(github_id, since=None):
+        return _response(mapping.get(github_id, []))
+
+    return _side_effect
+
+
+class TestMaintainerIssueDiscoverySkip:
+    """Maintainer-discovered issues earn nothing — the issue-discovery analogue
+    of the PR-side maintainer skip in oss_contributions/mirror/load.py."""
+
+    @pytest.mark.parametrize('association', ['OWNER', 'MEMBER', 'COLLABORATOR'])
+    def test_maintainer_discoverer_dropped_at_load(self, association, monkeypatch):
+        monkeypatch.delenv('DEV_MODE', raising=False)
+        client = Mock()
+        client.get_miner_issues.return_value = _response([_issue_dict(author_association=association)])
+        eval_ = _eval()
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        assert eval_.total_solved_issues == 0
+        assert eval_.issue_discovery_issues == []
+
+    def test_contributor_issues_kept_maintainer_issue_dropped(self, monkeypatch):
+        # Seven CONTRIBUTOR issues clear the issue-eligibility gate and score; an
+        # OWNER issue (whose solving PR is equally cached) is dropped at load.
+        monkeypatch.delenv('DEV_MODE', raising=False)
+        contributor_issues = [
+            _issue_dict(issue_number=10 + i, solved_by_pr=200 + i, author_association='CONTRIBUTOR') for i in range(7)
+        ]
+        maintainer_issue = _issue_dict(issue_number=99, solved_by_pr=299, author_association='OWNER')
+        client = Mock()
+        client.get_miner_issues.side_effect = _issues_by_github_id({'999': contributor_issues + [maintainer_issue]})
+        eval_ = _eval()
+        seed_eval = MinerEvaluation(uid=2, hotkey='hk2', github_id='seed')
+        seed_eval.merged_prs = [
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number) for pr_number in [*range(200, 207), 299]
+        ]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_, 2: seed_eval},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        assert eval_.total_solved_issues == 7
+        assert {issue.number for issue in eval_.issue_discovery_issues} == set(range(10, 17))
+
+    def test_dev_mode_bypasses_maintainer_skip(self, monkeypatch):
+        monkeypatch.setenv('DEV_MODE', '1')
+        client = Mock()
+        client.get_miner_issues.side_effect = _issues_by_github_id({'999': [_issue_dict(author_association='OWNER')]})
+        eval_ = _eval()
+        seed_eval = MinerEvaluation(uid=2, hotkey='hk2', github_id='seed')
+        seed_eval.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_, 2: seed_eval},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        assert eval_.total_solved_issues == 1

--- a/tests/validator/test_blend_emission_pools.py
+++ b/tests/validator/test_blend_emission_pools.py
@@ -85,8 +85,16 @@ def _discovered_issue(repo: str, number: int, earned_score: float) -> Issue:
     )
 
 
-def _config(emission_share: float, issue_discovery_share: float = 0.5) -> RepositoryConfig:
-    return RepositoryConfig(emission_share=emission_share, issue_discovery_share=issue_discovery_share)
+def _config(
+    emission_share: float,
+    issue_discovery_share: float = 0.5,
+    maintainer_cut: float = 0.0,
+) -> RepositoryConfig:
+    return RepositoryConfig(
+        emission_share=emission_share,
+        issue_discovery_share=issue_discovery_share,
+        maintainer_cut=maintainer_cut,
+    )
 
 
 class TestAllocationInvarianceToPrVolume:
@@ -339,3 +347,121 @@ class TestCaseInsensitiveRepoMatching:
         rewards = blend_emission_pools(evaluations, repos, miner_uids)
 
         assert rewards[_idx(miner_uids, 1)] == pytest.approx(0.2 * OSS_EMISSION_SHARE)
+
+
+class TestMaintainerCut:
+    def test_default_and_empty_map_match_no_arg(self):
+        repos = {'r/one': _config(emission_share=0.1, issue_discovery_share=0.0)}
+        miner_uids = _uids(1)
+        evaluations = {1: _evaluation(1, prs=[_scored_pr('r/one', 100, earned_score=10.0)])}
+
+        baseline = blend_emission_pools(evaluations, repos, miner_uids)
+        with_none = blend_emission_pools(evaluations, repos, miner_uids, None)
+        with_empty = blend_emission_pools(evaluations, repos, miner_uids, {})
+
+        assert list(with_none) == list(baseline)
+        assert list(with_empty) == list(baseline)
+
+    def test_zero_cut_ignores_maintainer_map(self):
+        repos = {'r/one': _config(emission_share=0.1, issue_discovery_share=0.0, maintainer_cut=0.0)}
+        miner_uids = _uids(1, 2)
+        evaluations = {
+            1: _evaluation(1),
+            2: _evaluation(2, prs=[_scored_pr('r/one', 100, earned_score=10.0)]),
+        }
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {'r/one': [1]})
+
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(0.0)
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(0.1 * OSS_EMISSION_SHARE)
+
+    def test_single_maintainer_gets_full_carve_out(self):
+        repos = {'r/one': _config(emission_share=0.1, issue_discovery_share=0.0, maintainer_cut=0.25)}
+        miner_uids = _uids(1, 2)
+        evaluations = {
+            1: _evaluation(1),
+            2: _evaluation(2, prs=[_scored_pr('r/one', 100, earned_score=10.0)]),
+        }
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {'r/one': [1]})
+
+        repo_slice = 0.1 * OSS_EMISSION_SHARE
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(repo_slice * 0.25)
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice * 0.75)
+
+    def test_even_split_among_n_maintainers(self):
+        repos = {'r/m': _config(emission_share=0.3, issue_discovery_share=0.0, maintainer_cut=0.4)}
+        miner_uids = _uids(1, 2, 3)
+        evaluations = {1: _evaluation(1), 2: _evaluation(2), 3: _evaluation(3)}
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {'r/m': [1, 2, 3]})
+
+        per_maintainer = 0.3 * OSS_EMISSION_SHARE * 0.4 / 3
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(per_maintainer)
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(per_maintainer)
+        assert rewards[_idx(miner_uids, 3)] == pytest.approx(per_maintainer)
+
+    def test_maintainer_also_scores_prs_gets_both(self):
+        repos = {'r/one': _config(emission_share=0.1, issue_discovery_share=0.0, maintainer_cut=0.2)}
+        miner_uids = _uids(1, 2)
+        evaluations = {
+            1: _evaluation(1, prs=[_scored_pr('r/one', 1, earned_score=10.0)]),
+            2: _evaluation(2, prs=[_scored_pr('r/one', 2, earned_score=10.0)]),
+        }
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {'r/one': [1]})
+
+        repo_slice = 0.1 * OSS_EMISSION_SHARE
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(repo_slice * 0.2 + repo_slice * 0.8 * 0.5)
+        assert rewards[_idx(miner_uids, 2)] == pytest.approx(repo_slice * 0.8 * 0.5)
+
+    def test_multi_repo_maintainer_stacks(self):
+        repos = {
+            'r/a': _config(emission_share=0.2, issue_discovery_share=0.0, maintainer_cut=0.5),
+            'r/b': _config(emission_share=0.3, issue_discovery_share=0.0, maintainer_cut=0.5),
+        }
+        miner_uids = _uids(1)
+        evaluations = {1: _evaluation(1)}
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {'r/a': [1], 'r/b': [1]})
+
+        slice_a = 0.2 * OSS_EMISSION_SHARE
+        slice_b = 0.3 * OSS_EMISSION_SHARE
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(slice_a * 0.5 + slice_b * 0.5)
+
+    def test_no_maintainer_falls_back_to_normal_scoring(self):
+        repos = {'r/one': _config(emission_share=0.1, issue_discovery_share=0.0, maintainer_cut=0.5)}
+        miner_uids = _uids(1)
+        evaluations = {1: _evaluation(1, prs=[_scored_pr('r/one', 100, earned_score=10.0)])}
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {})
+
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(0.1 * OSS_EMISSION_SHARE)
+        assert rewards[_idx(miner_uids, RECYCLE_UID)] == pytest.approx(0.9 * OSS_EMISSION_SHARE)
+
+    def test_carve_out_plus_recycle_interaction(self):
+        repos = {'r/one': _config(emission_share=1.0, issue_discovery_share=0.0, maintainer_cut=0.3)}
+        miner_uids = _uids(1)
+        evaluations = {1: _evaluation(1)}
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {'r/one': [1]})
+
+        assert rewards[_idx(miner_uids, 1)] == pytest.approx(0.3 * OSS_EMISSION_SHARE)
+        assert rewards[_idx(miner_uids, RECYCLE_UID)] == pytest.approx(0.7 * OSS_EMISSION_SHARE)
+
+    def test_round_total_sums_to_one_with_carve_out(self):
+        repos = {
+            'r/a': _config(emission_share=0.4, issue_discovery_share=0.0, maintainer_cut=0.5),
+            'r/b': _config(emission_share=0.3, issue_discovery_share=0.5),
+            'r/c': _config(emission_share=0.1, issue_discovery_share=0.0),
+        }
+        miner_uids = _uids(1, 2, 3)
+        evaluations = {
+            1: _evaluation(1, prs=[_scored_pr('r/a', 1, earned_score=5.0)]),
+            2: _evaluation(2, issues=[_discovered_issue('r/b', 10, earned_score=7.0)]),
+            3: _evaluation(3),
+        }
+
+        rewards = blend_emission_pools(evaluations, repos, miner_uids, {'r/a': [3]})
+
+        assert float(rewards.sum()) == pytest.approx(1.0)

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -294,6 +294,40 @@ class TestRepositoryConfigMirrorScoringFields:
             )
 
 
+class TestRepositoryConfigMaintainerCut:
+    """Dataclass + JSON-parsing tests for the maintainer_cut emission carve-out."""
+
+    def test_maintainer_cut_defaults_zero(self):
+        config = RepositoryConfig(emission_share=0.5)
+        assert config.maintainer_cut == pytest.approx(0.0)
+
+    def test_loader_parses_maintainer_cut(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        fake_weights_dir = tmp_path
+        (fake_weights_dir / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/with-cut': {'emission_share': 0.5, 'maintainer_cut': 0.3},
+                    'foo/defaults': {'emission_share': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/with-cut'].maintainer_cut == pytest.approx(0.3)
+        assert repos['foo/defaults'].maintainer_cut == pytest.approx(0.0)
+
+    @pytest.mark.parametrize('repo_name,metadata', _live_master_repo_metadata())
+    def test_live_maintainer_cut_is_in_range(self, repo_name, metadata):
+        if 'maintainer_cut' not in metadata:
+            return
+
+        assert 0.0 <= float(metadata['maintainer_cut']) <= 1.0, f'{repo_name} maintainer_cut must be within [0.0, 1.0]'
+
+
 class TestRepositoryEmissionShare:
     """Tests for bounded repo emission_share loading."""
 
@@ -349,6 +383,8 @@ class TestRepositoryEmissionShare:
             {'emission_share': 1.01},
             {'emission_share': 0.5, 'issue_discovery_share': -0.01},
             {'emission_share': 0.5, 'issue_discovery_share': 1.01},
+            {'emission_share': 0.5, 'maintainer_cut': -0.01},
+            {'emission_share': 0.5, 'maintainer_cut': 1.01},
         ],
     )
     def test_loader_rejects_out_of_range_values(self, tmp_path, monkeypatch, metadata):
@@ -366,6 +402,7 @@ class TestRepositoryEmissionShare:
         [
             {'emission_share': True},
             {'emission_share': 0.5, 'issue_discovery_share': False},
+            {'emission_share': 0.5, 'maintainer_cut': True},
         ],
     )
     def test_loader_rejects_boolean_share_values(self, tmp_path, monkeypatch, metadata):

--- a/tests/validator/test_maintainer_uids.py
+++ b/tests/validator/test_maintainer_uids.py
@@ -1,0 +1,134 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Unit tests for _build_maintainer_uids_by_repo — the forward-pass helper that
+resolves a repo's mirror maintainer roster to registered miner UIDs for the
+maintainer_cut carve-out."""
+
+from gittensor.classes import MinerEvaluation
+from gittensor.utils.mirror.client import MirrorRequestError
+from gittensor.utils.mirror.models import MirrorMaintainer, MirrorRepoMaintainersResponse
+from gittensor.validator import forward
+from gittensor.validator.forward import _build_maintainer_uids_by_repo
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+
+class _StubMirrorClient:
+    """Context-manager stand-in for MirrorClient with canned per-repo responses."""
+
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = []
+
+    def __enter__(self) -> '_StubMirrorClient':
+        return self
+
+    def __exit__(self, *args) -> None:
+        return None
+
+    def get_repo_maintainers(self, repo_full_name: str) -> MirrorRepoMaintainersResponse:
+        self.calls.append(repo_full_name)
+        result = self._responses[repo_full_name]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _install_stub(monkeypatch, responses) -> _StubMirrorClient:
+    stub = _StubMirrorClient(responses)
+    monkeypatch.setattr(forward, 'MirrorClient', lambda: stub)
+    return stub
+
+
+def _evaluation(uid: int, github_id: str) -> MinerEvaluation:
+    return MinerEvaluation(uid=uid, hotkey=f'hk-{uid}', github_id=github_id)
+
+
+def _response(repo: str, *github_ids: int) -> MirrorRepoMaintainersResponse:
+    return MirrorRepoMaintainersResponse(
+        repo_full_name=repo,
+        generated_at=None,
+        maintainers=[MirrorMaintainer(github_id=str(gid), login=f'u{gid}', association='MEMBER') for gid in github_ids],
+    )
+
+
+def _cut_repo(maintainer_cut: float = 0.5) -> RepositoryConfig:
+    return RepositoryConfig(emission_share=0.1, maintainer_cut=maintainer_cut)
+
+
+def test_resolves_github_ids_to_registered_uids(monkeypatch):
+    _install_stub(monkeypatch, {'r/one': _response('r/one', 100, 200)})
+    evaluations = {1: _evaluation(1, '100'), 2: _evaluation(2, '200'), 3: _evaluation(3, '300')}
+
+    result = _build_maintainer_uids_by_repo(evaluations, {'r/one': _cut_repo()}, {1, 2, 3})
+
+    assert result == {'r/one': [1, 2]}
+
+
+def test_unregistered_and_zero_github_id_maintainers_excluded(monkeypatch):
+    # gh 100 is a registered miner; gh 999 has no miner; uid 2 broadcast no PAT (github_id '0').
+    _install_stub(monkeypatch, {'r/one': _response('r/one', 100, 999)})
+    evaluations = {1: _evaluation(1, '100'), 2: _evaluation(2, '0')}
+
+    result = _build_maintainer_uids_by_repo(evaluations, {'r/one': _cut_repo()}, {1, 2})
+
+    assert result == {'r/one': [1]}
+
+
+def test_maintainer_uid_not_in_miner_uids_excluded(monkeypatch):
+    _install_stub(monkeypatch, {'r/one': _response('r/one', 100, 200)})
+    evaluations = {1: _evaluation(1, '100'), 2: _evaluation(2, '200')}
+
+    result = _build_maintainer_uids_by_repo(evaluations, {'r/one': _cut_repo()}, {1})
+
+    assert result == {'r/one': [1]}
+
+
+def test_only_queries_repos_with_positive_cut(monkeypatch):
+    stub = _install_stub(monkeypatch, {'r/cut': _response('r/cut', 100)})
+    evaluations = {1: _evaluation(1, '100')}
+    repos = {'r/cut': _cut_repo(0.5), 'r/no-cut': _cut_repo(0.0)}
+
+    result = _build_maintainer_uids_by_repo(evaluations, repos, {1})
+
+    assert stub.calls == ['r/cut']
+    assert result == {'r/cut': [1]}
+
+
+def test_mirror_failure_omits_repo(monkeypatch):
+    _install_stub(monkeypatch, {'r/one': MirrorRequestError('mirror down')})
+    evaluations = {1: _evaluation(1, '100')}
+
+    result = _build_maintainer_uids_by_repo(evaluations, {'r/one': _cut_repo()}, {1})
+
+    assert result == {}
+
+
+def test_empty_maintainers_omits_repo(monkeypatch):
+    _install_stub(monkeypatch, {'r/one': _response('r/one')})
+    evaluations = {1: _evaluation(1, '100')}
+
+    result = _build_maintainer_uids_by_repo(evaluations, {'r/one': _cut_repo()}, {1})
+
+    assert result == {}
+
+
+def test_duplicate_github_ids_dedup(monkeypatch):
+    _install_stub(monkeypatch, {'r/one': _response('r/one', 100, 100)})
+    evaluations = {1: _evaluation(1, '100')}
+
+    result = _build_maintainer_uids_by_repo(evaluations, {'r/one': _cut_repo()}, {1})
+
+    assert result == {'r/one': [1]}
+
+
+def test_no_cut_repos_returns_empty_without_client(monkeypatch):
+    def _boom() -> None:
+        raise AssertionError('MirrorClient should not be constructed when no repo has a cut')
+
+    monkeypatch.setattr(forward, 'MirrorClient', _boom)
+    evaluations = {1: _evaluation(1, '100')}
+
+    result = _build_maintainer_uids_by_repo(evaluations, {'r/one': _cut_repo(0.0)}, {1})
+
+    assert result == {}


### PR DESCRIPTION
## What

Adds **`maintainer_cut`** — a per-repository config field that carves a fraction of a repo's emission slice off the top and routes it evenly to the repo's maintainer miner neurons.

- New `RepositoryConfig.maintainer_cut` — float `[0, 1]`, default `0.0`, validated in `_validate_emission_shares`.
- `blend_emission_pools` carves `maintainer_cut × repo_slice` **off the top, before** the PR/issue-discovery split; the remainder scores normally.
- A maintainer miner = a registered miner whose GitHub identity holds an `OWNER`/`MEMBER`/`COLLABORATOR` association for the repo. `forward.py` resolves this via the das-github-mirror `GET /api/v1/repos/:owner/:repo/maintainers` endpoint, querying only repos with `maintainer_cut > 0`.
- N maintainer miners → carve-out split **evenly**; a miner maintaining multiple repos **accumulates** across them.
- **No maintainer miner registered** for a repo → carve-out skipped, full slice scores normally (never recycled).
- Maintainers are also **blocked from issue-discovery rewards** on repos they maintain — `_should_include_issue` drops maintainer-authored issues at load, mirroring the existing PR-side maintainer skip in `oss_contributions/mirror/load.py` (same `DEV_MODE` bypass).

## Why

Repositories are maintained by people, but the subnet had no way to compensate maintainers — and maintainers could still farm their own repos via issue discovery. This routes a defined cut directly to them while closing that gap.

## Rollout safety — inert by default

Every repo's `maintainer_cut` is `0.0` (explicit on the `entrius/*` repos, default for the rest), so this ships **completely inert**: `_build_maintainer_uids_by_repo` returns `{}` without ever calling the mirror. A non-zero cut activates it later. If the mirror endpoint were ever unreachable, the lookup catches `MirrorRequestError` and degrades to normal scoring — the round always completes.

## Dependency

Consumes the das-github-mirror maintainers endpoint, which is **already merged and deployed to prod** (verified live).

## Testing

- `ruff check`, `ruff format`, `pyright` clean on changed files.
- Full suite: **775 passing**. New coverage: carve-out scenarios in `test_blend_emission_pools.py` (even split, multi-repo stacking, no-maintainer fallback, recycle interaction, round-total invariant), `maintainer_cut` config parsing/validation in `test_load_weights.py`, `_build_maintainer_uids_by_repo` in the new `test_maintainer_uids.py`, and the maintainer issue-discovery skip in `test_scan.py`.