### PR TITLE
chore(weights): tune gittensor-hub scoring config

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -107,7 +107,23 @@
   },
   "MkDev11/gittensor-hub": {
     "emission_share": 0.015,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "feature": 2,
+      "bug": 1.2,
+      "refactor": 0.3
+    },
+    "scoring": {
+      "open_pr_collateral_percent": 0.2,
+      "review_penalty_rate": 0.2,
+      "maintainer_issue_multiplier": 2,
+      "time_decay": {
+        "grace_period_hours": 24,
+        "sigmoid_midpoint_days": 14,
+        "min_multiplier": 0.1
+      }
+    },
+    "maintainer_cut": 0.3
   },
   "vouchdev/vouch": {
     "emission_share": 0.0075,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -97,7 +97,12 @@
       "pr_lookback_days": 45,
       "open_pr_collateral_percent": 0.15,
       "review_penalty_rate": 0.2,
-      "maintainer_issue_multiplier": 1.75
+      "maintainer_issue_multiplier": 1.75,
+      "time_decay": {
+        "grace_period_hours": 24,
+        "sigmoid_midpoint_days": 14,
+        "min_multiplier": 0.1
+      }
     }
   },
   "MkDev11/gittensor-hub": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -97,12 +97,7 @@
       "pr_lookback_days": 45,
       "open_pr_collateral_percent": 0.15,
       "review_penalty_rate": 0.2,
-      "maintainer_issue_multiplier": 1.75,
-      "time_decay": {
-        "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 14,
-        "min_multiplier": 0.1
-      }
+      "maintainer_issue_multiplier": 1.75
     }
   },
   "MkDev11/gittensor-hub": {


### PR DESCRIPTION
## Summary
- Tune the `MkDev11/gittensor-hub` repo-local scoring parameters without changing its allocated share or PR/issue split.

## What changed
- Add three label multipliers: `feature=2.0`, `bug=1.2`, and `refactor=0.3`.
- Set open PR collateral to `0.20`, review penalty rate to `0.20`, and maintainer-authored linked issue multiplier to `2.0`.
- Configure time decay with a 24-hour grace period, 14-day midpoint, and `0.10` floor.
- Add a `0.30` maintainer cut.
- Leave `emission_share`, `issue_discovery_share`, `additional_acceptable_branches`, and `trusted_label_pipeline` unchanged.

## Why
- `gittensor-hub` should reward feature-oriented contributions most strongly, give smaller boosts to bug fixes, and reduce scoring for refactor-only work.
- The maintainer cut gives the repo maintainer a direct share of the repo emission slice while keeping the repo's total allocation unchanged.
- The scoring changes are limited to repo-local quality knobs for the existing registry entry.

## Validation
- `jq empty gittensor/validator/weights/master_repositories.json`
- `git diff --check -- gittensor/validator/weights/master_repositories.json`
- `uv run pytest tests/validator/test_load_weights.py -q`

## Notes
- No repositories are added or removed.
- No `additional_acceptable_branches` entries are added.
- Net emission weight change is `0.00`.
