### PR TITLE
chore(weights): add phase-rs/phase + JSONbored/gittensory, rebalance community shares

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -138,7 +138,7 @@
     "additional_acceptable_branches": ["test"]
   },
   "phase-rs/phase": {
-    "emission_share": 0.018,
+    "emission_share": 0.015,
     "issue_discovery_share": 0.0
   },
   "seroperson/jvm-live-reload": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,6 @@
 {
   "aglover1221/product-data-extractor": {
-    "emission_share": 0.0025,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0
   },
   "entrius/allways": {
@@ -14,20 +14,8 @@
     "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
-  "entrius/allways-ui": {
-    "emission_share": 0.01107,
-    "issue_discovery_share": 0.0,
-    "label_multipliers": {
-      "bug": 1.1,
-      "enhancement": 1.0,
-      "feature": 1.25,
-      "refactor": 0.5
-    },
-    "maintainer_cut": 0.0,
-    "trusted_label_pipeline": true
-  },
   "entrius/das-github-mirror": {
-    "emission_share": 0.0118,
+    "emission_share": 0.006,
     "issue_discovery_share": 0.5,
     "label_multipliers": {
       "bug": 1.25,
@@ -50,7 +38,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
-    "emission_share": 0.01966,
+    "emission_share": 0.01,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,
@@ -79,7 +67,7 @@
     "trusted_label_pipeline": true
   },
   "Geniepod/genie-claw": {
-    "emission_share": 0.02,
+    "emission_share": 0.033,
     "issue_discovery_share": 0.0
   },
   "infiniflow/ragflow": {
@@ -87,7 +75,7 @@
     "issue_discovery_share": 0.0
   },
   "JSONbored/awesome-claude": {
-    "emission_share": 0.01,
+    "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -105,8 +93,12 @@
       }
     }
   },
+  "JSONbored/gittensory": {
+    "emission_share": 0.01,
+    "issue_discovery_share": 0.0
+  },
   "MkDev11/gittensor-hub": {
-    "emission_share": 0.015,
+    "emission_share": 0.02,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 2,
@@ -126,7 +118,7 @@
     "maintainer_cut": 0.3
   },
   "vouchdev/vouch": {
-    "emission_share": 0.0075,
+    "emission_share": 0.01,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -145,16 +137,20 @@
     },
     "additional_acceptable_branches": ["test"]
   },
+  "phase-rs/phase": {
+    "emission_share": 0.018,
+    "issue_discovery_share": 0.0
+  },
   "seroperson/jvm-live-reload": {
-    "emission_share": 0.01,
+    "emission_share": 0.011,
     "issue_discovery_share": 0.0
   },
   "touchpilot/touchpilot": {
-    "emission_share": 0.02,
+    "emission_share": 0.025,
     "issue_discovery_share": 0.0
   },
   "we-promise/sure": {
-    "emission_share": 0.001,
+    "emission_share": 0.03,
     "issue_discovery_share": 0.0
   }
 }


### PR DESCRIPTION
Adjusts `master_repositories.json`.

## Additions
- **phase-rs/phase** @ `0.015` — MTG rules engine (Rust/WASM + React/Tauri). Clean provenance: not a fork, no contributor is a registered miner, organic history (Mar→May), 25+ contributors, 428 open issues, daily releases. Standard mid-band tier; revisit at ~30 days against realized output.
- **JSONbored/gittensory** @ `0.01` — backend/MCP tooling for Gittensor contributors. Young (6 days, 1★); flagged for 30-day revisit.

## Rebalances
| repo | old | new |
|---|---:|---:|
| aglover1221/product-data-extractor | 0.00250 | 0.00000 |
| entrius/das-github-mirror | 0.01180 | 0.00600 |
| entrius/gittensor-ui | 0.01966 | 0.01000 |
| Geniepod/genie-claw | 0.02000 | 0.03300 |
| JSONbored/awesome-claude | 0.01000 | 0.00500 |
| MkDev11/gittensor-hub | 0.01500 | 0.02000 |
| seroperson/jvm-live-reload | 0.01000 | 0.01100 |
| touchpilot/touchpilot | 0.02000 | 0.02500 |
| vouchdev/vouch | 0.00750 | 0.01000 |
| we-promise/sure | 0.00100 | 0.03000 |

## Removal
- **entrius/allways-ui** removed entirely (was 0.01107).

## Totals
- Previous: `0.33498` (headroom 0.66502)
- New: `0.38445` (headroom 0.61555)

189 config/weights tests pass; JSON lints clean.