### PR TITLE
feat(validator): gate issue bonus behind a minimum issue-to-PR age

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -164,6 +164,12 @@ MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER = 2.0  # Cap open PR collateral growth 
 # Issue multiplier (flat values, no age scaling)
 STANDARD_ISSUE_MULTIPLIER = 1.33  # Non-maintainer issue author
 MAINTAINER_ISSUE_MULTIPLIER = 1.66  # Issue author is OWNER/MEMBER/COLLABORATOR
+# Anti-gaming: minimum hours that must elapse between an issue's creation and the
+# solving PR's creation for the issue to grant its bonus multiplier. Blocks the
+# "file an issue and immediately solve it (often via a coordinated alt account)
+# for a free multiplier" pattern (see issue #462). 0.0 disables the gate; the
+# value is an opt-in per-repo override via scoring.min_issue_solve_gap_hours.
+MIN_ISSUE_SOLVE_GAP_HOURS = 0.0
 # Excessive open PRs penalty (per-repo: counts a repo's own open PRs)
 # Multiplier = 1.0 if open PRs <= threshold, 0.0 otherwise
 EXCESSIVE_PR_PENALTY_BASE_THRESHOLD = 2

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -37,6 +37,7 @@ from gittensor.constants import (
     MERGED_PR_BASE_SCORE,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     SECONDS_PER_DAY,
+    SECONDS_PER_HOUR,
 )
 from gittensor.utils.github_api_tools import FileContentPair, branch_matches_pattern
 from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
@@ -415,7 +416,7 @@ def _calculate_issue_multiplier(scored: ScoredPR, scoring: ResolvedScoring) -> f
         bt.logging.info(f'PR #{pr.pr_number} - Contains no linked issues')
         return 1.0
 
-    valid = [li for li in pr.linked_issues if _is_valid_linked_issue(li, pr)]
+    valid = [li for li in pr.linked_issues if _is_valid_linked_issue(li, pr, scoring.min_issue_solve_gap_hours)]
     if not valid:
         bt.logging.info(f'PR #{pr.pr_number} - Solved no valid linked issues')
         return 1.0
@@ -433,12 +434,16 @@ def _calculate_issue_multiplier(scored: ScoredPR, scoring: ResolvedScoring) -> f
     return multiplier
 
 
