### PR TITLE
fix(validator): filter stale closed mirror PRs

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -74,7 +74,7 @@ def load_miner_prs(
 
     for pr in response.pull_requests:
         try:
-            _maybe_add_pr(eval_, pr, master_repositories)
+            _maybe_add_pr(eval_, pr, master_repositories, since_by_repo)
         except Exception as e:
             bt.logging.warning(f'Error processing PR #{pr.pr_number} ({pr.repo_full_name}): {e}')
 
@@ -87,11 +87,13 @@ def _maybe_add_pr(
     eval_: MinerEvaluation,
     pr: MirrorPullRequest,
     master_repositories: Dict[str, RepositoryConfig],
+    since_by_repo: Dict[str, datetime],
 ) -> None:
     """Apply load-time filters and bucket pr by state if it passes.
 
     Time-windowing (each repo's ``pr_lookback_days``) is applied by the mirror,
-    so every PR here is already inside its repo's window.
+    but CLOSED PRs are also checked locally before credibility accounting so a
+    stale mirror response cannot count old failed attempts as current.
     """
 
     repo_config = master_repositories.get(pr.repo_full_name)
@@ -109,6 +111,13 @@ def _maybe_add_pr(
     if pr.state == 'OPEN':
         eval_.open_prs.append(ScoredPR(pr=pr))
     elif pr.state == 'CLOSED':
+        cutoff = since_by_repo.get(pr.repo_full_name)
+        if cutoff is not None and pr.created_at < cutoff:
+            bt.logging.debug(
+                f'Skipping CLOSED PR #{pr.pr_number} in {pr.repo_full_name} - '
+                f'created_at {pr.created_at.isoformat()} is before cutoff {cutoff.isoformat()}'
+            )
+            return
         eval_.closed_prs.append(ScoredPR(pr=pr))
     elif pr.state == 'MERGED':
         # Apply the merge-eligibility gate at LOAD time so the merged_count used

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -229,6 +229,46 @@ class TestLookbackWindow:
         assert before - timedelta(days=30) <= since_by_repo['entrius/gittensor-ui'] <= after - timedelta(days=30)
         assert before - timedelta(days=60) <= since_by_repo['entrius/gittensor'] <= after - timedelta(days=60)
 
+    def test_stale_closed_pr_before_repo_lookback_is_dropped_defensively(self):
+        """A stale CLOSED PR returned by the mirror must not count against
+        current credibility if its creation time is outside the repo window."""
+        RepoScoringConfig = load_weights.RepoScoringConfig
+        repo = 'entrius/gittensor-ui'
+        repos = {
+            repo: RepositoryConfig(emission_share=0.3, scoring=RepoScoringConfig(pr_lookback_days=30)),
+        }
+        stale_created = datetime.now(timezone.utc) - timedelta(days=120)
+        fresh_created = datetime.now(timezone.utc) - timedelta(days=5)
+        recent_closed = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat().replace('+00:00', 'Z')
+
+        client = Mock()
+        client.get_miner_pulls.return_value = _build_response(
+            [
+                _pr_dict(
+                    1,
+                    repo=repo,
+                    state='CLOSED',
+                    created_at=stale_created.isoformat().replace('+00:00', 'Z'),
+                    merged_at=recent_closed,
+                ),
+                _pr_dict(
+                    2,
+                    repo=repo,
+                    state='CLOSED',
+                    created_at=fresh_created.isoformat().replace('+00:00', 'Z'),
+                    merged_at=recent_closed,
+                ),
+            ]
+        )
+        eval_ = _eval()
+
+        load_miner_prs(eval_, repos, client=client)
+
+        since_by_repo = client.get_miner_pulls.call_args.kwargs['since_by_repo']
+        assert stale_created < since_by_repo[repo]
+        assert fresh_created > since_by_repo[repo]
+        assert [pr.pr.pr_number for pr in eval_.closed_prs] == [2]
+
 
 # ============================================================================
 # Error paths
@@ -328,11 +368,11 @@ class TestErrorPaths:
         call_count = {'n': 0}
         original = load_mod._maybe_add_pr
 
-        def flaky(eval_, pr, repos):
+        def flaky(eval_, pr, repos, since_by_repo):
             call_count['n'] += 1
             if call_count['n'] == 1:
                 raise RuntimeError('synthetic failure on first PR')
-            original(eval_, pr, repos)
+            original(eval_, pr, repos, since_by_repo)
 
         monkeypatch.setattr(load_mod, '_maybe_add_pr', flaky)
 


### PR DESCRIPTION
## Summary

Defensively re-apply the repo lookback cutoff for CLOSED PRs returned by the mirror before they enter current credibility accounting.

## What changed

- Pass the same per-repo `since_by_repo` cutoff map used for the mirror request into `_maybe_add_pr`.
- Drop returned CLOSED PRs whose `created_at` is older than that repo's cutoff.
- Add a regression test covering mixed stale/fresh CLOSED PRs from a mirror response.

## Why

`load_miner_prs()` already computes per-repo lookback cutoffs and sends them to the mirror, but the loader currently assumes every returned PR is in-window. Since CLOSED PRs feed current credibility accounting, keeping the local cutoff preserves the existing invariant that out-of-window CLOSED PRs do not count as current attempts.

## Proof

The new regression test builds a fake mirror response with:

- one stale CLOSED PR created 120 days ago
- one fresh CLOSED PR created 5 days ago
- a repo lookback of 30 days

Before this patch, the test fails because both CLOSED PRs are loaded:

```text
assert [pr.pr.pr_number for pr in eval_.closed_prs] == [2]
E       assert [1, 2] == [2]
```

With this patch, the stale PR is filtered and only the fresh CLOSED PR remains in `eval_.closed_prs`.

I also checked the end-to-end loader/finalizer behavior locally with one current merged PR and one stale CLOSED PR returned by the mirror:

```text
control:     closed_prs_loaded=0, credibility=1.0, eligible=true,  repo_score=100.0
before fix:  closed_prs_loaded=1, credibility=0.5, eligible=false, repo_score=0.0
after fix:   closed_prs_loaded=0, credibility=1.0, eligible=true,  repo_score=100.0
```

## Validation

- `uv run --extra dev pytest tests/validator/oss_contributions/mirror/test_load.py::TestLookbackWindow::test_stale_closed_pr_before_repo_lookback_is_dropped_defensively -q`
- `uv run --extra dev pytest tests/validator/oss_contributions/mirror tests/validator/test_blend_emission_pools.py tests/validator/test_scoring_classes.py tests/validator/test_scoring_resolver.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ruff check gittensor/validator/oss_contributions/mirror/load.py tests/validator/oss_contributions/mirror/test_load.py`
- `git diff --check`
