### PR TITLE
fix(issue-discovery): keep fresh scoring data when open-count fetch fails (#1249)

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -198,12 +198,19 @@ async def run_issue_discovery(
         try:
             current_response = await asyncio.to_thread(client.get_miner_issues, evaluation.github_id)
         except MirrorRequestError as e:
-            bt.logging.warning(f'├─ UID {uid}: open-issue count fetch failed ({e}) — skipped this miner')
-            _restore_issue_discovery_from_cache(evaluation, evaluation_cache)
-            fetch_errors += 1
-            continue
-
-        open_counts = _count_open_issues(current_response.issues, enabled_names)
+            # Soft-fail: the open-count call is supplementary to the scoring
+            # payload already fetched above. Discarding fresh solved-issue
+            # evidence because of a transient open-count failure penalises
+            # miners for mirror flakiness. Fall back to last cycle's per-repo
+            # open counts when available; otherwise zero. Scoring proceeds.
+            open_counts = _open_counts_from_cache(evaluation, evaluation_cache, enabled_names)
+            bt.logging.warning(
+                f'├─ UID {uid}: open-issue count fetch failed ({e}) — '
+                f'using cached open counts ({sum(open_counts.values())} total); '
+                f'scoring proceeds with fresh lookback data'
+            )
+        else:
+            open_counts = _count_open_issues(current_response.issues, enabled_names)
         filtered = [i for i in response.issues if i.repo_full_name in enabled_names and _should_include_issue(i)]
         if not filtered:
             _clear_issue_discovery_fields(evaluation)
@@ -359,6 +366,28 @@ def _count_open_issues(issues: List[MirrorIssue], enabled_names: Set[str]) -> Di
     for issue in issues:
         if issue.repo_full_name in enabled_names and issue.state == 'OPEN':
             counts[issue.repo_full_name] = counts.get(issue.repo_full_name, 0) + 1
+    return counts
+
+
+def _open_counts_from_cache(
+    evaluation: MinerEvaluation,
+    evaluation_cache: Optional[MinerEvaluationCache],
+    enabled_names: Set[str],
+) -> Dict[str, int]:
+    """Recover per-repo open-issue counts from the prior cycle's cached
+    evaluation. Used as the soft-fail fallback when the open-count fetch
+    fails but the scoring fetch succeeded, so fresh solved-issue evidence
+    isn't discarded. Returns {} when no cache row is available — scoring
+    then runs with zero open counts rather than dropping the miner."""
+    if evaluation_cache is None:
+        return {}
+    cached = evaluation_cache.get(evaluation.uid, evaluation.hotkey, evaluation.github_id or '')
+    if cached is None:
+        return {}
+    counts: Dict[str, int] = {}
+    for repo_name, repo_eval in cached.repo_evaluations.items():
+        if repo_name in enabled_names and repo_eval.total_open_issues:
+            counts[repo_name] = repo_eval.total_open_issues
     return counts
 
 


### PR DESCRIPTION
## Summary

`run_issue_discovery` makes two mirror calls per miner — one for the scoring payload (`since=lookback`) and one for the open-issue count. When call 1 succeeds and call 2 fails, the current code calls `_restore_issue_discovery_from_cache` and `continue`s, discarding the freshly-fetched solved-issue evidence and reverting to stale cached aggregates.

Soft-fail the open-count call: when it raises, fall back to the prior cycle's per-repo `total_open_issues` via a new helper `_open_counts_from_cache(evaluation, evaluation_cache, enabled_names)`. Scoring then proceeds against the lookback dataset that was already retrieved. Empty fallback (`{}`) when no cache row exists — still better than dropping the miner entirely.

Implementation matches the issue's "Possible Solution" section.

Closes #1249

## Test plan

- `uv run pytest tests/validator/issue_discovery/` — 54/54 pass.
- Manual reasoning:
  - Path A: both calls succeed → behavior unchanged (`_count_open_issues` over fresh `current_response`).
  - Path B: call 1 fails → behavior unchanged (still restore from cache + continue).
  - Path C: call 1 succeeds, call 2 fails → NEW: `_open_counts_from_cache` returns prior-cycle per-repo counts (or `{}`), scoring runs over `response.issues`.