-def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool:
+def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest, min_solve_gap_hours: float = 0.0) -> bool:
     """Anti-gaming gates for issue → PR multiplier credit.
 
     - Reject transferred issues.
     - Missing author / self-issue (uses github_id for immutability).
     - Issue created after the PR.
+    - Solve-gap floor: the PR must be created at least ``min_solve_gap_hours``
+      after the issue. Blocks the "file an issue and immediately solve it (often
+      via a coordinated alt account, which slips the self-issue github_id check)
+      for a free multiplier" pattern — see issue #462. ``0.0`` disables the gate.
     - Any CLOSED issue must have state_reason=COMPLETED — NOT_PLANNED / reopened
       closures never grant a multiplier. Applies regardless of PR state, so the
       gate covers OPEN-PR collateral as well.
@@ -462,6 +467,15 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
     if li.created_at and li.created_at > pr.created_at:
         bt.logging.warning(f'Skipping linked issue #{li.number} - created after PR')
         return False
+
+    if min_solve_gap_hours > 0 and li.created_at:
+        gap_hours = (pr.created_at - li.created_at).total_seconds() / SECONDS_PER_HOUR
+        if gap_hours < min_solve_gap_hours:
+            bt.logging.warning(
+                f'Skipping linked issue #{li.number} - PR created {gap_hours:.2f}h after issue '
+                f'(min {min_solve_gap_hours}h) — too fast, no issue bonus'
+            )
+            return False
 
     # state_reason check applies regardless of PR state — OPEN-PR collateral
     # also requires that any CLOSED linked issue closed as COMPLETED.

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -16,6 +16,7 @@ from gittensor.constants import (
     MAX_OPEN_PR_THRESHOLD,
     MIN_CREDIBILITY,
     MIN_ISSUE_CREDIBILITY,
+    MIN_ISSUE_SOLVE_GAP_HOURS,
     MIN_TOKEN_SCORE_FOR_BASE_SCORE,
     MIN_TOKEN_SCORE_FOR_VALID_ISSUE,
     MIN_VALID_MERGED_PRS,
@@ -121,6 +122,7 @@ class RepoScoringConfig:
     review_penalty_rate: Optional[float] = None
     standard_issue_multiplier: Optional[float] = None
     maintainer_issue_multiplier: Optional[float] = None
+    min_issue_solve_gap_hours: Optional[float] = None
     time_decay: RepoTimeDecayConfig = field(default_factory=RepoTimeDecayConfig)
 
 
@@ -133,6 +135,7 @@ class ResolvedScoring:
     review_penalty_rate: float
     standard_issue_multiplier: float
     maintainer_issue_multiplier: float
+    min_issue_solve_gap_hours: float
     time_decay: ResolvedTimeDecay
 
 
@@ -234,6 +237,7 @@ def resolve_scoring(cfg: Optional[RepoScoringConfig]) -> ResolvedScoring:
         review_penalty_rate=float(pick(cfg.review_penalty_rate, REVIEW_PENALTY_RATE)),
         standard_issue_multiplier=float(pick(cfg.standard_issue_multiplier, STANDARD_ISSUE_MULTIPLIER)),
         maintainer_issue_multiplier=float(pick(cfg.maintainer_issue_multiplier, MAINTAINER_ISSUE_MULTIPLIER)),
+        min_issue_solve_gap_hours=float(pick(cfg.min_issue_solve_gap_hours, MIN_ISSUE_SOLVE_GAP_HOURS)),
         time_decay=resolve_time_decay(cfg.time_decay),
     )
 
@@ -347,6 +351,7 @@ _SCORING_FLOAT_FIELDS = (
     'review_penalty_rate',
     'standard_issue_multiplier',
     'maintainer_issue_multiplier',
+    'min_issue_solve_gap_hours',
 )
 
 
@@ -485,6 +490,11 @@ def _validate_scoring_configs(configs: Dict[str, RepositoryConfig]) -> None:
             raise RepositoryRegistryError(
                 f'{repo_name} scoring.maintainer_issue_multiplier must be within [1, 5], '
                 f'got {resolved.maintainer_issue_multiplier}'
+            )
+        if not 0.0 <= resolved.min_issue_solve_gap_hours <= 720.0:
+            raise RepositoryRegistryError(
+                f'{repo_name} scoring.min_issue_solve_gap_hours must be within [0, 720], '
+                f'got {resolved.min_issue_solve_gap_hours}'
             )
         if not 0 <= resolved.time_decay.grace_period_hours <= 168:
             raise RepositoryRegistryError(

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -820,6 +820,58 @@ class TestLinkedIssueValidity:
         assert _is_valid_linked_issue(li, scored.pr) is True
 
 
+class TestMinIssueSolveGap:
+    """Issue #462 — minimum issue-to-PR age gate for the issue bonus multiplier.
+
+    The PR's created_at is fixed at 2026-04-15T00:00:00Z by ``_pr``; the gap is
+    controlled by varying the linked issue's ``created_at``.
+    """
+
+    def test_gate_disabled_by_default(self):
+        # Default min_solve_gap_hours=0.0 → gate off, issue created 5d before PR.
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue())
+        assert _is_valid_linked_issue(li, scored.pr) is True
+        assert _is_valid_linked_issue(li, scored.pr, 0.0) is True
+
+    def test_too_fast_solve_blocked(self):
+        # Issue created 1h before the PR; a 24h floor rejects it.
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(created_at='2026-04-14T23:00:00Z'))
+        assert _is_valid_linked_issue(li, scored.pr, 24.0) is False
+
+    def test_sufficient_gap_allowed(self):
+        # Issue created 5 days (120h) before the PR clears a 24h floor.
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(created_at='2026-04-10T00:00:00Z'))
+        assert _is_valid_linked_issue(li, scored.pr, 24.0) is True
+
+    def test_gap_exactly_at_floor_allowed(self):
+        # Exactly 24h before the PR — boundary is inclusive (gap < floor rejects).
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(created_at='2026-04-14T00:00:00Z'))
+        assert _is_valid_linked_issue(li, scored.pr, 24.0) is True
+
+    def test_multiplier_neutralized_for_fast_solve(self):
+        """End-to-end through ``_calculate_issue_multiplier`` with a per-repo override:
+        a too-fast self-filed-then-solved issue earns no bonus."""
+        from gittensor.validator.utils.load_weights import RepoScoringConfig
+
+        scoring = resolve_scoring(RepoScoringConfig(min_issue_solve_gap_hours=24.0))
+        fast = _linked_issue(created_at='2026-04-14T23:00:00Z', author_github_id='888')
+        scored = ScoredPR(pr=_pr(linked_issues=[fast]))
+        assert _calculate_issue_multiplier(scored, scoring) == 1.0
+
+    def test_multiplier_applies_when_gap_met(self):
+        from gittensor.constants import STANDARD_ISSUE_MULTIPLIER
+        from gittensor.validator.utils.load_weights import RepoScoringConfig
+
+        scoring = resolve_scoring(RepoScoringConfig(min_issue_solve_gap_hours=24.0))
+        slow = _linked_issue(created_at='2026-04-10T00:00:00Z', author_github_id='888')
+        scored = ScoredPR(pr=_pr(linked_issues=[slow]))
+        assert _calculate_issue_multiplier(scored, scoring) == STANDARD_ISSUE_MULTIPLIER
+
+
 class TestIssueMultiplierPreference:
     def test_prefer_maintainer_authored_when_multiple_valid(self):
         """Legacy parity (PR #673): the issue multiplier should pick a

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -448,6 +448,38 @@ class TestRepositoryConfigScoringBlock:
         with pytest.raises(RepositoryRegistryError):
             lw.load_master_repo_weights()
 
+    def test_loader_parses_min_issue_solve_gap_hours(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps(
+                {
+                    'foo/gated': {'emission_share': 0.5, 'scoring': {'min_issue_solve_gap_hours': 24}},
+                    'foo/defaults': {'emission_share': 0.3},
+                }
+            )
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/gated'].scoring.min_issue_solve_gap_hours == pytest.approx(24.0)
+        # Unset → resolves to the global default (0.0, gate disabled).
+        assert repos['foo/defaults'].scoring.min_issue_solve_gap_hours is None
+        assert resolve_scoring(repos['foo/defaults'].scoring).min_issue_solve_gap_hours == pytest.approx(0.0)
+
+    @pytest.mark.parametrize('bad_value', [-1.0, 720.1, 10000.0])
+    def test_loader_rejects_out_of_range_min_issue_solve_gap_hours(self, tmp_path, monkeypatch, bad_value):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps({'foo/bad': {'emission_share': 0.5, 'scoring': {'min_issue_solve_gap_hours': bad_value}}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        with pytest.raises(RepositoryRegistryError, match='min_issue_solve_gap_hours must be within'):
+            lw.load_master_repo_weights()
+
     def test_loader_parses_time_decay_overrides(self, tmp_path, monkeypatch):
         from gittensor.validator.utils import load_weights as lw
 


### PR DESCRIPTION
Closes #462. A miner (often with a coordinated alt account that slips the self-issue github_id check) can file an issue and immediately open a PR that closes it, harvesting the issue-bonus multiplier (1.33x standard / 1.66x maintainer) for no real discovery work.

Adds a per-repo scoring override scoring.min_issue_solve_gap_hours: the linked issue grants its multiplier only when the solving PR was created at least N hours after the issue. _is_valid_linked_issue now rejects too-fast solves; the gate runs for both merged-PR scoring and open-PR collateral. Defaults to 0.0 (disabled), opt-in per repo like maintainer_cut; range-checked to [0, 720] by the loader.

Scoped to the PR issue-multiplier path, where both pr.created_at and issue.created_at are available. The issue-discovery path can't enforce this yet — MirrorSolvingPR carries merged_at but not created_at — so that half needs a mirror schema addition (follow-up), mirroring the two-layer framing of #1243.