### PR TITLE
fix(cli): guard _drain_logs when bittensor logging is in Warning state

### DIFF
--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -294,7 +294,11 @@ def _drain_logs() -> None:
 
     import bittensor as bt
 
-    bt.logging.off()
+    # bittensor's LoggingMachine has no `disable_logging` transition from the
+    # Warning state (only `disable_warning = Warning.to(Default)` exists).
+    # info/debug/trace all permit the transition, so guard only Warning.
+    if bt.logging.current_state_value != 'Warning':
+        bt.logging.off()
     queue = bt.logging.get_queue()
     if not queue.empty():
         deadline = time.monotonic() + 2.0

--- a/tests/cli/test_miner_score.py
+++ b/tests/cli/test_miner_score.py
@@ -12,7 +12,7 @@ import pytest
 from click.testing import CliRunner
 
 from gittensor.cli.main import cli
-from gittensor.cli.miner_commands.score import _DEV_HOTKEY, _DEV_UID
+from gittensor.cli.miner_commands.score import _DEV_HOTKEY, _DEV_UID, _apply_log_level, _drain_logs
 
 
 @pytest.fixture
@@ -466,6 +466,14 @@ class TestScoreCommand:
             result = runner.invoke(cli, ['miner', 'score', '--pat', 'ghp_injected'], env={})
         assert result.exit_code == 0, result.output
         assert captured['pats'] == [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': 'ghp_injected'}]
+
+
+@pytest.mark.parametrize('level', ['warning', 'info', 'debug', 'trace'])
+def test_drain_logs_tolerates_every_advertised_level(level):
+    """_drain_logs must not raise for any --log-level Click accepts (#1373)."""
+    _apply_log_level(level)
+    _drain_logs()
+    _drain_logs()
 
 
 def _multi_patch(patches):


### PR DESCRIPTION
## Summary
- Fixes crash when running `gitt miner score --log-level warning` (`TransitionNotAllowed` from bittensor's `Warning` logging state).
- Skips `bt.logging.off()` in `_drain_logs()` when already in `Warning`.
- Adds regression tests for all advertised `--log-level` values.

Fixes #1373

## Test plan
- [x] `pytest tests/cli/test_miner_score.py::test_drain_logs_tolerates_every_advertised_level -v`
- [x] `pytest tests/cli/test_miner_score.py -q`
- [ ] `uv run --extra dev gitt miner score --pat <PAT> --json --log-level warning` (should exit cleanly)

Made with [Cursor](https://cursor.com)