### PR TITLE
perf(cli): read a single on-chain issue by ID instead of scanning all

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -672,6 +672,53 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
         return None
 
 
+_ISSUE_STATUS_NAMES = ['Registered', 'Active', 'Completed', 'Cancelled']
+
+
+def _read_one_issue_from_child_storage(
+    substrate, child_key: str, issue_id: int, verbose: bool = False
+) -> Optional[Dict[str, Any]]:
+    """Read and decode a single issue from contract child storage by ID (one RPC)."""
+    encoded_id = struct.pack('<Q', issue_id)
+    lazy_key = compute_ink5_lazy_key(ISSUES_MAPPING_ROOT_KEY, encoded_id)
+
+    val_result = substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
+    if not val_result.get('result'):
+        if verbose:
+            err_console.print(f'[dim]Debug: No storage found for issue_id={issue_id} (key={lazy_key[:20]}...)[/dim]')
+        return None
+
+    data = bytes.fromhex(val_result['result'].replace('0x', ''))
+    try:
+        decoded = decode_issue_from_storage(data)
+        if decoded is None:
+            raise ValueError('Issue decode returned no data')
+
+        status = (
+            _ISSUE_STATUS_NAMES[decoded.status_byte]
+            if decoded.status_byte < len(_ISSUE_STATUS_NAMES)
+            else 'Unknown'
+        )
+        issue = {
+            'id': decoded.id,
+            'repository_full_name': decoded.repository_full_name,
+            'issue_number': decoded.issue_number,
+            'bounty_amount': decoded.bounty_amount,
+            'target_bounty': decoded.target_bounty,
+            'status': status,
+        }
+        if verbose:
+            err_console.print(
+                f'[dim]Debug: Decoded issue {issue["id"]}: '
+                f'{issue["repository_full_name"]}#{issue["issue_number"]}[/dim]'
+            )
+        return issue
+    except Exception as e:
+        if verbose:
+            err_console.print(f'[dim]Debug: Failed to decode issue {issue_id}: {e}[/dim]')
+        return None
+
+
 def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool = False) -> List[Dict[str, Any]]:
     """
     Read all issues from contract child storage.
@@ -721,54 +768,16 @@ def _read_issues_from_child_storage(substrate, contract_addr: str, verbose: bool
             err_console.print('[dim]Debug: No issues registered (next_issue_id <= 1)[/dim]')
         return []
 
-    issues = []
-    status_names = ['Registered', 'Active', 'Completed', 'Cancelled']
-
     # Iterate through all issue IDs (1 to next_issue_id - 1)
     # Issues mapping root key is '52789899'
     if verbose:
         err_console.print(f'[dim]Debug: Reading issues 1 to {next_issue_id - 1} using mapping key 52789899[/dim]')
 
+    issues = []
     for issue_id in range(1, next_issue_id):
-        # SCALE encode u64 as little-endian 8 bytes
-        encoded_id = struct.pack('<Q', issue_id)
-        lazy_key = compute_ink5_lazy_key(ISSUES_MAPPING_ROOT_KEY, encoded_id)
-
-        val_result = substrate.rpc_request('childstate_getStorage', [child_key, lazy_key, None])
-        if not val_result.get('result'):
-            if verbose:
-                err_console.print(
-                    f'[dim]Debug: No storage found for issue_id={issue_id} (key={lazy_key[:20]}...)[/dim]'
-                )
-            continue
-
-        data = bytes.fromhex(val_result['result'].replace('0x', ''))
-        try:
-            decoded = decode_issue_from_storage(data)
-            if decoded is None:
-                raise ValueError('Issue decode returned no data')
-
-            status = status_names[decoded.status_byte] if decoded.status_byte < len(status_names) else 'Unknown'
-
-            issues.append(
-                {
-                    'id': decoded.id,
-                    'repository_full_name': decoded.repository_full_name,
-                    'issue_number': decoded.issue_number,
-                    'bounty_amount': decoded.bounty_amount,
-                    'target_bounty': decoded.target_bounty,
-                    'status': status,
-                }
-            )
-            if verbose:
-                err_console.print(
-                    f'[dim]Debug: Decoded issue {decoded.id}: '
-                    f'{decoded.repository_full_name}#{decoded.issue_number}[/dim]'
-                )
-        except Exception as e:
-            if verbose:
-                err_console.print(f'[dim]Debug: Failed to decode issue {issue_id}: {e}[/dim]')
-            continue
+        issue = _read_one_issue_from_child_storage(substrate, child_key, issue_id, verbose)
+        if issue is not None:
+            issues.append(issue)
 
     # Sort by ID
     issues.sort(key=lambda x: x['id'])
@@ -837,6 +846,34 @@ def read_issues_from_contract(ws_endpoint: str, contract_addr: str, verbose: boo
         return []
 
 
+def read_issue_from_contract(
+    ws_endpoint: str,
+    contract_addr: str,
+    issue_id: int,
+    verbose: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Read one issue from the contract by ID with a single childstate RPC (no full scan)."""
+    try:
+        from async_substrate_interface import SubstrateInterface
+
+        substrate = SubstrateInterface(url=ws_endpoint)
+        child_key = get_contract_child_storage_key(substrate, contract_addr)
+        if not child_key:
+            if verbose:
+                err_console.print(f'[dim]Debug: Cannot read issue - no child storage key for {contract_addr}[/dim]')
+            return None
+        return _read_one_issue_from_child_storage(substrate, child_key, issue_id, verbose)
+    except ImportError as e:
+        err_console.print(f'[yellow]Cannot read from contract: {e}[/yellow]')
+        err_console.print('[dim]Install with: uv sync[/dim]')
+        return None
+    except Exception as e:
+        if verbose:
+            err_console.print(f'[dim]Debug: Connection/read error: {e}[/dim]')
+        err_console.print(f'[yellow]Error reading from contract: {e}[/yellow]')
+        return None
+
+
 def fetch_issue_from_contract(
     ws_endpoint: str,
     contract_addr: str,
@@ -844,8 +881,7 @@ def fetch_issue_from_contract(
     verbose: bool = False,
 ) -> Dict[str, Any]:
     """Resolve an on-chain issue and validate bountied status."""
-    issues = read_issues_from_contract(ws_endpoint, contract_addr, verbose)
-    issue = next((i for i in issues if i.get('id') == issue_id), None)
+    issue = read_issue_from_contract(ws_endpoint, contract_addr, issue_id, verbose)
     if not issue:
         raise click.ClickException(f'Issue ID {issue_id} not found on-chain.')
 

--- a/tests/cli/test_issue_single_read.py
+++ b/tests/cli/test_issue_single_read.py
@@ -1,0 +1,86 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""CLI tests for single-issue contract read (no full scan)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from gittensor.cli.issue_commands import helpers
+
+
+def _decoded(issue_id, status_byte=1):
+    return SimpleNamespace(
+        id=issue_id,
+        repository_full_name='entrius/gittensor',
+        issue_number=223,
+        bounty_amount=1000,
+        target_bounty=2000,
+        status_byte=status_byte,
+    )
+
+
+def test_read_one_issue_does_a_single_rpc():
+    substrate = MagicMock()
+    substrate.rpc_request.return_value = {'result': '0x00'}
+    with patch.object(helpers, 'decode_issue_from_storage', return_value=_decoded(42, status_byte=1)):
+        issue = helpers._read_one_issue_from_child_storage(substrate, '0xchild', 42)
+
+    substrate.rpc_request.assert_called_once()  # one read, not a full scan
+    assert issue == {
+        'id': 42,
+        'repository_full_name': 'entrius/gittensor',
+        'issue_number': 223,
+        'bounty_amount': 1000,
+        'target_bounty': 2000,
+        'status': 'Active',
+    }
+
+
+def test_read_one_issue_returns_none_when_absent():
+    substrate = MagicMock()
+    substrate.rpc_request.return_value = {'result': None}
+    assert helpers._read_one_issue_from_child_storage(substrate, '0xchild', 7) is None
+
+
+def test_fetch_issue_uses_single_read_not_full_scan():
+    sample = {
+        'id': 42,
+        'repository_full_name': 'entrius/gittensor',
+        'issue_number': 223,
+        'bounty_amount': 1,
+        'target_bounty': 2,
+        'status': 'Active',
+    }
+    with (
+        patch.object(helpers, 'read_issue_from_contract', return_value=sample) as single,
+        patch.object(helpers, 'read_issues_from_contract') as full_scan,
+    ):
+        result = helpers.fetch_issue_from_contract('ws://x', '0xabc', 42)
+
+    assert result == sample
+    single.assert_called_once_with('ws://x', '0xabc', 42, False)
+    full_scan.assert_not_called()  # no O(N) scan to find one issue
+
+
+def test_fetch_issue_not_found_raises():
+    with patch.object(helpers, 'read_issue_from_contract', return_value=None):
+        with pytest.raises(click.ClickException):
+            helpers.fetch_issue_from_contract('ws://x', '0xabc', 99)
+
+
+def test_fetch_issue_non_bountied_status_raises():
+    sample = {
+        'id': 42,
+        'repository_full_name': 'entrius/gittensor',
+        'issue_number': 223,
+        'bounty_amount': 1,
+        'target_bounty': 2,
+        'status': 'Completed',
+    }
+    with patch.object(helpers, 'read_issue_from_contract', return_value=sample):
+        with pytest.raises(click.ClickException):
+            helpers.fetch_issue_from_contract('ws://x', '0xabc', 42)


### PR DESCRIPTION
**Why this is necessary:** `fetch_issue_from_contract` is used to act on *one* issue by ID (e.g. `gitt issues submissions --id <N>`), but it currently reads **every** issue registered on the contract to find it:

```python
issues = read_issues_from_contract(...)          # one childstate RPC per issue, 1..next_issue_id
issue = next((i for i in issues if i.get('id') == issue_id), None)
```

That's O(N) substrate RPC round-trips to fetch O(1) data. `next_issue_id` only ever grows — completed and cancelled issues are never removed from storage — so every single-issue command gets progressively slower and pounds the node with N round-trips for data whose storage key it can compute directly. The Ink! 5 lazy mapping key for a specific `issue_id` is already computable inline, so a single read was always possible; the code just wasn't using it.

**The fix:** add `read_issue_from_contract`, which computes the one issue's lazy key and does a single `childstate_getStorage` call, and route `fetch_issue_from_contract` through it. O(N) → O(1).

The per-issue decode is factored into a shared `_read_one_issue_from_child_storage` helper, so the full-scan path (`read_issues_from_contract`, used by `issues list`) and the new single-read path share one decode implementation instead of duplicating it. Behavior is unchanged: `fetch_issue_from_contract` still raises the same `ClickException`s for not-found, non-bountied, and incomplete issues.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (performance)

## Testing

- New `tests/cli/test_issue_single_read.py`: single read does exactly one RPC,
  returns `None` when absent, `fetch_issue_from_contract` uses the single read
  (asserts the full scan is **not** called), and the not-found / non-bountied
  paths still raise `ClickException`.
- `uv run pytest` — 882 passed.
- `uv run pyright` / `ruff check` / `vulture` on changed files — clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
