### PR TITLE
feat(bounties): explain validator vote decisions

### DIFF
--- a/gittensor/cli/issue_commands/vote.py
+++ b/gittensor/cli/issue_commands/vote.py
@@ -10,13 +10,19 @@ Commands:
     gitt vote list
 """
 
+import json
 import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 import click
 from rich.panel import Panel
 from rich.table import Table
 
 from gittensor.cli.json_output import emit_json
+from gittensor.validator import pat_storage
+from gittensor.validator.issue_competitions.vote_decision import BountyVoteDecision, explain_bounty_vote
 
 from .help import StyledGroup
 from .helpers import (
@@ -36,6 +42,53 @@ from .helpers import (
     with_wallet_options,
 )
 from .types import CONTRACT_ISSUE, SS58
+
+
+def _load_registered_miners_from_pat_file(pat_file: Path) -> Dict[str, str]:
+    if not pat_file.exists():
+        return {}
+
+    data = json.loads(pat_file.read_text())
+    if not isinstance(data, list):
+        raise click.ClickException(f'Expected a list in PAT storage file: {pat_file}')
+
+    registered: Dict[str, str] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        github_id = str(entry.get('github_id') or '')
+        hotkey = str(entry.get('hotkey') or '')
+        if github_id and github_id != '0' and hotkey:
+            registered[github_id] = hotkey
+    return registered
+
+
+def _decision_to_dict(decision: BountyVoteDecision) -> Dict[str, Any]:
+    return asdict(decision)
+
+
+def _render_vote_explain_table(decisions: List[BountyVoteDecision]) -> None:
+    table = Table(show_header=True, header_style='bold magenta')
+    table.add_column('ID', style='cyan', justify='right')
+    table.add_column('Repo')
+    table.add_column('Issue', justify='right')
+    table.add_column('Action', style='green')
+    table.add_column('Reason')
+    table.add_column('Solver')
+    table.add_column('PR', justify='right')
+
+    for decision in decisions:
+        table.add_row(
+            str(decision.issue_id),
+            decision.repository_full_name,
+            f'#{decision.issue_number}',
+            decision.action,
+            decision.reason,
+            decision.solver_github_id or '-',
+            f'#{decision.pr_number}' if decision.pr_number else '-',
+        )
+
+    console.print(table)
 
 
 def parse_pr_number(pr_input: str) -> int:
@@ -268,6 +321,117 @@ def vote_list_validators(network: str, rpc_url: str, contract: str, as_json: boo
         else:
             err_console.print('[yellow]No validators whitelisted.[/yellow]')
             err_console.print('[dim]Add validators with: gitt admin add-vali <HOTKEY>[/dim]')
+
+    except Exception as e:
+        handle_exception(as_json=as_json, message=str(e))
+
+
+@vote.command('explain')
+@click.option('--issue-id', type=CONTRACT_ISSUE, default=None, help='Explain one on-chain issue ID.')
+@click.option(
+    '--github-token',
+    envvar='GITTENSOR_VALIDATOR_PAT',
+    default='',
+    help='GitHub token for closure lookup. Prefer GITTENSOR_VALIDATOR_PAT.',
+)
+@click.option(
+    '--pat-file',
+    type=click.Path(path_type=Path),
+    default=pat_storage.PATS_FILE,
+    show_default='data/miner_pats.json',
+    help='Validator PAT storage file used to map GitHub IDs to miner hotkeys.',
+)
+@with_cli_behavior_options(include_json=True)
+@with_network_contract_options('Contract address (uses config if empty)')
+def vote_explain(
+    issue_id: Optional[int],
+    github_token: str,
+    pat_file: Path,
+    network: str,
+    rpc_url: str,
+    contract: str,
+    as_json: bool,
+):
+    """Dry-run validator issue-bounty voting decisions.
+
+    [dim]No votes are submitted. The command reads active contract issues,
+    checks GitHub closure state, maps the solver GitHub ID through validator PAT
+    storage, resolves the miner coldkey, and reports the action the validator
+    would take.[/dim]
+    """
+    if not github_token:
+        handle_exception(
+            as_json=as_json,
+            message='GITTENSOR_VALIDATOR_PAT is required for GitHub solver lookup.',
+            error_type='missing_github_token',
+        )
+
+    contract_addr, ws_endpoint, network_name = _resolve_contract_and_network(contract, network, rpc_url)
+    if not as_json:
+        print_network_header(network_name, contract_addr)
+
+    try:
+        import bittensor as bt
+
+        from gittensor.utils.github_api_tools import check_github_issue_closed
+        from gittensor.validator.issue_competitions.contract_client import (
+            IssueCompetitionContractClient,
+            IssueStatus,
+        )
+        from gittensor.validator.utils.issue_competitions import get_miner_coldkey
+
+        registered_miners = _load_registered_miners_from_pat_file(pat_file)
+
+        with loading_context('Reading bounty issues from contract...', as_json):
+            subtensor = bt.Subtensor(network=ws_endpoint)
+            client = IssueCompetitionContractClient(
+                contract_address=contract_addr,
+                subtensor=subtensor,
+            )
+            if issue_id is None:
+                issues = client.get_issues_by_status(IssueStatus.ACTIVE)
+            else:
+                issue = client.get_issue(issue_id)
+                if issue is None:
+                    handle_exception(as_json=as_json, message=f'Issue {issue_id} not found.', error_type='not_found')
+                assert issue is not None
+                issues = [issue]
+
+        decisions: List[BountyVoteDecision] = []
+        with loading_context('Explaining vote decisions...', as_json):
+            for issue in issues:
+                github_state = check_github_issue_closed(
+                    issue.repository_full_name,
+                    issue.issue_number,
+                    github_token,
+                )
+                decisions.append(
+                    explain_bounty_vote(
+                        issue=issue,
+                        github_state=github_state,
+                        registered_miners=registered_miners,
+                        coldkey_lookup=lambda hotkey: get_miner_coldkey(hotkey, subtensor),
+                    )
+                )
+
+        if as_json:
+            emit_json(
+                {
+                    'success': True,
+                    'dry_run': True,
+                    'issue_count': len(issues),
+                    'registered_miner_count': len(registered_miners),
+                    'decisions': [_decision_to_dict(decision) for decision in decisions],
+                }
+            )
+            return
+
+        if not decisions:
+            err_console.print('[yellow]No active issues found.[/yellow]')
+            return
+
+        _render_vote_explain_table(decisions)
+        err_console.print('\n[dim]Dry run only; no votes were submitted.[/dim]')
 
     except Exception as e:
         handle_exception(as_json=as_json, message=str(e))

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -11,6 +11,7 @@ from gittensor.classes import MinerEvaluation
 from gittensor.utils.github_api_tools import check_github_issue_closed
 from gittensor.utils.utils import get_contract_address
 from gittensor.validator.issue_competitions.contract_client import IssueCompetitionContractClient, IssueStatus
+from gittensor.validator.issue_competitions.vote_decision import explain_bounty_vote
 from gittensor.validator.utils.config import GITTENSOR_VALIDATOR_PAT
 from gittensor.validator.utils.issue_competitions import get_miner_coldkey
 
@@ -95,59 +96,42 @@ async def issue_competitions(
                     issue.repository_full_name, issue.issue_number, GITTENSOR_VALIDATOR_PAT
                 )
 
-                if github_state is None:
-                    bt.logging.warning(f'Could not check GitHub state for {issue_label}')
-                    continue
-
-                if not github_state.get('is_closed'):
-                    bt.logging.info(f'Issue still open on GitHub: {issue_label}')
-                    continue
-
-                solver_github_id = github_state.get('solver_github_id')
-                pr_number = github_state.get('pr_number')
-                solver_lookup_failed = bool(github_state.get('solver_lookup_failed'))
+                decision = explain_bounty_vote(
+                    issue=issue,
+                    github_state=github_state,
+                    registered_miners=registered_miners,
+                    coldkey_lookup=lambda hotkey: get_miner_coldkey(hotkey, self.subtensor),
+                )
+                solver_github_id = decision.solver_github_id
+                pr_number = decision.pr_number
                 bt.logging.info(
-                    f'Issue closed on GitHub: {issue_label} | solver_github_id={solver_github_id}, '
-                    f'pr_number={pr_number}, solver_lookup_failed={solver_lookup_failed}'
+                    f'Issue bounty decision: {issue_label} | action={decision.action}, '
+                    f'reason={decision.reason}, solver_github_id={solver_github_id}, pr_number={pr_number}, '
+                    f'solver_lookup_failed={decision.solver_lookup_failed}'
                 )
 
-                if solver_lookup_failed:
-                    bt.logging.warning(f'Skipping issue due to solver lookup failure: {issue_label}')
+                if decision.action == 'skip':
                     continue
 
-                if not solver_github_id:
-                    bt.logging.info(f'No identifiable solver, voting cancel: {issue_label}')
+                if decision.action == 'vote_cancel':
                     success = contract_client.vote_cancel_issue(
                         issue_id=issue.id,
-                        reason='Issue closed without identifiable solver',
+                        reason=decision.cancel_reason or decision.reason,
                         wallet=self.wallet,
                     )
                     if success:
                         cancels_cast += 1
-                        bt.logging.info(f'Voted cancel (no solver): {issue_label}')
+                        bt.logging.info(f'Voted cancel: {issue_label} ({decision.reason})')
                     continue
 
-                miner_hotkey = registered_miners.get(str(solver_github_id))
-                if not miner_hotkey:
-                    bt.logging.info(f'Solver {solver_github_id} not a registered miner, voting cancel: {issue_label}')
-                    success = contract_client.vote_cancel_issue(
-                        issue_id=issue.id,
-                        reason=f'Issue closed externally (not by a registered miner, solver: {solver_github_id})',
-                        wallet=self.wallet,
-                    )
-                    if success:
-                        cancels_cast += 1
-                        bt.logging.info(
-                            f'Voted cancel (solver {solver_github_id} not a registered miner): {issue_label}'
-                        )
+                if decision.action != 'vote_solution':
+                    bt.logging.warning(f'Unknown issue bounty decision action {decision.action!r}: {issue_label}')
                     continue
 
-                miner_coldkey = get_miner_coldkey(miner_hotkey, self.subtensor)
-                if not miner_coldkey:
-                    bt.logging.warning(
-                        f'Could not get coldkey for hotkey {miner_hotkey} (solver {solver_github_id}): {issue_label}'
-                    )
-                    continue
+                miner_hotkey = decision.solver_hotkey
+                miner_coldkey = decision.solver_coldkey
+                assert miner_hotkey is not None
+                assert miner_coldkey is not None
 
                 bt.logging.info(
                     f'Voting solution: {issue_label} | PR#{pr_number}, solver={solver_github_id}, hotkey={miner_hotkey[:12]}...'

--- a/gittensor/validator/issue_competitions/vote_decision.py
+++ b/gittensor/validator/issue_competitions/vote_decision.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from gittensor.validator.issue_competitions.contract_client import ContractIssue, IssueStatus
+
+
+@dataclass(frozen=True)
+class BountyVoteDecision:
+    issue_id: int
+    repository_full_name: str
+    issue_number: int
+    action: str
+    reason: str
+    is_closed: Optional[bool] = None
+    solver_github_id: Optional[str] = None
+    pr_number: Optional[int] = None
+    solver_lookup_failed: bool = False
+    solver_hotkey: Optional[str] = None
+    solver_coldkey: Optional[str] = None
+    cancel_reason: Optional[str] = None
+
+
+def explain_bounty_vote(
+    issue: ContractIssue,
+    github_state: Optional[Dict[str, Any]],
+    registered_miners: Dict[str, str],
+    coldkey_lookup: Callable[[str], Optional[str]],
+) -> BountyVoteDecision:
+    """Explain the vote action the validator would take for one bounty issue."""
+    base = {
+        'issue_id': issue.id,
+        'repository_full_name': issue.repository_full_name,
+        'issue_number': issue.issue_number,
+    }
+
+    issue_status = getattr(issue, 'status', IssueStatus.ACTIVE)
+    if issue_status is not IssueStatus.ACTIVE:
+        status_name = issue_status.name if isinstance(issue_status, IssueStatus) else str(issue_status)
+        return BountyVoteDecision(
+            **base,
+            action='skip',
+            reason=f'Issue status is {status_name}, not ACTIVE',
+        )
+
+    if github_state is None:
+        return BountyVoteDecision(
+            **base,
+            action='skip',
+            reason='Could not check GitHub issue state',
+        )
+
+    is_closed = bool(github_state.get('is_closed'))
+    if not is_closed:
+        return BountyVoteDecision(
+            **base,
+            action='skip',
+            reason='Issue is still open on GitHub',
+            is_closed=False,
+        )
+
+    solver_github_id_raw = github_state.get('solver_github_id')
+    solver_github_id = str(solver_github_id_raw) if solver_github_id_raw else None
+    pr_number = github_state.get('pr_number')
+    solver_lookup_failed = bool(github_state.get('solver_lookup_failed'))
+
+    if solver_lookup_failed:
+        return BountyVoteDecision(
+            **base,
+            action='skip',
+            reason='Solver lookup failed',
+            is_closed=True,
+            solver_github_id=solver_github_id,
+            pr_number=pr_number,
+            solver_lookup_failed=True,
+        )
+
+    if not solver_github_id:
+        cancel_reason = 'Issue closed without identifiable solver'
+        return BountyVoteDecision(
+            **base,
+            action='vote_cancel',
+            reason=cancel_reason,
+            is_closed=True,
+            pr_number=pr_number,
+            cancel_reason=cancel_reason,
+        )
+
+    miner_hotkey = registered_miners.get(solver_github_id)
+    if not miner_hotkey:
+        cancel_reason = f'Issue closed externally (not by a registered miner, solver: {solver_github_id})'
+        return BountyVoteDecision(
+            **base,
+            action='vote_cancel',
+            reason=cancel_reason,
+            is_closed=True,
+            solver_github_id=solver_github_id,
+            pr_number=pr_number,
+            cancel_reason=cancel_reason,
+        )
+
+    miner_coldkey = coldkey_lookup(miner_hotkey)
+    if not miner_coldkey:
+        return BountyVoteDecision(
+            **base,
+            action='skip',
+            reason=f'Could not resolve coldkey for registered solver hotkey {miner_hotkey}',
+            is_closed=True,
+            solver_github_id=solver_github_id,
+            pr_number=pr_number,
+            solver_hotkey=miner_hotkey,
+        )
+
+    return BountyVoteDecision(
+        **base,
+        action='vote_solution',
+        reason='Registered solver identity and coldkey resolved',
+        is_closed=True,
+        solver_github_id=solver_github_id,
+        pr_number=pr_number,
+        solver_hotkey=miner_hotkey,
+        solver_coldkey=miner_coldkey,
+    )

--- a/tests/cli/test_vote_explain.py
+++ b/tests/cli/test_vote_explain.py
@@ -1,0 +1,87 @@
+import json
+from unittest.mock import Mock, patch
+
+from gittensor.validator.issue_competitions.contract_client import ContractIssue, IssueStatus
+
+
+def _issue() -> ContractIssue:
+    return ContractIssue(
+        id=7,
+        github_url_hash=b'0' * 32,
+        repository_full_name='entrius/gittensor',
+        issue_number=12,
+        bounty_amount=1_000_000_000,
+        target_bounty=1_000_000_000,
+        status=IssueStatus.ACTIVE,
+        registered_at_block=1,
+        is_fully_funded=True,
+    )
+
+
+def test_vote_explain_json_reports_dry_run_solution(cli_root, runner, tmp_path):
+    pat_file = tmp_path / 'miner_pats.json'
+    pat_file.write_text(json.dumps([{'github_id': '999', 'hotkey': 'hk999', 'pat': 'redacted'}]))
+
+    client = Mock()
+    client.get_issues_by_status.return_value = [_issue()]
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+            return_value=('5Contract', 'wss://test.finney.opentensor.ai:443', 'test'),
+        ),
+        patch('bittensor.Subtensor') as mock_subtensor,
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient', return_value=client
+        ),
+        patch(
+            'gittensor.utils.github_api_tools.check_github_issue_closed',
+            return_value={
+                'is_closed': True,
+                'solver_github_id': '999',
+                'pr_number': 42,
+                'solver_lookup_failed': False,
+            },
+        ),
+        patch('gittensor.validator.utils.issue_competitions.get_miner_coldkey', return_value='ck999'),
+    ):
+        result = runner.invoke(
+            cli_root,
+            [
+                'vote',
+                'explain',
+                '--json',
+                '--github-token',
+                'ghp_validator',
+                '--pat-file',
+                str(pat_file),
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload['success'] is True
+    assert payload['dry_run'] is True
+    assert payload['registered_miner_count'] == 1
+    assert payload['decisions'][0]['action'] == 'vote_solution'
+    assert payload['decisions'][0]['solver_hotkey'] == 'hk999'
+    assert payload['decisions'][0]['solver_coldkey'] == 'ck999'
+    client.get_issues_by_status.assert_called_once_with(IssueStatus.ACTIVE)
+    mock_subtensor.assert_called_once()
+
+
+def test_vote_explain_missing_github_token_exits_non_zero(cli_root, runner, tmp_path):
+    pat_file = tmp_path / 'miner_pats.json'
+    pat_file.write_text('[]')
+
+    result = runner.invoke(
+        cli_root,
+        ['vote', 'explain', '--json', '--pat-file', str(pat_file)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'missing_github_token'

--- a/tests/validator/test_bounty_vote_decision.py
+++ b/tests/validator/test_bounty_vote_decision.py
@@ -1,0 +1,65 @@
+from gittensor.validator.issue_competitions.contract_client import ContractIssue, IssueStatus
+from gittensor.validator.issue_competitions.vote_decision import explain_bounty_vote
+
+
+def _issue(status: IssueStatus = IssueStatus.ACTIVE) -> ContractIssue:
+    return ContractIssue(
+        id=7,
+        github_url_hash=b'0' * 32,
+        repository_full_name='entrius/gittensor',
+        issue_number=12,
+        bounty_amount=1_000_000_000,
+        target_bounty=1_000_000_000,
+        status=status,
+        registered_at_block=1,
+        is_fully_funded=True,
+    )
+
+
+def test_explains_solution_vote_when_solver_is_registered():
+    decision = explain_bounty_vote(
+        issue=_issue(),
+        github_state={
+            'is_closed': True,
+            'solver_github_id': '999',
+            'pr_number': 42,
+            'solver_lookup_failed': False,
+        },
+        registered_miners={'999': 'hk999'},
+        coldkey_lookup=lambda hotkey: 'ck999' if hotkey == 'hk999' else None,
+    )
+
+    assert decision.action == 'vote_solution'
+    assert decision.solver_hotkey == 'hk999'
+    assert decision.solver_coldkey == 'ck999'
+    assert decision.pr_number == 42
+
+
+def test_explains_cancel_when_closed_without_registered_solver():
+    decision = explain_bounty_vote(
+        issue=_issue(),
+        github_state={
+            'is_closed': True,
+            'solver_github_id': '999',
+            'pr_number': 42,
+            'solver_lookup_failed': False,
+        },
+        registered_miners={},
+        coldkey_lookup=lambda _hotkey: None,
+    )
+
+    assert decision.action == 'vote_cancel'
+    assert decision.cancel_reason == 'Issue closed externally (not by a registered miner, solver: 999)'
+
+
+def test_explains_skip_when_solver_lookup_failed():
+    decision = explain_bounty_vote(
+        issue=_issue(),
+        github_state={'is_closed': True, 'solver_lookup_failed': True},
+        registered_miners={},
+        coldkey_lookup=lambda _hotkey: None,
+    )
+
+    assert decision.action == 'skip'
+    assert decision.reason == 'Solver lookup failed'
+    assert decision.solver_lookup_failed is True


### PR DESCRIPTION
## Summary
- Add a dry-run `gitt vote explain` command for issue-bounty validator decisions.
- Factor issue-bounty vote policy into a pure decision helper reused by the validator forward path.
- Add JSON and table output for explaining whether an issue would be skipped, cancelled, or voted as solved.

## What changed
- Added `BountyVoteDecision` and `explain_bounty_vote()` for deterministic per-issue vote explanations.
- Updated the issue-bounty forward path to execute the shared decision result instead of keeping policy inline.
- Added `gitt vote explain` with `--json`, `--issue-id`, `--github-token`, and `--pat-file` support.
- Added regression tests for decision outcomes and CLI dry-run JSON behavior.

## Why
Validators should be able to inspect what bounty vote action would be taken before submitting any on-chain vote. A shared decision helper keeps dry-run explanations aligned with the live forward path.

## Validation
- `uv run pytest tests/validator/test_bounty_vote_decision.py tests/validator/test_issue_competitions_forward.py tests/cli/test_vote_explain.py -q`
- `uv run pytest tests/validator/test_bounty_vote_decision.py tests/validator/test_issue_competitions_forward.py tests/cli/test_vote_explain.py tests/cli/test_cli_helpers.py tests/cli/test_cli_json_error_output.py tests/cli/test_issue_command_types.py -q`
- `uv run ruff check gittensor/validator/issue_competitions/vote_decision.py gittensor/validator/issue_competitions/forward.py gittensor/cli/issue_commands/vote.py tests/validator/test_bounty_vote_decision.py tests/cli/test_vote_explain.py`
- `uv run ruff format --check gittensor/validator/issue_competitions/vote_decision.py gittensor/validator/issue_competitions/forward.py gittensor/cli/issue_commands/vote.py tests/validator/test_bounty_vote_decision.py tests/cli/test_vote_explain.py`
- `uv run pyright gittensor/validator/issue_competitions/vote_decision.py gittensor/validator/issue_competitions/forward.py gittensor/cli/issue_commands/vote.py tests/validator/test_bounty_vote_decision.py tests/cli/test_vote_explain.py`
- `git diff --check`
- Codex Security control-path review: the explain command is read-only and does not call contract vote mutation methods; stored PAT values are not emitted.
- CodeRabbit CLI review: blocked by free-tier rate limit after authentication; no CodeRabbit findings were available for this PR.