### PR TITLE
feat(validator): add 6 community repos to master list, retune weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,4 +1,8 @@
 {
+  "aglover1221/product-data-extractor": {
+    "emission_share": 0.00250,
+    "issue_discovery_share": 0.0
+  },
   "entrius/allways": {
     "emission_share": 0.05018,
     "issue_discovery_share": 1.0,
@@ -35,7 +39,7 @@
   },
   "entrius/gittensor": {
     "emission_share": 0.10127,
-    "issue_discovery_share": 0.25,
+    "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,
       "enhancement": 1.25,
@@ -75,14 +79,34 @@
     "trusted_label_pipeline": true
   },
   "Geniepod/genie-claw": {
-    "emission_share": 0.04500,
+    "emission_share": 0.04000,
+    "issue_discovery_share": 0.0
+  },
+  "infiniflow/ragflow": {
+    "emission_share": 0.04000,
+    "issue_discovery_share": 0.0
+  },
+  "JSONbored/awesome-claude": {
+    "emission_share": 0.01000,
     "issue_discovery_share": 0.0
   },
   "MkDev11/gittensor-hub": {
     "emission_share": 0.03500,
     "issue_discovery_share": 0.0
   },
+  "plind-junior/vouch": {
+    "emission_share": 0.00500,
+    "issue_discovery_share": 0.0
+  },
   "seroperson/jvm-live-reload": {
+    "emission_share": 0.01000,
+    "issue_discovery_share": 0.0
+  },
+  "touchpilot/touchpilot": {
+    "emission_share": 0.03000,
+    "issue_discovery_share": 0.0
+  },
+  "we-promise/sure": {
     "emission_share": 0.03000,
     "issue_discovery_share": 0.0
   }


### PR DESCRIPTION
## Summary

Adds 6 vetted community repositories to the master repository list and retunes existing weights.

### New repositories

| Repo | emission_share |
|---|---|
| infiniflow/ragflow | 0.04000 |
| we-promise/sure | 0.03000 |
| touchpilot/touchpilot | 0.03000 |
| JSONbored/awesome-claude | 0.01000 |
| plind-junior/vouch | 0.00500 |
| aglover1221/product-data-extractor | 0.00250 |

All six use baseline config (`emission_share` + `issue_discovery_share: 0.0`).

### Existing entries changed

- `Geniepod/genie-claw` — `emission_share` 0.04500 -> 0.04000
- `seroperson/jvm-live-reload` — `emission_share` 0.03000 -> 0.01000
- `entrius/gittensor` — `issue_discovery_share` 0.25 -> 0.0

### Other

- Registry entries sorted alphabetically (no behavior change).

Total configured `emission_share`: ~0.396 (within the <= 1.0 bound). Verified with `pytest tests/validator/test_load_weights.py`.