### PR TITLE
feat(validator): per-repository eligibility

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -235,6 +235,52 @@ class PullRequest:
 
 
 @dataclass
+class RepoEvaluation:
+    """Per-repository scoring + eligibility result for one miner.
+
+    Eligibility is computed per repo from only that repo's PRs/issues; one
+    row per (miner, repo) is persisted to the miner_evaluations table.
+    """
+
+    repository_full_name: str
+
+    # PR-side eligibility / scoring
+    is_eligible: bool = False
+    credibility: float = 0.0
+    base_total_score: float = 0.0
+    total_score: float = 0.0
+    total_collateral_score: float = 0.0
+    total_nodes_scored: int = 0
+    total_token_score: float = 0.0
+    total_structural_count: int = 0
+    total_structural_score: float = 0.0
+    total_leaf_count: int = 0
+    total_leaf_score: float = 0.0
+    total_merged_prs: int = 0
+    total_open_prs: int = 0
+    total_closed_prs: int = 0
+
+    # Issue-discovery eligibility / scoring
+    is_issue_eligible: bool = False
+    issue_credibility: float = 0.0
+    issue_discovery_score: float = 0.0
+    issue_token_score: float = 0.0
+    total_solved_issues: int = 0
+    total_valid_solved_issues: int = 0
+    total_closed_issues: int = 0
+    total_open_issues: int = 0
+
+    @property
+    def total_prs(self) -> int:
+        return self.total_merged_prs + self.total_open_prs + self.total_closed_prs
+
+    def copy_issue_discovery_from(self, other: 'RepoEvaluation') -> None:
+        """Copy the issue-discovery-owned fields from another RepoEvaluation."""
+        for name in _ISSUE_DISCOVERY_REPO_FIELDS:
+            setattr(self, name, getattr(other, name))
+
+
+@dataclass
 class MinerEvaluation:
     uid: int
     hotkey: str
@@ -277,6 +323,10 @@ class MinerEvaluation:
     total_closed_issues: int = 0
     total_open_issues: int = 0  # current mirror-tracked open issues (set by issue_discovery.scan)
     issue_discovery_issues: List[Issue] = field(default_factory=list)
+
+    # Per-repository eligibility + scoring, keyed by lowercased repository_full_name.
+    # The top-level scalars above are round-level rollups of this map.
+    repo_evaluations: Dict[str, RepoEvaluation] = field(default_factory=dict)
 
     @property
     def total_prs(self) -> int:
@@ -496,6 +546,19 @@ _ISSUE_DISCOVERY_FIELDS: Tuple[str, ...] = (
     'issue_discovery_issues',
 )
 
+# Per-repo RepoEvaluation fields owned by the issue-discovery phase — preserved
+# across rounds by store() exactly like the top-level _ISSUE_DISCOVERY_FIELDS.
+_ISSUE_DISCOVERY_REPO_FIELDS: Tuple[str, ...] = (
+    'is_issue_eligible',
+    'issue_credibility',
+    'issue_discovery_score',
+    'issue_token_score',
+    'total_solved_issues',
+    'total_valid_solved_issues',
+    'total_closed_issues',
+    'total_open_issues',
+)
+
 
 class MinerEvaluationCache:
     """
@@ -538,6 +601,12 @@ class MinerEvaluationCache:
             for name in _ISSUE_DISCOVERY_FIELDS:
                 value = getattr(existing.evaluation, name)
                 setattr(cached_eval, name, _copy_issue_discovery_value(name, value))
+            for repo_name, prior_repo in existing.evaluation.repo_evaluations.items():
+                target = cached_eval.repo_evaluations.get(repo_name)
+                if target is None:
+                    target = RepoEvaluation(repository_full_name=prior_repo.repository_full_name)
+                    cached_eval.repo_evaluations[repo_name] = target
+                target.copy_issue_discovery_from(prior_repo)
 
         self._cache[evaluation.uid] = CachedEvaluation(
             hotkey=evaluation.hotkey,
@@ -573,6 +642,13 @@ class MinerEvaluationCache:
         for name in _ISSUE_DISCOVERY_FIELDS:
             value = getattr(evaluation, name)
             setattr(existing.evaluation, name, _copy_issue_discovery_value(name, value))
+
+        for repo_name, repo_eval in evaluation.repo_evaluations.items():
+            target = existing.evaluation.repo_evaluations.get(repo_name)
+            if target is None:
+                target = RepoEvaluation(repository_full_name=repo_eval.repository_full_name)
+                existing.evaluation.repo_evaluations[repo_name] = target
+            target.copy_issue_discovery_from(repo_eval)
 
         bt.logging.debug(f'Refreshed cached issue discovery for UID {evaluation.uid}')
 
@@ -616,6 +692,7 @@ class MinerEvaluationCache:
         cached = copy.copy(evaluation)
         cached.unique_repos_contributed_to = set(evaluation.unique_repos_contributed_to)
         cached.issue_discovery_issues = _copy_issue_discovery_issues(evaluation.issue_discovery_issues)
+        cached.repo_evaluations = {name: copy.copy(re) for name, re in evaluation.repo_evaluations.items()}
         cached.merged_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.merged_prs]
         cached.open_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.open_prs]
         cached.closed_prs = [_scored_mirror_pr_for_cache(pr) for pr in evaluation.closed_prs]
@@ -629,6 +706,7 @@ class MinerEvaluationCache:
         copy_eval = copy.copy(cached_eval)
         copy_eval.unique_repos_contributed_to = set(cached_eval.unique_repos_contributed_to)
         copy_eval.issue_discovery_issues = _copy_issue_discovery_issues(cached_eval.issue_discovery_issues)
+        copy_eval.repo_evaluations = {name: copy.copy(re) for name, re in cached_eval.repo_evaluations.items()}
         return copy_eval
 
 

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -66,6 +66,7 @@ _EVAL_SKIP: frozenset = frozenset(
         'closed_prs',
         'issue_discovery_issues',
         'unique_repos_contributed_to',
+        'repo_evaluations',
     }
 )
 _PR_SKIP: frozenset = frozenset({'pr', 'files'})
@@ -104,6 +105,9 @@ def _serialize_evaluation(miner_eval) -> Dict[str, Any]:
     payload['merged_pull_requests'] = [_serialize_pr(s) for s in miner_eval.merged_prs]
     payload['open_pull_requests'] = [_serialize_pr(s) for s in miner_eval.open_prs]
     payload['closed_pull_requests'] = [_serialize_pr(s) for s in miner_eval.closed_prs]
+    payload['repo_evaluations'] = {
+        repo: _project(re, extra_properties=('total_prs',)) for repo, re in sorted(miner_eval.repo_evaluations.items())
+    }
     return payload
 
 
@@ -120,10 +124,10 @@ def _render_table(payload: Dict[str, Any]) -> None:
         console.print(table)
         return
 
-    table.add_row('Eligible (OSS)', str(miner['is_eligible']))
-    table.add_row('Credibility (OSS)', f'{miner["credibility"]:.4f}')
-    table.add_row('Eligible (issue discovery)', str(miner['is_issue_eligible']))
-    table.add_row('Credibility (issue)', f'{miner["issue_credibility"]:.4f}')
+    table.add_row('Eligible (any repo)', str(miner['is_eligible']))
+    table.add_row('Best credibility (OSS)', f'{miner["credibility"]:.4f}')
+    table.add_row('Issue-eligible (any repo)', str(miner['is_issue_eligible']))
+    table.add_row('Best issue credibility', f'{miner["issue_credibility"]:.4f}')
     table.add_row(
         'PRs merged / open / closed',
         f'{miner["total_merged_prs"]} / {miner["total_open_prs"]} / {miner["total_closed_prs"]}',
@@ -142,6 +146,29 @@ def _render_table(payload: Dict[str, Any]) -> None:
         '[bold green]Final blended reward[/bold green]', f'[bold green]{rewards["blended_final"]:.6f}[/bold green]'
     )
     console.print(table)
+
+    repo_evals = miner.get('repo_evaluations') or {}
+    if repo_evals:
+        repo_table = Table(title='Per-repository eligibility', show_lines=False)
+        repo_table.add_column('Repository', style='cyan')
+        repo_table.add_column('Eligible', justify='center')
+        repo_table.add_column('Credibility', justify='right')
+        repo_table.add_column('Earned', justify='right')
+        repo_table.add_column('Issue elig.', justify='center')
+        repo_table.add_column('Issue cred.', justify='right')
+        repo_table.add_column('Issue score', justify='right')
+        for repo_name in sorted(repo_evals):
+            re = repo_evals[repo_name]
+            repo_table.add_row(
+                repo_name,
+                '[green]✓[/green]' if re['is_eligible'] else '[red]✗[/red]',
+                f'{re["credibility"]:.2f}',
+                f'{re["total_score"]:.2f}',
+                '[green]✓[/green]' if re['is_issue_eligible'] else '[red]✗[/red]',
+                f'{re["issue_credibility"]:.2f}',
+                f'{re["issue_discovery_score"]:.2f}',
+            )
+        console.print(repo_table)
 
     pr_table = Table(title='Per-PR breakdown', show_lines=False)
     pr_table.add_column('Repo#PR', style='cyan')

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -120,23 +120,24 @@ INLINE_TEST_PATTERNS: Dict[str, re.Pattern] = {
 # =============================================================================
 # Eligibility Gate (OSS Contributions)
 # =============================================================================
-MIN_VALID_MERGED_PRS = 5  # minimum "valid" merged PRs (token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE) to receive score
+# Per-repo defaults — each repo may override these in master_repositories.json.
+MIN_VALID_MERGED_PRS = 3  # minimum "valid" merged PRs (token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE) to receive score
 MIN_CREDIBILITY = 0.80  # minimum credibility ratio to receive score
-CREDIBILITY_MULLIGAN_COUNT = 1  # number of closed PRs forgiven (erased from merged+closed counts entirely)
 
 # =============================================================================
 # Issue Discovery
 # =============================================================================
-# Eligibility gate (stricter than OSS contributions)
-MIN_VALID_SOLVED_ISSUES = 7  # minimum solved issues where solving PR has token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
-MIN_ISSUE_CREDIBILITY = 0.80  # minimum issue credibility ratio
+# Eligibility gate — per-repo defaults, overridable in master_repositories.json.
+MIN_VALID_SOLVED_ISSUES = 3  # minimum solved issues where solving PR has token_score >= MIN_TOKEN_SCORE_FOR_VALID_ISSUE
+MIN_ISSUE_CREDIBILITY = 0.70  # minimum issue credibility ratio
+MIN_TOKEN_SCORE_FOR_VALID_ISSUE = 5  # solving-PR token_score for a solved issue to count as "valid"
 
 # Review quality cliff model (different from OSS: has clean bonus + steeper penalty)
 ISSUE_REVIEW_CLEAN_BONUS = 1.1  # multiplier when 0 CHANGES_REQUESTED rounds
 ISSUE_REVIEW_PENALTY_RATE = 0.15  # per CHANGES_REQUESTED round after cliff
 
-# Open issue spam threshold
-OPEN_ISSUE_SPAM_BASE_THRESHOLD = 5  # half the PR base of 10
+# Open issue spam threshold (per-repo: counts a repo's own open issues)
+OPEN_ISSUE_SPAM_BASE_THRESHOLD = 2
 OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT = 300.0  # +1 allowed open issue per this much token score
 MAX_OPEN_ISSUE_THRESHOLD = 30
 
@@ -167,9 +168,9 @@ MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER = 2.0  # Cap open PR collateral growth 
 # Issue multiplier (flat values, no age scaling)
 STANDARD_ISSUE_MULTIPLIER = 1.33  # Non-maintainer issue author
 MAINTAINER_ISSUE_MULTIPLIER = 1.66  # Issue author is OWNER/MEMBER/COLLABORATOR
-# Excessive open PRs penalty
+# Excessive open PRs penalty (per-repo: counts a repo's own open PRs)
 # Multiplier = 1.0 if open PRs <= threshold, 0.0 otherwise
-EXCESSIVE_PR_PENALTY_BASE_THRESHOLD = 10
+EXCESSIVE_PR_PENALTY_BASE_THRESHOLD = 2
 
 # Dynamic open PR threshold bonus for top contributors
 # Bonus = floor(total_token_score / 300)

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -72,7 +72,7 @@ async def forward(self: 'Validator') -> None:
         await issue_competitions(self, miner_evaluations)
 
         # 4. Store all evaluations to DB (includes issue discovery fields)
-        await self.bulk_store_evaluation(miner_evaluations, skip_uids=cached_uids)
+        await self.bulk_store_evaluation(miner_evaluations, master_repositories, skip_uids=cached_uids)
 
         # 5. Allocate repo-bounded emission shares into final rewards
         maintainer_uids_by_repo = _build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -61,15 +61,19 @@ async def issue_competitions(
         if harvest_result and harvest_result.get('status') == 'success':
             bt.logging.success(f'Harvested emissions! Extrinsic: {harvest_result.get("tx_hash", "")}')
 
-        # Build mapping of github_id->hotkey for eligible miners only
-        eligible_miners = {
+        # Build mapping of github_id->hotkey for every registered miner. Bounty
+        # payouts are not eligibility-gated — any miner who solves a bounty
+        # issue can receive the reward.
+        registered_miners = {
             eval.github_id: eval.hotkey
             for eval in miner_evaluations.values()
-            if eval.github_id and eval.github_id != '0' and eval.is_eligible
+            if eval.github_id and eval.github_id != '0'
         }
-        bt.logging.info(f'Issue bounties: {len(eligible_miners)} eligible miners out of {len(miner_evaluations)} total')
-        for github_id, hotkey in eligible_miners.items():
-            bt.logging.info(f'  Eligible miner: github_id={github_id}, hotkey={hotkey[:12]}...')
+        bt.logging.info(
+            f'Issue bounties: {len(registered_miners)} registered miners out of {len(miner_evaluations)} total'
+        )
+        for github_id, hotkey in registered_miners.items():
+            bt.logging.info(f'  Registered miner: github_id={github_id}, hotkey={hotkey[:12]}...')
 
         # Get active issues from contract
         active_issues = contract_client.get_issues_by_status(IssueStatus.ACTIVE)
@@ -123,17 +127,19 @@ async def issue_competitions(
                         bt.logging.info(f'Voted cancel (no solver): {issue_label}')
                     continue
 
-                miner_hotkey = eligible_miners.get(str(solver_github_id))
+                miner_hotkey = registered_miners.get(str(solver_github_id))
                 if not miner_hotkey:
-                    bt.logging.info(f'Solver {solver_github_id} not in eligible miners, voting cancel: {issue_label}')
+                    bt.logging.info(f'Solver {solver_github_id} not a registered miner, voting cancel: {issue_label}')
                     success = contract_client.vote_cancel_issue(
                         issue_id=issue.id,
-                        reason=f'Issue closed externally (not by eligible miner, solver: {solver_github_id})',
+                        reason=f'Issue closed externally (not by a registered miner, solver: {solver_github_id})',
                         wallet=self.wallet,
                     )
                     if success:
                         cancels_cast += 1
-                        bt.logging.info(f'Voted cancel (solver {solver_github_id} not eligible): {issue_label}')
+                        bt.logging.info(
+                            f'Voted cancel (solver {solver_github_id} not a registered miner): {issue_label}'
+                        )
                     continue
 
                 miner_coldkey = get_miner_coldkey(miner_hotkey, self.subtensor)

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -34,13 +34,13 @@ to the cache so sibling discoveries benefit.
 
 import asyncio
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
-from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache
+from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache, RepoEvaluation
 from gittensor.constants import (
     MAINTAINER_ASSOCIATIONS,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
@@ -62,6 +62,7 @@ from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepositoryConfig,
     TokenConfig,
+    resolve_eligibility,
 )
 
 
@@ -97,6 +98,18 @@ class _CacheStats:
     hits: int = 0
     misses: int = 0
     fetch_failures: int = 0
+
+
+@dataclass
+class _RepoIssueAcc:
+    """Per-repository issue-discovery accumulator for one miner."""
+
+    solved: int = 0
+    valid_solved: int = 0
+    closed: int = 0
+    issue_token_score: float = 0.0
+    fetch_failed: bool = False
+    scored_issues: List[Issue] = field(default_factory=list)
 
 
 _FAR_FUTURE = datetime.max.replace(tzinfo=timezone.utc)
@@ -158,7 +171,7 @@ async def run_issue_discovery(
 
     # Phase 1: fetch each miner's issues.  The one-issue-per-PR rule is round-
     # global, so scoring is deferred until every miner's batch is in hand.
-    pending: List[Tuple[MinerEvaluation, List[MirrorIssue], int]] = []
+    pending: List[Tuple[MinerEvaluation, List[MirrorIssue], Dict[str, int]]] = []
     for uid, evaluation in miner_evaluations.items():
         if not evaluation.github_id or evaluation.github_id == '0':
             skipped_no_gh += 1
@@ -183,19 +196,19 @@ async def run_issue_discovery(
             fetch_errors += 1
             continue
 
-        open_issue_count = _count_open_issues(current_response.issues, enabled_names)
+        open_counts = _count_open_issues(current_response.issues, enabled_names)
         filtered = [i for i in response.issues if i.repo_full_name in enabled_names and _should_include_issue(i)]
         if not filtered:
             _clear_issue_discovery_fields(evaluation)
-            evaluation.total_open_issues = open_issue_count
+            _apply_open_issue_counts(evaluation, open_counts)
             cacheable_uids.add(uid)
             no_issues += 1
             continue
 
-        pending.append((evaluation, filtered, open_issue_count))
+        pending.append((evaluation, filtered, open_counts))
 
     canonical_pr_owners = _build_canonical_pr_owners(pending)
-    for evaluation, filtered, open_issue_count in pending:
+    for evaluation, filtered, open_counts in pending:
         complete = await _score_miner_issues(
             evaluation,
             filtered,
@@ -205,7 +218,7 @@ async def run_issue_discovery(
             client,
             programming_languages,
             token_config,
-            open_issue_count=open_issue_count,
+            open_counts=open_counts,
             canonical_pr_owners=canonical_pr_owners,
         )
         if complete:
@@ -242,6 +255,27 @@ def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
     evaluation.total_closed_issues = 0
     evaluation.total_open_issues = 0
     evaluation.issue_discovery_issues = []
+    for repo_eval in evaluation.repo_evaluations.values():
+        repo_eval.is_issue_eligible = False
+        repo_eval.issue_credibility = 0.0
+        repo_eval.issue_discovery_score = 0.0
+        repo_eval.issue_token_score = 0.0
+        repo_eval.total_solved_issues = 0
+        repo_eval.total_valid_solved_issues = 0
+        repo_eval.total_closed_issues = 0
+        repo_eval.total_open_issues = 0
+
+
+def _apply_open_issue_counts(evaluation: MinerEvaluation, open_counts: Dict[str, int]) -> None:
+    """Record per-repo open-issue counts (and the round-level total) for a miner
+    with no in-window issues to score."""
+    for repo_name, count in open_counts.items():
+        repo_eval = evaluation.repo_evaluations.get(repo_name)
+        if repo_eval is None:
+            repo_eval = RepoEvaluation(repository_full_name=repo_name)
+            evaluation.repo_evaluations[repo_name] = repo_eval
+        repo_eval.total_open_issues = count
+    evaluation.total_open_issues = sum(open_counts.values())
 
 
 def _copy_issue_discovery_fields(target: MinerEvaluation, source: MinerEvaluation) -> None:
@@ -254,6 +288,12 @@ def _copy_issue_discovery_fields(target: MinerEvaluation, source: MinerEvaluatio
     target.total_closed_issues = source.total_closed_issues
     target.total_open_issues = source.total_open_issues
     target.issue_discovery_issues = list(source.issue_discovery_issues)
+    for repo_name, source_repo in source.repo_evaluations.items():
+        target_repo = target.repo_evaluations.get(repo_name)
+        if target_repo is None:
+            target_repo = RepoEvaluation(repository_full_name=source_repo.repository_full_name)
+            target.repo_evaluations[repo_name] = target_repo
+        target_repo.copy_issue_discovery_from(source_repo)
 
 
 def _restore_issue_discovery_from_cache(
@@ -279,7 +319,7 @@ def _restore_issue_discovery_from_cache(
 
 
 def _build_canonical_pr_owners(
-    pending: List[Tuple[MinerEvaluation, List[MirrorIssue], int]],
+    pending: List[Tuple[MinerEvaluation, List[MirrorIssue], Dict[str, int]]],
 ) -> Dict[Tuple[str, int], Tuple[datetime, int, int]]:
     """Cross-miner one-issue-per-PR resolution.
 
