### PR TITLE
perf(validator): score miners concurrently

### DIFF
--- a/gittensor/utils/logging.py
+++ b/gittensor/utils/logging.py
@@ -1,9 +1,55 @@
-from typing import TYPE_CHECKING, List, Optional
+import contextvars
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 import bittensor as bt
 
 if TYPE_CHECKING:
     from gittensor.classes import FileScoreResult, ScoreBreakdown
+
+
+# Set per-task while a miner is being scored so concurrent evaluations stay
+# attributable in the log (see ``scoring_uid``). ``None`` means "not in a
+# per-miner scope" — the filter then leaves the line untouched.
+_scoring_uid: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar('scoring_uid', default=None)
+
+
+class _UidLogFilter(logging.Filter):
+    """Prefix each log line with the UID of the miner currently being scored.
+
+    Attached to the ``bittensor`` logger, this runs synchronously in the thread
+    that emitted the record — including ``asyncio.to_thread`` workers, which
+    inherit the contextvar — so both on-loop and threaded lines get tagged.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        uid = _scoring_uid.get()
+        if uid is not None and not getattr(record, '_uid_tagged', False):
+            record.msg = f'[UID {uid}] {record.msg}'
+            record._uid_tagged = True
+        return True
+
+
+_uid_filter_installed = False
+
+
+def install_uid_log_filter() -> None:
+    """Idempotently attach the per-miner UID tag filter to the bittensor logger."""
+    global _uid_filter_installed
+    if not _uid_filter_installed:
+        logging.getLogger('bittensor').addFilter(_UidLogFilter())
+        _uid_filter_installed = True
+
+
+@contextmanager
+def scoring_uid(uid: int) -> Iterator[None]:
+    """Tag every log line emitted within this scope (and its threads) with ``uid``."""
+    token = _scoring_uid.set(uid)
+    try:
+        yield
+    finally:
+        _scoring_uid.reset(token)
 
 
 def log_scoring_results(

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -54,7 +54,11 @@ async def evaluate_miners_pull_requests(
 
     bt.logging.info(f'******* Reward function called for UID: {uid} *******')
 
-    miner_eval = validate_response_and_initialize_miner_evaluation(
+    # Off-thread: this does a blocking GitHub /user lookup. Keeping it on the
+    # event loop would serialize identity checks across concurrently-scored
+    # miners (the semaphore can't yield through a blocking call).
+    miner_eval = await asyncio.to_thread(
+        validate_response_and_initialize_miner_evaluation,
         uid,
         hotkey,
         pat,

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 import bittensor as bt
 
 from gittensor.classes import MinerEvaluation
+from gittensor.utils.logging import install_uid_log_filter, scoring_uid
 from gittensor.utils.mirror.client import MirrorClient
 from gittensor.validator import pat_storage
 from gittensor.validator.oss_contributions.inspections import (
@@ -107,32 +108,36 @@ async def get_rewards(
 
     bt.logging.info(f'PAT storage snapshot: {len(pat_by_uid)} miners have stored PATs')
 
+    # Tag every log line with its UID so the concurrently-scored miners below
+    # stay attributable in the interleaved log.
+    install_uid_log_filter()
     semaphore = asyncio.Semaphore(MINER_EVALUATION_CONCURRENCY)
 
     async def evaluate_one(uid: int) -> Tuple[int, MinerEvaluation]:
-        hotkey = self.metagraph.hotkeys[uid]
-        pat_entry = pat_by_uid.get(uid)
-        pat = None
-        stale_hotkey = None
-        stored_github_id = None
-        if pat_entry:
-            if pat_entry.get('hotkey') == hotkey:
-                pat = pat_entry['pat']
-                stored_github_id = pat_entry.get('github_id')
-            else:
-                stale_hotkey = pat_entry.get('hotkey')
+        with scoring_uid(uid):
+            hotkey = self.metagraph.hotkeys[uid]
+            pat_entry = pat_by_uid.get(uid)
+            pat = None
+            stale_hotkey = None
+            stored_github_id = None
+            if pat_entry:
+                if pat_entry.get('hotkey') == hotkey:
+                    pat = pat_entry['pat']
+                    stored_github_id = pat_entry.get('github_id')
+                else:
+                    stale_hotkey = pat_entry.get('hotkey')
 
-        async with semaphore:
-            evaluation = await evaluate_miners_pull_requests(
-                uid,
-                hotkey,
-                pat,
-                master_repositories,
-                programming_languages,
-                token_config,
-                stale_hotkey=stale_hotkey,
-                stored_github_id=stored_github_id,
-            )
+            async with semaphore:
+                evaluation = await evaluate_miners_pull_requests(
+                    uid,
+                    hotkey,
+                    pat,
+                    master_repositories,
+                    programming_languages,
+                    token_config,
+                    stale_hotkey=stale_hotkey,
+                    stored_github_id=stored_github_id,
+                )
         return uid, evaluation
 
     # Score miners concurrently (bounded by the semaphore) so the mirror's

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -17,6 +17,7 @@ from gittensor.validator.oss_contributions.inspections import (
 from gittensor.validator.oss_contributions.mirror.load import load_miner_prs
 from gittensor.validator.oss_contributions.mirror.scoring import score_miner_prs
 from gittensor.validator.oss_contributions.scoring import finalize_miner_scores
+from gittensor.validator.utils.config import MINER_EVALUATION_CONCURRENCY
 from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig
 
 # NOTE: there was a circular import error, needed this if to resolve it
@@ -102,10 +103,9 @@ async def get_rewards(
 
     bt.logging.info(f'PAT storage snapshot: {len(pat_by_uid)} miners have stored PATs')
 
-    miner_evaluations: Dict[int, MinerEvaluation] = {}
+    semaphore = asyncio.Semaphore(MINER_EVALUATION_CONCURRENCY)
 
-    # Look up PATs and calculate score.
-    for uid in uids:
+    async def evaluate_one(uid: int) -> Tuple[int, MinerEvaluation]:
         hotkey = self.metagraph.hotkeys[uid]
         pat_entry = pat_by_uid.get(uid)
         pat = None
@@ -118,18 +118,24 @@ async def get_rewards(
             else:
                 stale_hotkey = pat_entry.get('hotkey')
 
-        # Calculate score
-        miner_evaluation = await evaluate_miners_pull_requests(
-            uid,
-            hotkey,
-            pat,
-            master_repositories,
-            programming_languages,
-            token_config,
-            stale_hotkey=stale_hotkey,
-            stored_github_id=stored_github_id,
-        )
-        miner_evaluations[uid] = miner_evaluation
+        async with semaphore:
+            evaluation = await evaluate_miners_pull_requests(
+                uid,
+                hotkey,
+                pat,
+                master_repositories,
+                programming_languages,
+                token_config,
+                stale_hotkey=stale_hotkey,
+                stored_github_id=stored_github_id,
+            )
+        return uid, evaluation
+
+    # Score miners concurrently (bounded by the semaphore) so the mirror's
+    # per-request latency overlaps across miners instead of summing. Each miner
+    # uses its own MirrorClient, so the tasks share no mutable state.
+    results = await asyncio.gather(*(evaluate_one(uid) for uid in uids))
+    miner_evaluations: Dict[int, MinerEvaluation] = dict(results)
 
     # If evaluation of miner was successful, store to cache, if api failure, fallback to previous successful evaluation if any
     cached_uids = self.store_or_use_cached_evaluation(miner_evaluations)

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -5,6 +5,12 @@ import bittensor as bt
 VALIDATOR_WAIT = 60  # 60 seconds
 VALIDATOR_STEPS_INTERVAL = 120  # 2 hours, every time a scoring round happens
 
+# How many miners to evaluate concurrently. Each evaluation is network-bound on
+# the mirror; scoring them in parallel overlaps that latency. The cap keeps
+# in-flight requests within the mirror's 50 req / 10s rate limit (the client
+# still backs off on 429 as a safety net). Override with MINER_EVALUATION_CONCURRENCY.
+MINER_EVALUATION_CONCURRENCY = max(1, int(os.getenv('MINER_EVALUATION_CONCURRENCY', '8')))
+
 # required env vars
 GITTENSOR_VALIDATOR_PAT = os.getenv('GITTENSOR_VALIDATOR_PAT')
 WANDB_API_KEY = os.getenv('WANDB_API_KEY')
@@ -17,4 +23,5 @@ STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'
 # log values
 bt.logging.info(f'VALIDATOR_WAIT: {VALIDATOR_WAIT}')
 bt.logging.info(f'VALIDATOR_STEPS_INTERVAL: {VALIDATOR_STEPS_INTERVAL}')
+bt.logging.info(f'MINER_EVALUATION_CONCURRENCY: {MINER_EVALUATION_CONCURRENCY}')
 bt.logging.info(f'WANDB_PROJECT: {WANDB_PROJECT}')

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,52 @@
+"""The per-miner UID log filter keeps concurrent scoring lines attributable."""
+
+import logging
+
+from gittensor.utils.logging import (
+    _scoring_uid,
+    _UidLogFilter,
+    install_uid_log_filter,
+    scoring_uid,
+)
+
+
+def _record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord('bittensor', logging.INFO, 'f.py', 1, msg, None, None)
+
+
+def test_filter_tags_message_when_uid_is_set():
+    flt = _UidLogFilter()
+    record = _record('scoring 3 merged')
+    with scoring_uid(42):
+        flt.filter(record)
+    assert record.msg == '[UID 42] scoring 3 merged'
+
+
+def test_filter_leaves_message_untouched_without_uid():
+    flt = _UidLogFilter()
+    record = _record('startup line')
+    flt.filter(record)
+    assert record.msg == 'startup line'
+
+
+def test_filter_tags_each_record_once():
+    flt = _UidLogFilter()
+    record = _record('once')
+    with scoring_uid(1):
+        flt.filter(record)
+        flt.filter(record)  # a second pass must not double-prefix
+    assert record.msg == '[UID 1] once'
+
+
+def test_scoring_uid_resets_on_exit():
+    assert _scoring_uid.get() is None
+    with scoring_uid(9):
+        assert _scoring_uid.get() == 9
+    assert _scoring_uid.get() is None
+
+
+def test_install_uid_log_filter_is_idempotent():
+    install_uid_log_filter()
+    install_uid_log_filter()
+    bittensor_logger = logging.getLogger('bittensor')
+    assert sum(isinstance(f, _UidLogFilter) for f in bittensor_logger.filters) == 1

--- a/tests/validator/oss_contributions/test_reward_concurrency.py
+++ b/tests/validator/oss_contributions/test_reward_concurrency.py
@@ -41,7 +41,9 @@ def _run_with_tracking(uids, cap):
         patch.object(reward_module, 'finalize_miner_scores'),
     ):
         evaluations, _cached, _penalized = asyncio.run(
-            get_rewards(_fake_validator(uids), uids, master_repositories={}, programming_languages={}, token_config=None)
+            get_rewards(
+                _fake_validator(uids), uids, master_repositories={}, programming_languages={}, token_config=None
+            )
         )
     return evaluations, state['max']
 

--- a/tests/validator/oss_contributions/test_reward_concurrency.py
+++ b/tests/validator/oss_contributions/test_reward_concurrency.py
@@ -1,0 +1,65 @@
+"""get_rewards scores miners concurrently, bounded by MINER_EVALUATION_CONCURRENCY."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+reward_module = pytest.importorskip('gittensor.validator.oss_contributions.reward')
+classes = pytest.importorskip('gittensor.classes')
+
+get_rewards = reward_module.get_rewards
+MinerEvaluation = classes.MinerEvaluation
+
+
+def _fake_validator(uids):
+    return SimpleNamespace(
+        metagraph=SimpleNamespace(hotkeys={uid: f'hk{uid}' for uid in uids}),
+        store_or_use_cached_evaluation=lambda evals: set(),
+        evaluation_cache=SimpleNamespace(evict_many=lambda u: None),
+    )
+
+
+def _run_with_tracking(uids, cap):
+    """Run get_rewards with a fake per-miner scorer that records how many
+    evaluations are in flight at once. Returns (evaluations, max_in_flight)."""
+    state = {'current': 0, 'max': 0}
+
+    async def fake_score(uid, hotkey, *args, **kwargs):
+        state['current'] += 1
+        state['max'] = max(state['max'], state['current'])
+        await asyncio.sleep(0.02)
+        state['current'] -= 1
+        return MinerEvaluation(uid=uid, hotkey=hotkey, github_id=str(uid))
+
+    with (
+        patch.object(reward_module.pat_storage, 'load_all_pats', return_value=[]),
+        patch.object(reward_module, 'MINER_EVALUATION_CONCURRENCY', cap),
+        patch.object(reward_module, 'evaluate_miners_pull_requests', side_effect=fake_score),
+        patch.object(reward_module, 'detect_and_penalize_miners_sharing_github', return_value=set()),
+        patch.object(reward_module, 'finalize_miner_scores'),
+    ):
+        evaluations, _cached, _penalized = asyncio.run(
+            get_rewards(_fake_validator(uids), uids, master_repositories={}, programming_languages={}, token_config=None)
+        )
+    return evaluations, state['max']
+
+
+def test_every_miner_is_evaluated():
+    uids = set(range(6))
+    evaluations, _ = _run_with_tracking(uids, cap=3)
+    assert set(evaluations) == uids
+    assert all(evaluations[uid].uid == uid for uid in uids)
+
+
+def test_miners_run_in_parallel():
+    """With headroom, more than one evaluation is in flight at once."""
+    _, max_in_flight = _run_with_tracking(set(range(6)), cap=4)
+    assert max_in_flight > 1
+
+
+def test_concurrency_is_bounded_by_the_cap():
+    """In-flight evaluations never exceed the configured cap."""
+    _, max_in_flight = _run_with_tracking(set(range(8)), cap=2)
+    assert max_in_flight == 2


