### PR TITLE
fix(mirror): reject cross-repo linked-issue references in _is_valid_linked_issue

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -87,6 +87,7 @@ class MirrorLinkedIssue:
     is_transferred: bool
     solved_by_pr: Optional[int]
     labels: List[MirrorLabel] = field(default_factory=list)
+    repository_full_name: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict) -> 'MirrorLinkedIssue':
@@ -107,6 +108,7 @@ class MirrorLinkedIssue:
             is_transferred=bool(data.get('is_transferred', False)),
             solved_by_pr=data.get('solved_by_pr'),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
+            repository_full_name=data.get('repository_full_name'),
         )
 
 

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -447,6 +447,13 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
         bt.logging.warning(f'Skipping linked issue #{li.number} - transferred')
         return False
 
+    if li.repository_full_name is not None and li.repository_full_name.lower() != pr.repo_full_name.lower():
+        bt.logging.warning(
+            f'Skipping linked issue #{li.number} - cross-repo reference '
+            f'(issue in {li.repository_full_name}, PR in {pr.repo_full_name})'
+        )
+        return False
+
     if li.author_github_id is None:
         bt.logging.warning(f'Skipping linked issue #{li.number} - missing author_github_id')
         return False

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -703,6 +703,7 @@ def _linked_issue(
     closed_at: str | None = '2026-04-18T10:00:00Z',
     author_association: str | None = 'CONTRIBUTOR',
     number: int = 50,
+    repository_full_name: str | None = None,
 ):
     return {
         'number': number,
@@ -717,6 +718,7 @@ def _linked_issue(
         'is_transferred': is_transferred,
         'solved_by_pr': 100,
         'labels': [],
+        'repository_full_name': repository_full_name,
     }
 
 
@@ -817,6 +819,24 @@ class TestLinkedIssueValidity:
         gates CLOSED issues)."""
         scored = ScoredPR(pr=_pr(state='OPEN'))
         li = MirrorLinkedIssue.from_dict(_linked_issue(state='OPEN', state_reason=None, closed_at=None))
+        assert _is_valid_linked_issue(li, scored.pr) is True
+
+    def test_cross_repo_known_mismatch_blocks(self):
+        """Issue from a different repo than the PR is rejected when repository_full_name is known."""
+        scored = ScoredPR(pr=_pr())  # repo_full_name = 'entrius/gittensor-ui'
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name='attacker/throwaway'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+
+    def test_same_repo_known_match_passes(self):
+        """Issue from the same repo as the PR passes the cross-repo check."""
+        scored = ScoredPR(pr=_pr())  # repo_full_name = 'entrius/gittensor-ui'
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name='entrius/gittensor-ui'))
+        assert _is_valid_linked_issue(li, scored.pr) is True
+
+    def test_unknown_repo_none_passes(self):
+        """Older mirror snapshots without repository_full_name preserve existing behaviour."""
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name=None))
         assert _is_valid_linked_issue(li, scored.pr) is True
 
 


### PR DESCRIPTION
## Summary

PR #1038 fixed cross-repo linked-issue leakage on the legacy OSS scoring path. That fix was explicitly scoped out of the mirror path because MirrorLinkedIssue carried no repository identity field. After PR #1202 stripped the legacy pipeline, mirror/scoring.py _is_valid_linked_issue became the sole PR scoring path, making the missing cross-repo guard the entire attack surface.

This implements Layer 1 of the two-layer fix described in #1243.

## What changed

**gittensor/utils/mirror/models.py**: Added repository_full_name: Optional[str] = None to MirrorLinkedIssue. from_dict populates it from data.get("repository_full_name"), defaulting to None on older mirror snapshots with no regression.

**gittensor/validator/oss_contributions/mirror/scoring.py**: Added cross-repo guard in _is_valid_linked_issue that rejects any linked issue whose repository_full_name is known (not None) and differs from pr.repo_full_name (case-insensitive). When repository_full_name is None the check is a no-op, preserving current behaviour until das-github-mirror ships the field (Layer 2).

**tests/validator/oss_contributions/mirror/test_scoring.py**: Added repository_full_name parameter to _linked_issue helper. Three new tests: test_cross_repo_known_mismatch_blocks, test_same_repo_known_match_passes, test_unknown_repo_none_passes.

## Acceptance criteria

- [x] MirrorLinkedIssue carries repository_full_name: Optional[str], defaulting to None
- [x] _is_valid_linked_issue rejects known cross-repo references (case-insensitive)
- [x] None field preserves current behavior on older mirror snapshots
- [x] Three test fixtures added

Closes #1243