### PR TITLE
retune hyperparameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,6 @@
 {
   "aglover1221/product-data-extractor": {
-    "emission_share": 0.00250,
+    "emission_share": 0.0025,
     "issue_discovery_share": 0.0
   },
   "entrius/allways": {
@@ -27,7 +27,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/das-github-mirror": {
-    "emission_share": 0.01180,
+    "emission_share": 0.0118,
     "issue_discovery_share": 0.5,
     "label_multipliers": {
       "bug": 1.25,
@@ -69,7 +69,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.00000,
+    "emission_share": 0.0,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -79,15 +79,15 @@
     "trusted_label_pipeline": true
   },
   "Geniepod/genie-claw": {
-    "emission_share": 0.04000,
+    "emission_share": 0.02,
     "issue_discovery_share": 0.0
   },
   "infiniflow/ragflow": {
-    "emission_share": 0.04000,
+    "emission_share": 0.05,
     "issue_discovery_share": 0.0
   },
   "JSONbored/awesome-claude": {
-    "emission_share": 0.01000,
+    "emission_share": 0.01,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -106,23 +106,23 @@
     }
   },
   "MkDev11/gittensor-hub": {
-    "emission_share": 0.03500,
+    "emission_share": 0.015,
     "issue_discovery_share": 0.0
   },
   "vouchdev/vouch": {
-    "emission_share": 0.00500,
+    "emission_share": 0.0075,
     "issue_discovery_share": 0.0
   },
   "seroperson/jvm-live-reload": {
-    "emission_share": 0.01000,
+    "emission_share": 0.01,
     "issue_discovery_share": 0.0
   },
   "touchpilot/touchpilot": {
-    "emission_share": 0.03000,
+    "emission_share": 0.02,
     "issue_discovery_share": 0.0
   },
   "we-promise/sure": {
-    "emission_share": 0.03000,
+    "emission_share": 0.04,
     "issue_discovery_share": 0.0
   }
 }


### PR DESCRIPTION
## Summary
- Adjust emission shares across master repositories: Geniepod/genie-claw 0.04→0.02, infiniflow/ragflow 0.04→0.05, MkDev11/gittensor-hub 0.035→0.015, vouchdev/vouch 0.005→0.0075, touchpilot/touchpilot 0.03→0.02, we-promise/sure 0.03→0.04.
- Normalize numeric formatting (e.g., 0.00250 → 0.0025).

## Test plan
- [ ] Confirm emission shares sum within expected bounds
- [ ] Spot-check weights apply correctly on next validator run