### PR TITLE
refactor: inline single-use _resolve_pr_state into _search_issue_referencing_prs_graphql

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -197,13 +197,6 @@ query($owner: String!, $name: String!, $issueNumber: Int!) {
 """
 
 
-def _resolve_pr_state(raw_state: str, merged: bool = False) -> str:
-    """Normalize PR state to uppercase GraphQL-style values."""
-    if merged:
-        return 'MERGED'
-    return (raw_state or '').upper() or 'OPEN'
-
-
 def _closing_issue_numbers_for_repo(closing_ref: Optional[Dict[str, Any]], repo: str) -> List[int]:
     """Return only closing issue numbers whose GraphQL repository matches ``repo``."""
     target_repo = repo.lower()
@@ -269,7 +262,7 @@ def _search_issue_referencing_prs_graphql(
         if not pr_number:
             continue
 
-        state = _resolve_pr_state(pr.get('state', ''), merged=bool(pr.get('merged', False)))
+        state = 'MERGED' if pr.get('merged') else (pr.get('state') or '').upper() or 'OPEN'
         if open_only and state != 'OPEN':
             continue
 


### PR DESCRIPTION
## Summary

[`_resolve_pr_state`](gittensor/utils/github_api_tools.py) is a 5-line wrapper used at **exactly one site** — `_search_issue_referencing_prs_graphql`. Its body collapses to a single expression: `'MERGED'` when the GraphQL response's `merged` flag is set, otherwise the uppercased `state` with `'OPEN'` as the empty-string fallback. The inline form reads naturally at the call site:

```diff
-        state = _resolve_pr_state(pr.get('state', ''), merged=bool(pr.get('merged', False)))
+        state = 'MERGED' if pr.get('merged') else (pr.get('state') or '').upper() or 'OPEN'
```

`grep -rn _resolve_pr_state --include='*.py' .` returns only the (now removed) definition — no other call sites and no test references in `gittensor/`, `neurons/`, or `tests/`.

Same shape as the merged single-use-helper-inline pattern from #748 (`get_github_user` → `get_github_id`) and #818 (`_single_paragraph` / `_get_contract_info_value`).

Net: **+1 / -8 lines**, single file.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 838 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)