### PR TITLE
fix(cli): surface contract read failures in gitt issues list

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -624,10 +624,15 @@ def _resolve_contract_and_network(
 
 def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool = False) -> Optional[Dict[str, Any]]:
     """
-    Read the packed root storage from a contract using childstate RPC
+    Read the packed root storage from a contract using childstate RPC.
 
     This bypasses the broken state_call/ContractsApi_call method and reads
     storage directly. Works around substrate-interface Ink! 5 compatibility issues.
+
+    Returns ``None`` only when the contract genuinely has no readable packed
+    storage at this address (no child key, no bytes, undersized payload).
+    RPC / decode failures propagate so callers can distinguish a failed read
+    from a clean "no storage yet" state.
 
     Args:
         substrate: SubstrateInterface instance
@@ -635,41 +640,37 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
         verbose: If True, print debug output
 
     Returns:
-        Dict with owner, netuid, next_issue_id, etc. or None on error
+        Dict with owner, netuid, next_issue_id, etc., or ``None`` when the
+        contract has no packed storage at this address.
     """
-    try:
-        child_key = get_contract_child_storage_key(substrate, contract_addr)
-        if not child_key:
-            if verbose:
-                err_console.print('[dim]Debug: Failed to get contract child storage key[/dim]')
-            return None
-
-        packed_bytes = read_contract_packed_storage_bytes(substrate, child_key)
-        if not packed_bytes:
-            if verbose:
-                err_console.print('[dim]Debug: No packed storage bytes returned[/dim]')
-            return None
-
+    child_key = get_contract_child_storage_key(substrate, contract_addr)
+    if not child_key:
         if verbose:
-            err_console.print(f'[dim]Debug: Packed storage data length = {len(packed_bytes)} bytes[/dim]')
-
-        packed = decode_packed_contract_storage(packed_bytes)
-        if not packed:
-            if verbose:
-                err_console.print(f'[dim]Debug: Packed storage too small ({len(packed_bytes)} < 74 bytes)[/dim]')
-            return None
-
-        return {
-            'owner': substrate.ss58_encode(packed.owner.hex()),
-            'treasury_hotkey': substrate.ss58_encode(packed.treasury_hotkey.hex()),
-            'netuid': packed.netuid,
-            'next_issue_id': packed.next_issue_id,
-            'alpha_pool': packed.alpha_pool,
-        }
-    except Exception as e:
-        if verbose:
-            err_console.print(f'[dim]Debug: Failed to read packed storage: {e}[/dim]')
+            err_console.print('[dim]Debug: Contract has no child storage key[/dim]')
         return None
+
+    packed_bytes = read_contract_packed_storage_bytes(substrate, child_key)
+    if not packed_bytes:
+        if verbose:
+            err_console.print('[dim]Debug: No packed storage bytes returned[/dim]')
+        return None
+
+    if verbose:
+        err_console.print(f'[dim]Debug: Packed storage data length = {len(packed_bytes)} bytes[/dim]')
+
+    packed = decode_packed_contract_storage(packed_bytes)
+    if not packed:
+        if verbose:
+            err_console.print(f'[dim]Debug: Packed storage too small ({len(packed_bytes)} < 74 bytes)[/dim]')
+        return None
+
+    return {
+        'owner': substrate.ss58_encode(packed.owner.hex()),
+        'treasury_hotkey': substrate.ss58_encode(packed.treasury_hotkey.hex()),
+        'netuid': packed.netuid,
+        'next_issue_id': packed.next_issue_id,
+        'alpha_pool': packed.alpha_pool,
+    }
 
 
 def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool = False) -> List[Dict[str, Any]]:
@@ -678,21 +679,20 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
 
     Uses Ink! 5 lazy mapping key computation to directly read issue storage.
 
+    Returns ``[]`` only when the contract genuinely has no issues yet
+    (no child storage key, missing packed storage, ``next_issue_id <= 1``).
+    RPC / decode failures propagate so callers can distinguish a failed read
+    from a real empty contract.
+
     Args:
         substrate: SubstrateInterface instance
         contract_addr: Contract address
         verbose: If True, print debug output
 
     Returns:
-        List of issue dictionaries
+        List of issue dictionaries (empty for a real empty contract).
     """
-    try:
-        child_key = get_contract_child_storage_key(substrate, contract_addr)
-    except Exception as e:
-        if verbose:
-            err_console.print(f'[dim]Debug: Contract info query failed: {e}[/dim]')
-        child_key = None
-
+    child_key = get_contract_child_storage_key(substrate, contract_addr)
     if not child_key:
         if verbose:
             err_console.print(f'[dim]Debug: Cannot read issues - no child storage key for {contract_addr}[/dim]')
@@ -803,6 +803,10 @@ def read_issues_from_contract(ws_endpoint: str, contract_addr: str, verbose: boo
     Uses childstate_getStorage RPC to read contract storage directly,
     bypassing the broken ContractsApi_call method in substrate-interface.
 
+    Raises on connection / RPC / decode failures so callers can distinguish a
+    failed read from an empty contract. ``ImportError`` is also propagated;
+    callers are expected to route both through their CLI error handler.
+
     Args:
         ws_endpoint: WebSocket endpoint for Subtensor
         contract_addr: Contract address
@@ -811,30 +815,17 @@ def read_issues_from_contract(ws_endpoint: str, contract_addr: str, verbose: boo
     Returns:
         List of issue dictionaries
     """