### PR DESCRIPTION
# perf(validator): score miners concurrently

## Problem

`get_rewards` scores miners one at a time. Each miner is almost entirely waiting on the network (the mirror for PRs/files, GitHub for identity), so while one miner waits, the rest sit idle and that network budget goes unused.

## Fix

Run miners in parallel with a semaphore to cap how many go at once (stays under the mirror's 50 req/10s limit).

```python
semaphore = asyncio.Semaphore(MINER_EVALUATION_CONCURRENCY)

async def evaluate_one(uid):
    async with semaphore:
        evaluation = await evaluate_miners_pull_requests(uid, ...)
    return uid, evaluation

results = await asyncio.gather(*(evaluate_one(uid) for uid in uids))
miner_evaluations = dict(results)
```

The blocking GitHub `/user` identity lookup is also moved off the event loop (`asyncio.to_thread`) — otherwise it would block the loop and serialize identity checks even under the semaphore.

## What actually overlaps

The network-bound work overlaps across miners: the mirror PR/file fetches (already threaded) and now the GitHub identity lookup. The tree-sitter token scoring is CPU work that still runs on the event loop, so it's not parallelized — but it's cheap next to the network round-trips, which are the real cost. So this overlaps the waiting, it doesn't magically parallelize everything.

## Why no try/except here?

Not needed. The layers below already catch network errors and turn them into a failed/cache-fallback eval — they never reach this loop:

- `load_miner_prs` catches `MirrorRequestError` and sets the fetch-failed flags.
- `score_miner_prs` / `get_pr_files` catch per-PR errors.

So one miner failing doesn't abort the round (same as before). If something truly unexpected raised, the old serial loop didn't catch it either — `gather` keeps that same behavior. Adding a catch here would only hide real bugs.

## Config

`MINER_EVALUATION_CONCURRENCY` (default 8, env override). Default value is open to maintainer input.

## Tests

`tests/validator/oss_contributions/test_reward_concurrency.py` — all miners scored, runs in parallel, never exceeds the cap.

Full suite: 861 passed. pyright / ruff / vulture clean.
