### PR TITLE
docs: add open-item rate limit rule to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,14 @@ PRs missing this evidence may be closed without review, or returned for updates 
 
 - Assign `anderdc` and `landyndev` to your PR for review
 
+## Automatic Closures
+
+The maintainer bot enforces these rules without manual review. Contributions that violate them are closed automatically.
+
+### Open item limits
+
+Each contributor may have at most **3 open PRs** and **3 open issues** in this repository at any time. Submitting a 4th of either type while at the cap closes the new one on submission. The limits apply independently — you can have 3 open PRs and 3 open issues at the same time.
+
 ## PR Labels
 
 Apply appropriate labels to help categorize and track your contribution:


### PR DESCRIPTION
## Summary

Adds an "Automatic Closures" section documenting the bot-enforced open-item rate limit: each contributor capped at 3 open PRs and 3 open issues in this repo; a 4th of either type is auto-closed on submission. Limits apply independently.

gittensor uses a higher cap (3) than other entrius repos (2) because more contributors are active here and the maintainer can absorb the volume.

Companion to entrius/gittensor-ui#1265, entrius/das-github-mirror#122, entrius/allways#368. The maintainer bot (agentic-maintainer) gets a follow-up change to make rate limits per-repo.

The existing CLI before/after media rule under "CLI Changes" covers gittensor's analog to gittensor-ui's UI/UX media rule; no UI/UX rule needed here.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe below)