### PR TITLE
fix(validator): add SCALE string encoding support to contract_client

### DIFF
--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -564,6 +564,21 @@ class IssueCompetitionContractClient:
                 encoded += struct.pack('<Q', value)
             elif type_def == 'u128':
                 encoded += struct.pack('<QQ', value & 0xFFFFFFFFFFFFFFFF, value >> 64)
+            elif type_def == 'str':
+                if not isinstance(value, str):
+                    raise ValueError(f'Expected string for {arg_name}, got {type(value)}')
+                str_bytes = value.encode('utf-8')
+                length = len(str_bytes)
+                # Basic SCALE compact encoding for lengths
+                if length < 64:
+                    encoded += struct.pack('<B', length << 2)
+                elif length < 16384:
+                    encoded += struct.pack('<H', (length << 2) | 1)
+                elif length < 1073741824:
+                    encoded += struct.pack('<I', (length << 2) | 2)
+                else:
+                    raise ValueError(f'String too long: {length}')
+                encoded += str_bytes
             elif type_def == 'AccountId':
                 if isinstance(value, str):
                     encoded += bytes.fromhex(self.subtensor.substrate.ss58_decode(value))


### PR DESCRIPTION
Fixes #1375. 

After #1335, `gitt issues register` routes through `IssueCompetitionContractClient._encode_args()`. However, this method lacked a branch to encode strings (the `str` type definition from `metadata.json`), causing a `ValueError` when registering issues.

This PR adds SCALE compact length encoding and UTF-8 byte serialization for strings in `_encode_args()`, correctly restoring the issue registration capability.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana) / Algora