@@ -306,8 +346,13 @@ def _build_canonical_pr_owners(
     return canonical
 
 
-def _count_open_issues(issues: List[MirrorIssue], enabled_names: Set[str]) -> int:
-    return sum(1 for issue in issues if issue.repo_full_name in enabled_names and issue.state == 'OPEN')
+def _count_open_issues(issues: List[MirrorIssue], enabled_names: Set[str]) -> Dict[str, int]:
+    """Count current OPEN issues per repository (enabled repos only)."""
+    counts: Dict[str, int] = {}
+    for issue in issues:
+        if issue.repo_full_name in enabled_names and issue.state == 'OPEN':
+            counts[issue.repo_full_name] = counts.get(issue.repo_full_name, 0) + 1
+    return counts
 
 
 def _build_solving_pr_cache(
@@ -343,13 +388,14 @@ async def _score_miner_issues(
     client: MirrorClient,
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
-    open_issue_count: int,
+    open_counts: Dict[str, int],
     canonical_pr_owners: Dict[Tuple[str, int], Tuple[datetime, int, int]],
 ) -> bool:
-    """Classify + score one miner's mirror issues, populate MinerEvaluation fields.
+    """Classify + score one miner's mirror issues, per repository.
 
-    ``open_issue_count`` is the miner's current OPEN issue count across
-    registered repos, independent of the issue-scoring lookback window.
+    Each repository gates issue discovery independently from only its own
+    issues. ``open_counts`` maps repo -> the miner's current OPEN issue count
+    there, independent of the issue-scoring lookback window.
 
     ``canonical_pr_owners`` enforces the cross-miner one-issue-per-PR rule:
     only the marker-matching issue scores, siblings count for credibility.
@@ -357,13 +403,7 @@ async def _score_miner_issues(
     Returns ``True`` when all required solving-PR score data was available, so
     the caller can safely refresh the cache with this complete issue snapshot.
     """
-    solved_count = 0
-    valid_solved_count = 0
-    closed_count = 0
-    issue_token_score = 0.0
-    score_fetch_failed = False
-    scored_issues: List[Issue] = []
-    evaluation.issue_discovery_issues = []
+    repo_acc: Dict[str, _RepoIssueAcc] = {}
 
     issues_sorted = sorted(
         issues,
@@ -375,9 +415,15 @@ async def _score_miner_issues(
     )
 
     for issue in issues_sorted:
+        repo_config = mirror_repos.get(issue.repo_full_name)
+        if repo_config is None:
+            continue
+        cfg = resolve_eligibility(repo_config.eligibility)
+        acc = repo_acc.setdefault(issue.repo_full_name, _RepoIssueAcc())
+
         classification = _classify_issue(issue)
         if classification == 'not-solved-closed':
-            closed_count += 1
+            acc.closed += 1
             continue
         if classification == 'ignore':
             continue
@@ -386,10 +432,9 @@ async def _score_miner_issues(
         assert issue.solving_pr is not None  # _classify_issue guarantees
         solving_pr = issue.solving_pr
 
-        solved_count += 1
+        acc.solved += 1
 
         # Resolve real base_score + token_score for the solving PR (cache or fetch)
-        repo_config = mirror_repos.get(issue.repo_full_name)
         cached = await _resolve_solving_pr_score(
             issue,
             solving_pr,
@@ -403,17 +448,17 @@ async def _score_miner_issues(
         if cached is None:
             # Fetch failed — issue still counts for solved/credibility but not scored.
             # Can't apply the valid-solved gate without a real token_score, so be
-            # conservative and don't increment valid_solved_count.
-            score_fetch_failed = True
+            # conservative and don't increment valid_solved.
+            acc.fetch_failed = True
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): solver score unavailable '
                 f'(fetch failed) — credibility only'
             )
             continue
 
-        # Valid-solved gate: solving PR must meet the token threshold.
-        if cached.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE:
-            valid_solved_count += 1
+        # Valid-solved gate: solving PR must meet the repo's token threshold.
+        if cached.token_score >= cfg.min_token_score_for_valid_issue:
+            acc.valid_solved += 1
 
         # Same-account: discoverer == solver gets credibility only, no score
         if issue.author_github_id == solving_pr.author_github_id:
@@ -432,17 +477,13 @@ async def _score_miner_issues(
             )
             continue
 
-        repo_config = mirror_repos.get(issue.repo_full_name)
-        if repo_config is None:
-            continue
-
         # Quality gate: below-threshold solving PRs add credibility only, no
         # discovery score.
-        if cached.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+        if cached.token_score < cfg.min_token_score_for_valid_issue:
             bt.logging.debug(
                 f'  issue #{issue.issue_number} ({issue.repo_full_name}): solving PR '
                 f'#{solving_pr.pr_number} token_score {cached.token_score:.2f} < '
-                f'{MIN_TOKEN_SCORE_FOR_BASE_SCORE} — credibility only'
+                f'{cfg.min_token_score_for_valid_issue} — credibility only'
             )
             continue
 
@@ -450,55 +491,93 @@ async def _score_miner_issues(
         if adapted is None:
             continue
 
-        scored_issues.append(adapted)
-        # Legacy parity: issue_token_score accumulates per-solving-PR token scores
-        # for the open-issue spam multiplier threshold calc.
-        issue_token_score += cached.token_score
+        acc.scored_issues.append(adapted)
+        # issue_token_score accumulates per-solving-PR token scores for the
+        # open-issue spam multiplier threshold calc.
+        acc.issue_token_score += cached.token_score
 
-    evaluation.total_solved_issues = solved_count
-    evaluation.total_valid_solved_issues = valid_solved_count
-    evaluation.total_closed_issues = closed_count
-    evaluation.total_open_issues = open_issue_count
-    evaluation.issue_token_score = round(issue_token_score, 2)
+    _finalize_repo_issue_scores(evaluation, repo_acc, open_counts, mirror_repos)
+    return not any(acc.fetch_failed for acc in repo_acc.values())
 
-    is_eligible, credibility, reason = check_issue_eligibility(solved_count, valid_solved_count, closed_count)
-    evaluation.is_issue_eligible = is_eligible
-    evaluation.issue_credibility = credibility
 
-    if not is_eligible:
+def _finalize_repo_issue_scores(
+    evaluation: MinerEvaluation,
+    repo_acc: Dict[str, _RepoIssueAcc],
+    open_counts: Dict[str, int],
+    mirror_repos: Dict[str, RepositoryConfig],
+) -> None:
+    """Gate + score issue discovery per repository, then roll up the totals."""
+    evaluation.issue_discovery_issues = []
+
+    for repo_name in sorted(set(repo_acc) | set(open_counts)):
+        repo_config = mirror_repos.get(repo_name)
+        if repo_config is None:
+            continue
+        cfg = resolve_eligibility(repo_config.eligibility)
+        acc = repo_acc.get(repo_name) or _RepoIssueAcc()
+        open_count = open_counts.get(repo_name, 0)
+
+        repo_eval = evaluation.repo_evaluations.get(repo_name)
+        if repo_eval is None:
+            repo_eval = RepoEvaluation(repository_full_name=repo_name)
+            evaluation.repo_evaluations[repo_name] = repo_eval
+
+        repo_eval.total_solved_issues = acc.solved
+        repo_eval.total_valid_solved_issues = acc.valid_solved
+        repo_eval.total_closed_issues = acc.closed
+        repo_eval.total_open_issues = open_count
+        repo_eval.issue_token_score = round(acc.issue_token_score, 2)
+
+        is_eligible, credibility, reason = check_issue_eligibility(cfg, acc.solved, acc.valid_solved, acc.closed)
+        repo_eval.is_issue_eligible = is_eligible
+        repo_eval.issue_credibility = credibility
+
+        if not is_eligible:
+            repo_eval.issue_discovery_score = 0.0
+            if acc.solved or acc.closed:
+                bt.logging.info(
+                    f'├─ {repo_name}: issue-ineligible ({reason}) | {acc.solved} solved '
+                    f'({acc.valid_solved} valid) | {acc.closed} closed | {open_count} open'
+                )
+            continue
+
+        spam_mult = calculate_open_issue_spam_multiplier(cfg, open_count, acc.issue_token_score)
+        repo_score = 0.0
+        for issue in acc.scored_issues:
+            issue.discovery_credibility_multiplier = round(credibility, 2)
+            issue.discovery_open_issue_spam_multiplier = spam_mult
+            issue.discovery_earned_score = round(
+                issue.discovery_base_score
+                * issue.discovery_time_decay_multiplier
+                * issue.discovery_review_quality_multiplier
+                * issue.discovery_credibility_multiplier
+                * issue.discovery_open_issue_spam_multiplier,
+                2,
+            )
+            repo_score += issue.discovery_earned_score
+
+        repo_eval.issue_discovery_score = round(repo_score, 2)
+        evaluation.issue_discovery_issues.extend(acc.scored_issues)
         bt.logging.info(
-            f'├─ UID {evaluation.uid}: ineligible ({reason}) | '
-            f'{solved_count} solved ({valid_solved_count} valid) | {closed_count} closed | '
-            f'{open_issue_count} open'
+            f'├─ {repo_name}: {acc.solved} solved ({acc.valid_solved} valid) | {acc.closed} closed | '
+            f'{open_count} open | {len(acc.scored_issues)} scored | credibility={credibility:.2f} | '
+            f'spam_mult={spam_mult:.1f} | discovery_score={repo_eval.issue_discovery_score:.2f}'
         )
-        return not score_fetch_failed
 
-    spam_mult = calculate_open_issue_spam_multiplier(open_issue_count, issue_token_score)
+    _roll_up_issue_totals(evaluation)
 
-    total_discovery_score = 0.0
-    for issue in scored_issues:
-        issue.discovery_credibility_multiplier = round(credibility, 2)
-        issue.discovery_open_issue_spam_multiplier = spam_mult
-        issue.discovery_earned_score = round(
-            issue.discovery_base_score
-            * issue.discovery_time_decay_multiplier
-            * issue.discovery_review_quality_multiplier
-            * issue.discovery_credibility_multiplier
-            * issue.discovery_open_issue_spam_multiplier,
-            2,
-        )
-        total_discovery_score += issue.discovery_earned_score
 
-    evaluation.issue_discovery_score = round(total_discovery_score, 2)
-    evaluation.issue_discovery_issues = scored_issues
-
-    bt.logging.info(
-        f'├─ UID {evaluation.uid}: {solved_count} solved ({valid_solved_count} valid) | '
-        f'{closed_count} closed | {open_issue_count} open | {len(scored_issues)} scored | '
-        f'credibility={credibility:.2f} | spam_mult={spam_mult:.1f} | '
-        f'discovery_score={total_discovery_score:.2f}'
-    )
-    return not score_fetch_failed
+def _roll_up_issue_totals(evaluation: MinerEvaluation) -> None:
+    """Roll per-repo issue-discovery results up into the round-level scalars."""
+    repo_evals = list(evaluation.repo_evaluations.values())
+    evaluation.total_solved_issues = sum(re.total_solved_issues for re in repo_evals)
+    evaluation.total_valid_solved_issues = sum(re.total_valid_solved_issues for re in repo_evals)
+    evaluation.total_closed_issues = sum(re.total_closed_issues for re in repo_evals)
+    evaluation.total_open_issues = sum(re.total_open_issues for re in repo_evals)
+    evaluation.issue_token_score = round(sum(re.issue_token_score for re in repo_evals), 2)
+    evaluation.issue_discovery_score = round(sum(re.issue_discovery_score for re in repo_evals), 2)
+    evaluation.is_issue_eligible = any(re.is_issue_eligible for re in repo_evals)
+    evaluation.issue_credibility = max((re.issue_credibility for re in repo_evals), default=0.0)
 
 
 async def _resolve_solving_pr_score(

--- a/gittensor/validator/issue_discovery/scoring.py
+++ b/gittensor/validator/issue_discovery/scoring.py
@@ -7,25 +7,21 @@ The legacy timeline-scraping path (``score_discovered_issues``,
 ``_collect_issues_from_prs``, ``_merge_scan_issues``, ``scan_closed_issues``)
 has been removed — unreliable solver detection was the original motivator for
 migrating issue discovery to the mirror. The functions here are the math-only
-helpers still used by ``issue_discovery.scan``: the
-review-quality multiplier, open-issue spam threshold, credibility formula, and
-eligibility gate.
+helpers still used by ``issue_discovery.scan``: the review-quality multiplier,
+open-issue spam threshold, credibility formula, and per-repo eligibility gate.
 """
 
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 
 import bittensor as bt
 
 from gittensor.constants import (
-    CREDIBILITY_MULLIGAN_COUNT,
     ISSUE_REVIEW_CLEAN_BONUS,
     ISSUE_REVIEW_PENALTY_RATE,
-    MAX_OPEN_ISSUE_THRESHOLD,
-    MIN_ISSUE_CREDIBILITY,
-    MIN_VALID_SOLVED_ISSUES,
-    OPEN_ISSUE_SPAM_BASE_THRESHOLD,
-    OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
 )
+
+if TYPE_CHECKING:
+    from gittensor.validator.utils.load_weights import ResolvedEligibility
 
 
 def calculate_issue_review_quality_multiplier(changes_requested_count: int) -> float:
@@ -47,44 +43,50 @@ def calculate_issue_review_quality_multiplier(changes_requested_count: int) -> f
     return multiplier
 
 
-def calculate_open_issue_spam_multiplier(total_open_issues: int, solved_token_score: float) -> float:
-    """Binary penalty for excessive open issues.
+def calculate_open_issue_spam_multiplier(
+    cfg: 'ResolvedEligibility', total_open_issues: int, solved_token_score: float
+) -> float:
+    """Binary penalty for excessive open issues within one repository.
 
-    threshold = min(BASE + floor(token_score / PER_SLOT), MAX)
-    Returns 1.0 if under threshold, 0.0 otherwise.
+    threshold = min(base + floor(token_score / per_slot), max)
+    Returns 1.0 if at or under threshold, 0.0 otherwise.
     """
-    bonus = int(solved_token_score // OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT)
-    threshold = min(OPEN_ISSUE_SPAM_BASE_THRESHOLD + bonus, MAX_OPEN_ISSUE_THRESHOLD)
+    bonus = int(solved_token_score // cfg.open_issue_spam_token_score_per_slot)
+    threshold = min(cfg.open_issue_spam_base_threshold + bonus, cfg.max_open_issue_threshold)
     return 1.0 if total_open_issues <= threshold else 0.0
 
 
 def calculate_issue_credibility(solved_count: int, closed_count: int) -> float:
-    """Calculate issue credibility with mulligan.
+    """Calculate issue credibility: solved / (solved + closed).
 
-    credibility = solved / (solved + max(0, closed - mulligan))
+    Returns credibility in [0.0, 1.0], or 0.0 when there are no attempts.
     """
-    adjusted_closed = max(0, closed_count - CREDIBILITY_MULLIGAN_COUNT)
-    total = solved_count + adjusted_closed
+    total = solved_count + closed_count
     if total == 0:
         return 0.0
     return solved_count / total
 
 
-def check_issue_eligibility(solved_count: int, valid_solved_count: int, closed_count: int) -> Tuple[bool, float, str]:
-    """Check if a miner passes the issue discovery eligibility gate.
+def check_issue_eligibility(
+    cfg: 'ResolvedEligibility',
+    solved_count: int,
+    valid_solved_count: int,
+    closed_count: int,
+) -> Tuple[bool, float, str]:
+    """Check whether a miner passes one repository's issue-discovery gate.
 
-    Credibility uses total solved / total attempts (with mulligan).
-    The gate uses ``valid_solved_count`` (solving PR meets token threshold)
-    so low-quality solves don't carry the miner past the minimum.
+    Credibility uses total solved / total attempts. The gate uses
+    ``valid_solved_count`` (solving PR meets the token threshold) so
+    low-quality solves don't carry the miner past the minimum.
 
     Returns (is_eligible, issue_credibility, reason).
     """
     credibility = calculate_issue_credibility(solved_count, closed_count)
 
-    if valid_solved_count < MIN_VALID_SOLVED_ISSUES:
-        return False, credibility, f'{valid_solved_count}/{MIN_VALID_SOLVED_ISSUES} valid solved issues'
+    if valid_solved_count < cfg.min_valid_solved_issues:
+        return False, credibility, f'{valid_solved_count}/{cfg.min_valid_solved_issues} valid solved issues'
 
-    if credibility < MIN_ISSUE_CREDIBILITY:
-        return False, credibility, f'Issue credibility {credibility:.2f} < {MIN_ISSUE_CREDIBILITY}'
+    if credibility < cfg.min_issue_credibility:
+        return False, credibility, f'issue credibility {credibility:.2f} < {cfg.min_issue_credibility}'
 
     return True, credibility, ''

--- a/gittensor/validator/oss_contributions/credibility.py
+++ b/gittensor/validator/oss_contributions/credibility.py
@@ -3,63 +3,47 @@
 
 from typing import TYPE_CHECKING, Sequence, Tuple
 
-import bittensor as bt
-
-from gittensor.constants import (
-    CREDIBILITY_MULLIGAN_COUNT,
-    MIN_CREDIBILITY,
-    MIN_TOKEN_SCORE_FOR_BASE_SCORE,
-    MIN_VALID_MERGED_PRS,
-)
-
 if TYPE_CHECKING:
     from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
+    from gittensor.validator.utils.load_weights import ResolvedEligibility
 
 
 def calculate_credibility(merged_prs: Sequence['ScoredPR'], closed_prs: Sequence['ScoredPR']) -> float:
-    """Calculate flat credibility ratio with mulligan applied.
+    """Calculate the flat credibility ratio: merged / (merged + closed).
 
-    Mulligan: up to CREDIBILITY_MULLIGAN_COUNT closed PRs are erased entirely —
-    they don't count in the denominator (merged + closed).
-
-    Returns credibility in [0.0, 1.0], or 0.0 if no attempts after mulligan.
+    Returns credibility in [0.0, 1.0], or 0.0 when there are no attempts.
     """
-    merged_count = len(merged_prs)
-    closed_count = max(0, len(closed_prs) - CREDIBILITY_MULLIGAN_COUNT)
-    total_attempts = merged_count + closed_count
-
+    total_attempts = len(merged_prs) + len(closed_prs)
     if total_attempts == 0:
         return 0.0
 
-    return merged_count / total_attempts
+    return len(merged_prs) / total_attempts
 
 
-def check_eligibility(merged_prs: Sequence['ScoredPR'], closed_prs: Sequence['ScoredPR']) -> Tuple[bool, float, str]:
-    """Check if a miner passes the eligibility gate.
+def check_eligibility(
+    merged_prs: Sequence['ScoredPR'],
+    closed_prs: Sequence['ScoredPR'],
+    cfg: 'ResolvedEligibility',
+) -> Tuple[bool, float, str]:
+    """Check whether a miner passes one repository's eligibility gate.
 
     Gate requires:
-    1. At least MIN_VALID_MERGED_PRS merged PRs with token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE
-       (after mulligan — if a closed PR was "valid", it no longer counts toward the minimum)
-    2. At least MIN_CREDIBILITY credibility (after mulligan)
+    1. At least ``cfg.min_valid_merged_prs`` merged PRs with
+       ``token_score >= cfg.min_token_score_for_base_score``
+    2. At least ``cfg.min_credibility`` credibility
 
     Returns:
         (is_eligible, credibility, reason)
-        reason is empty string if eligible, otherwise explains why not.
+        reason is an empty string when eligible, otherwise explains why not.
     """
     credibility = calculate_credibility(merged_prs, closed_prs)
 
-    # Count valid merged PRs (token_score >= threshold)
-    valid_merged_count = sum(1 for pr in merged_prs if pr.token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE)
+    valid_merged_count = sum(1 for pr in merged_prs if pr.token_score >= cfg.min_token_score_for_base_score)
 
-    if valid_merged_count < MIN_VALID_MERGED_PRS:
-        reason = f'{valid_merged_count}/{MIN_VALID_MERGED_PRS} valid merged PRs (need {MIN_VALID_MERGED_PRS})'
-        bt.logging.info(f'Ineligible: {reason}')
-        return False, credibility, reason
+    if valid_merged_count < cfg.min_valid_merged_prs:
+        return False, credibility, f'{valid_merged_count}/{cfg.min_valid_merged_prs} valid merged PRs'
 
-    if credibility < MIN_CREDIBILITY:
-        reason = f'Credibility {credibility:.2f} < {MIN_CREDIBILITY} minimum'
-        bt.logging.info(f'Ineligible: {reason}')
-        return False, credibility, reason
+    if credibility < cfg.min_credibility:
+        return False, credibility, f'credibility {credibility:.2f} < {cfg.min_credibility} minimum'
 
-    bt.logging.info(f'Eligible: {valid_merged_count} valid PRs, credibility {credibility:.2f}')
     return True, credibility, ''

--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -72,6 +72,7 @@ def _zero_for_duplicate_penalty(eval_: MinerEvaluation, reason: str) -> None:
     eval_.closed_prs = []
     eval_.unique_repos_contributed_to = set()
     eval_.unique_repos_count = 0
+    eval_.repo_evaluations = {}
     eval_.is_eligible = False
     eval_.credibility = 0.0
     eval_.total_score = 0.0

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -1,24 +1,21 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import bittensor as bt
 
-from gittensor.classes import MinerEvaluation
+from gittensor.classes import MinerEvaluation, RepoEvaluation
 
 if TYPE_CHECKING:
     from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
 from gittensor.constants import (
-    EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
     MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER,
-    MAX_OPEN_PR_THRESHOLD,
     OPEN_PR_COLLATERAL_PERCENT,
-    OPEN_PR_THRESHOLD_TOKEN_SCORE,
     REVIEW_PENALTY_RATE,
 )
 from gittensor.validator.oss_contributions.credibility import check_eligibility
-from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.utils.load_weights import RepositoryConfig, ResolvedEligibility, resolve_eligibility
 
 
 def calculate_review_quality_multiplier(changes_requested_count: int, pr_number: Optional[int] = None) -> float:
@@ -56,42 +53,40 @@ def calculate_review_collateral_multiplier(changes_requested_count: int, pr_numb
     return multiplier
 
 
-def calculate_open_pr_threshold(total_token_score: float = 0.0) -> int:
-    """Calculate dynamic open PR threshold based on total token score.
+def calculate_open_pr_threshold(cfg: ResolvedEligibility, total_token_score: float = 0.0) -> int:
+    """Calculate the dynamic open-PR threshold for one repository.
 
-    Bonus = floor(total_token_score / OPEN_PR_THRESHOLD_TOKEN_SCORE)
-    Threshold = min(BASE_THRESHOLD + bonus, MAX_OPEN_PR_THRESHOLD)
+    Bonus = floor(total_token_score / cfg.open_pr_threshold_token_score)
+    Threshold = min(cfg.excessive_pr_penalty_base_threshold + bonus, cfg.max_open_pr_threshold)
     """
-    bonus = int(total_token_score // OPEN_PR_THRESHOLD_TOKEN_SCORE)
-    return min(EXCESSIVE_PR_PENALTY_BASE_THRESHOLD + bonus, MAX_OPEN_PR_THRESHOLD)
+    bonus = int(total_token_score // cfg.open_pr_threshold_token_score)
+    return min(cfg.excessive_pr_penalty_base_threshold + bonus, cfg.max_open_pr_threshold)
 
 
-def calculate_pr_spam_penalty_multiplier(total_open_prs: int, total_token_score: float = 0.0) -> float:
-    """Apply penalty for excessive open PRs.
+def calculate_pr_spam_penalty_multiplier(
+    cfg: ResolvedEligibility, total_open_prs: int, total_token_score: float = 0.0
+) -> float:
+    """Apply the penalty for excessive open PRs within one repository.
 
-    Binary multiplier: 1.0 if open PRs <= threshold, 0.0 otherwise.
+    Binary multiplier: 1.0 if the repo's open PRs <= threshold, 0.0 otherwise.
     """
-    threshold = calculate_open_pr_threshold(total_token_score)
+    threshold = calculate_open_pr_threshold(cfg, total_token_score)
     return 1.0 if total_open_prs <= threshold else 0.0
-
-
-def _pr_bypasses_eligibility(
-    pr: 'ScoredPR',
-    master_repositories: Dict[str, RepositoryConfig],
-) -> bool:
-    repo_config = master_repositories.get(pr.repository_full_name)
-    return repo_config is not None and not repo_config.eligibility_mode
 
 
 def finalize_miner_scores(
     miner_evaluations: Dict[int, MinerEvaluation],
     master_repositories: Optional[Dict[str, RepositoryConfig]] = None,
 ) -> None:
-    """Finalize all miner scores: compute earned_scores, then collateral, then aggregate."""
+    """Finalize miner scores per repository.
+
+    Each repository gates and scores independently, from only its own PRs,
+    against its own resolved eligibility config. Per-repo results land on
+    ``evaluation.repo_evaluations`` and roll up into the round-level scalars.
+    """
     bt.logging.info('**Finalizing miner scores**')
     master_repositories = master_repositories or {}
 
-    # Phase 1: Compute all earned_scores (base × multipliers) for every miner
     for uid, evaluation in miner_evaluations.items():
         if not evaluation:
             continue
@@ -101,101 +96,117 @@ def finalize_miner_scores(
         bt.logging.info(f'UID {uid}')
         bt.logging.info('=' * 50)
 
-        # Compute collateral on each open PR; defer accumulation so eligibility-disabled
-        # repos don't reduce gated repo rewards (and vice versa).
         for pr in evaluation.open_prs:
             pr.collateral_score = calculate_open_pr_collateral_score(pr)
 
-        has_contributions = evaluation.total_merged_prs > 0 or evaluation.total_closed_prs > 0
-
-        if not has_contributions:
-            evaluation.total_collateral_score += sum(pr.collateral_score for pr in evaluation.open_prs)
-            bt.logging.info('No merged or closed PRs - skipping evaluation')
-            continue
-
-        gated_open_prs = [pr for pr in evaluation.open_prs if not _pr_bypasses_eligibility(pr, master_repositories)]
-        bypass_open_prs = [pr for pr in evaluation.open_prs if _pr_bypasses_eligibility(pr, master_repositories)]
-        gated_merged_prs = [pr for pr in evaluation.merged_prs if not _pr_bypasses_eligibility(pr, master_repositories)]
-        gated_closed_prs = [pr for pr in evaluation.closed_prs if not _pr_bypasses_eligibility(pr, master_repositories)]
-        bypass_merged_prs = [pr for pr in evaluation.merged_prs if _pr_bypasses_eligibility(pr, master_repositories)]
-
-        # Check eligibility for the gated portfolio only. eligibility_mode=false
-        # PRs must neither unlock nor penalize repos where the gate still applies.
-        is_eligible, credibility, reason = check_eligibility(gated_merged_prs, gated_closed_prs)
-        evaluation.is_eligible = is_eligible
-        evaluation.credibility = credibility
-
-        scorable_prs: list['ScoredPR'] = []
-        if is_eligible:
-            scorable_prs.extend(gated_merged_prs)
-        elif bypass_merged_prs:
-            bt.logging.info(
-                f'UID {uid} ineligible: {reason} — scoring '
-                f'{len(bypass_merged_prs)} PR(s) from eligibility_mode=false repos'
-            )
-        else:
-            bt.logging.info(f'UID {uid} ineligible: {reason} — score set to 0')
-            evaluation.total_collateral_score += sum(pr.collateral_score for pr in gated_open_prs)
-            continue
-        scorable_prs.extend(bypass_merged_prs)
-
-        gated_token_score = sum(pr.token_score for pr in gated_merged_prs)
-        gated_spam_multiplier = calculate_pr_spam_penalty_multiplier(len(gated_open_prs), gated_token_score)
-
-        # Bypass spam math intentionally uses total_open_prs (one-way isolation): gated
-        # open PRs penalize bypass earnings so eligibility-disabled repos can't be used
-        # as a spam-vector escape hatch.
-        bypass_token_score = sum(pr.token_score for pr in bypass_merged_prs)
-        bypass_spam_multiplier = calculate_pr_spam_penalty_multiplier(evaluation.total_open_prs, bypass_token_score)
-
-        if is_eligible:
-            evaluation.total_collateral_score += sum(pr.collateral_score for pr in gated_open_prs)
-        if bypass_merged_prs:
-            evaluation.total_collateral_score += sum(pr.collateral_score for pr in bypass_open_prs)
-
-        credibility_multiplier = round(credibility, 2)
-
-        for pr in scorable_prs:
-            bypasses_gate = _pr_bypasses_eligibility(pr, master_repositories)
-            pr.open_pr_spam_multiplier = bypass_spam_multiplier if bypasses_gate else gated_spam_multiplier
-            pr.credibility_multiplier = 1.0 if bypasses_gate else credibility_multiplier
-            pr.calculate_final_earned_score()
-
-            evaluation.total_token_score += pr.token_score
-            evaluation.total_structural_count += pr.structural_count
-            evaluation.total_structural_score += pr.structural_score
-            evaluation.total_leaf_count += pr.leaf_count
-            evaluation.total_leaf_score += pr.leaf_score
-
-    # Phase 2: Aggregate totals, apply collateral, log summary
-    for uid, evaluation in miner_evaluations.items():
-        if not evaluation:
-            continue
-
-        has_contributions = evaluation.total_merged_prs > 0 or evaluation.total_closed_prs > 0
-        if not has_contributions:
-            continue
-
-        for pr in evaluation.merged_prs:
-            evaluation.base_total_score += pr.base_score
-            evaluation.total_score += pr.earned_score
-            evaluation.total_nodes_scored += pr.total_nodes_scored
-
-        earned_score = evaluation.total_score
-        evaluation.total_score = max(0.0, earned_score - evaluation.total_collateral_score)
-        evaluation.unique_repos_count = len(evaluation.unique_repos_contributed_to)
-
-        bt.logging.info('')
-        bt.logging.info('Summary:')
-        bt.logging.info(
-            f'├─ Score: {earned_score:.2f} - {evaluation.total_collateral_score:.2f} collateral = {evaluation.total_score:.2f}'
-        )
-        bt.logging.info(
-            f'├─ PRs: {evaluation.total_merged_prs} merged | {evaluation.total_open_prs} open | {evaluation.total_closed_prs} closed'
-        )
-        bt.logging.info(f'└─ Eligible: {evaluation.is_eligible} | Credibility: {evaluation.credibility:.2f}')
+        _score_miner_repos(evaluation, master_repositories)
+        _roll_up_miner_totals(evaluation)
 
     bt.logging.info('Finalization complete.')
+
+
+def _group_prs_by_repo(prs: List['ScoredPR']) -> Dict[str, List['ScoredPR']]:
+    grouped: Dict[str, List['ScoredPR']] = {}
+    for pr in prs:
+        grouped.setdefault(pr.repository_full_name.lower(), []).append(pr)
+    return grouped
+
+
+def _score_miner_repos(
+    evaluation: MinerEvaluation,
+    master_repositories: Dict[str, RepositoryConfig],
+) -> None:
+    """Gate and score each repository the miner contributed to, independently."""
+    merged_by_repo = _group_prs_by_repo(evaluation.merged_prs)
+    open_by_repo = _group_prs_by_repo(evaluation.open_prs)
+    closed_by_repo = _group_prs_by_repo(evaluation.closed_prs)
+
+    for repo_name in sorted(set(merged_by_repo) | set(open_by_repo) | set(closed_by_repo)):
+        repo_config = master_repositories.get(repo_name)
+        if repo_config is None:
+            # PRs from untracked repos are dropped upstream; skip defensively.
+            continue
+        cfg = resolve_eligibility(repo_config.eligibility)
+        merged = merged_by_repo.get(repo_name, [])
+        open_prs = open_by_repo.get(repo_name, [])
+        closed = closed_by_repo.get(repo_name, [])
+
+        repo_eval = RepoEvaluation(
+            repository_full_name=repo_name,
+            total_merged_prs=len(merged),
+            total_open_prs=len(open_prs),
+            total_closed_prs=len(closed),
+        )
+        repo_eval.total_collateral_score = sum(pr.collateral_score for pr in open_prs)
+        repo_eval.base_total_score = sum(pr.base_score for pr in merged)
+        repo_eval.total_token_score = sum(pr.token_score for pr in merged)
+        repo_eval.total_structural_count = sum(pr.structural_count for pr in merged)
+        repo_eval.total_structural_score = sum(pr.structural_score for pr in merged)
+        repo_eval.total_leaf_count = sum(pr.leaf_count for pr in merged)
+        repo_eval.total_leaf_score = sum(pr.leaf_score for pr in merged)
+        repo_eval.total_nodes_scored = sum(pr.total_nodes_scored for pr in merged)
+
+        is_eligible, credibility, reason = check_eligibility(merged, closed, cfg)
+        repo_eval.is_eligible = is_eligible
+        repo_eval.credibility = credibility
+
+        if is_eligible:
+            _score_eligible_repo_prs(repo_eval, merged, open_prs, cfg)
+        else:
+            bt.logging.info(f'├─ {repo_name}: ineligible — {reason}')
+
+        repo_eval.total_score = max(0.0, repo_eval.total_score - repo_eval.total_collateral_score)
+        evaluation.repo_evaluations[repo_name] = repo_eval
+
+
+def _score_eligible_repo_prs(
+    repo_eval: RepoEvaluation,
+    merged: List['ScoredPR'],
+    open_prs: List['ScoredPR'],
+    cfg: ResolvedEligibility,
+) -> None:
+    """Compute earned scores for an eligible repository's merged PRs."""
+    spam_multiplier = calculate_pr_spam_penalty_multiplier(cfg, len(open_prs), repo_eval.total_token_score)
+    credibility_multiplier = round(repo_eval.credibility, 2)
+
+    for pr in merged:
+        pr.open_pr_spam_multiplier = spam_multiplier
+        pr.credibility_multiplier = credibility_multiplier
+        pr.calculate_final_earned_score()
+        repo_eval.total_score += pr.earned_score
+
+    bt.logging.info(
+        f'├─ {repo_eval.repository_full_name}: eligible — '
+        f'credibility {repo_eval.credibility:.2f}, earned {repo_eval.total_score:.2f}'
+    )
+
+
+def _roll_up_miner_totals(evaluation: MinerEvaluation) -> None:
+    """Roll the per-repo evaluations up into the miner's round-level scalars."""
+    repo_evals = list(evaluation.repo_evaluations.values())
+
+    evaluation.base_total_score = sum(re.base_total_score for re in repo_evals)
+    evaluation.total_score = sum(re.total_score for re in repo_evals)
+    evaluation.total_collateral_score = sum(re.total_collateral_score for re in repo_evals)
+    evaluation.total_token_score = sum(re.total_token_score for re in repo_evals)
+    evaluation.total_structural_count = sum(re.total_structural_count for re in repo_evals)
+    evaluation.total_structural_score = sum(re.total_structural_score for re in repo_evals)
+    evaluation.total_leaf_count = sum(re.total_leaf_count for re in repo_evals)
+    evaluation.total_leaf_score = sum(re.total_leaf_score for re in repo_evals)
+    evaluation.total_nodes_scored = sum(re.total_nodes_scored for re in repo_evals)
+    evaluation.is_eligible = any(re.is_eligible for re in repo_evals)
+    evaluation.credibility = max((re.credibility for re in repo_evals), default=0.0)
+    evaluation.unique_repos_count = len(evaluation.unique_repos_contributed_to)
+
+    eligible_repos = sum(1 for re in repo_evals if re.is_eligible)
+    bt.logging.info('')
+    bt.logging.info('Summary:')
+    bt.logging.info(f'├─ Score: {evaluation.total_score:.2f} | collateral {evaluation.total_collateral_score:.2f}')
+    bt.logging.info(
+        f'├─ PRs: {evaluation.total_merged_prs} merged | {evaluation.total_open_prs} open '
+        f'| {evaluation.total_closed_prs} closed'
+    )
+    bt.logging.info(f'└─ Eligible in {eligible_repos}/{len(repo_evals)} repo(s)')
 
 
 def calculate_open_pr_collateral_score(pr: 'ScoredPR') -> float:

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -159,24 +159,24 @@ DO UPDATE SET
     file_extension = EXCLUDED.file_extension
 """
 
-# Miner Evaluation Queries
+# Miner Evaluation Queries — one row per (uid, hotkey, github_id, repository_full_name).
 BULK_UPSERT_MINER_EVALUATION = """
 INSERT INTO miner_evaluations (
-    uid, hotkey, github_id, failed_reason, base_total_score, total_score, total_collateral_score,
-    total_nodes_scored, total_open_prs, total_closed_prs, total_merged_prs, total_prs,
+    uid, hotkey, github_id, repository_full_name, failed_reason, base_total_score, total_score,
+    total_collateral_score, total_nodes_scored, total_open_prs, total_closed_prs, total_merged_prs, total_prs,
     unique_repos_count, is_eligible, credibility,
     total_token_score, total_structural_count, total_structural_score, total_leaf_count, total_leaf_score,
     issue_discovery_score, issue_token_score, issue_credibility, is_issue_eligible,
     total_solved_issues, total_valid_solved_issues, total_closed_issues, total_open_issues
 ) VALUES (
     %s, %s, %s, %s, %s, %s, %s,
-    %s, %s, %s, %s, %s,
+    %s, %s, %s, %s, %s, %s,
     %s, %s, %s,
     %s, %s, %s, %s, %s,
     %s, %s, %s, %s,
     %s, %s, %s, %s
 )
-ON CONFLICT (uid, hotkey, github_id)
+ON CONFLICT (uid, hotkey, github_id, repository_full_name)
 DO UPDATE SET
     failed_reason = EXCLUDED.failed_reason,
     base_total_score = EXCLUDED.base_total_score,

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -8,11 +8,12 @@ and miner evaluations.
 
 import logging
 from contextlib import contextmanager
-from typing import List
+from typing import Dict, List
 
 import numpy as np
 
-from gittensor.classes import FileChange, Issue, Miner, MinerEvaluation, PullRequest
+from gittensor.classes import FileChange, Issue, Miner, MinerEvaluation, PullRequest, RepoEvaluation
+from gittensor.validator.utils.load_weights import RepositoryConfig
 
 from .queries import (
     BULK_UPSERT_FILE_CHANGES,
@@ -333,49 +334,65 @@ class Repository(BaseRepository):
             self.logger.error(f'Error in bulk file change storage: {e} | PRs: {prs}')
             return 0
 
-    def set_miner_evaluation(self, evaluation: MinerEvaluation, commit: bool = True) -> bool:
+    def set_miner_evaluation(
+        self,
+        evaluation: MinerEvaluation,
+        master_repositories: Dict[str, RepositoryConfig],
+        commit: bool = True,
+    ) -> bool:
         """
-        Insert or update a miner evaluation.
+        Insert or update a miner evaluation, one row per master-list repository.
+
+        A row is written for every repo in ``master_repositories``; repos the
+        miner never engaged get a zeroed RepoEvaluation.
 
         Args:
             evaluation: MinerEvaluation object to store
+            master_repositories: The full master repo registry (one row each)
             commit: Whether to commit after execution (default True)
 
         Returns:
             True if successful, False otherwise
         """
-        eval_values = [
-            (
-                evaluation.uid,
-                evaluation.hotkey,
-                evaluation.github_id,
-                evaluation.failed_reason,
-                evaluation.base_total_score,
-                evaluation.total_score,
-                evaluation.total_collateral_score,
-                evaluation.total_nodes_scored,
-                evaluation.total_open_prs,
-                evaluation.total_closed_prs,
-                evaluation.total_merged_prs,
-                evaluation.total_prs,
-                evaluation.unique_repos_count,
-                evaluation.is_eligible,
-                evaluation.credibility,
-                evaluation.total_token_score,
-                evaluation.total_structural_count,
-                evaluation.total_structural_score,
-                evaluation.total_leaf_count,
-                evaluation.total_leaf_score,
-                evaluation.issue_discovery_score,
-                evaluation.issue_token_score,
-                evaluation.issue_credibility,
-                evaluation.is_issue_eligible,
-                evaluation.total_solved_issues,
-                evaluation.total_valid_solved_issues,
-                evaluation.total_closed_issues,
-                evaluation.total_open_issues,
+        eval_values = []
+        for repo_name in master_repositories:
+            repo_eval = evaluation.repo_evaluations.get(repo_name) or RepoEvaluation(repository_full_name=repo_name)
+            eval_values.append(
+                (
+                    evaluation.uid,
+                    evaluation.hotkey,
+                    evaluation.github_id,
+                    repo_name,
+                    evaluation.failed_reason,
+                    repo_eval.base_total_score,
+                    repo_eval.total_score,
+                    repo_eval.total_collateral_score,
+                    repo_eval.total_nodes_scored,
+                    repo_eval.total_open_prs,
+                    repo_eval.total_closed_prs,
+                    repo_eval.total_merged_prs,
+                    repo_eval.total_prs,
+                    evaluation.unique_repos_count,
+                    repo_eval.is_eligible,
+                    repo_eval.credibility,
+                    repo_eval.total_token_score,
+                    repo_eval.total_structural_count,
+                    repo_eval.total_structural_score,
+                    repo_eval.total_leaf_count,
+                    repo_eval.total_leaf_score,
+                    repo_eval.issue_discovery_score,
+                    repo_eval.issue_token_score,
+                    repo_eval.issue_credibility,
+                    repo_eval.is_issue_eligible,
+                    repo_eval.total_solved_issues,
+                    repo_eval.total_valid_solved_issues,
+                    repo_eval.total_closed_issues,
+                    repo_eval.total_open_issues,
+                )
             )
-        ]
+
+        if not eval_values:
+            return True
 
         try:
             with self.get_cursor() as cursor:

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -7,7 +7,23 @@ from typing import Any, Dict, List, Optional
 
 import bittensor as bt
 
-from gittensor.constants import DEFAULT_ISSUE_DISCOVERY_SHARE, EMISSION_SHARE_TOLERANCE, NON_CODE_EXTENSIONS
+from gittensor.constants import (
+    DEFAULT_ISSUE_DISCOVERY_SHARE,
+    EMISSION_SHARE_TOLERANCE,
+    EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
+    MAX_OPEN_ISSUE_THRESHOLD,
+    MAX_OPEN_PR_THRESHOLD,
+    MIN_CREDIBILITY,
+    MIN_ISSUE_CREDIBILITY,
+    MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+    MIN_TOKEN_SCORE_FOR_VALID_ISSUE,
+    MIN_VALID_MERGED_PRS,
+    MIN_VALID_SOLVED_ISSUES,
+    NON_CODE_EXTENSIONS,
+    OPEN_ISSUE_SPAM_BASE_THRESHOLD,
+    OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
+    OPEN_PR_THRESHOLD_TOKEN_SCORE,
+)
 
 
 @dataclass
@@ -21,6 +37,46 @@ class LanguageConfig:
 
     weight: float
     language: Optional[str] = None
+
+
+@dataclass
+class RepoEligibilityConfig:
+    """Per-repo overrides for the eligibility / spam knobs.
+
+    Every field is optional; ``None`` means "use the global default constant".
+    Resolve a config into concrete values with ``resolve_eligibility``.
+    """
+
+    min_valid_merged_prs: Optional[int] = None
+    min_credibility: Optional[float] = None
+    min_token_score_for_base_score: Optional[float] = None
+    excessive_pr_penalty_base_threshold: Optional[int] = None
+    open_pr_threshold_token_score: Optional[float] = None
+    max_open_pr_threshold: Optional[int] = None
+    min_valid_solved_issues: Optional[int] = None
+    min_issue_credibility: Optional[float] = None
+    min_token_score_for_valid_issue: Optional[float] = None
+    open_issue_spam_base_threshold: Optional[int] = None
+    open_issue_spam_token_score_per_slot: Optional[float] = None
+    max_open_issue_threshold: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ResolvedEligibility:
+    """A ``RepoEligibilityConfig`` with every override resolved to a concrete value."""
+
+    min_valid_merged_prs: int
+    min_credibility: float
+    min_token_score_for_base_score: float
+    excessive_pr_penalty_base_threshold: int
+    open_pr_threshold_token_score: float
+    max_open_pr_threshold: int
+    min_valid_solved_issues: int
+    min_issue_credibility: float
+    min_token_score_for_valid_issue: float
+    open_issue_spam_base_threshold: int
+    open_issue_spam_token_score_per_slot: float
+    max_open_issue_threshold: int
 
 
 @dataclass
@@ -41,8 +97,9 @@ class RepositoryConfig:
             pattern matches. Defaults to neutral scoring.
         fixed_base_score: Override for the PR base score. Expected
             to be within [0.0, 100.0]; range is enforced by the live-config test.
-        eligibility_mode: Flag controlling whether the global miner
-            eligibility gate applies to PRs in this repo.
+        eligibility: Per-repo overrides for the eligibility / spam knobs. Unset
+            fields fall back to the global default constants — see
+            ``resolve_eligibility``.
         maintainer_cut: Fraction [0.0, 1.0] of this repo's emission slice
             routed directly to its maintainer miner neurons, split evenly,
             before normal scoring. Defaults to 0.0 (no carve-out).
@@ -56,8 +113,37 @@ class RepositoryConfig:
     label_multipliers: Optional[Dict[str, float]] = None
     default_label_multiplier: float = 1.0
     fixed_base_score: Optional[float] = None
-    eligibility_mode: bool = True
+    eligibility: RepoEligibilityConfig = field(default_factory=RepoEligibilityConfig)
     maintainer_cut: float = 0.0
+
+
+def resolve_eligibility(cfg: Optional[RepoEligibilityConfig]) -> ResolvedEligibility:
+    """Overlay a repo's eligibility overrides onto the global default constants."""
+    cfg = cfg or RepoEligibilityConfig()
+
+    def pick(value: Any, default: Any) -> Any:
+        return default if value is None else value
+
+    return ResolvedEligibility(
+        min_valid_merged_prs=int(pick(cfg.min_valid_merged_prs, MIN_VALID_MERGED_PRS)),
+        min_credibility=float(pick(cfg.min_credibility, MIN_CREDIBILITY)),
+        min_token_score_for_base_score=float(pick(cfg.min_token_score_for_base_score, MIN_TOKEN_SCORE_FOR_BASE_SCORE)),
+        excessive_pr_penalty_base_threshold=int(
+            pick(cfg.excessive_pr_penalty_base_threshold, EXCESSIVE_PR_PENALTY_BASE_THRESHOLD)
+        ),
+        open_pr_threshold_token_score=float(pick(cfg.open_pr_threshold_token_score, OPEN_PR_THRESHOLD_TOKEN_SCORE)),
+        max_open_pr_threshold=int(pick(cfg.max_open_pr_threshold, MAX_OPEN_PR_THRESHOLD)),
+        min_valid_solved_issues=int(pick(cfg.min_valid_solved_issues, MIN_VALID_SOLVED_ISSUES)),
+        min_issue_credibility=float(pick(cfg.min_issue_credibility, MIN_ISSUE_CREDIBILITY)),
+        min_token_score_for_valid_issue=float(
+            pick(cfg.min_token_score_for_valid_issue, MIN_TOKEN_SCORE_FOR_VALID_ISSUE)
+        ),
+        open_issue_spam_base_threshold=int(pick(cfg.open_issue_spam_base_threshold, OPEN_ISSUE_SPAM_BASE_THRESHOLD)),
+        open_issue_spam_token_score_per_slot=float(
+            pick(cfg.open_issue_spam_token_score_per_slot, OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT)
+        ),
+        max_open_issue_threshold=int(pick(cfg.max_open_issue_threshold, MAX_OPEN_ISSUE_THRESHOLD)),
+    )
 
 
 @dataclass
@@ -114,6 +200,55 @@ def _coerce_share(repo_name: str, field_name: str, raw_value: Any) -> float:
     return float(raw_value)
 
 
+_ELIGIBILITY_INT_FIELDS = (
+    'min_valid_merged_prs',
+    'excessive_pr_penalty_base_threshold',
+    'max_open_pr_threshold',
+    'min_valid_solved_issues',
+    'open_issue_spam_base_threshold',
+    'max_open_issue_threshold',
+)
+_ELIGIBILITY_FLOAT_FIELDS = (
+    'min_credibility',
+    'min_token_score_for_base_score',
+    'open_pr_threshold_token_score',
+    'min_issue_credibility',
+    'min_token_score_for_valid_issue',
+    'open_issue_spam_token_score_per_slot',
+)
+
+
+def _coerce_eligibility_value(repo_name: str, field_name: str, raw_value: Any, caster: Any) -> Any:
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, bool):
+        raise RepositoryRegistryError(f'{repo_name} eligibility.{field_name} must be a number, got bool')
+    try:
+        return caster(raw_value)
+    except (TypeError, ValueError) as e:
+        raise RepositoryRegistryError(f'{repo_name} eligibility.{field_name} must be a number: {e}') from e
+
+
+def _parse_eligibility(repo_name: str, raw: Any) -> RepoEligibilityConfig:
+    """Parse the optional ``eligibility`` object from a master_repositories.json entry."""
+    if raw is None:
+        return RepoEligibilityConfig()
+    if not isinstance(raw, dict):
+        raise RepositoryRegistryError(f'{repo_name} eligibility must be an object, got {type(raw)}')
+
+    known = set(_ELIGIBILITY_INT_FIELDS) | set(_ELIGIBILITY_FLOAT_FIELDS)
+    unknown = sorted(set(raw) - known)
+    if unknown:
+        raise RepositoryRegistryError(f'{repo_name} eligibility has unknown keys: {unknown}')
+
+    kwargs: Dict[str, Any] = {}
+    for field_name in _ELIGIBILITY_INT_FIELDS:
+        kwargs[field_name] = _coerce_eligibility_value(repo_name, field_name, raw.get(field_name), int)
+    for field_name in _ELIGIBILITY_FLOAT_FIELDS:
+        kwargs[field_name] = _coerce_eligibility_value(repo_name, field_name, raw.get(field_name), float)
+    return RepoEligibilityConfig(**kwargs)
+
+
 def _validate_emission_shares(configs: Dict[str, RepositoryConfig]) -> None:
     total_share = 0.0
     for repo_name, config in configs.items():
@@ -133,6 +268,39 @@ def _validate_emission_shares(configs: Dict[str, RepositoryConfig]) -> None:
 
     if total_share > 1.0 + EMISSION_SHARE_TOLERANCE:
         raise RepositoryRegistryError(f'total emission_share must be <= 1.0, got {total_share}')
+
+
+def _validate_eligibility_configs(configs: Dict[str, RepositoryConfig]) -> None:
+    """Range-check every repo's resolved eligibility config."""
+    for repo_name, config in configs.items():
+        resolved = resolve_eligibility(config.eligibility)
+        for field_name in ('min_credibility', 'min_issue_credibility'):
+            value = getattr(resolved, field_name)
+            if not 0.0 <= value <= 1.0:
+                raise RepositoryRegistryError(
+                    f'{repo_name} eligibility.{field_name} must be within [0, 1], got {value}'
+                )
+        non_negative = (
+            'min_valid_merged_prs',
+            'min_token_score_for_base_score',
+            'excessive_pr_penalty_base_threshold',
+            'max_open_pr_threshold',
+            'min_valid_solved_issues',
+            'min_token_score_for_valid_issue',
+            'open_issue_spam_base_threshold',
+            'max_open_issue_threshold',
+        )
+        for field_name in non_negative:
+            value = getattr(resolved, field_name)
+            if value < 0:
+                raise RepositoryRegistryError(f'{repo_name} eligibility.{field_name} must be >= 0, got {value}')
+        # Used as divisors in the open-PR / open-issue slot math.
+        for field_name in ('open_pr_threshold_token_score', 'open_issue_spam_token_score_per_slot'):
+            value = getattr(resolved, field_name)
+            if value <= 0:
+                raise RepositoryRegistryError(
+                    f'{repo_name} eligibility.{field_name} must be > 0 (used as a divisor), got {value}'
+                )
 
 
 def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
@@ -177,7 +345,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     ),
                     default_label_multiplier=float(metadata.get('default_label_multiplier', 1.0)),
                     fixed_base_score=metadata.get('fixed_base_score'),
-                    eligibility_mode=metadata.get('eligibility_mode', True),
+                    eligibility=_parse_eligibility(repo_name, metadata.get('eligibility')),
                     maintainer_cut=_coerce_share(repo_name, 'maintainer_cut', metadata.get('maintainer_cut', 0.0)),
                 )
                 normalized_data[repo_name.lower()] = config
@@ -187,6 +355,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                 raise ValueError(f'Could not parse config for {repo_name}: {e}') from e
 
         _validate_emission_shares(normalized_data)
+        _validate_eligibility_configs(normalized_data)
 
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -7,6 +7,7 @@ import bittensor as bt
 from gittensor.classes import Miner, MinerEvaluation
 from gittensor.validator.storage.database import create_database_connection
 from gittensor.validator.storage.repository import Repository
+from gittensor.validator.utils.load_weights import RepositoryConfig
 
 
 @dataclass
@@ -27,12 +28,15 @@ class DatabaseStorage:
     def is_enabled(self) -> bool:
         return self.db_connection is not None
 
-    def store_evaluation(self, miner_eval: MinerEvaluation) -> StorageResult:
+    def store_evaluation(
+        self, miner_eval: MinerEvaluation, master_repositories: Dict[str, RepositoryConfig]
+    ) -> StorageResult:
         """
         Store all evaluation data in an optimized manner with proper error handling.
 
         Args:
             miner_eval: Complete miner evaluation with all related data
+            master_repositories: Master repo registry — one miner_evaluations row per repo
 
         Returns:
             StorageResult with success status, errors, and counts
@@ -77,7 +81,7 @@ class DatabaseStorage:
                 )
                 self.repo.cleanup_stale_miner_data(miner_eval, commit=False)
                 result.stored_counts['evaluations'] = (
-                    1 if self.repo.set_miner_evaluation(miner_eval, commit=False) else 0
+                    1 if self.repo.set_miner_evaluation(miner_eval, master_repositories, commit=False) else 0
                 )
 
             self.db_connection.commit()

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -59,7 +59,12 @@
   },
   "entrius/oc-1": {
     "default_label_multiplier": 0.0,
-    "eligibility_mode": false,
+    "eligibility": {
+      "min_credibility": 0.0,
+      "min_issue_credibility": 0.0,
+      "min_valid_merged_prs": 0,
+      "min_valid_solved_issues": 0
+    },
     "emission_share": 0.00000,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -22,8 +22,8 @@ from functools import partial
 from typing import Dict, List, Set
 
 import bittensor as bt
-
 import wandb
+
 from gittensor import __version__
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.validator import pat_storage

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -22,8 +22,8 @@ from functools import partial
 from typing import Dict, List, Set
 
 import bittensor as bt
-import wandb
 
+import wandb
 from gittensor import __version__
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.validator import pat_storage
@@ -37,6 +37,7 @@ from gittensor.validator.pat_handler import (
     priority_pat_check,
 )
 from gittensor.validator.utils.config import STORE_DB_RESULTS, WANDB_PROJECT, WANDB_VALIDATOR_NAME
+from gittensor.validator.utils.load_weights import RepositoryConfig
 from gittensor.validator.utils.storage import DatabaseStorage
 from neurons.base.validator import BaseValidatorNeuron
 
@@ -98,11 +99,17 @@ class Validator(BaseValidatorNeuron):
         bt.logging.info('load_state()')
         self.load_state()
 
-    async def bulk_store_evaluation(self, miner_evals: Dict[int, MinerEvaluation], skip_uids: Set[int] = None):
+    async def bulk_store_evaluation(
+        self,
+        miner_evals: Dict[int, MinerEvaluation],
+        master_repositories: Dict[str, RepositoryConfig],
+        skip_uids: Set[int] = None,
+    ):
         """Store all miner evaluations, log summary rather than per-UID.
 
         Args:
             miner_evals: Dict of UID -> MinerEvaluation to store.
+            master_repositories: Master repo registry — one miner_evaluations row per repo.
             skip_uids: Set of UIDs to skip (e.g. cached evaluations that were already stored previously).
         """
         if self.db_storage is None:
@@ -119,7 +126,7 @@ class Validator(BaseValidatorNeuron):
                 continue
 
             try:
-                storage_result = self.db_storage.store_evaluation(evaluation)
+                storage_result = self.db_storage.store_evaluation(evaluation, master_repositories)
                 if storage_result.success:
                     successful_count += 1
                 else:

--- a/tests/validator/conftest.py
+++ b/tests/validator/conftest.py
@@ -247,19 +247,7 @@ def ineligible_low_credibility(pr_factory) -> MinerScenario:
         merged=pr_factory.merged_batch(count=5, unique_repos=True, token_score=10.0),
         closed=pr_factory.closed_batch(count=4, unique_repos=True),
         open=[],
-        description='Ineligible: 5/9 = 55.6% credibility (after mulligan: 5/8 = 62.5%)',
-    )
-
-
-@pytest.fixture
-def miner_with_mulligan(pr_factory) -> MinerScenario:
-    """Miner who benefits from the mulligan (1 closed PR forgiven)."""
-    pr_factory.reset()
-    return MinerScenario(
-        merged=pr_factory.merged_batch(count=5, unique_repos=True, token_score=10.0),
-        closed=pr_factory.closed_batch(count=1, unique_repos=True),
-        open=[],
-        description='Miner with mulligan: 5/5 = 100% credibility (1 closed forgiven)',
+        description='Ineligible: 5 merged / 4 closed = 55.6% credibility',
     )
 
 

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -1077,7 +1077,7 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], 0), (e_b, [b_issue], 0)])
+        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
 
         # Earlier-created issue (#50, uid 1) wins canonical for PR 100
         owner = canonical[('entrius/gittensor-ui', 100)]
@@ -1109,7 +1109,7 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], 0), (e_b, [b_issue], 0)])
+        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
 
         owner = canonical[('entrius/gittensor-ui', 100)]
         assert owner[1] == 50  # lower issue_number wins
@@ -1141,7 +1141,7 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], 0), (e_b, [b_issue], 0)])
+        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
 
         owner = canonical[('entrius/gittensor-ui', 100)]
         assert owner[1] == 51  # B's issue claims canonical

--- a/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
@@ -1,4 +1,9 @@
-"""Regression coverage for mirror-only repository scoring config fields."""
+"""Per-repository eligibility coverage for finalize_miner_scores.
+
+Each repository gates and scores independently from only its own PRs, against
+its own resolved eligibility config. Work in one repo never unlocks or
+penalizes another.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +11,7 @@ from gittensor.classes import MinerEvaluation
 from gittensor.utils.mirror.models import MirrorPullRequest
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
 from gittensor.validator.oss_contributions.scoring import finalize_miner_scores
-from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.utils.load_weights import RepoEligibilityConfig, RepositoryConfig
 
 
 def _mirror_pr(repo: str, number: int, state: str = 'MERGED') -> ScoredPR:
@@ -48,176 +53,119 @@ def _mirror_pr(repo: str, number: int, state: str = 'MERGED') -> ScoredPR:
     return ScoredPR(pr=pr)
 
 
-def test_ineligible_miner_earns_only_from_eligibility_disabled_repo():
-    opt_out = _mirror_pr('foo/open-door', 1)
-    opt_out.base_score = 10.0
-    opt_out.token_score = 0.0
+def _merged(repo: str, number: int, base: float = 10.0, token: float = 10.0) -> ScoredPR:
+    pr = _mirror_pr(repo, number)
+    pr.base_score = base
+    pr.token_score = token
+    return pr
 
-    gated = _mirror_pr('foo/gated', 2)
-    gated.base_score = 50.0
-    gated.token_score = 0.0
 
-    closed_prs = [_mirror_pr('foo/gated', number, state='CLOSED') for number in range(3, 18)]
+def _gate_repo() -> RepositoryConfig:
+    """A repo on the default eligibility gate (3 valid merged PRs, 0.80 credibility)."""
+    return RepositoryConfig(emission_share=1.0)
+
+
+def test_eligibility_does_not_pool_across_repos():
+    """3 valid merged PRs in repo A + 2 in repo B: eligible in A, not B."""
+    repo_a = [_merged('foo/a', n) for n in range(1, 4)]
+    repo_b = [_merged('foo/b', n) for n in range(10, 12)]
+
     evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
-    evaluation.merged_prs = [opt_out, gated]
-    evaluation.closed_prs = closed_prs
+    evaluation.merged_prs = repo_a + repo_b
 
-    repos = {
-        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
-    }
+    finalize_miner_scores({1: evaluation}, {'foo/a': _gate_repo(), 'foo/b': _gate_repo()})
 
-    finalize_miner_scores({1: evaluation}, repos)
-
-    assert evaluation.is_eligible is False
-    assert evaluation.credibility < 0.8
-    assert opt_out.earned_score == 10.0
-    assert opt_out.credibility_multiplier == 1.0
-    assert gated.earned_score == 0.0
-    assert evaluation.total_score == 10.0
+    assert evaluation.repo_evaluations['foo/a'].is_eligible is True
+    assert evaluation.repo_evaluations['foo/b'].is_eligible is False
+    assert all(pr.earned_score == 10.0 for pr in repo_a)
+    assert all(pr.earned_score == 0.0 for pr in repo_b)
+    assert evaluation.total_score == 30.0
+    assert evaluation.is_eligible is True  # eligible in at least one repo
 
 
-def test_eligibility_disabled_prs_do_not_unlock_gated_repo_rewards():
-    opt_out_prs = [_mirror_pr(f'foo/open-door-{number}', number) for number in range(1, 6)]
-    for pr in opt_out_prs:
+def test_zeroed_thresholds_repo_has_no_gate():
+    """A repo with zeroed thresholds scores a miner the default gate would reject."""
+    pr = _merged('foo/open', 1)
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.merged_prs = [pr]
+
+    no_gate = RepositoryConfig(
+        emission_share=1.0,
+        eligibility=RepoEligibilityConfig(min_valid_merged_prs=0, min_credibility=0.0),
+    )
+    finalize_miner_scores({1: evaluation}, {'foo/open': no_gate})
+
+    assert evaluation.repo_evaluations['foo/open'].is_eligible is True
+    assert pr.earned_score == 10.0  # single PR, credibility 1.0
+
+
+def test_per_repo_credibility_multiplier():
+    """An eligible repo applies its own credibility ratio as the PR multiplier."""
+    merged = [_merged('foo/a', n) for n in range(1, 5)]
+    closed = [_mirror_pr('foo/a', 99, state='CLOSED')]
+
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.merged_prs = merged
+    evaluation.closed_prs = closed
+
+    finalize_miner_scores({1: evaluation}, {'foo/a': _gate_repo()})
+
+    # credibility = 4 / (4 + 1) = 0.80, exactly at the gate
+    assert evaluation.repo_evaluations['foo/a'].is_eligible is True
+    assert evaluation.repo_evaluations['foo/a'].credibility == 0.8
+    assert all(pr.credibility_multiplier == 0.8 for pr in merged)
+    assert all(pr.earned_score == 8.0 for pr in merged)
+
+
+def test_open_pr_spam_is_scoped_per_repo():
+    """Excess open PRs in one repo do not spam-penalize another repo's earnings."""
+    repo_a = [_merged('foo/a', n) for n in range(1, 4)]
+    repo_b = [_merged('foo/b', n) for n in range(1, 4)]
+    # repo B carries open PRs well past its base threshold of 2
+    repo_b_open = [_mirror_pr('foo/b', n, state='OPEN') for n in range(50, 60)]
+
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.merged_prs = repo_a + repo_b
+    evaluation.open_prs = repo_b_open
+
+    finalize_miner_scores({1: evaluation}, {'foo/a': _gate_repo(), 'foo/b': _gate_repo()})
+
+    assert all(pr.open_pr_spam_multiplier == 1.0 for pr in repo_a)
+    assert all(pr.earned_score == 10.0 for pr in repo_a)
+    assert all(pr.open_pr_spam_multiplier == 0.0 for pr in repo_b)
+    assert all(pr.earned_score == 0.0 for pr in repo_b)
+
+
+def test_open_pr_collateral_is_scoped_per_repo():
+    """Open-PR collateral in one repo does not reduce another repo's earnings."""
+    repo_a = [_merged('foo/a', n) for n in range(1, 4)]
+    repo_b_open = [_mirror_pr('foo/b', n, state='OPEN') for n in range(50, 53)]
+    for pr in repo_b_open:
         pr.base_score = 10.0
-        pr.token_score = 10.0
-
-    gated = _mirror_pr('foo/gated', 100)
-    gated.base_score = 50.0
-    gated.token_score = 10.0
 
     evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
-    evaluation.merged_prs = opt_out_prs + [gated]
+    evaluation.merged_prs = repo_a
+    evaluation.open_prs = repo_b_open
 
-    repos = {
-        **{pr.repository_full_name: RepositoryConfig(emission_share=1.0, eligibility_mode=False) for pr in opt_out_prs},
-        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
-    }
+    finalize_miner_scores({1: evaluation}, {'foo/a': _gate_repo(), 'foo/b': _gate_repo()})
 
-    finalize_miner_scores({1: evaluation}, repos)
-
-    assert evaluation.is_eligible is False
-    assert all(pr.earned_score == 10.0 for pr in opt_out_prs)
-    assert all(pr.credibility_multiplier == 1.0 for pr in opt_out_prs)
-    assert gated.earned_score == 0.0
-    assert evaluation.total_score == 50.0
+    assert evaluation.repo_evaluations['foo/a'].total_score == 30.0
+    assert evaluation.repo_evaluations['foo/b'].total_collateral_score > 0.0
+    assert evaluation.repo_evaluations['foo/b'].total_score == 0.0
+    assert evaluation.total_score == 30.0
 
 
-def test_eligibility_disabled_closed_prs_do_not_penalize_gated_repo_eligibility():
-    gated_prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
-    for pr in gated_prs:
-        pr.base_score = 10.0
-        pr.token_score = 10.0
-
-    opt_out_closed_prs = [_mirror_pr('foo/open-door', number, state='CLOSED') for number in range(100, 120)]
+def test_repo_evaluations_recorded_for_every_touched_repo():
+    """finalize_miner_scores records a RepoEvaluation per repo the miner touched."""
     evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
-    evaluation.merged_prs = gated_prs
-    evaluation.closed_prs = opt_out_closed_prs
+    evaluation.merged_prs = [_merged('foo/a', 1), _merged('foo/b', 1)]
+    evaluation.open_prs = [_mirror_pr('foo/c', 1, state='OPEN')]
 
-    repos = {
-        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
-    }
+    finalize_miner_scores(
+        {1: evaluation},
+        {'foo/a': _gate_repo(), 'foo/b': _gate_repo(), 'foo/c': _gate_repo()},
+    )
 
-    finalize_miner_scores({1: evaluation}, repos)
-
-    assert evaluation.is_eligible is True
-    assert evaluation.credibility == 1.0
-    assert all(pr.earned_score == 10.0 for pr in gated_prs)
-    assert evaluation.total_score == 50.0
-
-
-def test_eligibility_disabled_open_prs_do_not_spam_penalize_gated_rewards():
-    gated_prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
-    for pr in gated_prs:
-        pr.base_score = 10.0
-        pr.token_score = 10.0
-
-    opt_out_open_prs = [_mirror_pr('foo/open-door', number, state='OPEN') for number in range(100, 111)]
-    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
-    evaluation.merged_prs = gated_prs
-    evaluation.open_prs = opt_out_open_prs
-
-    repos = {
-        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
-    }
-
-    finalize_miner_scores({1: evaluation}, repos)
-
-    assert evaluation.is_eligible is True
-    assert all(pr.open_pr_spam_multiplier == 1.0 for pr in gated_prs)
-    assert all(pr.earned_score == 10.0 for pr in gated_prs)
-    assert evaluation.total_score == 50.0
-
-
-def test_eligible_miner_scores_all_repos_with_existing_credibility_multiplier():
-    prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
-    for pr in prs:
-        pr.base_score = 10.0
-        pr.token_score = 10.0
-
-    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
-    evaluation.merged_prs = prs
-
-    repos = {'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True)}
-
-    finalize_miner_scores({1: evaluation}, repos)
-
-    assert evaluation.is_eligible is True
-    assert evaluation.credibility == 1.0
-    assert all(pr.earned_score == 10.0 for pr in prs)
-
-
-def test_zero_history_miner_earns_only_from_eligibility_disabled_repo():
-    """Deliverable #5: a miner with zero merged PRs and zero credibility earns from
-    eligibility_mode=false repos but not from eligibility_mode=true repos in the same round."""
-    opt_out = _mirror_pr('foo/open-door', 1)
-    opt_out.base_score = 10.0
-    opt_out.token_score = 0.0
-
-    gated = _mirror_pr('foo/gated', 2)
-    gated.base_score = 50.0
-    gated.token_score = 0.0
-
-    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
-    evaluation.merged_prs = [opt_out, gated]
-
-    repos = {
-        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
-        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
-    }
-
-    finalize_miner_scores({1: evaluation}, repos)
-
-    assert evaluation.is_eligible is False
-    assert opt_out.earned_score == 10.0
-    assert opt_out.credibility_multiplier == 1.0
-    assert gated.earned_score == 0.0
-    assert evaluation.total_score == 10.0
-
-
-def test_eligibility_disabled_repo_open_collateral_does_not_reduce_gated_only_earnings():
-    """Bypass open-PR collateral must not reduce earnings from gated repos."""
-    gated_prs = [_mirror_pr('foo/gated', number) for number in range(1, 6)]
-    for pr in gated_prs:
-        pr.base_score = 10.0
-        pr.token_score = 10.0
-
-    bypass_open_prs = [_mirror_pr('foo/open-door', number, state='OPEN') for number in range(100, 103)]
-
-    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
-    evaluation.merged_prs = gated_prs
-    evaluation.open_prs = bypass_open_prs
-
-    repos = {
-        'foo/gated': RepositoryConfig(emission_share=1.0, eligibility_mode=True),
-        'foo/open-door': RepositoryConfig(emission_share=1.0, eligibility_mode=False),
-    }
-
-    finalize_miner_scores({1: evaluation}, repos)
-
-    assert evaluation.is_eligible is True
-    assert evaluation.total_collateral_score == 0.0
-    assert evaluation.total_score == 50.0
+    assert set(evaluation.repo_evaluations) == {'foo/a', 'foo/b', 'foo/c'}
+    assert evaluation.repo_evaluations['foo/a'].total_merged_prs == 1
+    assert evaluation.repo_evaluations['foo/c'].total_open_prs == 1

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -109,7 +109,6 @@ def _config(
     label_multipliers: dict | None = None,
     default_label_multiplier: float = 1.0,
     fixed_base_score: float | None = None,
-    eligibility_mode: bool = True,
 ) -> RepositoryConfig:
     return RepositoryConfig(
         emission_share=emission_share,
@@ -118,7 +117,6 @@ def _config(
         label_multipliers=label_multipliers,
         default_label_multiplier=default_label_multiplier,
         fixed_base_score=fixed_base_score,
-        eligibility_mode=eligibility_mode,
     )
 
 

--- a/tests/validator/test_dynamic_open_pr_threshold.py
+++ b/tests/validator/test_dynamic_open_pr_threshold.py
@@ -1,84 +1,55 @@
-"""
-Tests for dynamic open PR threshold based on total token score.
+"""Tests for the dynamic per-repository open-PR spam threshold.
 
-Bonus = floor(total_token_score / 300)
-Example: 900 total token score / 300 = +3 bonus
-
-Multiplier is binary: 1.0 if <= threshold, 0.0 otherwise
-
-Run tests:
-    pytest tests/validator/test_dynamic_open_pr_threshold.py -v
+Threshold = min(base + floor(total_token_score / per_slot), max), all resolved
+per repository from its eligibility config.
 """
 
-from gittensor.constants import (
-    EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
-    MAX_OPEN_PR_THRESHOLD,
-)
 from gittensor.validator.oss_contributions.scoring import (
     calculate_open_pr_threshold,
     calculate_pr_spam_penalty_multiplier,
 )
+from gittensor.validator.utils.load_weights import RepoEligibilityConfig, resolve_eligibility
+
+_CFG = resolve_eligibility(None)  # global defaults
+_BASE = _CFG.excessive_pr_penalty_base_threshold
+_PER_SLOT = _CFG.open_pr_threshold_token_score
+_MAX = _CFG.max_open_pr_threshold
 
 
 class TestCalculateOpenPrThreshold:
-    """Tests for calculate_open_pr_threshold function."""
-
     def test_no_token_score_returns_base_threshold(self):
-        """Without token score, threshold should be the base threshold."""
-        assert calculate_open_pr_threshold() == EXCESSIVE_PR_PENALTY_BASE_THRESHOLD
+        assert calculate_open_pr_threshold(_CFG) == _BASE
 
     def test_zero_token_score_returns_base_threshold(self):
-        """With zero token score, threshold should be the base threshold."""
-        assert calculate_open_pr_threshold(0.0) == EXCESSIVE_PR_PENALTY_BASE_THRESHOLD
+        assert calculate_open_pr_threshold(_CFG, 0.0) == _BASE
 
-    def test_below_300_no_bonus(self):
-        """Token score below 300 doesn't grant bonus."""
-        assert calculate_open_pr_threshold(299.0) == EXCESSIVE_PR_PENALTY_BASE_THRESHOLD
+    def test_below_one_slot_no_bonus(self):
+        assert calculate_open_pr_threshold(_CFG, _PER_SLOT - 1) == _BASE
 
-    def test_300_token_score_gets_bonus(self):
-        """300 token score grants +1 bonus."""
-        assert calculate_open_pr_threshold(300.0) == EXCESSIVE_PR_PENALTY_BASE_THRESHOLD + 1
+    def test_one_slot_grants_bonus(self):
+        assert calculate_open_pr_threshold(_CFG, _PER_SLOT) == _BASE + 1
 
-    def test_600_token_score_gets_double_bonus(self):
-        """600 token score grants +2 bonus."""
-        assert calculate_open_pr_threshold(600.0) == EXCESSIVE_PR_PENALTY_BASE_THRESHOLD + 2
-
-    def test_900_token_score_gets_triple_bonus(self):
-        """900 token score grants +3 bonus."""
-        assert calculate_open_pr_threshold(900.0) == EXCESSIVE_PR_PENALTY_BASE_THRESHOLD + 3
+    def test_two_slots_grant_double_bonus(self):
+        assert calculate_open_pr_threshold(_CFG, _PER_SLOT * 2) == _BASE + 2
 
     def test_threshold_capped_at_max(self):
-        """Threshold is capped at MAX_OPEN_PR_THRESHOLD."""
-        assert calculate_open_pr_threshold(50000.0) == MAX_OPEN_PR_THRESHOLD
+        assert calculate_open_pr_threshold(_CFG, _PER_SLOT * 10_000) == _MAX
+
+    def test_per_repo_override(self):
+        cfg = resolve_eligibility(RepoEligibilityConfig(excessive_pr_penalty_base_threshold=10))
+        assert calculate_open_pr_threshold(cfg) == 10
 
 
 class TestCalculatePrSpamPenaltyMultiplier:
-    """Tests for calculate_pr_spam_penalty_multiplier function (binary multiplier)."""
-
-    def test_no_penalty_below_threshold(self):
-        """No penalty when open PRs are below threshold."""
-        assert calculate_pr_spam_penalty_multiplier(5) == 1.0
-
     def test_no_penalty_at_threshold(self):
-        """No penalty when open PRs are exactly at threshold."""
-        assert calculate_pr_spam_penalty_multiplier(10) == 1.0
+        assert calculate_pr_spam_penalty_multiplier(_CFG, _BASE) == 1.0
 
     def test_zero_multiplier_above_threshold(self):
-        """Multiplier is 0.0 when open PRs exceed threshold."""
-        assert calculate_pr_spam_penalty_multiplier(11) == 0.0
+        assert calculate_pr_spam_penalty_multiplier(_CFG, _BASE + 1) == 0.0
 
     def test_zero_multiplier_well_above_threshold(self):
-        """Multiplier is 0.0 regardless of how far above threshold."""
-        assert calculate_pr_spam_penalty_multiplier(20) == 0.0
+        assert calculate_pr_spam_penalty_multiplier(_CFG, _BASE + 50) == 0.0
 
-    def test_bonus_increases_threshold(self):
-        """Token score bonus increases the threshold."""
-        # 600 token score = +2 bonus -> threshold = 12
-        assert calculate_pr_spam_penalty_multiplier(12, 600.0) == 1.0
-        assert calculate_pr_spam_penalty_multiplier(13, 600.0) == 0.0
-
-    def test_high_threshold_for_top_contributor(self):
-        """Top contributor with high token score gets higher threshold."""
-        # 1800 token score -> floor(1800/300) = +6 bonus -> threshold = 16
-        assert calculate_pr_spam_penalty_multiplier(16, 1800.0) == 1.0
-        assert calculate_pr_spam_penalty_multiplier(17, 1800.0) == 0.0
+    def test_token_score_bonus_increases_threshold(self):
+        assert calculate_pr_spam_penalty_multiplier(_CFG, _BASE + 2, _PER_SLOT * 2) == 1.0
+        assert calculate_pr_spam_penalty_multiplier(_CFG, _BASE + 3, _PER_SLOT * 2) == 0.0

--- a/tests/validator/test_eligibility_resolver.py
+++ b/tests/validator/test_eligibility_resolver.py
@@ -1,0 +1,55 @@
+"""Tests for resolve_eligibility — per-repo override resolution against the
+global default constants."""
+
+from gittensor.constants import (
+    EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
+    MAX_OPEN_ISSUE_THRESHOLD,
+    MAX_OPEN_PR_THRESHOLD,
+    MIN_CREDIBILITY,
+    MIN_ISSUE_CREDIBILITY,
+    MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+    MIN_TOKEN_SCORE_FOR_VALID_ISSUE,
+    MIN_VALID_MERGED_PRS,
+    MIN_VALID_SOLVED_ISSUES,
+    OPEN_ISSUE_SPAM_BASE_THRESHOLD,
+    OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
+    OPEN_PR_THRESHOLD_TOKEN_SCORE,
+)
+from gittensor.validator.utils.load_weights import RepoEligibilityConfig, resolve_eligibility
+
+
+def test_none_resolves_entirely_to_global_defaults():
+    resolved = resolve_eligibility(None)
+    assert resolved.min_valid_merged_prs == MIN_VALID_MERGED_PRS
+    assert resolved.min_credibility == MIN_CREDIBILITY
+    assert resolved.min_token_score_for_base_score == MIN_TOKEN_SCORE_FOR_BASE_SCORE
+    assert resolved.excessive_pr_penalty_base_threshold == EXCESSIVE_PR_PENALTY_BASE_THRESHOLD
+    assert resolved.open_pr_threshold_token_score == OPEN_PR_THRESHOLD_TOKEN_SCORE
+    assert resolved.max_open_pr_threshold == MAX_OPEN_PR_THRESHOLD
+    assert resolved.min_valid_solved_issues == MIN_VALID_SOLVED_ISSUES
+    assert resolved.min_issue_credibility == MIN_ISSUE_CREDIBILITY
+    assert resolved.min_token_score_for_valid_issue == MIN_TOKEN_SCORE_FOR_VALID_ISSUE
+    assert resolved.open_issue_spam_base_threshold == OPEN_ISSUE_SPAM_BASE_THRESHOLD
+    assert resolved.open_issue_spam_token_score_per_slot == OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT
+    assert resolved.max_open_issue_threshold == MAX_OPEN_ISSUE_THRESHOLD
+
+
+def test_empty_config_resolves_to_global_defaults():
+    assert resolve_eligibility(RepoEligibilityConfig()) == resolve_eligibility(None)
+
+
+def test_overrides_take_precedence_over_defaults():
+    cfg = RepoEligibilityConfig(min_valid_merged_prs=1, min_credibility=0.5, max_open_pr_threshold=99)
+    resolved = resolve_eligibility(cfg)
+    assert resolved.min_valid_merged_prs == 1
+    assert resolved.min_credibility == 0.5
+    assert resolved.max_open_pr_threshold == 99
+    # unset fields still fall back to the global default
+    assert resolved.min_token_score_for_base_score == MIN_TOKEN_SCORE_FOR_BASE_SCORE
+
+
+def test_zero_override_is_respected_not_treated_as_unset():
+    """0 is a real value (a repo opting out of a gate), not 'use the default'."""
+    resolved = resolve_eligibility(RepoEligibilityConfig(min_valid_merged_prs=0, min_credibility=0.0))
+    assert resolved.min_valid_merged_prs == 0
+    assert resolved.min_credibility == 0.0

--- a/tests/validator/test_issue_competitions_forward.py
+++ b/tests/validator/test_issue_competitions_forward.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+from gittensor.classes import MinerEvaluation
 from gittensor.validator.issue_competitions.forward import issue_competitions
 
 
@@ -98,3 +99,39 @@ def test_no_solver_without_lookup_failure_votes_cancel():
         wallet=validator.wallet,
     )
     contract_client.vote_solution.assert_not_called()
+
+
+def test_ineligible_miner_still_receives_solution_vote():
+    """Bounty payouts are not eligibility-gated: an is_eligible=False miner who
+    solves the bounty issue still receives a solution vote."""
+    validator = _make_validator()
+    contract_client = MagicMock()
+    contract_client.harvest_emissions.return_value = None
+    contract_client.get_issues_by_status.return_value = [_make_issue()]
+    contract_client.vote_solution.return_value = True
+
+    miner_eval = MinerEvaluation(uid=5, hotkey='hk5', github_id='999')
+    miner_eval.is_eligible = False
+
+    with (
+        patch('gittensor.validator.issue_competitions.forward.GITTENSOR_VALIDATOR_PAT', 'ghp_validator'),
+        patch('gittensor.validator.issue_competitions.forward.get_contract_address', return_value='5Contract'),
+        patch(
+            'gittensor.validator.issue_competitions.forward.check_github_issue_closed',
+            return_value={
+                'is_closed': True,
+                'solver_github_id': '999',
+                'pr_number': 42,
+                'solver_lookup_failed': False,
+            },
+        ),
+        patch('gittensor.validator.issue_competitions.forward.get_miner_coldkey', return_value='ck5'),
+        patch(
+            'gittensor.validator.issue_competitions.forward.IssueCompetitionContractClient',
+            return_value=contract_client,
+        ),
+    ):
+        _run(issue_competitions(cast(Any, validator), {5: miner_eval}))
+
+    contract_client.vote_solution.assert_called_once()
+    contract_client.vote_cancel_issue.assert_not_called()

--- a/tests/validator/test_issue_eligibility.py
+++ b/tests/validator/test_issue_eligibility.py
@@ -1,27 +1,30 @@
-"""Tests for check_issue_eligibility — the shared helper used by mirror issue
-discovery's per-miner gating logic.
+"""Tests for check_issue_eligibility — the per-repository issue-discovery gate.
 
-Previously part of test_issue_discovery_scoring.py, which tested legacy
-timeline-scraping internals that were removed along with scan_closed_issues
-and score_discovered_issues.
+Credibility is solved / (solved + closed); the gate also requires a minimum
+number of *valid* solved issues (solving PR meets the token threshold).
 """
 
 import pytest
 
 from gittensor.validator.issue_discovery.scoring import check_issue_eligibility
+from gittensor.validator.utils.load_weights import RepoEligibilityConfig, resolve_eligibility
+
+_CFG = resolve_eligibility(None)  # defaults: 3 valid solved issues, 0.70 issue credibility
 
 
 @pytest.mark.parametrize(
     'solved_count,valid_solved_count,closed_count,expected_credibility,expected_eligible',
     [
-        # Credibility uses total (10), eligibility gate uses valid (7)
-        (10, 7, 2, pytest.approx(10 / 11, abs=1e-3), True),
-        # Valid count below threshold → not eligible regardless of credibility
-        (10, 6, 2, pytest.approx(10 / 11, abs=1e-3), False),
-        # Zero solved → credibility 0, not eligible
+        # credibility uses total solved/attempts; the gate uses valid_solved
+        (10, 7, 2, pytest.approx(10 / 12, abs=1e-3), True),
+        # valid below the minimum -> ineligible regardless of credibility
+        (10, 2, 2, pytest.approx(10 / 12, abs=1e-3), False),
+        # no solved issues -> credibility 0, ineligible
         (0, 0, 2, 0.0, False),
-        # All solved counts equal (no low-token solvers) → fix is no-op for this case
-        (7, 7, 2, pytest.approx(7 / 8, abs=1e-3), True),
+        # credibility below 0.70 -> ineligible even with enough valid solves
+        (4, 4, 3, pytest.approx(4 / 7, abs=1e-3), False),
+        # exactly at both gates
+        (3, 3, 0, 1.0, True),
     ],
 )
 def test_check_issue_eligibility_uses_total_for_credibility_valid_for_gate(
@@ -31,6 +34,13 @@ def test_check_issue_eligibility_uses_total_for_credibility_valid_for_gate(
     expected_credibility: float,
     expected_eligible: bool,
 ) -> None:
-    is_eligible, credibility, _ = check_issue_eligibility(solved_count, valid_solved_count, closed_count)
+    is_eligible, credibility, _ = check_issue_eligibility(_CFG, solved_count, valid_solved_count, closed_count)
     assert credibility == expected_credibility
     assert is_eligible is expected_eligible
+
+
+def test_per_repo_override_relaxes_gate() -> None:
+    """A repo can lower its issue gate below the global default."""
+    relaxed = resolve_eligibility(RepoEligibilityConfig(min_valid_solved_issues=1, min_issue_credibility=0.0))
+    is_eligible, _, _ = check_issue_eligibility(relaxed, solved_count=1, valid_solved_count=1, closed_count=5)
+    assert is_eligible is True

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -14,12 +14,14 @@ import pytest
 
 from gittensor.validator.utils.load_weights import (
     LanguageConfig,
+    RepoEligibilityConfig,
     RepositoryConfig,
     RepositoryRegistryError,
     TokenConfig,
     load_master_repo_weights,
     load_programming_language_weights,
     load_token_config,
+    resolve_eligibility,
 )
 
 
@@ -244,42 +246,81 @@ class TestRepositoryConfigLabelMultipliers:
 
 
 class TestRepositoryConfigMirrorScoringFields:
-    """Dataclass + JSON-parsing tests for mirror-only scoring fields."""
+    """Dataclass + JSON-parsing tests for mirror scoring + per-repo eligibility fields."""
 
     def test_mirror_scoring_field_defaults(self):
         config = RepositoryConfig(emission_share=0.5)
 
         assert config.fixed_base_score is None
-        assert config.eligibility_mode is True
+        assert config.eligibility == RepoEligibilityConfig()
 
-    def test_loader_parses_mirror_scoring_fields(self, tmp_path, monkeypatch):
+    def test_loader_parses_fixed_base_score(self, tmp_path, monkeypatch):
         from gittensor.validator.utils import load_weights as lw
 
-        fake_weights_dir = tmp_path
-        (fake_weights_dir / 'master_repositories.json').write_text(
+        (tmp_path / 'master_repositories.json').write_text(
             json.dumps(
                 {
-                    'foo/fixed': {
+                    'foo/fixed': {'emission_share': 0.5, 'fixed_base_score': 12.5},
+                    'foo/defaults': {'emission_share': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/fixed'].fixed_base_score == pytest.approx(12.5)
+        assert repos['foo/defaults'].fixed_base_score is None
+
+    def test_loader_parses_eligibility_overrides(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/custom': {
                         'emission_share': 0.5,
-                        'fixed_base_score': 12.5,
-                        'eligibility_mode': False,
+                        'eligibility': {'min_valid_merged_prs': 1, 'min_credibility': 0.5},
                     },
                     'foo/defaults': {'emission_share': 0.3},
                 }
             )
         )
-        monkeypatch.setattr(lw, '_get_weights_dir', lambda: fake_weights_dir)
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
 
         repos = lw.load_master_repo_weights()
 
-        assert repos['foo/fixed'].fixed_base_score == pytest.approx(12.5)
-        assert repos['foo/fixed'].eligibility_mode is False
-        assert repos['foo/defaults'].fixed_base_score is None
-        assert repos['foo/defaults'].eligibility_mode is True
+        assert repos['foo/custom'].eligibility.min_valid_merged_prs == 1
+        assert repos['foo/custom'].eligibility.min_credibility == pytest.approx(0.5)
+        # unset fields stay None and resolve to the global default
+        assert repos['foo/custom'].eligibility.max_open_pr_threshold is None
+        assert repos['foo/defaults'].eligibility == RepoEligibilityConfig()
+
+    def test_loader_rejects_unknown_eligibility_key(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps({'foo/bad': {'emission_share': 0.5, 'eligibility': {'min_valid_prs': 1}}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        with pytest.raises(RepositoryRegistryError):
+            lw.load_master_repo_weights()
+
+    def test_loader_rejects_out_of_range_credibility(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps({'foo/bad': {'emission_share': 0.5, 'eligibility': {'min_credibility': 1.5}}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        with pytest.raises(RepositoryRegistryError):
+            lw.load_master_repo_weights()
 
     def test_live_mirror_scoring_fields_have_valid_shape(self):
-        """Loader passes mirror scoring fields through unchanged — CI fails when a
-        bad value is committed to master_repositories.json."""
+        """Loader passes scoring + eligibility fields through unchanged — CI fails
+        when a bad value is committed to master_repositories.json."""
         repos = load_master_repo_weights()
         for repo_name, config in repos.items():
             if config.fixed_base_score is not None:
@@ -289,9 +330,18 @@ class TestRepositoryConfigMirrorScoringFields:
                 assert 0.0 <= float(config.fixed_base_score) <= 100.0, (
                     f'{repo_name} fixed_base_score must be within [0.0, 100.0]'
                 )
-            assert isinstance(config.eligibility_mode, bool), (
-                f'{repo_name} eligibility_mode must be bool, got {type(config.eligibility_mode)}'
-            )
+            resolved = resolve_eligibility(config.eligibility)
+            assert 0.0 <= resolved.min_credibility <= 1.0, f'{repo_name} min_credibility out of range'
+            assert 0.0 <= resolved.min_issue_credibility <= 1.0, f'{repo_name} min_issue_credibility out of range'
+            assert resolved.min_valid_merged_prs >= 0, f'{repo_name} min_valid_merged_prs negative'
+
+    def test_oc_1_runs_ungated(self):
+        """The oc-1 benchmark repo opts out of the gate via zeroed thresholds."""
+        repos = load_master_repo_weights()
+        resolved = resolve_eligibility(repos['entrius/oc-1'].eligibility)
+        assert resolved.min_valid_merged_prs == 0
+        assert resolved.min_credibility == 0.0
+        assert resolved.min_valid_solved_issues == 0
 
 
 class TestRepositoryConfigMaintainerCut:

--- a/tests/validator/test_set_miner_evaluation.py
+++ b/tests/validator/test_set_miner_evaluation.py
@@ -1,0 +1,56 @@
+"""Tests for Repository.set_miner_evaluation — the per-(miner, repo) row fan-out."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from gittensor.classes import MinerEvaluation, RepoEvaluation
+from gittensor.validator.storage.repository import Repository
+from gittensor.validator.utils.load_weights import RepositoryConfig
+
+# Column positions in the BULK_UPSERT_MINER_EVALUATION value tuple.
+_REPO_NAME = 3
+_TOTAL_SCORE = 6
+_IS_ELIGIBLE = 14
+
+
+def _repo_with_mock_cursor():
+    repo = Repository(MagicMock())
+    cursor = MagicMock()
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    repo.get_cursor = fake_cursor  # type: ignore[method-assign]
+    return repo, cursor
+
+
+def test_writes_one_row_per_master_repo():
+    repo, cursor = _repo_with_mock_cursor()
+    master = {f'owner/repo{i}': RepositoryConfig(emission_share=0.1) for i in range(4)}
+
+    evaluation = MinerEvaluation(uid=7, hotkey='hk', github_id='99')
+    evaluation.repo_evaluations['owner/repo0'] = RepoEvaluation(
+        repository_full_name='owner/repo0', is_eligible=True, credibility=1.0, total_score=42.0
+    )
+
+    assert repo.set_miner_evaluation(evaluation, master, commit=False) is True
+
+    rows = cursor.executemany.call_args.args[1]
+    assert len(rows) == len(master)
+    by_repo = {row[_REPO_NAME]: row for row in rows}
+    assert set(by_repo) == set(master)
+    # the touched repo carries its RepoEvaluation
+    assert by_repo['owner/repo0'][_IS_ELIGIBLE] is True
+    assert by_repo['owner/repo0'][_TOTAL_SCORE] == 42.0
+    # untouched repos get a zeroed row
+    assert by_repo['owner/repo1'][_IS_ELIGIBLE] is False
+    assert by_repo['owner/repo1'][_TOTAL_SCORE] == 0.0
+
+
+def test_empty_master_repositories_writes_nothing():
+    repo, cursor = _repo_with_mock_cursor()
+    evaluation = MinerEvaluation(uid=7, hotkey='hk', github_id='99')
+
+    assert repo.set_miner_evaluation(evaluation, {}, commit=False) is True
+    cursor.executemany.assert_not_called()

--- a/tests/validator/utils/test_storage_mirror.py
+++ b/tests/validator/utils/test_storage_mirror.py
@@ -83,7 +83,7 @@ class TestStoreEvaluationAdaptsMirrorPRs:
         eval_ = MinerEvaluation(uid=1, hotkey='hk', github_id='123')
         eval_.merged_prs = [_mirror_scored(100), _mirror_scored(101)]
 
-        storage.store_evaluation(eval_)
+        storage.store_evaluation(eval_, {})
 
         merged_call = mock_repo.store_pull_requests_bulk.call_args_list[0]
         merged_arg = merged_call.args[0]
@@ -102,7 +102,7 @@ class TestStoreEvaluationAdaptsMirrorPRs:
         eval_ = MinerEvaluation(uid=1, hotkey='hk', github_id='123')
         eval_.open_prs = [_mirror_scored(105, state='OPEN')]
 
-        storage.store_evaluation(eval_)
+        storage.store_evaluation(eval_, {})
 
         open_call = mock_repo.store_pull_requests_bulk.call_args_list[1]
         open_arg = open_call.args[0]
@@ -114,7 +114,7 @@ class TestStoreEvaluationAdaptsMirrorPRs:
 
         eval_ = MinerEvaluation(uid=1, hotkey='hk', github_id='123')
 
-        storage.store_evaluation(eval_)
+        storage.store_evaluation(eval_, {})
 
         merged_arg = mock_repo.store_pull_requests_bulk.call_args_list[0].args[0]
         assert merged_arg == []
@@ -137,7 +137,7 @@ def test_cleanup_stale_called_with_commit_false():
         'gittensor.validator.oss_contributions.mirror.adapters.mirror_scored_pr_to_legacy_pull_request',
         side_effect=lambda s, *a, **kw: s,
     ):
-        storage.store_evaluation(eval_obj)
+        storage.store_evaluation(eval_obj, {})
 
     mock_repo.cleanup_stale_miner_data.assert_called_once_with(eval_obj, commit=False)
 
@@ -156,7 +156,7 @@ def test_failure_after_cleanup_triggers_rollback():
         'gittensor.validator.oss_contributions.mirror.adapters.mirror_scored_pr_to_legacy_pull_request',
         side_effect=lambda s, *a, **kw: s,
     ):
-        result = storage.store_evaluation(eval_obj)
+        result = storage.store_evaluation(eval_obj, {})
 
     assert result.success is False
     storage.db_connection.rollback.assert_called_once()


### PR DESCRIPTION
## What

Eligibility moves from a single global gate per miner to an independent gate **per repository**. Each repo computes its own eligible/ineligible miner set from only that repo's PRs/issues, against its own thresholds — work in one repo never unlocks or penalizes another.

## Changes

- **Config**: `RepositoryConfig` gains an optional `eligibility` block — 12 overridable knobs (`min_valid_merged_prs`, `min_credibility`, spam thresholds, the issue-discovery equivalents). `resolve_eligibility()` overlays a repo's overrides onto the global default constants. The `eligibility_mode` bool is removed — "no gate" is now a repo with zeroed thresholds (`oc-1` migrated accordingly).
- **Scoring**: `finalize_miner_scores` groups PRs by repo and gates each repo independently; the gated/bypass split is gone. `MinerEvaluation` carries a per-repo `RepoEvaluation` map; the round-level scalars are rollups.
- **Issue discovery**: gates per repo, with a new `MIN_TOKEN_SCORE_FOR_VALID_ISSUE` constant mirroring `MIN_TOKEN_SCORE_FOR_BASE_SCORE`.
- **Storage**: `miner_evaluations` is written one row per `(uid, hotkey, github_id, repository_full_name)`.
- **Issue bounties**: payouts are no longer eligibility-gated — any registered miner who solves a bounty issue is paid.
- **Mulligan removed**: credibility is now plain `merged / (merged + closed)`.

## Retuned defaults

`MIN_VALID_MERGED_PRS` 5→3, `MIN_VALID_SOLVED_ISSUES` 7→3, `MIN_ISSUE_CREDIBILITY` 0.80→0.70, open-PR/open-issue spam bases 10/5→2/2. `MIN_CREDIBILITY` stays 0.80.

## Behaviour / emissions impact

This is stricter: work no longer pools across repos, so on-chain emissions reallocate the first round after deploy. Intended — see the feature plan.

## Deploy order

The matching **gittensor-db** schema change (adds `repository_full_name`, 4-tuple unique constraint) **must merge first** — the old constraint rejects multi-repo rows. **das-gittensor** API changes follow. PRs linked separately.

## Testing

`ruff`, `ruff format`, `pyright`, and `pytest` (795 passing) all green locally.