### PR TITLE
fix(validator): count only canonical valid solved issues

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -463,10 +463,6 @@ async def _score_miner_issues(
             )
             continue
 
-        # Valid-solved gate: solving PR must meet the repo's token threshold.
-        if cached.token_score >= cfg.min_token_score_for_valid_issue:
-            acc.valid_solved += 1
-
         # Same-account: discoverer == solver gets credibility only, no score
         if issue.author_github_id == solving_pr.author_github_id:
             bt.logging.debug(
@@ -493,6 +489,12 @@ async def _score_miner_issues(
                 f'{cfg.min_token_score_for_valid_issue} — credibility only'
             )
             continue
+
+        # Past every credibility-only gate (same-account, canonical one-issue-
+        # per-PR, token threshold). Non-canonical siblings would have continued
+        # above; counting them here would let one qualifying PR satisfy the
+        # valid-solved eligibility gate through duplicate issue rows.
+        acc.valid_solved += 1
 
         adapted = _mirror_issue_for_scoring(issue, solving_pr, repo_config, base_score=cached.base_score)
         if adapted is None:

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -1022,12 +1022,21 @@ class TestOpenIssueSpamSourceIsMirror:
             )
             for i in range(2)
         ]
-        solved_issues = [_issue_dict(issue_number=300 + i, author_github_id=f'discoverer{i}') for i in range(8)]
+        # Give each solved issue its own solving PR so each is canonical and
+        # contributes to valid_solved. Sharing one PR across all eight would
+        # leave seven non-canonical siblings credibility-only post-#1269 and
+        # the miner would fall below MIN_VALID_SOLVED_ISSUES, defeating the
+        # spam-mult assertion this test exists to make.
+        solved_issues = [
+            _issue_dict(issue_number=300 + i, author_github_id=f'discoverer{i}', solved_by_pr=300 + i) for i in range(8)
+        ]
         client = Mock()
         client.get_miner_issues.return_value = _response(open_issues + solved_issues)
 
         eval_ = _eval()
