### PR TITLE
fix: guard handle_pat_check against deregistered hotkey TOCTOU race (#1297)

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -105,6 +105,11 @@ async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSy
 async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> PatCheckSynapse:
     """Check if the validator has the miner's PAT stored and re-validate it."""
     hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        synapse.has_pat = False
+        synapse.pat_valid = False
+        synapse.rejection_reason = 'Hotkey not registered on subnet'
+        return synapse
     uid = validator.metagraph.hotkeys.index(hotkey)
     entry = pat_storage.get_pat_by_uid(uid)
 


### PR DESCRIPTION
## Summary

`handle_pat_check` calls `metagraph.hotkeys.index(hotkey)` without verifying the hotkey is still registered. A metagraph refresh between the blacklist pass and handler execution creates a TOCTOU race — the blacklist passes on a stale view, then `.index()` raises `ValueError`, crashing the axon coroutine.

Every sibling function in `pat_handler.py` already guards this correctly. This fix applies the same pattern used in `handle_pat_broadcast`.

## Validation

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean

Closes #1297