### PR TITLE
fix: guard handle_pat_check against unregistered hotkey 

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -105,6 +105,11 @@ async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSy
 async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> PatCheckSynapse:
     """Check if the validator has the miner's PAT stored and re-validate it."""
     hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        synapse.has_pat = False
+        synapse.pat_valid = False
+        synapse.rejection_reason = 'Hotkey not registered on subnet'
+        return synapse
     uid = validator.metagraph.hotkeys.index(hotkey)
     entry = pat_storage.get_pat_by_uid(uid)
 


### PR DESCRIPTION
Closes #1297

`handle_pat_check` called `validator.metagraph.hotkeys.index(hotkey)` 
without first checking that the hotkey is still registered. If a miner 
deregisters between the blacklist check and the handler, `.index()` raises 
an uncaught `ValueError` that crashes the axon handler.

Added the same guard already present in `handle_pat_broadcast`: return 
early with `has_pat=False` if the hotkey is not found in the metagraph.
