### PR TITLE
fix(issue-discovery): make credibility a gate, not a per-issue multiplier

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -583,7 +583,10 @@ def _finalize_repo_issue_scores(
         spam_mult = calculate_open_issue_spam_multiplier(cfg, open_count, acc.issue_token_score)
         repo_score = 0.0
         for issue in acc.scored_issues:
-            issue.discovery_credibility_multiplier = round(credibility, 2)
+            # Credibility is a gate only: the repo already cleared
+            # min_issue_credibility above, so we don't also tax every issue by
+            # the same ratio. Mirrors the OSS gate-only treatment (#1340).
+            issue.discovery_credibility_multiplier = 1.0
             issue.discovery_open_issue_spam_multiplier = spam_mult
             issue.discovery_earned_score = round(
                 issue.discovery_base_score

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -289,6 +289,38 @@ class TestRunMirrorIssueDiscovery:
         # No fetch needed — everything came from the cache
         client.get_pr_files.assert_not_called()
 
+    def test_credibility_is_gate_only_not_a_per_issue_tax(self):
+        """#1340 applied to the issue path: past the gate, credibility no longer
+        taxes earned score. 4 valid-solved + 1 closed -> credibility 0.80
+        (eligible, < 1.0); each scored issue keeps a neutral 1.0 multiplier
+        instead of being taxed by 0.80."""
+        client = Mock()
+        solved = [_issue_dict(issue_number=50 + i, solved_by_pr=100 + i) for i in range(4)]
+        closed = [_issue_dict(issue_number=99, state_reason='NOT_PLANNED', solved_by_pr=None)]
+        client.get_miner_issues.return_value = _response(solved + closed)
+
+        eval_ = _eval()
+        seed = MinerEvaluation(uid=2, hotkey='hk2', github_id='seed')
+        seed.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100 + i) for i in range(4)]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_, 2: seed},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        repo_eval = eval_.repo_evaluations['entrius/gittensor-ui']
+        assert repo_eval.is_issue_eligible is True
+        assert repo_eval.issue_credibility == pytest.approx(0.80, abs=0.01)
+        scored = eval_.issue_discovery_issues
+        assert scored, 'expected scored issues'
+        assert all(issue.discovery_credibility_multiplier == 1.0 for issue in scored)
+        assert all(issue.discovery_earned_score > 0 for issue in scored)
+
     def test_self_issue_counts_credibility_but_no_score(self):
         # author_github_id == solving_pr.author_github_id
         client = Mock()


### PR DESCRIPTION
Issue-discovery credibility (`solved / (solved + closed)`) is used **twice**:

- as the eligibility **gate** — below `MIN_ISSUE_CREDIBILITY = 0.80` you score zero (`issue_discovery/scoring.py:81`)
- as a **multiplier** on every scored issue (`scan.py:586` → `scan.py:593`)

So a discoverer who already cleared the 0.80 gate is taxed again by the same ratio on every issue — and because the ratio is flat, a few NOT_PLANNED/duplicate closures drop an active discoverer below 0.80 and zero them out. Same failure mode as #1340, but on the issue-discovery path #1340 doesn't cover.

## Fix

Make credibility a **gate only** — exactly the OSS direction in #1340 / #1359:

```python
# scan.py
issue.discovery_credibility_multiplier = 1.0  # gate already enforced above
```

Credibility is still computed, reported, and gates eligibility; it just no longer double-charges past the gate. Each issue is scored on its own multipliers (label, time decay, review quality).

Kept in-place (no shared OSS/issue helper — that was declined in #491). The flat-ratio smoothing is left as a follow-up to track whatever #1359 lands.

## Tests

`test_credibility_is_gate_only_not_a_per_issue_tax`: an eligible discoverer at credibility 0.80 (4 valid-solved + 1 closed) keeps a neutral 1.0 multiplier and earns untaxed score.

Full suite: 878 passed. pyright / ruff / vulture clean.
