### PR TITLE
fix(validator): treat transient PAT test-query failures as inconclusive

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -6,6 +6,7 @@ Miners push their GitHub PAT to validators via PatBroadcastSynapse.
 Miners check if a validator has their PAT via PatCheckSynapse.
 """
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import bittensor as bt
@@ -22,6 +23,22 @@ from gittensor.validator.utils.github_validation import (
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
+
+
+_TRANSIENT_PAT_TEST_MESSAGE = 'GitHub API temporarily unavailable; retry the check in a few minutes.'
+
+
+@dataclass(frozen=True)
+class PatTestResult:
+    """Outcome of the GraphQL test query against a PAT.
+
+    Mirrors the shape of ``GitHubCredentialValidation`` so callers can
+    distinguish transient transport failures (worth retrying) from permanent
+    rejections (the PAT really is bad).
+    """
+
+    error: Optional[str] = None
+    transient_failure: bool = False
 
 
 def _get_hotkey(synapse: bt.Synapse) -> str:
@@ -66,9 +83,14 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
             )
 
     # 4. Test query against a known repo to catch org-restricted PATs
-    test_error = _test_pat_against_repo(synapse.github_access_token)
-    if test_error:
-        return _reject(f'PAT test query failed: {test_error}')
+    test_result = _test_pat_against_repo(synapse.github_access_token)
+    if test_result.transient_failure:
+        return _reject(
+            f'GitHub API temporarily unavailable during PAT test query; retry the broadcast in a few minutes. '
+            f'({test_result.error})'
+        )
+    if test_result.error:
+        return _reject(f'PAT test query failed: {test_result.error}')
 
     # 5. Store PAT (github_id guaranteed non-None after validate_github_credentials success)
     pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=github_id or '0')
@@ -124,7 +146,7 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
     validation = validate_github_credentials_result(uid, entry['pat'], stored_github_id=entry.get('github_id'))
     if validation.transient_failure:
         synapse.pat_valid = None
-        synapse.rejection_reason = 'GitHub API temporarily unavailable; retry the check in a few minutes.'
+        synapse.rejection_reason = _TRANSIENT_PAT_TEST_MESSAGE
         bt.logging.warning(f'PAT check result — UID: {uid}: GitHub identity lookup temporarily unavailable')
         return synapse
     if validation.error:
@@ -133,11 +155,16 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
         bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {validation.error}')
         return synapse
 
-    test_error = _test_pat_against_repo(entry['pat'])
-    if test_error:
+    test_result = _test_pat_against_repo(entry['pat'])
+    if test_result.transient_failure:
+        synapse.pat_valid = None
+        synapse.rejection_reason = _TRANSIENT_PAT_TEST_MESSAGE
+        bt.logging.warning(f'PAT check result — UID: {uid}: test query temporarily unavailable: {test_result.error}')
+        return synapse
+    if test_result.error:
         synapse.pat_valid = False
-        synapse.rejection_reason = f'PAT test query failed: {test_error}'
-        bt.logging.warning(f'PAT check result — UID: {uid}: test query failed: {test_error}')
+        synapse.rejection_reason = f'PAT test query failed: {test_result.error}'
+        bt.logging.warning(f'PAT check result — UID: {uid}: test query failed: {test_result.error}')
         return synapse
 
     synapse.pat_valid = True
@@ -167,11 +194,16 @@ async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -
 # ---------------------------------------------------------------------------
 
 
-def _test_pat_against_repo(pat: str) -> Optional[str]:
+def _test_pat_against_repo(pat: str) -> PatTestResult:
     """Run a test GraphQL call to verify the PAT has the access scoring requires.
 
     Scoring uses the GraphQL API to fetch miner PRs, so this mirrors the real path.
