### PR TITLE
chore(weights): reduce sure to 0.001, bump ragflow to 0.055

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -83,7 +83,7 @@
     "issue_discovery_share": 0.0
   },
   "infiniflow/ragflow": {
-    "emission_share": 0.05,
+    "emission_share": 0.055,
     "issue_discovery_share": 0.0
   },
   "JSONbored/awesome-claude": {
@@ -139,7 +139,7 @@
     "issue_discovery_share": 0.0
   },
   "we-promise/sure": {
-    "emission_share": 0.04,
+    "emission_share": 0.001,
     "issue_discovery_share": 0.0
   }
 }


### PR DESCRIPTION
## Summary
- `we-promise/sure`: `0.04` → `0.001`
- `infiniflow/ragflow`: `0.05` → `0.055`

## Test plan
- [ ] Verify weights load on test subnet without error
- [ ] Confirm emission distribution reflects new shares after next set_weights