### PR TITLE
perf(validator): cache contract child-trie key during issue scans

### DIFF
--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -100,6 +100,7 @@ class IssueCompetitionContractClient:
 
         self.contract_address = contract_address
         self.subtensor = subtensor
+        self._child_storage_key: Optional[str] = None
 
         # Validate the contract exists on-chain
         try:
@@ -121,9 +122,16 @@ class IssueCompetitionContractClient:
     # =========================================================================
 
     def _get_child_storage_key(self) -> Optional[str]:
-        """Get the child storage key for the contract's trie."""
+        """Get the child storage key for the contract's trie.
+
+        Cached after first success: the trie id is fixed for a deployed contract,
+        so scanning many issues no longer costs a ContractInfoOf query per read.
+        """
+        if self._child_storage_key is not None:
+            return self._child_storage_key
         try:
-            return get_contract_child_storage_key(self.subtensor.substrate, self.contract_address)
+            self._child_storage_key = get_contract_child_storage_key(self.subtensor.substrate, self.contract_address)
+            return self._child_storage_key
         except Exception as e:
             bt.logging.debug(f'Error getting child storage key: {e}')
             return None

--- a/tests/validator/test_contract_client_transactions.py
+++ b/tests/validator/test_contract_client_transactions.py
@@ -11,6 +11,7 @@ import pytest
 from gittensor.validator.issue_competitions.contract_client import (
     DEFAULT_GAS_LIMIT,
     IssueCompetitionContractClient,
+    IssueStatus,
 )
 
 # (method, call_kwargs, expected_contract_method, expected_args, uses_hotkey, explicit_gas)
@@ -102,3 +103,21 @@ def test_revert_returns_false(client, wallet, method, kwargs_fn, _cm, _ea, _hk, 
 def test_exception_returns_false(client, wallet, method, kwargs_fn, _cm, _ea, _hk, _gas):
     with patch.object(client, '_exec_contract_raw', side_effect=RuntimeError('node down')):
         assert getattr(client, method)(**kwargs_fn(wallet)) is False
+
+
+def test_get_issues_by_status_caches_child_key_across_scan(client):
+    """The child-trie key is invariant, so scanning N issues must look it up once, not per issue."""
+    client._child_storage_key = None
+    client.subtensor.substrate.rpc_request.return_value = {'result': None}
+    with (
+        patch.object(client, '_read_packed_storage', return_value={'next_issue_id': 6}),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.get_contract_child_storage_key',
+            return_value='0xchildkey',
+        ) as mock_key,
+    ):
+        assert client.get_issues_by_status(IssueStatus.ACTIVE) == []
+    # Issue ids 1..5 each attempted a storage read...
+    assert client.subtensor.substrate.rpc_request.call_count == 5
+    # ...but the invariant child-trie key was fetched only once.
+    mock_key.assert_called_once()


### PR DESCRIPTION
## Summary

`get_issues_by_status` scans every registered issue once per round to find the ACTIVE ones. For each issue it calls `read_issue_from_child_storage`, which calls `_get_child_storage_key()` — and that ran an on-chain `Contracts.ContractInfoOf` query **on every iteration**.

The contract's child-trie key is fixed for the lifetime of a deployed contract, so re-fetching it per issue is pure waste. This caches it on the client after the first successful lookup.

**Effect:** a scan of N issues drops from `2N` contract RPCs (key + storage per issue) to `N + 1`. The client is rebuilt each round so the cache can't go stale, and `next_issue_id` only grows over time (completed/cancelled issues are re-scanned every round), so the saving compounds as the subnet ages.

Only successful lookups are cached — a transient RPC failure leaves the cache empty and retries on the next call, so error behavior is unchanged.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (performance)

## Testing

- Added `test_get_issues_by_status_caches_child_key_across_scan`: scanning 5   issues performs 5 storage reads but only **1** child-trie key lookup (was 5).
- `uv run pytest tests/validator/test_contract_client_transactions.py` — 29 passed.
- `uv run pyright` on the changed files — 0 errors.
- `uv run ruff check` on the changed files — clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