-        eval_.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100, token_score=100.0)]
+        eval_.merged_prs = [
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number, token_score=100.0) for pr_number in range(300, 308)
+        ]
 
         _run(
             run_issue_discovery(
@@ -1208,14 +1217,17 @@ class TestCrossMinerOneIssuePerPr:
         # Both miners count the shared-PR issue toward credibility, but only
         # the canonical owner (A) counts it toward the valid-solved gate.
         # B's shared-PR issue is one-issue-per-PR credibility-only, so it must
-        # not satisfy the eligibility threshold — preventing one qualifying PR
-        # from unlocking MIN_VALID_SOLVED_ISSUES through duplicate issue rows.
+        # not increment valid_solved — preventing one qualifying PR from
+        # padding the gate via duplicate issue rows (#1269).
         assert e_a.total_solved_issues == 7
         assert e_b.total_solved_issues == 7
         assert e_a.total_valid_solved_issues == 7
         assert e_b.total_valid_solved_issues == 6
+        # Both stay above MIN_VALID_SOLVED_ISSUES (currently 3) and remain
+        # eligible. The orthogonal eligibility-gate assertion lives in
+        # ``test_non_canonical_siblings_do_not_satisfy_valid_solved_gate``.
         assert e_a.is_issue_eligible
-        assert not e_b.is_issue_eligible
+        assert e_b.is_issue_eligible
 
         # ``issue_token_score`` accumulates only over SCORED PRs (default
         # ``_scored_mirror_pr`` token_score is 100.0), so this is the
@@ -1223,10 +1235,10 @@ class TestCrossMinerOneIssuePerPr:
         # 6 (shared PR 100 is canonical for A only and credibility-only for B).
         assert e_a.issue_token_score == 700.0
         assert e_b.issue_token_score == 600.0
-        # B's ineligibility zeroes its issue_discovery_score regardless of the
-        # six canonical issues that would otherwise have scored.
-        assert e_a.issue_discovery_score > 0
-        assert e_b.issue_discovery_score == 0
+        # All solving PRs share identical scoring inputs at this issue mix, so
+        # the discovery_score ratio collapses to 7:6.
+        assert e_a.issue_discovery_score > e_b.issue_discovery_score > 0
+        assert e_a.issue_discovery_score / e_b.issue_discovery_score == pytest.approx(7 / 6, rel=1e-2)
 
     def test_non_canonical_siblings_do_not_satisfy_valid_solved_gate(self):
         """Regression for #1269: seven sibling issues all closed by one

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -307,6 +307,8 @@ class TestRunMirrorIssueDiscovery:
             )
         )
         assert eval_.total_solved_issues == 1  # credibility counts
+        # Same-account is credibility-only — must not satisfy the valid-solved gate.
+        assert eval_.total_valid_solved_issues == 0
         # But no discovery_earned_score because self-solve
         assert eval_.issue_discovery_score == 0
 
@@ -1203,13 +1205,17 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        # Both miners count the shared-PR issue toward credibility.
+        # Both miners count the shared-PR issue toward credibility, but only
+        # the canonical owner (A) counts it toward the valid-solved gate.
+        # B's shared-PR issue is one-issue-per-PR credibility-only, so it must
+        # not satisfy the eligibility threshold — preventing one qualifying PR
+        # from unlocking MIN_VALID_SOLVED_ISSUES through duplicate issue rows.
         assert e_a.total_solved_issues == 7
         assert e_b.total_solved_issues == 7
         assert e_a.total_valid_solved_issues == 7
-        assert e_b.total_valid_solved_issues == 7
+        assert e_b.total_valid_solved_issues == 6
         assert e_a.is_issue_eligible
-        assert e_b.is_issue_eligible
+        assert not e_b.is_issue_eligible
 
         # ``issue_token_score`` accumulates only over SCORED PRs (default
         # ``_scored_mirror_pr`` token_score is 100.0), so this is the
@@ -1217,10 +1223,107 @@ class TestCrossMinerOneIssuePerPr:
         # 6 (shared PR 100 is canonical for A only and credibility-only for B).
         assert e_a.issue_token_score == 700.0
         assert e_b.issue_token_score == 600.0
-        # All solving PRs share identical scoring inputs at this issue mix, so
-        # the discovery_score ratio collapses to 7:6.
-        assert e_a.issue_discovery_score > e_b.issue_discovery_score > 0
-        assert e_a.issue_discovery_score / e_b.issue_discovery_score == pytest.approx(7 / 6, rel=1e-2)
+        # B's ineligibility zeroes its issue_discovery_score regardless of the
+        # six canonical issues that would otherwise have scored.
+        assert e_a.issue_discovery_score > 0
+        assert e_b.issue_discovery_score == 0
+
+    def test_non_canonical_siblings_do_not_satisfy_valid_solved_gate(self):
+        """Regression for #1269: seven sibling issues all closed by one
+        qualifying PR must count as one canonical valid solved issue, not
+        seven. Otherwise a single solving PR could satisfy the per-repo
+        MIN_VALID_SOLVED_ISSUES eligibility gate through duplicate rows."""
+        client = Mock()
+        issues = [
+            _issue_dict(
+                issue_number=50 + i,
+                author_github_id='A',
+                solved_by_pr=100,
+                solving_pr_author='SOLVER',
+                created_at=f'2026-04-{i + 1:02d}T00:00:00Z',
+            )
+            for i in range(7)
+        ]
+        client.get_miner_issues.return_value = _response(issues)
+
+        eval_ = _eval(uid=1, github_id='A')
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_, 99: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # All seven count for credibility (solved/closed) but only the canonical
+        # owner increments valid_solved — so the miner remains ineligible.
+        assert eval_.total_solved_issues == 7
+        assert eval_.total_valid_solved_issues == 1
+        assert eval_.issue_discovery_issues == []
+        assert not eval_.is_issue_eligible
+        assert eval_.issue_discovery_score == 0
+
+    def test_non_canonical_siblings_per_repo_eligibility(self):
+        """Multi-repo variant of the #1269 regression. Per-repo eligibility
+        means each repo's valid_solved is independent; a single solving PR
+        in one repo must not pad another repo's count, and a shared PR
+        within a repo must not pad that repo's count via duplicate rows."""
+        client = Mock()
+
+        # Repo A: 7 unique-PR canonical issues — repo-A eligible.
+        repo_a_issues = [
+            _issue_dict(
+                issue_number=10 + i,
+                author_github_id='A',
+                solved_by_pr=200 + i,
+                solving_pr_author='SOLVER',
+                repo='entrius/gittensor-ui',
+            )
+            for i in range(7)
+        ]
+        # Repo B: 7 siblings on a single shared PR — only 1 canonical, repo-B
+        # must remain ineligible despite seven credibility hits.
+        repo_b_issues = [
+            _issue_dict(
+                issue_number=50 + i,
+                author_github_id='A',
+                solved_by_pr=100,
+                solving_pr_author='SOLVER',
+                repo='entrius/other-repo',
+                created_at=f'2026-04-{i + 1:02d}T00:00:00Z',
+            )
+            for i in range(7)
+        ]
+        client.get_miner_issues.return_value = _response(repo_a_issues + repo_b_issues)
+
+        eval_ = _eval(uid=1, github_id='A')
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr_number) for pr_number in range(200, 207)] + [
+            _scored_mirror_pr('entrius/other-repo', 100)
+        ]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_, 99: seed},
+                _mirror_repos('entrius/gittensor-ui', 'entrius/other-repo'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Repo A's 7 canonical issues drive the evaluation-wide totals;
+        # repo B contributes 7 solved + 1 valid_solved (canonical only).
+        assert eval_.total_solved_issues == 14
+        assert eval_.total_valid_solved_issues == 8
+        # Only the 7 repo-A canonical issues land in the scored set.
+        assert len(eval_.issue_discovery_issues) == 7
+        assert {issue.number for issue in eval_.issue_discovery_issues} == set(range(10, 17))
 
     def test_within_miner_one_issue_per_pr_still_holds(self):
         """One miner authoring two issues both closed by the same PR — the
@@ -1269,9 +1372,12 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        # 8 solved (both shared-PR issues counted for credibility), eligible.
+        # 8 solved (both shared-PR issues counted for credibility), eligible
+        # on the strength of 7 canonical valid solved (6 unique PRs + 1
+        # canonical issue on the shared PR — the later sibling is one-issue-
+        # per-PR credibility-only and does not increment valid_solved).
         assert eval_.total_solved_issues == 8
-        assert eval_.total_valid_solved_issues == 8
+        assert eval_.total_valid_solved_issues == 7
         assert eval_.is_issue_eligible
         # ``issue_token_score`` only accumulates over SCORED PRs (default
         # ``_scored_mirror_pr`` token_score is 100.0). 7 distinct scoring PRs


### PR DESCRIPTION
## Summary

Move `acc.valid_solved += 1` in `_score_miner_issues` past every credibility-only gate (same-account, one-issue-per-PR canonical, per-repo token threshold). Previously the increment fired on token-score alone, _before_ the canonical check, so seven sibling issues closed by one qualifying PR could satisfy the per-repo `MIN_VALID_SOLVED_ISSUES` eligibility gate even though only one was scoreable.

Adds regression coverage for both the single-repo and per-repo (#1293) shapes, plus a credibility-only assertion on the same-account path, and updates two existing tests whose assertions/fixtures encoded the buggy "seven-counts-as-seven" behavior.

This is a rebased, refactor-aware re-do of #1273 (closed for unresolved conflicts after #1293 landed `feat(validator): per-repository eligibility`). The original patch was written against the pre-refactor global `valid_solved_count` / `MIN_TOKEN_SCORE_FOR_BASE_SCORE`; this one targets `acc.valid_solved` / `cfg.min_token_score_for_valid_issue` and also moves the increment _after_ the token-threshold quality gate so below-threshold canonical issues no longer inflate the count.

## Related Issues

Fixes #1269. Supersedes #1273.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

**Local verification:**

- `pytest tests/validator/issue_discovery/` — **56 / 56 pass**
- `ruff check gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py` — clean
- `ruff format --check ...` — clean
- Manually inspected the diff against the canonical-rule semantics in #1269 and the per-repo eligibility refactor in #1293.

**Test changes:**

- `test_self_issue_counts_credibility_but_no_score` — adds `total_valid_solved_issues == 0` assertion (same-account is credibility-only, must not bump the gate).
- `test_two_miners_shared_pr_only_earliest_scores` — B now has `total_valid_solved_issues == 6` (was 7, the bug). B stays eligible since `MIN_VALID_SOLVED_ISSUES` was dropped to 3 since #1269 was filed; the dedicated eligibility-gate regression lives in the new sibling test below.
- `test_within_miner_one_issue_per_pr_still_holds` — miner now has `total_valid_solved_issues == 7` (was 8). Still eligible (7 unique canonical valid solved).
- `test_all_mirror_miner_below_threshold_passes_spam` — existing test that relied on the bug (eight issues sharing one PR all counted as valid_solved). Gave each issue its own solving PR and seeded all eight so the spam-mult assertion still has an eligible miner post-fix.
- **New** `test_non_canonical_siblings_do_not_satisfy_valid_solved_gate` — direct #1269 repro: seven sibling issues, one canonical PR → `valid_solved == 1`, ineligible (1 < 3), score == 0.
- **New** `test_non_canonical_siblings_per_repo_eligibility` — multi-repo variant: 7 unique canonical issues in repo A and 7 siblings on one shared PR in repo B → only repo A contributes to scored issues; total `valid_solved == 8` (7 + 1 canonical sibling).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
