### PR TITLE
fix(issue-discovery): honor per-repo min_token_score in solving-PR cache

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -162,7 +162,7 @@ async def run_issue_discovery(
     }
     enabled_names: Set[str] = set(mirror_repos.keys())
 
-    solving_pr_cache: Dict[Tuple[str, int], CachedSolvingPR] = _build_solving_pr_cache(miner_evaluations)
+    solving_pr_cache: Dict[Tuple[str, int], CachedSolvingPR] = _build_solving_pr_cache(miner_evaluations, mirror_repos)
     cache_stats = _CacheStats()
     bt.logging.info(
         f'Cross-miner solving-PR cache: {len(solving_pr_cache)} entries from '
@@ -396,17 +396,31 @@ def _fallback_open_issue_counts(
 
 def _build_solving_pr_cache(
     miner_evaluations: Dict[int, MinerEvaluation],
+    mirror_repos: Dict[str, RepositoryConfig],
 ) -> Dict[Tuple[str, int], CachedSolvingPR]:
     """Pre-populate the cross-miner cache from already-scored mirror PRs.
 
     Any PR that was scored during OSS (in any miner's merged_prs) is
     keyed by (repo, pr_number) → CachedSolvingPR. Issue-discovery lookups hit
     this cache instead of re-fetching for miners' own PRs or other miners' PRs.
+
+    Filters out PRs whose ``token_score`` is below the repo's
+    ``min_token_score_for_base_score`` threshold so the cache-HIT path applies
+    the same gate as the cache-MISS path (``_resolve_solving_pr_score``) and
+    the OSS scoring path (``calculate_base_score_for_pr_files``). Falls back to
+    the global default for repos missing from ``mirror_repos`` (defensive —
+    in practice every ``merged_prs`` entry is from a tracked repo).
     """
     cache: Dict[Tuple[str, int], CachedSolvingPR] = {}
     for evaluation in miner_evaluations.values():
         for scored in evaluation.merged_prs:
-            if scored.token_score < MIN_TOKEN_SCORE_FOR_BASE_SCORE:
+            repo_config = mirror_repos.get(scored.pr.repo_full_name)
+            threshold = (
+                resolve_eligibility(repo_config.eligibility).min_token_score_for_base_score
+                if repo_config is not None
+                else MIN_TOKEN_SCORE_FOR_BASE_SCORE
+            )
+            if scored.token_score < threshold:
                 continue
             key = (scored.pr.repo_full_name, scored.pr.pr_number)
             if key in cache:

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -36,6 +36,7 @@ MirrorRequestError = mirror_client_mod.MirrorRequestError
 MinerEvaluation = classes.MinerEvaluation
 MinerEvaluationCache = classes.MinerEvaluationCache
 RepoEvaluation = classes.RepoEvaluation
+RepoEligibilityConfig = load_weights.RepoEligibilityConfig
 RepositoryConfig = load_weights.RepositoryConfig
 TokenConfig = load_weights.TokenConfig
 ScoredPR = scored_pr_module.ScoredPR
@@ -748,7 +749,7 @@ class TestSolvingPrCache:
         e2 = MinerEvaluation(uid=2, hotkey='hk2', github_id='g2')
         e2.merged_prs = [_scored_mirror_pr('foo/b', 2, token_score=80, base_score=20)]
 
-        cache = _build_solving_pr_cache({1: e1, 2: e2})
+        cache = _build_solving_pr_cache({1: e1, 2: e2}, _mirror_repos('foo/a', 'foo/b'))
         assert cache[('foo/a', 1)].token_score == 50
         assert cache[('foo/a', 1)].base_score == 10
         assert cache[('foo/b', 2)].token_score == 80
@@ -762,7 +763,7 @@ class TestSolvingPrCache:
         e2 = MinerEvaluation(uid=2, hotkey='hk2', github_id='g2')
         e2.merged_prs = [_scored_mirror_pr('foo/a', 1, token_score=99)]
 
-        cache = _build_solving_pr_cache({1: e1, 2: e2})
+        cache = _build_solving_pr_cache({1: e1, 2: e2}, _mirror_repos('foo/a'))
         assert cache[('foo/a', 1)].token_score == 50  # first wins
 
     def test_below_threshold_prs_excluded_from_cache(self):
@@ -771,9 +772,48 @@ class TestSolvingPrCache:
             _scored_mirror_pr('foo/poisoned', 1, token_score=0.0, base_score=0.0),
             _scored_mirror_pr('foo/healthy', 2, token_score=50, base_score=10),
         ]
-        cache = _build_solving_pr_cache({1: e1})
+        cache = _build_solving_pr_cache({1: e1}, _mirror_repos('foo/poisoned', 'foo/healthy'))
         assert ('foo/poisoned', 1) not in cache
         assert ('foo/healthy', 2) in cache
+
+    def test_per_repo_override_keeps_pr_above_repo_threshold(self):
+        """A repo with min_token_score_for_base_score below the global default
+        keeps PRs whose token_score clears the override but not the default.
+
+        Mirrors the per-repo gating already applied on the cache-MISS path
+        (``_resolve_solving_pr_score``) and on the OSS scoring path
+        (``calculate_base_score_for_pr_files``) — see PR #1330.
+        """
+        repos = {
+            'foo/lenient': RepositoryConfig(
+                emission_share=0.5,
+                eligibility=RepoEligibilityConfig(min_token_score_for_base_score=2.0),
+            ),
+            'foo/strict': RepositoryConfig(emission_share=0.5),  # global default (5)
+        }
+        e1 = MinerEvaluation(uid=1, hotkey='hk1', github_id='g1')
+        e1.merged_prs = [
+            _scored_mirror_pr('foo/lenient', 1, token_score=3.0, base_score=4.0),
+            _scored_mirror_pr('foo/strict', 2, token_score=3.0, base_score=0.0),
+        ]
+        cache = _build_solving_pr_cache({1: e1}, repos)
+        assert ('foo/lenient', 1) in cache  # clears per-repo threshold of 2
+        assert cache[('foo/lenient', 1)].token_score == 3.0
+        assert cache[('foo/lenient', 1)].base_score == 4.0
+        assert ('foo/strict', 2) not in cache  # below global default of 5
+
+    def test_untracked_repo_falls_back_to_global_threshold(self):
+        """Defensive: a merged PR whose repo isn't in mirror_repos still gates
+        on the global default rather than crashing.
+        """
+        e1 = MinerEvaluation(uid=1, hotkey='hk1', github_id='g1')
+        e1.merged_prs = [
+            _scored_mirror_pr('foo/untracked', 1, token_score=3.0, base_score=0.0),
+            _scored_mirror_pr('foo/untracked', 2, token_score=50.0, base_score=10.0),
+        ]
+        cache = _build_solving_pr_cache({1: e1}, {})  # no mirror_repos entries
+        assert ('foo/untracked', 1) not in cache
+        assert ('foo/untracked', 2) in cache
 
     def test_cache_hit_reuses_base_score_no_fetch(self):
         """A solving PR already in cache must not trigger a get_pr_files call."""


### PR DESCRIPTION
## Summary

PR #1330 plumbed `min_token_score_for_base_score` through the OSS scoring path ([`mirror/scoring.py`](../blob/test/gittensor/validator/oss_contributions/mirror/scoring.py)) and the issue-discovery solving-PR cache-MISS path ([`scan.py:676-680`](../blob/test/gittensor/validator/issue_discovery/scan.py#L676-L680)), but the solving-PR **cache-population** path at [`scan.py:409`](../blob/test/gittensor/validator/issue_discovery/scan.py#L409) kept reading the global `MIN_TOKEN_SCORE_FOR_BASE_SCORE` constant — silent state asymmetry between the cache and the path that fills its misses.

With a repo-level override set, OSS gives a merged PR with `token_score = 3` a non-zero `base_score` (post-#1330), but `_build_solving_pr_cache` drops the entry because `3 < 5`. Every sibling discoverer's lookup for that PR then cache-MISSes and refetches via `MirrorClient.get_pr_files`; on a `MirrorRequestError` or `scoring_data_stored = False` the per-repo accumulator sets `fetch_failed = True`, and the discoverer loses both `valid_solved` credit and `discovery_earned_score` for that issue — even though the data was already in memory on this validator round. No repo in `master_repositories.json` currently sets the override, so the bug is latent, but the moment an admin uses the field the cache and the cache-MISS path disagree about which PRs are scorable. Same forward-looking-consistency posture as #1330.

The docs are explicit on the contract: every eligibility constant "is a global default that any repository can override in its config entry" (`docs.gittensor.io/oss-contributions.html` §"Per-repo configs vary"), and the cross-miner cache is specified as a pure pass-through — "Miners' own PRs are pre-scored during OSS evaluation and reused for free" (`docs.gittensor.io/issue-discovery.html` §"Base Score Calculation"). The current cache filter breaks the "reused for free" promise whenever the override is in effect.

Closes #1355.

## Fix

- `_build_solving_pr_cache` now takes `mirror_repos: Dict[str, RepositoryConfig]` and resolves the per-PR threshold via `resolve_eligibility(repo_config.eligibility).min_token_score_for_base_score`, falling back to the global `MIN_TOKEN_SCORE_FOR_BASE_SCORE` when the repo isn't in `mirror_repos` (defensive — in practice every `merged_prs` entry is from a tracked repo).
- The single call site in `run_issue_discovery` ([`scan.py:165`](../blob/test/gittensor/validator/issue_discovery/scan.py#L165)) now passes `mirror_repos`.
- Docstring updated to spell out the parity with the cache-MISS path and the OSS scoring path.

## Test plan

- [x] New regression tests in `tests/validator/issue_discovery/test_scan.py::TestSolvingPrCache`:
  - `test_per_repo_override_keeps_pr_above_repo_threshold` — a repo with `min_token_score_for_base_score = 2` keeps a PR whose `token_score = 3` (clears override, fails global default).
  - `test_untracked_repo_falls_back_to_global_threshold` — defensive: a repo missing from `mirror_repos` still gates on the global default, doesn't crash.
- [x] Existing `TestSolvingPrCache` tests (`test_build_cache_from_multiple_miners`, `test_cache_first_occurrence_wins_on_duplicate`, `test_below_threshold_prs_excluded_from_cache`) updated to pass `mirror_repos`; behavior preserved when no override is configured.
- [x] `uv run pytest tests/validator/issue_discovery/test_scan.py -q` — 66 passed.
- [x] `uv run pytest tests/validator/ -q` — 519 passed.
- [x] `uv run ruff check gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py` — clean.
- [x] `uv run ruff format --check gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py` — clean.
- [x] `uv run pyright gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py` — 0 errors, 0 warnings.

## Files changed

- `gittensor/validator/issue_discovery/scan.py` — `_build_solving_pr_cache` accepts and uses the resolved per-repo threshold; call site in `run_issue_discovery` updated to pass `mirror_repos`.
- `tests/validator/issue_discovery/test_scan.py` — 2 new regression tests; 3 existing `TestSolvingPrCache` tests updated to pass `mirror_repos`; `RepoEligibilityConfig` added to the existing `load_weights` import block.
