### PR TITLE
fix: apply repository label policy to issue-discovery scoring

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -154,6 +154,7 @@ class Issue:
     discovery_time_decay_multiplier: float = 1.0
     discovery_credibility_multiplier: float = 1.0
     discovery_open_issue_spam_multiplier: float = 1.0
+    discovery_label_multiplier: float = 1.0
 
     @property
     def is_transferred(self) -> bool:

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -51,6 +51,7 @@ from gittensor.validator.issue_discovery.scoring import (
     calculate_open_issue_spam_multiplier,
     check_issue_eligibility,
 )
+from gittensor.validator.oss_contributions.label_resolution import resolve_highest_label_multiplier
 from gittensor.validator.oss_contributions.mirror.adapters import mirror_files_to_legacy
 from gittensor.validator.oss_contributions.mirror.scoring import (
     calculate_base_score_for_pr_files,
@@ -468,6 +469,7 @@ async def _score_miner_issues(
             * issue.discovery_repo_weight_multiplier
             * issue.discovery_time_decay_multiplier
             * issue.discovery_review_quality_multiplier
+            * issue.discovery_label_multiplier
             * issue.discovery_credibility_multiplier
             * issue.discovery_open_issue_spam_multiplier,
             2,
@@ -635,5 +637,9 @@ def _mirror_issue_for_scoring(
         calculate_issue_review_quality_multiplier(solving_pr.review_summary.maintainer_changes_requested_count),
         2,
     )
+    _, label_multiplier = resolve_highest_label_multiplier(
+        [label.name for label in solving_pr.labels], repo_config
+    )
+    adapted.discovery_label_multiplier = round(label_multiplier, 2)
 
     return adapted


### PR DESCRIPTION
Closes #1281

Issue-discovery scoring in `_mirror_issue_for_scoring` had no label
multiplier, unlike the OSS scoring path. Repos configured with
`default_label_multiplier: 0.0` would incorrectly award full discovery
rewards for unlabelled solving PRs.

Changes:
- Added `discovery_label_multiplier` field to `Issue` (default 1.0)
- Resolved the highest-matching label from the solving PR's labels
  against the repo's label policy via `resolve_highest_label_multiplier`
- Applied `discovery_label_multiplier` in the earned-score calculation
  alongside the existing multipliers
