### PR TITLE
fix: add test branch for vouchdev/vouch weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -111,7 +111,8 @@
   },
   "vouchdev/vouch": {
     "emission_share": 0.0075,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "additional_acceptable_branches": ["test"]
   },
   "seroperson/jvm-live-reload": {
     "emission_share": 0.01,


### PR DESCRIPTION
## Summary

Adds `test` to `additional_acceptable_branches` for `vouchdev/vouch`. No repository weights are changed.
[https://github.com/owner/repo/pull/123 (merged)
](https://github.com/vouchdev/vouch/pull/91)

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other: weight configuration update

## Testing

- [ ] Tests added/updated
- [x] Manually tested

Verified the JSON update and checked for linter errors.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