-    Returns an error string on failure, None on success.
+
+    Returns a ``PatTestResult``. Transient transport failures (HTTP 5xx, network
+    errors, timeouts) set ``transient_failure=True`` so callers can surface them
+    as inconclusive — mirroring the identity-check path established in #1107.
+    Permanent rejections (4xx, GraphQL errors, missing viewer scope) set
+    ``error`` only and leave ``transient_failure=False``.
     """
     try:
         response = requests.post(
@@ -180,14 +212,19 @@ def _test_pat_against_repo(pat: str) -> Optional[str]:
             headers=make_graphql_headers(pat),
             timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
         )
+        if response.status_code >= 500:
+            return PatTestResult(
+                error=f'GitHub GraphQL API returned {response.status_code}',
+                transient_failure=True,
+            )
         if response.status_code != 200:
-            return f'GitHub GraphQL API returned {response.status_code}'
+            return PatTestResult(error=f'GitHub GraphQL API returned {response.status_code}')
         data = response.json()
         errors = data.get('errors')
         if errors:
-            return f'GraphQL error: {errors[0].get("message", "unknown")}'
+            return PatTestResult(error=f'GraphQL error: {errors[0].get("message", "unknown")}')
         if (data.get('data') or {}).get('viewer') is None:
-            return "Fine-grained PATs need 'Public Repositories (read-only)' permission"
-        return None
+            return PatTestResult(error="Fine-grained PATs need 'Public Repositories (read-only)' permission")
+        return PatTestResult()
     except requests.RequestException as e:
-        return str(e)
+        return PatTestResult(error=str(e), transient_failure=True)

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -7,12 +7,14 @@ from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from bittensor.core.synapse import TerminalInfo
 
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.utils.github_api_tools import GitHubIdentityResult, GitHubIdentityStatus
 from gittensor.validator import pat_storage
 from gittensor.validator.pat_handler import (
+    PatTestResult,
     _test_pat_against_repo,
     blacklist_pat_broadcast,
     blacklist_pat_check,
@@ -103,7 +105,7 @@ class TestBlacklistPatCheck:
 
 
 class TestHandlePatBroadcast:
-    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=PatTestResult())
     @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
     def test_valid_pat_accepted(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_valid')
@@ -140,7 +142,10 @@ class TestHandlePatBroadcast:
         # Verify PAT was NOT stored
         assert pat_storage.get_pat_by_uid(1) is None
 
-    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value='GitHub API returned 403')
+    @patch(
+        'gittensor.validator.pat_handler._test_pat_against_repo',
+        return_value=PatTestResult(error='GitHub GraphQL API returned 403'),
+    )
     @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
     def test_test_query_failure_rejected(self, mock_validate, mock_test_query, mock_validator):
         synapse = _make_broadcast_synapse('hotkey_1')
@@ -149,7 +154,28 @@ class TestHandlePatBroadcast:
         assert result.accepted is False
         assert '403' in (result.rejection_reason or '')
 
-    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch(
+        'gittensor.validator.pat_handler._test_pat_against_repo',
+        return_value=PatTestResult(error='GitHub GraphQL API returned 503', transient_failure=True),
+    )
+    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    def test_test_query_transient_failure_rejected_with_retry_message(
+        self, mock_validate, mock_test_query, mock_validator
+    ):
+        """Transient PAT test-query failures should reject with a retry message and not store the PAT."""
+        synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_unverifiable')
+        result = _run(handle_pat_broadcast(mock_validator, synapse))
+
+        assert result.accepted is False
+        reason = result.rejection_reason or ''
+        assert 'temporarily unavailable' in reason.lower()
+        assert 'retry' in reason.lower()
+        # Underlying status should still surface for debugging
+        assert '503' in reason
+        # PAT must not be stored when the test query is inconclusive
+        assert pat_storage.get_pat_by_uid(1) is None
+
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=PatTestResult())
     @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
     def test_github_identity_change_rejected(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey cannot switch to a different GitHub account."""
@@ -166,7 +192,7 @@ class TestHandlePatBroadcast:
         assert entry is not None
         assert entry['github_id'] == 'github_42'
 
-    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=PatTestResult())
     @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
     def test_pat_rotation_same_github_accepted(self, mock_validate, mock_test_query, mock_validator):
         """Same hotkey can rotate PATs if GitHub identity stays the same."""
@@ -181,7 +207,7 @@ class TestHandlePatBroadcast:
         assert entry['pat'] == 'ghp_refreshed'
         assert entry['github_id'] == 'github_42'
 
-    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=PatTestResult())
     @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
     def test_new_miner_on_uid_can_use_any_github(self, mock_validate, mock_test_query, mock_validator):
         """A new hotkey on the same UID (new miner) can register any GitHub account."""
@@ -198,7 +224,7 @@ class TestHandlePatBroadcast:
 
 
 class TestHandlePatCheck:
-    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=PatTestResult())
     @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
     def test_valid_pat(self, mock_validate, mock_test_query, mock_validator):
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_test', 'github_42')
@@ -244,7 +270,7 @@ class TestHandlePatCheck:
         mock_get_identity.assert_called_once_with('ghp_stored')
         mock_test_query.assert_not_called()
 
