### PR TITLE
fix(scoring): make credibility a gate signal only, drop per-PR multiplier

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -173,13 +173,16 @@ def _score_eligible_repo_prs(
     open_prs: List['ScoredPR'],
     cfg: ResolvedEligibility,
 ) -> None:
-    """Compute earned scores for an eligible repository's merged PRs."""
+    """Compute earned scores for an eligible repository's merged PRs.
+
+    Credibility is the eligibility gate only; once a repo clears the gate, PRs
+    earn on their own merits (review quality, label, time decay). It is not
+    re-applied as a per-PR multiplier.
+    """
     spam_multiplier = calculate_pr_spam_penalty_multiplier(cfg, len(open_prs), repo_eval.total_token_score)
-    credibility_multiplier = round(repo_eval.credibility, 2)
 
     for pr in merged:
         pr.open_pr_spam_multiplier = spam_multiplier
-        pr.credibility_multiplier = credibility_multiplier
         pr.calculate_final_earned_score()
         repo_eval.total_score += pr.earned_score
 

--- a/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
@@ -99,8 +99,11 @@ def test_zeroed_thresholds_repo_has_no_gate():
     assert pr.earned_score == 10.0  # single PR, credibility 1.0
 
 
-def test_per_repo_credibility_multiplier():
-    """An eligible repo applies its own credibility ratio as the PR multiplier."""
+def test_credibility_is_gate_only_not_per_pr_multiplier():
+    """Once a repo clears the credibility gate, the ratio is NOT re-applied as a
+    per-PR multiplier. PRs stand on their own — otherwise the same signal is
+    charged twice, taxing a miner's busiest repo on every merged PR.
+    """
     merged = [_merged('foo/a', n) for n in range(1, 5)]
     closed = [_mirror_pr('foo/a', 99, state='CLOSED')]
 
@@ -110,11 +113,13 @@ def test_per_repo_credibility_multiplier():
 
     finalize_miner_scores({1: evaluation}, {'foo/a': _gate_repo()})
 
-    # credibility = 4 / (4 + 1) = 0.80, exactly at the gate
+    # credibility = 4 / (4 + 1) = 0.80, exactly at the gate — eligible
     assert evaluation.repo_evaluations['foo/a'].is_eligible is True
     assert evaluation.repo_evaluations['foo/a'].credibility == 0.8
-    assert all(pr.credibility_multiplier == 0.8 for pr in merged)
-    assert all(pr.earned_score == 8.0 for pr in merged)
+    # Credibility multiplier stays neutral on every PR — the 0.80 ratio
+    # already did its job at the gate.
+    assert all(pr.credibility_multiplier == 1.0 for pr in merged)
+    assert all(pr.earned_score == 10.0 for pr in merged)
 
 
 def test_open_pr_spam_is_scoped_per_repo():


### PR DESCRIPTION
Closes #1340

Credibility (`merged / (merged + closed)`) was being used twice: as the 0.80 eligibility gate AND as a multiplier on every merged PR's earned score. That charges the same signal twice : a miner at 0.83 clears the gate but still loses 17% on every PR they ship.

This makes credibility the gate only. Once a repo is eligible, its PRs earn on their own merits (review quality, label, time decay).

`check_eligibility` is unchanged, so the gate behavior is the same. The `credibility_multiplier` field stays on the dataclasses with default 1.0 (neutral) to preserve DB and adapter compatibility — only the per-PR application in `_score_eligible_repo_prs` is removed.