-    try:
-        from async_substrate_interface import SubstrateInterface
+    from async_substrate_interface import SubstrateInterface
 
-        if verbose:
-            err_console.print(f'[dim]Debug: Connecting to {ws_endpoint}...[/dim]')
+    if verbose:
+        err_console.print(f'[dim]Debug: Connecting to {ws_endpoint}...[/dim]')
 
-        # Connect to subtensor
-        substrate = SubstrateInterface(url=ws_endpoint)
+    substrate = SubstrateInterface(url=ws_endpoint)
 
-        if verbose:
-            err_console.print('[dim]Debug: Connected successfully[/dim]')
+    if verbose:
+        err_console.print('[dim]Debug: Connected successfully[/dim]')
 
-        # Read issues directly from child storage
-        return _read_issues_from_child_storage(substrate, contract_addr, verbose)
-
-    except ImportError as e:
-        err_console.print(f'[yellow]Cannot read from contract: {e}[/yellow]')
-        err_console.print('[dim]Install with: uv sync[/dim]')
-        return []
-    except Exception as e:
-        if verbose:
-            err_console.print(f'[dim]Debug: Connection/read error: {e}[/dim]')
-        err_console.print(f'[yellow]Error reading from contract: {e}[/yellow]')
-        return []
+    return _read_issues_from_child_storage(substrate, contract_addr, verbose)
 
 
 def fetch_issue_from_contract(
@@ -844,7 +835,13 @@ def fetch_issue_from_contract(
     verbose: bool = False,
 ) -> Dict[str, Any]:
     """Resolve an on-chain issue and validate bountied status."""
-    issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
+    try:
+        issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(f'Error reading from contract: {e}')
+
     issue = next((i for i in issues if i.get('id') == issue_id), None)
     if not issue:
         raise click.ClickException(f'Issue ID {issue_id} not found on-chain.')

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -92,8 +92,17 @@ def issues_list(
 
     print_network_header(network_name, contract_addr)
 
-    with loading_context('Reading issues from contract...', as_json):
-        issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
+    try:
+        with loading_context('Reading issues from contract...', as_json):
+            issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
+    except ImportError as e:
+        handle_exception(
+            as_json=as_json,
+            message=f'Missing dependency: {e}. Install with: uv sync',
+            error_type='missing_dependency',
+        )
+    except Exception as e:
+        handle_exception(as_json=as_json, message=f'Error reading from contract: {e}', error_type='read_failed')
 
     if as_json:
         # Enrich with human-readable ALPHA amounts for JSON consumers

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -6,6 +6,8 @@
 import json
 from unittest.mock import patch
 
+import click
+
 
 def test_submissions_json_schema_is_stable(cli_root, runner, sample_issue, sample_prs):
     with (
@@ -108,6 +110,32 @@ def test_submissions_human_no_open_prs_message(cli_root, runner, sample_issue):
 
     assert result.exit_code == 0
     assert 'No open submissions available' in result.output
+
+
+def test_submissions_json_contract_read_failure_returns_structured_error(cli_root, runner):
+    """`fetch_issue_from_contract` now converts contract-read failures to a
+    `ClickException`, which `submissions` routes through `handle_exception` —
+    a contract outage must surface as `success: false` instead of the old
+    misleading `Issue ID <N> not found on-chain.` message."""
+    with (
+        patch('gittensor.cli.issue_commands.submissions.get_contract_address', return_value='0xabc'),
+        patch('gittensor.cli.issue_commands.submissions.resolve_network', return_value=('ws://x', 'test')),
+        patch(
+            'gittensor.cli.issue_commands.submissions.fetch_issue_from_contract',
+            side_effect=click.ClickException('Error reading from contract: [Errno 111] Connection refused'),
+        ),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'submissions', '--id', '42', '--json'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert 'Error reading from contract' in payload['error']['message']
+    assert 'not found on-chain' not in payload['error']['message']
 
 
 def test_submissions_help_via_issue_alias_routes_to_command_help(cli_root, runner):

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -64,3 +64,114 @@ def test_issues_list_rejects_invalid_id_human(cli_root, runner, bad_id):
     assert result.exit_code != 0
     assert 'not in the range' in result.output
     mock_read.assert_not_called()
+
+
+def test_issues_list_json_contract_read_failure_returns_structured_error(cli_root, runner):
+    """A contract read failure must surface as `success: false` JSON with non-zero exit,
+    not as a `success: true, issue_count: 0` payload that looks like a clean empty contract."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch(
+            'gittensor.cli.issue_commands.view.read_issues_from_contract',
+            side_effect=ConnectionRefusedError('[Errno 111] Connection refused'),
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'
+    assert 'Connection refused' in payload['error']['message']
+    assert 'issue_count' not in payload
+
+
+def test_issues_list_human_contract_read_failure_exits_non_zero(cli_root, runner):
+    """Human mode must exit non-zero and not print `No issues found.` when the contract read fails."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch(
+            'gittensor.cli.issue_commands.view.read_issues_from_contract',
+            side_effect=ConnectionRefusedError('[Errno 111] Connection refused'),
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'No issues found' not in result.output
+    assert 'Connection refused' in result.output
+
+
+def test_issues_list_json_empty_contract_still_succeeds(cli_root, runner):
+    """A reachable contract with zero issues must keep emitting `success: true, issue_count: 0`."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.view.read_issues_from_contract', return_value=[]),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+
+    payload = json.loads(result.stdout)
+    assert payload['success'] is True
+    assert payload['issue_count'] == 0
+    assert payload['issues'] == []
+
+
+def test_issues_list_json_deeper_storage_read_failure_returns_structured_error(cli_root, runner):
+    """A failure inside `_read_issues_from_child_storage` (e.g. the contract-info RPC raising)
+    must surface as `success: false`, not be silently coerced to an empty issue list."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('async_substrate_interface.SubstrateInterface', return_value=object()),
+        patch(
+            'gittensor.cli.issue_commands.helpers.get_contract_child_storage_key',
+            side_effect=RuntimeError('contract-info query failed'),
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'
+    assert 'contract-info query failed' in payload['error']['message']
+    assert 'issue_count' not in payload
+
+
+def test_issues_list_json_missing_dependency_emits_install_hint(cli_root, runner):
+    """A missing-dependency ImportError must surface a structured error with the install hint,
+    distinct from a generic read failure."""
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch(
+            'gittensor.cli.issue_commands.view.read_issues_from_contract',
+            side_effect=ImportError("No module named 'substrateinterface'"),
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'missing_dependency'
+    assert 'uv sync' in payload['error']['message']
+    assert 'substrateinterface' in payload['error']['message']


### PR DESCRIPTION
## Summary

`gitt issues list` used to treat contract-read failures as an empty issue list. When the RPC/contract read failed, the helper returned `[]`, so the command emitted `success: true`, `issue_count: 0`, and exited `0`.

This PR makes contract-read failures explicit:

- `gitt issues list --json` now emits `success: false` with `error.type == "read_failed"` and exits `1`.
- Human mode now prints the read error and exits `1`.
- A reachable contract with zero issues still returns `success: true`, `issue_count: 0`, `issues: []`, and exits `0`.
- Missing `substrateinterface` now returns `error.type == "missing_dependency"` and keeps the `Install with: uv sync` hint.

The fix also lets deeper contract-info / packed-storage read failures propagate instead of being silently converted to `[]` / `None`.

`fetch_issue_from_contract`, used by `gitt issues submissions --id ...`, now also surfaces contract-read failures instead of turning them into the misleading `Issue ID <N> not found on-chain.` message.

## Related Issues

Closes #1357

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Before / After

### JSON mode before

```text
$ uv run gitt issues list --rpc-url ws://127.0.0.1:1 --contract 5GrwvaEF5zXb26Fz9rcQpDWS2Tw7Rn3myGUFcLDN7Jxxpx12 --json
Network: custom • Contract: 5GrwvaEF5zXb...xxpx12
Error reading from contract: [Errno 111] Connection refused
{
  "success": true,
  "issue_count": 0,
  "issues": []
}
$ echo $?
0
```

### JSON mode after

```text
$ uv run gitt issues list --rpc-url ws://127.0.0.1:1 --contract 5GrwvaEF5zXb26Fz9rcQpDWS2Tw7Rn3myGUFcLDN7Jxxpx12 --json
Network: custom • Contract: 5GrwvaEF5zXb...xxpx12
{"success": false, "error": {"type": "read_failed", "message": "Error reading from contract: [Errno 111] Connection refused"}}
$ echo $?
1
```

### Human mode after

```text
$ uv run gitt issues list --rpc-url ws://127.0.0.1:1 --contract 5GrwvaEF5zXb26Fz9rcQpDWS2Tw7Rn3myGUFcLDN7Jxxpx12
Network: custom • Contract: 5GrwvaEF5zXb...xxpx12

✗ Error reading from contract: [Errno 111] Connection refused

$ echo $?
1
```

## Testing

Added regression tests for:

- JSON contract-read failure returns `success: false` and exits non-zero.
- Human contract-read failure exits non-zero and does not print `No issues found`.
- Empty reachable contract still succeeds with `issue_count: 0`.
- Deeper storage-read failure propagates as `read_failed`.
- Missing dependency keeps the `uv sync` install hint.
- `gitt issues submissions --json` surfaces contract-read failure as `success: false` instead of `issue not found`.

Commands run:

```bash
uv run pytest tests/cli/test_issues_list_json.py -q
uv run pytest tests/cli/test_issues_list_json.py tests/cli/test_issue_submission.py -q
uv run pytest tests/ -q
uv run ruff check gittensor/ tests/
uv run ruff format --check gittensor/ tests/
uv run pyright gittensor/cli/issue_commands/helpers.py gittensor/cli/issue_commands/view.py tests/cli/test_issues_list_json.py
uv run pre-commit run --hook-stage pre-push --files <changed files>
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
