### PR TITLE
fix: recycle treasury emission share when ISSUES_TREASURY_UID is absent

### DIFF
--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -97,6 +97,12 @@ def blend_emission_pools(
             f'Treasury allocation: UID {ISSUES_TREASURY_UID} receives '
             f'{ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% of emissions'
         )
+    elif ISSUES_TREASURY_UID > 0:
+        recycle_share += ISSUES_TREASURY_EMISSION_SHARE
+        bt.logging.warning(
+            f'Treasury UID {ISSUES_TREASURY_UID} not in miner set — '
+            f'recycling {ISSUES_TREASURY_EMISSION_SHARE * 100:.0f}% to UID {RECYCLE_UID}'
+        )
 
     # Recycle receives registry slack and empty repo slices.
     if RECYCLE_UID in miner_uids:


### PR DESCRIPTION
When `ISSUES_TREASURY_UID` (111) is not registered in `miner_uids`, the 10% treasury allocation was silently dropped — never added to `recycle_share`. The rewards array summed to only `OSS_EMISSION_SHARE` (0.90) instead of 1.0, losing 10% of emissions every round when the treasury UID is unregistered.

Added an `elif` branch that routes the unallocated treasury share to `recycle_share` so it reaches `RECYCLE_UID` (0) and the invariant `rewards.sum() == 1.0` is preserved.

Closes #1318