-    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=PatTestResult())
     @patch(
         'gittensor.validator.pat_handler.validate_github_credentials_result',
         return_value=_validation(None, 'PAT expired'),
@@ -258,6 +284,45 @@ class TestHandlePatCheck:
         assert result.has_pat is True
         assert result.pat_valid is False
         assert 'PAT expired' in (result.rejection_reason or '')
+
+    @patch(
+        'gittensor.validator.pat_handler._test_pat_against_repo',
+        return_value=PatTestResult(error='GitHub GraphQL API returned 502', transient_failure=True),
+    )
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
+    def test_transient_test_query_5xx_reports_inconclusive(self, mock_validate, mock_test_query, mock_validator):
+        """A transient 5xx from the GraphQL test query must be surfaced as pat_valid=None,
+        matching the identity-check transient handling from #1107."""
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_stored', 'github_42')
+
+        synapse = _make_check_synapse('hotkey_1')
+        result = _run(handle_pat_check(mock_validator, synapse))
+
+        assert result.has_pat is True
+        assert result.pat_valid is None  # NOT False — inconclusive, do not prompt rotation
+        assert result.rejection_reason == 'GitHub API temporarily unavailable; retry the check in a few minutes.'
+
+    @patch(
+        'gittensor.validator.pat_handler._test_pat_against_repo',
+        return_value=PatTestResult(
+            error="HTTPSConnectionPool(host='api.github.com', port=443): Read timed out",
+            transient_failure=True,
+        ),
+    )
+    @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
+    def test_transient_test_query_network_error_reports_inconclusive(
+        self, mock_validate, mock_test_query, mock_validator
+    ):
+        """A transport-layer failure (timeout, DNS, connection reset) must be surfaced as inconclusive,
+        not a permanent invalid-PAT."""
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_stored', 'github_42')
+
+        synapse = _make_check_synapse('hotkey_1')
+        result = _run(handle_pat_check(mock_validator, synapse))
+
+        assert result.has_pat is True
+        assert result.pat_valid is None
+        assert result.rejection_reason == 'GitHub API temporarily unavailable; retry the check in a few minutes.'
 
 
 # ---------------------------------------------------------------------------
@@ -274,45 +339,75 @@ def _mock_post_response(status_code: int = 200, payload=None):
 
 class TestPatAgainstRepo:
     @patch('gittensor.validator.pat_handler.requests.post')
-    def test_valid_viewer_returns_none(self, mock_post):
+    def test_valid_viewer_returns_ok(self, mock_post):
         mock_post.return_value = _mock_post_response(200, {'data': {'viewer': {'login': 'someone'}}})
-        assert _test_pat_against_repo('ghp_valid') is None
+        result = _test_pat_against_repo('ghp_valid')
+        assert result.error is None
+        assert result.transient_failure is False
 
     @patch('gittensor.validator.pat_handler.requests.post')
-    def test_non_200_returns_status_error(self, mock_post):
+    def test_4xx_returns_permanent_status_error(self, mock_post):
         mock_post.return_value = _mock_post_response(401)
         result = _test_pat_against_repo('ghp_bad')
-        assert result is not None
-        assert '401' in result
+        assert result.error is not None
+        assert '401' in result.error
+        assert result.transient_failure is False
 
     @patch('gittensor.validator.pat_handler.requests.post')
-    def test_errors_field_returns_message(self, mock_post):
+    def test_5xx_classified_as_transient(self, mock_post):
+        """GitHub 5xx is a server-side problem, not a bad PAT; must be transient."""
+        for status in (500, 502, 503, 504):
+            mock_post.return_value = _mock_post_response(status)
+            result = _test_pat_against_repo('ghp_test')
+            assert result.transient_failure is True, f'{status} should be transient'
+            assert str(status) in (result.error or '')
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_request_exception_classified_as_transient(self, mock_post):
+        """Network errors (timeout, DNS, connection reset) are transport failures, not bad PATs."""
+        mock_post.side_effect = requests.ConnectionError('Connection reset by peer')
+        result = _test_pat_against_repo('ghp_test')
+        assert result.transient_failure is True
+        assert 'Connection reset' in (result.error or '')
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_timeout_classified_as_transient(self, mock_post):
+        mock_post.side_effect = requests.Timeout('Read timed out')
+        result = _test_pat_against_repo('ghp_test')
+        assert result.transient_failure is True
+        assert 'timed out' in (result.error or '').lower()
+
+    @patch('gittensor.validator.pat_handler.requests.post')
+    def test_errors_field_returns_permanent_message(self, mock_post):
         mock_post.return_value = _mock_post_response(200, {'errors': [{'message': 'Bad credentials'}]})
         result = _test_pat_against_repo('ghp_bad')
-        assert result is not None
-        assert 'Bad credentials' in result
+        assert result.error is not None
+        assert 'Bad credentials' in result.error
+        assert result.transient_failure is False
 
     @patch('gittensor.validator.pat_handler.requests.post')
     def test_empty_errors_list_does_not_crash(self, mock_post):
         """Some proxies return {"errors": []}; must not raise IndexError."""
         mock_post.return_value = _mock_post_response(200, {'data': None, 'errors': []})
-        # Should not raise, and since viewer is not present, should reject with scope msg
         result = _test_pat_against_repo('ghp_proxy')
-        assert result is not None
-        assert 'Public Repositories (read-only)' in result
+        assert result.error is not None
+        assert 'Public Repositories (read-only)' in result.error
+        assert result.transient_failure is False
 
     @patch('gittensor.validator.pat_handler.requests.post')
     def test_viewer_null_rejected_with_scope_message(self, mock_post):
-        """Fine-grained PAT without read access returns viewer:null; must be rejected."""
+        """Fine-grained PAT without read access returns viewer:null; must be rejected permanently."""
         mock_post.return_value = _mock_post_response(200, {'data': {'viewer': None}})
         result = _test_pat_against_repo('ghp_scopeless')
-        assert result is not None
-        assert 'Public Repositories (read-only)' in result
+        assert result.error is not None
+        assert 'Public Repositories (read-only)' in result.error
+        assert result.transient_failure is False
 
     @patch('gittensor.validator.pat_handler.requests.post')
     def test_data_null_rejected_with_scope_message(self, mock_post):
-        """Proxy-shaped {"data": null} response must not crash and must be rejected."""
+        """Proxy-shaped {"data": null} response must not crash and must be rejected permanently."""
         mock_post.return_value = _mock_post_response(200, {'data': None})
         result = _test_pat_against_repo('ghp_nulldata')
-        assert result is not None
-        assert 'Public Repositories (read-only)' in result
+        assert result.error is not None
+        assert 'Public Repositories (read-only)' in result.error
+        assert result.transient_failure is False


### PR DESCRIPTION
## Summary

Extend the transient-failure handling from #1107 (identity check) to `_test_pat_against_repo` (repo test query) so a GitHub 5xx burst or transport-layer hiccup (DNS, timeout, connection reset) during `gitt miner check` no longer tells a miner their PAT is invalid.

**Root cause.** [`gittensor/validator/pat_handler.py:170-193`](https://github.com/entrius/gittensor/blob/test/gittensor/validator/pat_handler.py#L170-L193) collapsed every non-200 status and every `requests.RequestException` into a permanent error. Callers (`handle_pat_check`, `handle_pat_broadcast`) treated any error as invalid-PAT — even though the same handlers already distinguish transient identity failures via `validation.transient_failure` after #1107. The test-query path was left on the old shape, so the same outage that #1107 fixed on the identity path still misled miners on the test-query path.

**Fix.** `_test_pat_against_repo` now returns a `PatTestResult` dataclass mirroring `GitHubCredentialValidation`:

| Outcome | `error` | `transient_failure` |
|---|---|---|
| 200 with viewer present | `None` | `False` |
| HTTP **5xx** | set | **`True`** |
| `requests.RequestException` (timeout, ConnectionError, DNS) | set | **`True`** |
| HTTP 4xx | set | `False` |
| 200 with `errors[0]` | set | `False` |
| 200 with `data.viewer == null` (scope-less fine-grained PAT) | set | `False` |

`handle_pat_check` surfaces transient test-query failures as `pat_valid = None` with the same retry message #1107 established for the identity path. `handle_pat_broadcast` rejects on transient with a retry-oriented message and does not store the PAT (no behavior change on the storage side — the write was already gated on a successful test query; only the rejection message changes from "PAT failed" to "retry").

No changes to behavior on the happy path or to existing 4xx / GraphQL-error / viewer:null handling.

## Related Issues

Fixes #1331.

Follows #1107 (which fixed the identity-check side of the same asymmetry).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

**New regression tests in `tests/validator/test_pat_handler.py`:**

- `TestPatAgainstRepo::test_5xx_classified_as_transient` (500, 502, 503, 504)
- `TestPatAgainstRepo::test_request_exception_classified_as_transient`
- `TestPatAgainstRepo::test_timeout_classified_as_transient`
- `TestHandlePatCheck::test_transient_test_query_5xx_reports_inconclusive`
- `TestHandlePatCheck::test_transient_test_query_network_error_reports_inconclusive`
- `TestHandlePatBroadcast::test_test_query_transient_failure_rejected_with_retry_message`

Existing tests updated for the new `PatTestResult` return type; no behavioral assertions changed on the happy path or permanent-rejection paths.

**Local test run:**

```
$ uv run pytest tests/validator/test_pat_handler.py -v
============================== 28 passed in 0.99s ==============================
```

All 22 pre-existing tests plus the 6 new regression tests above pass. No regressions in the broadcast happy path, identity-transient path, permanent-rejection paths, or viewer:null scope handling.

**Static checks:**

- `ruff check gittensor/validator/pat_handler.py tests/validator/test_pat_handler.py` — clean.
- `ruff format --check` — clean.
- `pyright` on the changed files — no real type errors introduced.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
