### PR TITLE
perf(cli): reuse subtensor connection in issues pending-harvest

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -268,7 +268,6 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
 
     try:
         import bittensor as bt
-        from async_substrate_interface import SubstrateInterface
 
         from gittensor.validator.issue_competitions.contract_client import (
             IssueCompetitionContractClient,
@@ -282,8 +281,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
             )
             treasury_stake = client.get_treasury_stake()
 
-            substrate = SubstrateInterface(url=ws_endpoint)
-            issues = _read_issues_from_child_storage(substrate, contract_addr, verbose)
+            issues = _read_issues_from_child_storage(subtensor.substrate, contract_addr, verbose)
             total_bounty_pool = sum(issue.get('bounty_amount', 0) for issue in issues)
 
         pending_harvest = max(0, treasury_stake - total_bounty_pool)

--- a/tests/cli/test_pending_harvest_single_connection.py
+++ b/tests/cli/test_pending_harvest_single_connection.py
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""pending-harvest must reuse the subtensor connection, not open a second one."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def test_pending_harvest_reuses_subtensor_substrate(cli_root, runner):
+    fake_subtensor = MagicMock()
+    fake_client = MagicMock()
+    fake_client.get_treasury_stake.return_value = 5_000_000_000
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('bittensor.Subtensor', return_value=fake_subtensor),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+        patch('gittensor.cli.issue_commands.view._read_issues_from_child_storage', return_value=[]) as read_issues,
+        patch('async_substrate_interface.SubstrateInterface') as substrate_iface,
+    ):
+        result = runner.invoke(cli_root, ['issues', 'pending-harvest', '--json'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload['success'] is True
+    # The fix: no second connection is opened, and the issue read reuses subtensor.substrate.
+    substrate_iface.assert_not_called()
+    read_issues.assert_called_once()
+    assert read_issues.call_args.args[0] is fake_subtensor.substrate


### PR DESCRIPTION
**Why this is necessary:** `gitt issues pending-harvest` opens **two** WebSocket
connections to the same node for a single command — a `bt.Subtensor` (used for the
treasury-stake read via the contract client) and then a separate
`SubstrateInterface(url=ws_endpoint)` for the issue read:

```python
subtensor = bt.Subtensor(network=ws_endpoint)
...
treasury_stake = client.get_treasury_stake()

substrate = SubstrateInterface(url=ws_endpoint)   # second connection to the same node
issues = _read_issues_from_child_storage(substrate, contract_addr, verbose)
```

The bittensor `Subtensor` already wraps a `SubstrateInterface` at
`subtensor.substrate`, exposing the exact `rpc_request` / `query` API the issue
read uses (the contract client reads through `subtensor.substrate` already). So
the second connection is pure redundancy — extra socket setup/teardown against
the same endpoint for one command.

**The fix:** read issues through `subtensor.substrate` and drop the second
`SubstrateInterface` plus its now-unused import. One command, one connection.
Behavior is unchanged — same data, same code path, just one fewer socket.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (performance)

## Testing

- New `tests/cli/test_pending_harvest_single_connection.py`: asserts
  `pending-harvest --json` succeeds, opens **no** second `SubstrateInterface`,
  and the issue read reuses `subtensor.substrate`.
- Existing `--json` exception-path regression (`pending-harvest`) still passes.
- `uv run pytest` — 882 passed.
- `uv run pyright` / `ruff check` / `vulture` on changed files — clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
