### PR TITLE
fix(cli): reject viewer-null PAT preflight responses (#1195)

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -39,6 +39,9 @@ _PAT_POST_STATUS_MARKUP = {
     'rejected': '[red]✗[/red]',
     'no_response': '[yellow]—[/yellow]',
 }
+_PAT_GRAPHQL_ACCESS_ERROR = (
+    '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
+)
 
 
 @click.command()
@@ -214,9 +217,26 @@ def _validate_pat_locally(pat: str) -> str | None:
             timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
         if gql_resp.status_code != 200:
-            err_console.print(
-                '[red]PAT lacks GraphQL API access. Fine-grained PATs need "Public Repositories (read-only)" permission.[/red]'
-            )
+            err_console.print(_PAT_GRAPHQL_ACCESS_ERROR)
+            return None
+
+        try:
+            gql_data = gql_resp.json()
+        except ValueError:
+            return None
+
+        if not isinstance(gql_data, dict):
+            err_console.print(_PAT_GRAPHQL_ACCESS_ERROR)
+            return None
+
+        if gql_data.get('errors'):
+            err_console.print(_PAT_GRAPHQL_ACCESS_ERROR)
+            return None
+
+        response_data = gql_data.get('data')
+        viewer = response_data.get('viewer') if isinstance(response_data, dict) else None
+        if viewer is None:
+            err_console.print(_PAT_GRAPHQL_ACCESS_ERROR)
             return None
 
         return login

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -4,7 +4,7 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -19,7 +19,18 @@ from gittensor.cli.miner_commands.helpers import (
     _require_validator_axons,
     _resolve_endpoint,
 )
+from gittensor.cli.miner_commands.post import _validate_pat_locally
 from gittensor.constants import NETWORK_MAP
+
+
+def _mock_http_response(status_code: int = 200, payload=None, json_error=None):
+    response = MagicMock()
+    response.status_code = status_code
+    if json_error is not None:
+        response.json.side_effect = json_error
+    else:
+        response.json.return_value = payload if payload is not None else {}
+    return response
 
 
 def _fake_metagraph(rows: list[tuple[float, bool, float]]):
@@ -36,6 +47,37 @@ def _fake_metagraph(rows: list[tuple[float, bool, float]]):
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+class TestValidatePatLocally:
+    @patch('gittensor.cli.miner_commands.post.requests.post')
+    @patch('gittensor.cli.miner_commands.post.requests.get')
+    def test_valid_viewer_returns_login(self, mock_get, mock_post):
+        mock_get.return_value = _mock_http_response(200, {'login': 'octocat'})
+        mock_post.return_value = _mock_http_response(200, {'data': {'viewer': {'login': 'octocat'}}})
+        assert _validate_pat_locally('ghp_valid') == 'octocat'
+
+    @pytest.mark.parametrize(
+        'payload',
+        [
+            {'data': {'viewer': None}},
+            {'data': None},
+            {'errors': [{'message': 'Bad credentials'}]},
+        ],
+    )
+    @patch('gittensor.cli.miner_commands.post.requests.post')
+    @patch('gittensor.cli.miner_commands.post.requests.get')
+    def test_graphql_body_rejections_return_none(self, mock_get, mock_post, payload):
+        mock_get.return_value = _mock_http_response(200, {'login': 'octocat'})
+        mock_post.return_value = _mock_http_response(200, payload)
+        assert _validate_pat_locally('ghp_scopeless') is None
+
+    @patch('gittensor.cli.miner_commands.post.requests.post')
+    @patch('gittensor.cli.miner_commands.post.requests.get')
+    def test_graphql_json_decode_error_returns_none(self, mock_get, mock_post):
+        mock_get.return_value = _mock_http_response(200, {'login': 'octocat'})
+        mock_post.return_value = _mock_http_response(200, json_error=ValueError('not json'))
+        assert _validate_pat_locally('ghp_bad_json') is None
 
 
 class TestMinerPost:


### PR DESCRIPTION
## Summary

- Local PAT preflight in `gitt miner post` only checked the GraphQL HTTP status code, so fine-grained PATs missing **"Public Repositories (read-only)"** returned `HTTP 200` with `{"data": {"viewer": null}}` and falsely passed local validation — the CLI printed `PAT is valid. GitHub account: @...` and broadcast a token validators deterministically reject (validator-side fix landed in #764 / referenced by #751).
- Port the body-level checks from `_test_pat_against_repo` (`gittensor/validator/pat_handler.py`) to the CLI preflight: reject populated `errors`, missing / non-dict `data`, and `data.viewer is None`. Also return `None` on JSON decode failures.
- Extract the existing fine-grained-PAT permission message to a module-level `_PAT_GRAPHQL_ACCESS_ERROR` constant so the transport and body-level rejection paths render the same guidance.
- Add `TestValidatePatLocally` regression coverage: a happy-path viewer response, parametrized rejections for `viewer:null`, `data:null`, and populated `errors`, plus a JSON decode failure case.

## Related Issues

Closes #1195

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Commands run:

```bash
uv run pytest tests/cli/test_miner_commands.py -q
uv run ruff check gittensor/cli/miner_commands/post.py tests/cli/test_miner_commands.py
uv run ruff format --check gittensor/cli/miner_commands/post.py tests/cli/test_miner_commands.py
uv run pyright gittensor/cli/miner_commands/post.py tests/cli/test_miner_commands.py
```

Results: `39 passed`, ruff clean, format clean, `0 errors, 0 warnings, 0 informations`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
`