### PR TITLE
fix(issue-discovery): merge fallback open counts

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -373,25 +373,30 @@ def _fallback_open_issue_counts(
 
     The lookback fetch is the authoritative scoring payload. If the secondary
     current/open-count fetch flakes, preserve the fresh solved-issue data and
-    use the most recent cached per-repo open counts when available. Without a
-    cache entry, count open issues visible in the successful lookback payload.
+    count open issues visible in the successful lookback payload. Overlay the
+    most recent cached per-repo counts where available.
     """
+    counts = _count_open_issues(lookback_issues, enabled_names)
     cached = None
     if evaluation_cache is not None:
         cached = evaluation_cache.get(evaluation.uid, evaluation.hotkey, evaluation.github_id or '')
 
     if cached is not None:
-        counts = {
+        cached_counts = {
             repo_name: repo_eval.total_open_issues
             for repo_name, repo_eval in cached.repo_evaluations.items()
             if repo_name in enabled_names
         }
-        if counts:
+        if cached_counts:
+            for repo_name, cached_count in cached_counts.items():
+                counts[repo_name] = max(counts.get(repo_name, 0), cached_count)
             return counts
         if cached.total_open_issues is not None and len(enabled_names) == 1:
-            return {next(iter(enabled_names)): cached.total_open_issues}
+            repo_name = next(iter(enabled_names))
+            counts[repo_name] = max(counts.get(repo_name, 0), cached.total_open_issues)
+            return counts
 
-    return _count_open_issues(lookback_issues, enabled_names)
+    return counts
 
 
 def _build_solving_pr_cache(

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -532,7 +532,111 @@ class TestRunMirrorIssueDiscovery:
         assert eval_.total_open_issues == 2
         assert eval_.issue_discovery_score > 0
 
-    def test_open_count_fetch_error_uses_cached_single_repo_zero_open_count(self):
+    def test_open_count_fetch_error_merges_partial_cache_with_lookback_open_count(self):
+        cache = MinerEvaluationCache()
+        stale = _eval(uid=1, github_id='999')
+        stale.total_open_issues = 1
+        stale.repo_evaluations['entrius/gittensor'] = RepoEvaluation(
+            repository_full_name='entrius/gittensor',
+            total_open_issues=1,
+        )
+        cache.store(stale)
+
+        open_issues = [
+            _issue_dict(
+                issue_number=100 + i,
+                state='OPEN',
+                state_reason=None,
+                solved_by_pr=None,
+                repo='entrius/gittensor-ui',
+            )
+            for i in range(6)
+        ]
+        fresh_issues = [
+            _issue_dict(
+                issue_number=10 + i,
+                author_github_id=f'A{i}',
+                solved_by_pr=200 + i,
+                repo='entrius/gittensor-ui',
+            )
+            for i in range(7)
+        ]
+        client = Mock()
+        client.get_miner_issues.side_effect = [
+            _response(open_issues + fresh_issues),
+            MirrorRequestError('open count fetch failed'),
+        ]
+
+        eval_ = _eval(uid=1, github_id='999')
+        eval_.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr) for pr in range(200, 207)]
+        cache.store(eval_)
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor', 'entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        assert eval_.total_solved_issues == 7
+        assert eval_.total_valid_solved_issues == 7
+        assert eval_.repo_evaluations['entrius/gittensor'].total_open_issues == 1
+        assert eval_.repo_evaluations['entrius/gittensor-ui'].total_open_issues == 6
+        assert eval_.repo_evaluations['entrius/gittensor-ui'].issue_discovery_score == 0
+        assert eval_.total_open_issues == 7
+
+    def test_open_count_fetch_error_does_not_reduce_lookback_open_count_with_cached_zero(self):
+        cache = MinerEvaluationCache()
+        stale = _eval(uid=1, github_id='999')
+        stale.repo_evaluations['entrius/gittensor-ui'] = RepoEvaluation(
+            repository_full_name='entrius/gittensor-ui',
+            total_open_issues=0,
+        )
+        cache.store(stale)
+
+        open_issues = [
+            _issue_dict(
+                issue_number=100 + i,
+                state='OPEN',
+                state_reason=None,
+                solved_by_pr=None,
+            )
+            for i in range(6)
+        ]
+        fresh_issues = [
+            _issue_dict(issue_number=10 + i, author_github_id=f'A{i}', solved_by_pr=200 + i) for i in range(7)
+        ]
+        client = Mock()
+        client.get_miner_issues.side_effect = [
+            _response(open_issues + fresh_issues),
+            MirrorRequestError('open count fetch failed'),
+        ]
+
+        eval_ = _eval(uid=1, github_id='999')
+        eval_.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr) for pr in range(200, 207)]
+        cache.store(eval_)
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        assert eval_.total_solved_issues == 7
+        assert eval_.total_valid_solved_issues == 7
+        assert eval_.repo_evaluations['entrius/gittensor-ui'].total_open_issues == 6
+        assert eval_.issue_discovery_score == 0
+
+    def test_open_count_fetch_error_does_not_replace_lookback_count_with_cached_top_level_zero(self):
         cache = MinerEvaluationCache()
         stale = _eval(uid=1, github_id='999')
         stale.total_open_issues = 0
@@ -572,9 +676,53 @@ class TestRunMirrorIssueDiscovery:
 
         assert eval_.total_solved_issues == 7
         assert eval_.total_valid_solved_issues == 7
-        assert eval_.total_open_issues == 0
-        assert eval_.repo_evaluations['entrius/gittensor-ui'].total_open_issues == 0
+        assert eval_.total_open_issues == 2
+        assert eval_.repo_evaluations['entrius/gittensor-ui'].total_open_issues == 2
         assert eval_.issue_discovery_score > 0
+
+    def test_open_count_fetch_error_uses_cached_single_repo_top_level_count_when_higher(self):
+        cache = MinerEvaluationCache()
+        stale = _eval(uid=1, github_id='999')
+        stale.total_open_issues = 6
+        cache.store(stale)
+
+        open_issues = [
+            _issue_dict(
+                issue_number=100 + i,
+                state='OPEN',
+                state_reason=None,
+                solved_by_pr=None,
+            )
+            for i in range(2)
+        ]
+        fresh_issues = [
+            _issue_dict(issue_number=10 + i, author_github_id=f'A{i}', solved_by_pr=200 + i) for i in range(7)
+        ]
+        client = Mock()
+        client.get_miner_issues.side_effect = [
+            _response(open_issues + fresh_issues),
+            MirrorRequestError('open count fetch failed'),
+        ]
+
+        eval_ = _eval(uid=1, github_id='999')
+        eval_.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', pr) for pr in range(200, 207)]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+                evaluation_cache=cache,
+            )
+        )
+
+        assert eval_.total_solved_issues == 7
+        assert eval_.total_valid_solved_issues == 7
+        assert eval_.total_open_issues == 6
+        assert eval_.repo_evaluations['entrius/gittensor-ui'].total_open_issues == 6
+        assert eval_.issue_discovery_score == 0
 
     def test_successful_issue_fetch_refreshes_cache_after_scoring(self):
         cache = MinerEvaluationCache()


### PR DESCRIPTION
## Summary

Fix issue-discovery fallback open counts when the secondary current/open-count fetch fails.

The fallback now starts from OPEN issues visible in the successful lookback payload, then overlays cached per-repo or single-repo top-level counts using the larger value. This keeps cached stale data useful without letting partial cache entries or cached/default zero values erase fresh open-issue evidence and bypass the open-issue spam multiplier.

## Related Issues

N/A - no public issue filed for this follow-up.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

Commands run:

```bash
./.venv/bin/pytest tests/validator/issue_discovery/test_scan.py -q -k 'open_count_fetch_error or OpenIssueSpamSourceIsMirror'
./.venv/bin/pytest tests/validator/issue_discovery/test_scan.py -q
./.venv/bin/ruff check gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py
./.venv/bin/ruff format --check gittensor/validator/issue_discovery/scan.py tests/validator/issue_discovery/test_scan.py
git diff --check
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
