### PR TITLE
chore(weights): tune awesome-claude scoring parameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -88,7 +88,22 @@
   },
   "JSONbored/awesome-claude": {
     "emission_share": 0.01000,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "feature": 1.5,
+      "bug": 1.1
+    },
+    "scoring": {
+      "pr_lookback_days": 45,
+      "open_pr_collateral_percent": 0.15,
+      "review_penalty_rate": 0.2,
+      "maintainer_issue_multiplier": 1.75,
+      "time_decay": {
+        "grace_period_hours": 24,
+        "sigmoid_midpoint_days": 14,
+        "min_multiplier": 0.1
+      }
+    }
   },
   "MkDev11/gittensor-hub": {
     "emission_share": 0.03500,


### PR DESCRIPTION
## Summary
- Tune the `JSONbored/awesome-claude` repo-local scoring parameters for feature-oriented contributions without changing its allocated share or PR/issue split.

## What changed
- Add only two label multipliers: `feature=1.5` and `bug=1.1`.
- Extend the PR scoring lookback to 45 days and use a slower decay curve with a 24-hour grace period, 14-day midpoint, and 0.10 floor.
- Reduce open PR collateral to 0.15 so review latency is less punitive while increasing the review penalty rate to 0.20 for avoidable review churn.
- Raise the maintainer-authored linked issue multiplier to 1.75.
- Leave `emission_share`, `issue_discovery_share`, `maintainer_cut`, and `trusted_label_pipeline` unchanged.

## Why
- `awesome-claude` should primarily reward substantive feature work while still giving real bug fixes a smaller boost. This keeps the first tuning pass simple, conservative, and limited to repo-local quality knobs.

## Validation
- `python -m json.tool gittensor/validator/weights/master_repositories.json`
- `python -m pytest tests/validator/test_load_weights.py tests/validator/test_label_multiplier.py -q`
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push`
- `uv run pytest tests/ -q`

## Notes
- This intentionally does not add a maintainer cut. That can be considered separately after the initial quality-oriented tuning lands.
- This also leaves the default label trust gate in place, so GitHub App-applied labels are not newly trusted by this change.