### PR TITLE
fix: increment valid_solved only after exclusion guards

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -463,10 +463,6 @@ async def _score_miner_issues(
             )
             continue
 
-        # Valid-solved gate: solving PR must meet the repo's token threshold.
-        if cached.token_score >= cfg.min_token_score_for_valid_issue:
-            acc.valid_solved += 1
-
         # Same-account: discoverer == solver gets credibility only, no score
         if issue.author_github_id == solving_pr.author_github_id:
             bt.logging.debug(
@@ -493,6 +489,9 @@ async def _score_miner_issues(
                 f'{cfg.min_token_score_for_valid_issue} — credibility only'
             )
             continue
+
+        # Valid-solved gate: only increment after both exclusion guards pass
+        acc.valid_solved += 1
 
         adapted = _mirror_issue_for_scoring(issue, solving_pr, repo_config, base_score=cached.base_score)
         if adapted is None:


### PR DESCRIPTION
Closes #1298

`valid_solved_count` was incremented before the same-account guard and 
the canonical-PR-owner guard, allowing self-farmed and non-canonical 
issues to inflate the eligibility counter.

Moved the increment to after both `continue` guards so only issues that 
survive all exclusion checks contribute to the valid-solved threshold.
