### PR TITLE
fix: move PAT GitHub validation off event loop

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -6,12 +6,17 @@ Miners push their GitHub PAT to validators via PatBroadcastSynapse.
 Miners check if a validator has their PAT via PatCheckSynapse.
 """
 
+import asyncio
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import bittensor as bt
 import requests
 
-from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
+from gittensor.constants import (
+    BASE_GITHUB_API_URL,
+    GITHUB_HTTP_TIMEOUT_SECONDS,
+    GRAPHQL_VIEWER_QUERY,
+)
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
 from gittensor.utils.github_api_tools import make_graphql_headers
 from gittensor.validator import pat_storage
@@ -28,6 +33,14 @@ def _get_hotkey(synapse: bt.Synapse) -> str:
     """Extract the caller's hotkey from a synapse, raising if missing."""
     assert synapse.dendrite is not None and synapse.dendrite.hotkey is not None
     return synapse.dendrite.hotkey
+
+
+def _github_identity_pin_error(uid: int, hotkey: str, github_id: Optional[str]) -> Optional[str]:
+    existing = pat_storage.get_pat_by_uid(uid)
+    if existing and existing.get('hotkey') == hotkey and existing.get('github_id'):
+        if existing['github_id'] != github_id:
+            return 'GitHub identity is locked for this hotkey. Deregister and re-register to change GitHub accounts.'
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -53,22 +66,23 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     uid = validator.metagraph.hotkeys.index(hotkey)
 
     # 2. Validate PAT (checks it works, extracts github_id)
-    github_id, error = validate_github_credentials(uid, synapse.github_access_token)
+    github_id, error = await asyncio.to_thread(validate_github_credentials, uid, synapse.github_access_token)
     if error:
         return _reject(error)
 
     # 3. Enforce GitHub identity pinning — same hotkey cannot switch GitHub accounts
-    existing = pat_storage.get_pat_by_uid(uid)
-    if existing and existing.get('hotkey') == hotkey and existing.get('github_id'):
-        if existing['github_id'] != github_id:
-            return _reject(
-                'GitHub identity is locked for this hotkey. Deregister and re-register to change GitHub accounts.'
-            )
+    identity_error = _github_identity_pin_error(uid, hotkey, github_id)
+    if identity_error:
+        return _reject(identity_error)
 
     # 4. Test query against a known repo to catch org-restricted PATs
-    test_error = _test_pat_against_repo(synapse.github_access_token)
+    test_error = await asyncio.to_thread(_test_pat_against_repo, synapse.github_access_token)
     if test_error:
         return _reject(f'PAT test query failed: {test_error}')
+
+    identity_error = _github_identity_pin_error(uid, hotkey, github_id)
+    if identity_error:
+        return _reject(identity_error)
 
     # 5. Store PAT (github_id guaranteed non-None after validate_github_credentials success)
     pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=github_id or '0')
@@ -121,7 +135,12 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
     synapse.has_pat = True
 
     # Re-validate the stored PAT
-    validation = validate_github_credentials_result(uid, entry['pat'], stored_github_id=entry.get('github_id'))
+    validation = await asyncio.to_thread(
+        validate_github_credentials_result,
+        uid,
+        entry['pat'],
+        stored_github_id=entry.get('github_id'),
+    )
     if validation.transient_failure:
         synapse.pat_valid = None
         synapse.rejection_reason = 'GitHub API temporarily unavailable; retry the check in a few minutes.'
@@ -133,7 +152,7 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
         bt.logging.warning(f'PAT check result — UID: {uid}: validation failed: {validation.error}')
         return synapse
 
-    test_error = _test_pat_against_repo(entry['pat'])
+    test_error = await asyncio.to_thread(_test_pat_against_repo, entry['pat'])
     if test_error:
         synapse.pat_valid = False
         synapse.rejection_reason = f'PAT test query failed: {test_error}'

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -3,6 +3,8 @@
 """Tests for PAT broadcast and check handlers."""
 
 import asyncio
+import threading
+import time
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +27,12 @@ from gittensor.validator.utils.github_validation import GitHubCredentialValidati
 def _run(coro):
     """Run an async function synchronously."""
     return asyncio.run(coro)
+
+
+async def _short_sleep_delay() -> float:
+    start = time.perf_counter()
+    await asyncio.sleep(0.01)
+    return time.perf_counter() - start
 
 
 @pytest.fixture(autouse=True)
@@ -103,6 +111,60 @@ class TestBlacklistPatCheck:
 
 
 class TestHandlePatBroadcast:
