### PR TITLE
feat(registry): restore inactive repository cutoffs

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -6,6 +6,7 @@ touched.
 
 Filtering applied at load time:
 - Repo not in master_repositories: dropped (mirror returns all tracked repos).
+- PRs created at or after the repository's inactive_at cutoff: dropped.
 - PR author is a maintainer (OWNER/MEMBER/COLLABORATOR): silently dropped.
 - CLOSED PRs created before the lookback window: dropped — closing an old PR
   shouldn't trigger a fresh credibility penalty.
@@ -90,6 +91,13 @@ def _maybe_add_pr(
         # Mirror tracks more repos than the scoring set; skip-noise dominates the
         # log at info level when master_repositories is small. Demoted to debug.
         bt.logging.debug(f'Skipping PR #{pr.pr_number} in {pr.repo_full_name} - not in master_repositories')
+        return
+
+    if repo_config.inactive_at is not None and pr.created_at >= repo_config.inactive_at:
+        bt.logging.debug(
+            f'Skipping PR #{pr.pr_number} in {pr.repo_full_name} - created at '
+            f'{pr.created_at.isoformat()} after inactive_at {repo_config.inactive_at.isoformat()}'
+        )
         return
 
     # Silent maintainer skip — logging every maintainer-merged PR would dominate

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -2,6 +2,7 @@
 # Copyright © 2025 Entrius
 import json
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +25,7 @@ from gittensor.constants import (
     OPEN_ISSUE_SPAM_TOKEN_SCORE_PER_SLOT,
     OPEN_PR_THRESHOLD_TOKEN_SCORE,
 )
+from gittensor.validator.utils.datetime_utils import parse_optional_github_iso_to_utc
 
 
 @dataclass
@@ -87,6 +89,7 @@ class RepositoryConfig:
         emission_share: Fraction of the combined scoring pool allocated to this repo
         issue_discovery_share: Fraction of the repo allocation reserved for issue discovery
         additional_acceptable_branches: List of additional branch patterns to accept (None if only default branch)
+        inactive_at: UTC timestamp after which newly-created PRs are no longer scored for this repo
         trusted_label_pipeline: When True, scoring labels count regardless of
             actor — including GitHub Apps that surface as ``actor_association=NULL``.
             Defaults to False; only enable on repos with an authoritative label
@@ -109,6 +112,7 @@ class RepositoryConfig:
     emission_share: float
     issue_discovery_share: float = DEFAULT_ISSUE_DISCOVERY_SHARE
     additional_acceptable_branches: Optional[List[str]] = None
+    inactive_at: Optional[datetime] = None
     trusted_label_pipeline: bool = False
     label_multipliers: Optional[Dict[str, float]] = None
     default_label_multiplier: float = 1.0
@@ -337,6 +341,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                         metadata.get('issue_discovery_share', DEFAULT_ISSUE_DISCOVERY_SHARE),
                     ),
                     additional_acceptable_branches=metadata.get('additional_acceptable_branches'),
+                    inactive_at=parse_optional_github_iso_to_utc(metadata.get('inactive_at')),
                     trusted_label_pipeline=bool(metadata.get('trusted_label_pipeline', False)),
                     label_multipliers=(
                         {str(label): float(multiplier) for label, multiplier in metadata['label_multipliers'].items()}

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -162,6 +162,33 @@ class TestRepoFiltering:
         assert len(eval_.merged_prs) == 1
         assert eval_.merged_prs[0].pr.repo_full_name == 'entrius/gittensor-ui'
 
+    def test_pr_created_at_or_after_inactive_cutoff_dropped(self):
+        client = Mock()
+        client.get_miner_pulls.return_value = _build_response(
+            [
+                _pr_dict(1, state='MERGED', created_at='2026-04-09T23:59:59Z'),
+                _pr_dict(2, state='MERGED', created_at='2026-04-10T00:00:00Z'),
+                _pr_dict(3, state='OPEN', merged_at=None, created_at='2026-04-11T00:00:00Z'),
+                _pr_dict(4, state='CLOSED', merged_at=None, created_at='2026-04-12T00:00:00Z'),
+            ]
+        )
+        eval_ = _eval()
+
+        load_miner_prs(
+            eval_,
+            {
+                'entrius/gittensor-ui': RepositoryConfig(
+                    emission_share=0.5,
+                    inactive_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+                )
+            },
+            client=client,
+        )
+
+        assert [pr.pr.pr_number for pr in eval_.merged_prs] == [1]
+        assert eval_.open_prs == []
+        assert eval_.closed_prs == []
+
 
 # ============================================================================
 # Maintainer skip (legacy parity)

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -9,6 +9,7 @@ Run tests:
 """
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -253,6 +254,25 @@ class TestRepositoryConfigMirrorScoringFields:
 
         assert config.fixed_base_score is None
         assert config.eligibility == RepoEligibilityConfig()
+        assert config.inactive_at is None
+
+    def test_loader_parses_inactive_at(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/inactive': {'emission_share': 0.5, 'inactive_at': '2026-04-10T00:00:00Z'},
+                    'foo/defaults': {'emission_share': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/inactive'].inactive_at == datetime(2026, 4, 10, tzinfo=timezone.utc)
+        assert repos['foo/defaults'].inactive_at is None
 
     def test_loader_parses_fixed_base_score(self, tmp_path, monkeypatch):
         from gittensor.validator.utils import load_weights as lw


### PR DESCRIPTION
## Summary
- Restore optional `inactive_at` support in repository registry entries.
- Drop mirror PRs created at or after a repository's inactive cutoff before bucketing or scoring.
- Add loader and mirror-load regression tests for the cutoff behavior.

## What changed
- Added `RepositoryConfig.inactive_at` as an optional UTC timestamp parsed from `master_repositories.json`.
- Added a mirror PR load-time filter for PRs whose `created_at` is at or after the configured cutoff.
- Covered the default, parser, before-cutoff, at-cutoff, and after-cutoff behavior in tests.

## Why
Operators may need to freeze a repository while keeping it in the registry for historical or allocation reasons. The registry should be able to express that cutoff so newly-created PRs do not enter reward scoring for an inactive repository.

## Validation
- `uv run pytest tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_load.py -q`
- `uv run pytest tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_load.py tests/validator/oss_contributions/mirror/test_scoring.py tests/validator/oss_contributions/mirror/test_repo_config_fields.py -q`
- `uv run ruff check gittensor/validator/utils/load_weights.py gittensor/validator/oss_contributions/mirror/load.py tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_load.py`
- `uv run ruff format --check gittensor/validator/utils/load_weights.py gittensor/validator/oss_contributions/mirror/load.py tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_load.py`
- `uv run pyright gittensor/validator/utils/load_weights.py gittensor/validator/oss_contributions/mirror/load.py tests/validator/test_load_weights.py tests/validator/oss_contributions/mirror/test_load.py`
- `git diff --check`
- Codex Security control-path review: cutoff is parsed from registry config and enforced before PRs can affect open, closed, or merged scoring buckets.
- CodeRabbit CLI review: 0 issues.