### PR TITLE
fix(validator): let next-canonical sibling claim slot when winner can't score

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -21,8 +21,11 @@ Anti-gaming gates (all applied):
 Same-account ("solver is also discoverer") gives credibility only — no
 discovery score. One-issue-per-PR rule is round-global: a single solving PR
 awards at most one discovery score across the entire validator round, even
-when it closes issues authored by different miners. The earliest-created
-qualifying issue across all miners wins; the rest are credibility only.
+when it closes issues authored by different miners. Issues are processed in
+canonical order (earliest ``created_at``, then smaller ``issue_number``,
+then smaller ``uid``); the first one whose solving PR actually resolves to
+a score claims the slot. Later-canonical siblings — and the canonical
+winner itself, if its solving-PR fetch fails — are credibility only.
 
 Base-score resolution uses a per-cycle cross-miner cache. Most solving PRs
 will be miners' own PRs that OSS scoring already tokenized; the cache
@@ -214,21 +217,47 @@ async def run_issue_discovery(
 
         pending.append((evaluation, filtered, open_counts))
 
-    canonical_pr_owners = _build_canonical_pr_owners(pending)
-    for evaluation, filtered, open_counts in pending:
-        complete = await _score_miner_issues(
+    # Cross-miner round state. ``claimed_pr_keys`` replaces the legacy
+    # pre-built ``canonical_pr_owners`` map: a (repo, pr_number) slot is now
+    # claimed lazily by the first issue (in canonical order) whose solving PR
+    # actually resolves to a score. This stops a transient-fetch-failed
+    # canonical winner from wasting the slot — the next-canonical sibling
+    # gets a turn instead of being silently blocked.
+    per_miner_repo_acc: Dict[int, Dict[str, _RepoIssueAcc]] = {}
+    claimed_pr_keys: Set[Tuple[str, int]] = set()
+
+    # Global iteration in canonical order. Within a single sort, the first
+    # qualifying issue per (repo, pr_number) tries to score; on success it
+    # adds the slot to ``claimed_pr_keys`` and downstream siblings see the
+    # slot as taken (credibility only). On failure the slot stays unclaimed
+    # and the next sibling's iteration gets a fresh chance.
+    all_issues_sorted = sorted(
+        ((evaluation, issue) for evaluation, filtered, _ in pending for issue in filtered),
+        key=lambda t: _canonical_iteration_key(t[0], t[1]),
+    )
+    for evaluation, issue in all_issues_sorted:
+        repo_acc = per_miner_repo_acc.setdefault(evaluation.uid, {})
+        await _process_issue(
             evaluation,
-            filtered,
+            issue,
             mirror_repos,
             solving_pr_cache,
             cache_stats,
             client,
             programming_languages,
             token_config,
-            open_counts=open_counts,
-            canonical_pr_owners=canonical_pr_owners,
+            repo_acc,
+            claimed_pr_keys,
         )
-        if complete:
+
+    # Per-miner finalize: roll the (possibly-empty) accumulators into the
+    # evaluation's repo and round-level fields. Miners with no qualifying
+    # issues fall through to finalize against an empty repo_acc, which still
+    # writes the open-issue counts and resets the issue-discovery scalars.
+    for evaluation, _, open_counts in pending:
+        repo_acc = per_miner_repo_acc.get(evaluation.uid, {})
+        _finalize_repo_issue_scores(evaluation, repo_acc, open_counts, mirror_repos)
+        if not any(acc.fetch_failed for acc in repo_acc.values()):
             cacheable_uids.add(evaluation.uid)
 
     if evaluation_cache is not None:
@@ -325,32 +354,18 @@ def _restore_issue_discovery_from_cache(
     return True
 
 
-def _build_canonical_pr_owners(
-    pending: List[Tuple[MinerEvaluation, List[MirrorIssue], Dict[str, int]]],
-) -> Dict[Tuple[str, int], Tuple[datetime, int, int]]:
-    """Cross-miner one-issue-per-PR resolution.
+def _canonical_iteration_key(evaluation: MinerEvaluation, issue: MirrorIssue) -> Tuple[datetime, int, int]:
+    """Sort key for canonical-order iteration of issues across miners.
 
-    Returns ``(repo, pr_number) -> (created_at, issue_number, uid)`` for the
-    earliest-created qualifying issue across all miners. Same-account issues
-    (discoverer == solver) are excluded — they never claim the slot.
-    ``_score_miner_issues`` matches issue markers against this map to
-    gate scoring vs. credibility-only.
+    Earliest ``created_at`` wins, ties broken by smaller ``issue_number``,
+    final tiebreaker is smaller ``uid``. A round-global sort by this key
+    drives the cross-miner one-issue-per-PR rule: whichever qualifying issue
+    is iterated first per (repo, pr_number) gets to try to score, and only
+    claims the slot if its solving PR actually resolves. Failed-to-score
+    canonical winners do NOT block later-canonical siblings — the next one
+    in the global order gets its turn.
     """
-    canonical: Dict[Tuple[str, int], Tuple[datetime, int, int]] = {}
-    for evaluation, issues, _ in pending:
-        for issue in issues:
-            if _classify_issue(issue) != 'solved':
-                continue
-            sp = issue.solving_pr
-            assert sp is not None  # _classify_issue guarantees a solving_pr
-            if issue.author_github_id == sp.author_github_id:
-                continue
-            key = (issue.repo_full_name, sp.pr_number)
-            marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)
-            existing = canonical.get(key)
-            if existing is None or marker < existing:
-                canonical[key] = marker
-    return canonical
+    return (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)
 
 
 def _count_open_issues(issues: List[MirrorIssue], enabled_names: Set[str]) -> Dict[str, int]:
@@ -386,125 +401,118 @@ def _build_solving_pr_cache(
     return cache
 
 
-async def _score_miner_issues(
+async def _process_issue(
     evaluation: MinerEvaluation,
-    issues: List[MirrorIssue],
+    issue: MirrorIssue,
     mirror_repos: Dict[str, RepositoryConfig],
     solving_pr_cache: Dict[Tuple[str, int], CachedSolvingPR],
     cache_stats: _CacheStats,
     client: MirrorClient,
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
-    open_counts: Dict[str, int],
-    canonical_pr_owners: Dict[Tuple[str, int], Tuple[datetime, int, int]],
-) -> bool:
-    """Classify + score one miner's mirror issues, per repository.
+    repo_acc_map: Dict[str, _RepoIssueAcc],
+    claimed_pr_keys: Set[Tuple[str, int]],
+) -> None:
+    """Classify and (when applicable) score a single mirror issue.
 
-    Each repository gates issue discovery independently from only its own
-    issues. ``open_counts`` maps repo -> the miner's current OPEN issue count
-    there, independent of the issue-scoring lookback window.
-
-    ``canonical_pr_owners`` enforces the cross-miner one-issue-per-PR rule:
-    only the marker-matching issue scores, siblings count for credibility.
-
-    Returns ``True`` when all required solving-PR score data was available, so
-    the caller can safely refresh the cache with this complete issue snapshot.
+    Mutates the miner's ``repo_acc_map`` for credibility/score accumulation
+    and the shared ``claimed_pr_keys`` set on a successful claim. Iteration
+    order at the call site is canonical: the first qualifying issue per
+    (repo, pr_number) reaches the claim check first, and only succeeds when
+    its solving PR actually resolves. If it fails, the slot stays unclaimed
+    and the next-canonical sibling iteration will get a chance.
     """
-    repo_acc: Dict[str, _RepoIssueAcc] = {}
+    repo_config = mirror_repos.get(issue.repo_full_name)
+    if repo_config is None:
+        return
+    cfg = resolve_eligibility(repo_config.eligibility)
+    acc = repo_acc_map.setdefault(issue.repo_full_name, _RepoIssueAcc())
 
-    issues_sorted = sorted(
-        issues,
-        key=lambda i: (
-            i.repo_full_name,
-            i.solved_by_pr or 0,
-            i.created_at or _FAR_FUTURE,
-        ),
+    classification = _classify_issue(issue)
+    if classification == 'not-solved-closed':
+        acc.closed += 1
+        return
+    if classification == 'ignore':
+        return
+
+    # classification == 'solved'
+    assert issue.solving_pr is not None  # _classify_issue guarantees
+    solving_pr = issue.solving_pr
+
+    acc.solved += 1
+
+    # Resolve real base_score + token_score for the solving PR (cache or fetch)
+    cached = await _resolve_solving_pr_score(
+        issue,
+        solving_pr,
+        solving_pr_cache,
+        cache_stats,
+        client,
+        programming_languages,
+        token_config,
+        repo_config,
     )
-
-    for issue in issues_sorted:
-        repo_config = mirror_repos.get(issue.repo_full_name)
-        if repo_config is None:
-            continue
-        cfg = resolve_eligibility(repo_config.eligibility)
-        acc = repo_acc.setdefault(issue.repo_full_name, _RepoIssueAcc())
-
-        classification = _classify_issue(issue)
-        if classification == 'not-solved-closed':
-            acc.closed += 1
-            continue
-        if classification == 'ignore':
-            continue
-
-        # classification == 'solved'
-        assert issue.solving_pr is not None  # _classify_issue guarantees
-        solving_pr = issue.solving_pr
-
-        acc.solved += 1
-
-        # Resolve real base_score + token_score for the solving PR (cache or fetch)
-        cached = await _resolve_solving_pr_score(
-            issue,
-            solving_pr,
-            solving_pr_cache,
-            cache_stats,
-            client,
-            programming_languages,
-            token_config,
-            repo_config,
+    if cached is None:
+        # Fetch failed — issue still counts for solved/credibility but not scored.
+        # Can't apply the valid-solved gate without a real token_score, so be
+        # conservative and don't increment valid_solved. Importantly, the slot
+        # is NOT claimed: a later-canonical sibling whose own fetch succeeds
+        # can still claim it.
+        acc.fetch_failed = True
+        bt.logging.debug(
+            f'  issue #{issue.issue_number} ({issue.repo_full_name}): solver score unavailable '
+            f'(fetch failed) — credibility only, slot left unclaimed'
         )
-        if cached is None:
-            # Fetch failed — issue still counts for solved/credibility but not scored.
-            # Can't apply the valid-solved gate without a real token_score, so be
-            # conservative and don't increment valid_solved.
-            acc.fetch_failed = True
-            bt.logging.debug(
-                f'  issue #{issue.issue_number} ({issue.repo_full_name}): solver score unavailable '
-                f'(fetch failed) — credibility only'
-            )
-            continue
+        return
 
-        # Valid-solved gate: solving PR must meet the repo's token threshold.
-        if cached.token_score >= cfg.min_token_score_for_valid_issue:
-            acc.valid_solved += 1
+    # Valid-solved gate: solving PR must meet the repo's token threshold.
+    if cached.token_score >= cfg.min_token_score_for_valid_issue:
+        acc.valid_solved += 1
 
-        # Same-account: discoverer == solver gets credibility only, no score
-        if issue.author_github_id == solving_pr.author_github_id:
-            bt.logging.debug(
-                f'  issue #{issue.issue_number} ({issue.repo_full_name}): same-account '
-                f'(discoverer == solver {issue.author_github_id}) — credibility only'
-            )
-            continue
+    # Same-account: discoverer == solver gets credibility only, no score.
+    # Same-account issues never claim a slot regardless of canonical order.
+    if issue.author_github_id == solving_pr.author_github_id:
+        bt.logging.debug(
+            f'  issue #{issue.issue_number} ({issue.repo_full_name}): same-account '
+            f'(discoverer == solver {issue.author_github_id}) — credibility only'
+        )
+        return
 
-        pr_key = (issue.repo_full_name, solving_pr.pr_number)
-        own_marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)
-        if canonical_pr_owners.get(pr_key) != own_marker:
-            bt.logging.debug(
-                f'  issue #{issue.issue_number} ({issue.repo_full_name}): one-issue-per-PR '
-                f'(PR #{solving_pr.pr_number} canonical owner is a different issue) — credibility only'
-            )
-            continue
+    pr_key = (issue.repo_full_name, solving_pr.pr_number)
+    if pr_key in claimed_pr_keys:
+        # A previously-iterated canonical-earlier issue already claimed this
+        # solving-PR slot. One-issue-per-PR: later siblings are credibility only.
+        bt.logging.debug(
+            f'  issue #{issue.issue_number} ({issue.repo_full_name}): one-issue-per-PR '
+            f'(PR #{solving_pr.pr_number} slot already claimed by an earlier-canonical '
+            f'scoring sibling) — credibility only'
+        )
+        return
 
-        # Quality gate: below-threshold solving PRs add credibility only, no
-        # discovery score.
-        if cached.token_score < cfg.min_token_score_for_valid_issue:
-            bt.logging.debug(
-                f'  issue #{issue.issue_number} ({issue.repo_full_name}): solving PR '
-                f'#{solving_pr.pr_number} token_score {cached.token_score:.2f} < '
-                f'{cfg.min_token_score_for_valid_issue} — credibility only'
-            )
-            continue
+    # Quality gate: below-threshold solving PRs add credibility only, no
+    # discovery score. Don't claim the slot — siblings would see the same
+    # solving PR (same token_score) and also fail, but leaving the slot
+    # unclaimed keeps the invariant "only scoring issues claim".
+    if cached.token_score < cfg.min_token_score_for_valid_issue:
+        bt.logging.debug(
+            f'  issue #{issue.issue_number} ({issue.repo_full_name}): solving PR '
+            f'#{solving_pr.pr_number} token_score {cached.token_score:.2f} < '
+            f'{cfg.min_token_score_for_valid_issue} — credibility only'
+        )
+        return
 
-        adapted = _mirror_issue_for_scoring(issue, solving_pr, repo_config, base_score=cached.base_score)
-        if adapted is None:
-            continue
+    adapted = _mirror_issue_for_scoring(issue, solving_pr, repo_config, base_score=cached.base_score)
+    if adapted is None:
+        # Defensive: solving_pr.merged_at missing on a MERGED PR. Don't claim;
+        # any sibling iteration would hit the same missing field and skip too,
+        # but the invariant holds.
+        return
 
-        acc.scored_issues.append(adapted)
-        # issue_token_score accumulates per-solving-PR token scores for the
-        # open-issue spam multiplier threshold calc.
-        acc.issue_token_score += cached.token_score
-
-    _finalize_repo_issue_scores(evaluation, repo_acc, open_counts, mirror_repos)
-    return not any(acc.fetch_failed for acc in repo_acc.values())
+    acc.scored_issues.append(adapted)
+    # issue_token_score accumulates per-solving-PR token scores for the
+    # open-issue spam multiplier threshold calc.
+    acc.issue_token_score += cached.token_score
+    claimed_pr_keys.add(pr_key)
 
 
 def _finalize_repo_issue_scores(

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -1052,10 +1052,12 @@ class TestCrossMinerOneIssuePerPr:
     pre-#796 behavior in ``_collect_issues_from_prs``.
     """
 
-    def test_canonical_picks_earliest_created_across_miners(self):
-        """``_build_canonical_pr_owners`` keys (repo, pr_number) to the
-        earliest-created qualifying issue across all miners' fetches."""
-        from gittensor.validator.issue_discovery.scan import _build_canonical_pr_owners
+    def test_canonical_iteration_key_orders_by_created_at(self):
+        """``_canonical_iteration_key`` produces the round-global sort order
+        used to interleave issues across miners. Earlier ``created_at`` sorts
+        before a later one — that's what gives the earliest-created issue
+        first dibs on its solving-PR slot."""
+        from gittensor.validator.issue_discovery.scan import _canonical_iteration_key
 
         e_a = _eval(uid=1, github_id='A')
         e_b = _eval(uid=2, github_id='B')
@@ -1077,75 +1079,31 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
+        # A's earlier-created issue (#50, uid 1) sorts before B's (#51, uid 2).
+        assert _canonical_iteration_key(e_a, a_issue) < _canonical_iteration_key(e_b, b_issue)
 
-        # Earlier-created issue (#50, uid 1) wins canonical for PR 100
-        owner = canonical[('entrius/gittensor-ui', 100)]
-        assert owner[1] == 50
-        assert owner[2] == 1
+    def test_canonical_iteration_key_tie_breaks_on_issue_number_then_uid(self):
+        """Identical ``created_at`` → lower issue_number wins. Identical
+        ``created_at`` AND identical ``issue_number`` (very unlikely in
+        practice but possible across repos sharing numbers via the sort) →
+        lower uid wins."""
+        from gittensor.validator.issue_discovery.scan import _canonical_iteration_key
 
-    def test_canonical_tie_break_lower_issue_number(self):
-        """Identical ``created_at`` across miners → lower issue_number wins."""
-        from gittensor.validator.issue_discovery.scan import _build_canonical_pr_owners
+        e_low_uid = _eval(uid=1, github_id='A')
+        e_high_uid = _eval(uid=2, github_id='B')
 
-        # uid 2 first in iteration order, but uid 1's lower issue_number must win.
-        e_a = _eval(uid=2, github_id='A')
-        e_b = _eval(uid=1, github_id='B')
+        same_time = '2026-04-01T00:00:00Z'
 
-        a_issue = MirrorIssue.from_dict(
-            _issue_dict(
-                issue_number=51,
-                author_github_id='A',
-                solving_pr_author='SOLVER',
-                created_at='2026-04-01T00:00:00Z',
-            )
-        )
-        b_issue = MirrorIssue.from_dict(
-            _issue_dict(
-                issue_number=50,
-                author_github_id='B',
-                solving_pr_author='SOLVER',
-                created_at='2026-04-01T00:00:00Z',
-            )
-        )
+        i_low_number = MirrorIssue.from_dict(_issue_dict(issue_number=50, author_github_id='A', created_at=same_time))
+        i_high_number = MirrorIssue.from_dict(_issue_dict(issue_number=51, author_github_id='B', created_at=same_time))
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
+        # issue_number tiebreak: lower wins regardless of which uid holds it
+        assert _canonical_iteration_key(e_high_uid, i_low_number) < _canonical_iteration_key(e_low_uid, i_high_number)
 
-        owner = canonical[('entrius/gittensor-ui', 100)]
-        assert owner[1] == 50  # lower issue_number wins
-        assert owner[2] == 1  # ... which is uid 1 (e_b)
-
-    def test_canonical_excludes_same_account(self):
-        """Same-account issues never claim canonical ownership of a PR slot,
-        leaving non-same-account siblings on the same PR free to score."""
-        from gittensor.validator.issue_discovery.scan import _build_canonical_pr_owners
-
-        e_a = _eval(uid=1, github_id='A')
-        e_b = _eval(uid=2, github_id='B')
-
-        # A's issue is same-account (author == solver) and earlier — must be excluded.
-        a_issue = MirrorIssue.from_dict(
-            _issue_dict(
-                issue_number=50,
-                author_github_id='A',
-                solving_pr_author='A',
-                created_at='2026-04-01T00:00:00Z',
-            )
-        )
-        b_issue = MirrorIssue.from_dict(
-            _issue_dict(
-                issue_number=51,
-                author_github_id='B',
-                solving_pr_author='SOLVER',
-                created_at='2026-04-05T00:00:00Z',
-            )
-        )
-
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
-
-        owner = canonical[('entrius/gittensor-ui', 100)]
-        assert owner[1] == 51  # B's issue claims canonical
-        assert owner[2] == 2
+        # uid final tiebreak: same created_at, same issue_number, lower uid wins
+        i_same_a = MirrorIssue.from_dict(_issue_dict(issue_number=50, author_github_id='A', created_at=same_time))
+        i_same_b = MirrorIssue.from_dict(_issue_dict(issue_number=50, author_github_id='B', created_at=same_time))
+        assert _canonical_iteration_key(e_low_uid, i_same_a) < _canonical_iteration_key(e_high_uid, i_same_b)
 
     def test_two_miners_shared_pr_only_earliest_scores(self):
         """End-to-end: two miners each with 7 valid solved issues clearing
@@ -1350,6 +1308,183 @@ class TestCrossMinerOneIssuePerPr:
             return evaluation.issue_discovery_score
 
         assert _score_with_emission_share(0.1) == pytest.approx(_score_with_emission_share(0.9))
+
+    def test_canonical_winner_unscoreable_lets_sibling_claim(self):
+        """Core bug fix. The earlier-canonical miner A's solving-PR can't
+        actually produce a scored row (here: ``solving_pr.merged_at=None``,
+        a mirror anomaly that lands at ``_mirror_issue_for_scoring`` returning
+        ``None``). Under the old pre-built canonical map, B was credibility-
+        only — the slot was wasted. With lazy claiming, B claims the slot.
+
+        The same dynamics apply to transient ``get_pr_files`` failures
+        (``cached is None``): the canonical winner's iteration doesn't claim,
+        and the next-canonical sibling's iteration gets a turn. The
+        ``merged_at=None`` case is the deterministic variant — easier to
+        exercise in a unit test without monkeypatching the token-scoring math.
+        """
+        client = Mock()
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
+        # Padding seeds so each miner clears MIN_VALID_SOLVED_ISSUES=3.
+        seed.merged_prs.extend(
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number)
+            for pr_number in list(range(200, 203)) + list(range(300, 303))
+        )
+
+        # A's #50: solving_pr.merged_at forced to None -> _mirror_issue_for_scoring returns None.
+        a_shared = _issue_dict(
+            issue_number=50,
+            author_github_id='A',
+            solved_by_pr=100,
+            solving_pr_author='SOLVER',
+            created_at='2026-04-01T00:00:00Z',
+        )
+        a_shared['solving_pr']['merged_at'] = None
+
+        # B's #51: solving_pr.merged_at populated -> scoreable.
+        b_shared = _issue_dict(
+            issue_number=51,
+            author_github_id='B',
+            solved_by_pr=100,
+            solving_pr_author='SOLVER',
+            created_at='2026-04-05T00:00:00Z',
+        )
+
+        a_issues = [_issue_dict(issue_number=10 + i, author_github_id='A', solved_by_pr=200 + i) for i in range(3)]
+        a_issues.append(a_shared)
+        b_issues = [_issue_dict(issue_number=20 + i, author_github_id='B', solved_by_pr=300 + i) for i in range(3)]
+        b_issues.append(b_shared)
+
+        client.get_miner_issues.side_effect = _issues_by_github_id({'A': a_issues, 'B': b_issues})
+
+        e_a = _eval(uid=1, github_id='A')
+        e_b = _eval(uid=2, github_id='B')
+
+        _run(
+            run_issue_discovery(
+                {1: e_a, 2: e_b, 99: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Both miners are eligible (4 valid_solved each, well over MIN=3).
+        assert e_a.is_issue_eligible
+        assert e_b.is_issue_eligible
+
+        # A's #50 was canonical-earlier but couldn't be scored — NOT in
+        # scored issues. Under the old behavior B's #51 would also be blocked
+        # (canonical_pr_owners pinned A as the winner regardless of outcome).
+        assert not any(issue.number == 50 for issue in e_a.issue_discovery_issues)
+        # B's #51 took the slot.
+        assert any(issue.number == 51 for issue in e_b.issue_discovery_issues)
+
+    def test_canonical_winner_success_blocks_sibling_as_before(self):
+        """Regression coverage: when the canonical winner DOES score, siblings
+        on the same PR are still blocked. Legacy behavior preserved under
+        the lazy-claim semantics."""
+        client = Mock()
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
+        seed.merged_prs.extend(
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number)
+            for pr_number in list(range(200, 203)) + list(range(300, 303))
+        )
+
+        a_issues = [_issue_dict(issue_number=10 + i, author_github_id='A', solved_by_pr=200 + i) for i in range(3)]
+        a_issues.append(
+            _issue_dict(
+                issue_number=50,
+                author_github_id='A',
+                solved_by_pr=100,
+                solving_pr_author='SOLVER',
+                created_at='2026-04-01T00:00:00Z',
+            )
+        )
+        b_issues = [_issue_dict(issue_number=20 + i, author_github_id='B', solved_by_pr=300 + i) for i in range(3)]
+        b_issues.append(
+            _issue_dict(
+                issue_number=51,
+                author_github_id='B',
+                solved_by_pr=100,
+                solving_pr_author='SOLVER',
+                created_at='2026-04-05T00:00:00Z',
+            )
+        )
+        client.get_miner_issues.side_effect = _issues_by_github_id({'A': a_issues, 'B': b_issues})
+
+        e_a = _eval(uid=1, github_id='A')
+        e_b = _eval(uid=2, github_id='B')
+
+        _run(
+            run_issue_discovery(
+                {1: e_a, 2: e_b, 99: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # Canonical winner (A's #50) scored; sibling (B's #51) is credibility only.
+        assert any(issue.number == 50 for issue in e_a.issue_discovery_issues)
+        assert not any(issue.number == 51 for issue in e_b.issue_discovery_issues)
+        assert e_b.total_solved_issues == 4  # 3 padding + #51 (credibility-only)
+
+    def test_same_account_canonical_does_not_block_sibling(self):
+        """Preserves the legacy semantic that same-account issues never claim
+        a slot — even when they're the canonical-earlier issue by created_at.
+        The non-same-account sibling claims the PR."""
+        client = Mock()
+        seed = MinerEvaluation(uid=99, hotkey='hkS', github_id='SEED')
+        seed.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
+        seed.merged_prs.extend(
+            _scored_mirror_pr('entrius/gittensor-ui', pr_number)
+            for pr_number in list(range(200, 203)) + list(range(300, 303))
+        )
+
+        # A's earlier-created #50 is same-account (author == solver).
+        a_issues = [_issue_dict(issue_number=10 + i, author_github_id='A', solved_by_pr=200 + i) for i in range(3)]
+        a_issues.append(
+            _issue_dict(
+                issue_number=50,
+                author_github_id='A',
+                solved_by_pr=100,
+                solving_pr_author='A',  # same-account
+                created_at='2026-04-01T00:00:00Z',
+            )
+        )
+        b_issues = [_issue_dict(issue_number=20 + i, author_github_id='B', solved_by_pr=300 + i) for i in range(3)]
+        b_issues.append(
+            _issue_dict(
+                issue_number=51,
+                author_github_id='B',
+                solved_by_pr=100,
+                solving_pr_author='SOLVER',
+                created_at='2026-04-05T00:00:00Z',
+            )
+        )
+        client.get_miner_issues.side_effect = _issues_by_github_id({'A': a_issues, 'B': b_issues})
+
+        e_a = _eval(uid=1, github_id='A')
+        e_b = _eval(uid=2, github_id='B')
+
+        _run(
+            run_issue_discovery(
+                {1: e_a, 2: e_b, 99: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        # A's same-account #50 didn't claim — not in scored issues.
+        assert not any(issue.number == 50 for issue in e_a.issue_discovery_issues)
+        # B's #51 takes the slot.
+        assert any(issue.number == 51 for issue in e_b.issue_discovery_issues)
 
 
 def _issues_by_github_id(mapping: dict):


### PR DESCRIPTION
## Summary

The pre-built `canonical_pr_owners` map declared the earliest-created issue per `(repo, pr_number)` the canonical winner at the start of every round. When that winner couldn't actually score — `_resolve_solving_pr_score` returns `None` on a transient `get_pr_files` failure, or `_mirror_issue_for_scoring` returns `None` when the mirror's inline `MirrorSolvingPR.merged_at` is missing — the slot was silently wasted. The canonical map still pointed at the failed winner, so every sibling issue on the same solving PR was downgraded to credibility-only at the canonical check, even when the sibling's own iteration would have produced a valid score.

Replace the fixed canonical map with a lazy `claimed_pr_keys` set. Iterate every miner's issues in a single canonical-sorted pass (the same `(created_at, issue_number, uid)` tiebreak the old map used) and let each PR slot be claimed by the first issue whose solving PR actually resolves to a score.

## Problem

`gittensor/validator/issue_discovery/scan.py:_build_canonical_pr_owners` built the map before any scoring ran:

```python
canonical: Dict[Tuple[str, int], Tuple[datetime, int, int]] = {}
for evaluation, issues, _ in pending:
    for issue in issues:
        if _classify_issue(issue) != 'solved':
            continue
        sp = issue.solving_pr
        if issue.author_github_id == sp.author_github_id:
            continue
        key = (issue.repo_full_name, sp.pr_number)
        marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)
        existing = canonical.get(key)
        if existing is None or marker < existing:
            canonical[key] = marker
```

The map only filtered by `_classify_issue == 'solved'` and same-account exclusion. It did not — could not — account for the downstream checks in `_score_miner_issues` that decide whether the canonical winner actually ends up with a scored row:

- `_resolve_solving_pr_score` returns `None` on `get_pr_files` failure (transient mirror flake exhausting its three retries) or on `scoring_data_stored=False`.
- `_mirror_issue_for_scoring` returns `None` when the inline `solving_pr.merged_at` is missing on a state-`MERGED` PR (mirror data anomaly the existing code already defensively handles).

When the canonical winner hit either of those, its own iteration logged credibility-only and continued. The canonical map kept the winner's marker, so the gate at `scan.py:480` blocked every later-canonical sibling:

```python
if canonical_pr_owners.get(pr_key) != own_marker:
    bt.logging.debug('  ... canonical owner is a different issue — credibility only')
    continue
```

Concrete sybil-adjacent scenario the bug surfaces in: Miner A opens issue I_a at T1, Miner B opens issue I_b at T2 > T1, both closed by PR P. Miner A's `get_pr_files` exhausts its three retries on a transient mirror error. A is `fetch_failed`, doesn't score. Miner B's iteration kicks off a fresh fetch — could succeed (independent retry budget, possibly different mirror state) — and the cache populates. But B's marker doesn't match canonical (A's marker), so B is credibility-only too. PR P's discovery-score slot is silently wasted, even though B was scoreable.

The `merged_at=None` failure has the same shape but is deterministic: both A's and B's solving_pr objects share the same `(repo, pr_number)` but the mirror serializes them independently, so one can have `merged_at=None` while the other doesn't.

## Fix

Drop the pre-built canonical map. Iterate every miner's issues in one round-global pass sorted by canonical position, and let each PR slot be claimed lazily by the first issue whose solving PR actually resolves to a score.

1. New `_canonical_iteration_key(evaluation, issue)` returns the `(created_at, issue_number, uid)` tuple — same shape as the legacy marker; used as the sort key for the global iteration.
2. `run_issue_discovery` builds `all_issues_sorted` from every `pending` miner's filtered issues, then iterates that single list. A `Dict[uid, Dict[repo, _RepoIssueAcc]]` keeps per-miner-per-repo accumulators alongside the global iteration; `claimed_pr_keys: Set[Tuple[str, int]]` is the new shared "slot taken" set.
3. New `_process_issue` is the per-issue worker pulled out of the old `_score_miner_issues` body. It runs the same `_classify_issue`, `_resolve_solving_pr_score`, valid-solved, same-account, quality-gate, and `_mirror_issue_for_scoring` checks. The single semantic change: where the old code matched `canonical_pr_owners.get(pr_key) != own_marker`, the new code checks `pr_key in claimed_pr_keys`. Failed-to-score paths return WITHOUT adding to the set, so the next sibling's iteration gets a fresh chance.
4. After the global iteration, `_finalize_repo_issue_scores` runs once per miner against the captured `repo_acc` map. The completeness signal that gates the evaluation-cache refresh (`acc.fetch_failed`) is computed at this finalize step instead of inside the (now-removed) per-miner wrapper.
5. `_build_canonical_pr_owners` is removed — the global sort plus lazy claiming is its complete replacement.

## Semantics preserved

- **Earliest-created wins**: the global sort by `(created_at, issue_number, uid)` matches the legacy tiebreak exactly. When the canonical winner scores cleanly (which is the common case), behavior is identical.
- **Same-account never claims**: same-account issues hit the `return` before the claim check at every iteration, regardless of canonical position. Confirmed by the new `test_same_account_canonical_does_not_block_sibling`.
- **One-issue-per-PR**: still strictly enforced. `claimed_pr_keys` is mutated only on a successful claim; once a slot is claimed, every subsequent iteration on the same PR (within-miner or cross-miner) is credibility-only.
- **Cross-miner solving-PR cache**: untouched. The shared `solving_pr_cache` still amortizes fetches across miners; the iteration ordering is the only thing that changed.
- **Failed-fetch cache hygiene**: a fetch that fails still leaves the cache empty so a later miner's iteration can retry independently — same as before.
- **Eligibility math**: `acc.solved`, `acc.valid_solved`, `acc.closed`, and per-repo `_finalize_repo_issue_scores` run with the same inputs they always did.

## Changes

- `gittensor/validator/issue_discovery/scan.py`:
  - Replace `canonical_pr_owners` map + per-miner `_score_miner_issues` loop with global iteration + `claimed_pr_keys` set in `run_issue_discovery`.
  - Add `_canonical_iteration_key` helper (the sort key for the global iteration).
  - Remove `_build_canonical_pr_owners` and `_score_miner_issues`.
  - Add `_process_issue` — per-issue worker invoked once per `(evaluation, issue)` tuple from the sorted iteration.
  - Update the module-level docstring's "One-issue-per-PR" paragraph to describe the new lazy-claim semantics.
- `tests/validator/issue_discovery/test_scan.py`:
  - Three new tests in `TestCrossMinerOneIssuePerPr`:
    - `test_canonical_winner_unscoreable_lets_sibling_claim` — the regression test for the fix. A's canonical-earlier issue can't score (`solving_pr.merged_at=None`); B's sibling claims the slot. Under the old code B would be credibility-only.
    - `test_canonical_winner_success_blocks_sibling_as_before` — verifies the common case is unchanged.
    - `test_same_account_canonical_does_not_block_sibling` — verifies same-account never claims, even at the earliest canonical position.
  - Two unit tests for the new `_canonical_iteration_key` helper (`test_canonical_iteration_key_orders_by_created_at`, `test_canonical_iteration_key_tie_breaks_on_issue_number_then_uid`) replace the three old unit tests for `_build_canonical_pr_owners`. The legacy end-to-end behavior tests (`test_two_miners_shared_pr_only_earliest_scores`, `test_within_miner_one_issue_per_pr_still_holds`, `test_different_solving_prs_both_miners_score`) are unchanged and still cover the canonical-winner-success path end-to-end.

## Testing

```
UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ -q

Result:

840 passed in 22.94s
```

```
ruff check gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py
ruff format --check gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py
```

Both pass clean.