+    def test_validation_call_does_not_block_event_loop(self, mock_validator):
+        synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_valid')
+
+        def slow_validate(uid, pat):
+            time.sleep(0.3)
+            return 'github_42', None
+
+        async def exercise():
+            with (
+                patch('gittensor.validator.pat_handler.validate_github_credentials', side_effect=slow_validate),
+                patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None),
+            ):
+                sleep_task = asyncio.create_task(_short_sleep_delay())
+                handler_task = asyncio.create_task(handle_pat_broadcast(mock_validator, synapse))
+                sleep_delay = await sleep_task
+                result = await handler_task
+                return sleep_delay, result
+
+        sleep_delay, result = _run(exercise())
+
+        assert sleep_delay < 0.25
+        assert result.accepted is True
+
+    def test_concurrent_broadcast_rechecks_identity_pin_before_save(self, mock_validator):
+        synapse_a = _make_broadcast_synapse('hotkey_1', pat='ghp_account_a')
+        synapse_b = _make_broadcast_synapse('hotkey_1', pat='ghp_account_b')
+        test_query_barrier = threading.Barrier(2)
+
+        def validate(uid, pat):
+            github_id = 'github_a' if pat == 'ghp_account_a' else 'github_b'
+            return github_id, None
+
+        def wait_for_other_test_query(pat):
+            test_query_barrier.wait(timeout=1)
+            return None
+
+        async def exercise():
+            with (
+                patch('gittensor.validator.pat_handler.validate_github_credentials', side_effect=validate),
+                patch('gittensor.validator.pat_handler._test_pat_against_repo', side_effect=wait_for_other_test_query),
+            ):
+                return await asyncio.gather(
+                    handle_pat_broadcast(mock_validator, synapse_a),
+                    handle_pat_broadcast(mock_validator, synapse_b),
+                )
+
+        results = _run(exercise())
+
+        accepted = [result for result in results if result.accepted is True]
+        rejected = [result for result in results if result.accepted is False]
+        assert len(accepted) == 1
+        assert len(rejected) == 1
+        assert 'locked' in (rejected[0].rejection_reason or '').lower()
+
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
     @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
     def test_valid_pat_accepted(self, mock_validate, mock_test_query, mock_validator):
@@ -198,6 +260,31 @@ class TestHandlePatBroadcast:
 
 
 class TestHandlePatCheck:
+    def test_test_query_call_does_not_block_event_loop(self, mock_validator):
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_test', 'github_42')
+        synapse = _make_check_synapse('hotkey_1')
+
+        def slow_test_query(pat):
+            time.sleep(0.3)
+            return None
+
+        async def exercise():
+            with (
+                patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation()),
+                patch('gittensor.validator.pat_handler._test_pat_against_repo', side_effect=slow_test_query),
+            ):
+                sleep_task = asyncio.create_task(_short_sleep_delay())
+                handler_task = asyncio.create_task(handle_pat_check(mock_validator, synapse))
+                sleep_delay = await sleep_task
+                result = await handler_task
+                return sleep_delay, result
+
+        sleep_delay, result = _run(exercise())
+
+        assert sleep_delay < 0.25
+        assert result.has_pat is True
+        assert result.pat_valid is True
+
     @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
     @patch('gittensor.validator.pat_handler.validate_github_credentials_result', return_value=_validation())
     def test_valid_pat(self, mock_validate, mock_test_query, mock_validator):


### PR DESCRIPTION
## Summary

Move validator-side PAT GitHub validation and test-query work off the axon event loop with `asyncio.to_thread`.

Root cause: `handle_pat_broadcast` and `handle_pat_check` are async axon handlers, but they called synchronous GitHub `/user` validation and GraphQL test-query helpers directly. A slow or timing-out GitHub request could stall unrelated axon coroutines until the blocking `requests` call and retry sleeps completed.

Changes:

- Run PAT GitHub validation and test-query calls through the standard `asyncio.to_thread` pattern already used elsewhere in the repo.
- Keep existing PAT validation semantics, rejection messages, response fields, and storage shape unchanged.
- Recheck the GitHub identity pin immediately before saving a broadcast PAT. Moving the GitHub calls behind `await` points widens the gap between the existing pin check and `save_pat`, so this preserves the hotkey identity lock under concurrent broadcasts.
- Add regression tests proving unrelated coroutines are not delayed by slow PAT GitHub work.
- Add a concurrency regression test for the pre-save identity-pin recheck.

## Related Issues

Fixes #1386

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Commands run on the latest revision:

```bash
uv run pytest tests/validator/test_pat_handler.py -q
uv run ruff check
uv run ruff format --check
uv run pyright
git diff --check
```

Results:

```text
25 passed
ruff clean
format check clean
pyright clean
git diff --check clean
```

Earlier full-branch validation before the final `asyncio.to_thread` cleanup:

```text
uv run pytest tests/ -x -q  # 880 passed
uv run vulture              # clean
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
