### PR TITLE
fix: strip whitespace from GitHub PATs before validation

### DIFF
--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -32,7 +32,7 @@ from gittensor.cli.miner_commands.helpers import (
     err_console,
 )
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
-from gittensor.utils.github_api_tools import make_graphql_headers, make_headers
+from gittensor.utils.github_api_tools import make_graphql_headers, make_headers, normalize_github_pat
 
 _PAT_POST_STATUS_MARKUP = {
     'accepted': '[green]✓[/green]',
@@ -93,6 +93,11 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
             _error('--pat flag or GITTENSOR_MINER_PAT environment variable is required for JSON mode.', json_mode)
             sys.exit(1)
         pat = click.prompt('Enter your GitHub Personal Access Token', hide_input=True)
+
+    pat = normalize_github_pat(pat)
+    if not pat:
+        _error('GitHub PAT is empty after trimming whitespace.', json_mode)
+        sys.exit(1)
 
     # 1b. Validate PAT locally
     with _status('[bold]Validating PAT...'):

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -72,6 +72,14 @@ def make_anonymous_headers() -> Dict[str, str]:
     return {'Accept': 'application/vnd.github.v3+json', 'User-Agent': 'gittensor-cli'}
 
 
+def normalize_github_pat(pat: Optional[str]) -> Optional[str]:
+    """Strip whitespace from a PAT so Authorization headers are not corrupted."""
+    if pat is None:
+        return None
+    stripped = pat.strip()
+    return stripped if stripped else None
+
+
 def get_session(token: str) -> requests.Session:
     """Return a fresh requests.Session preconfigured with the appropriate headers."""
     session = requests.Session()
@@ -104,6 +112,7 @@ def get_github_identity(token: str) -> GitHubIdentityResult:
             permanent auth failures, or transient failure when GitHub/user JSON
             could not be reached after retries.
     """
+    token = normalize_github_pat(token)
     if not token:
         return GitHubIdentityResult(None, GitHubIdentityStatus.INVALID_AUTH)
 

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -13,7 +13,7 @@ import requests
 
 from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS, GRAPHQL_VIEWER_QUERY
 from gittensor.synapses import PatBroadcastSynapse, PatCheckSynapse
-from gittensor.utils.github_api_tools import make_graphql_headers
+from gittensor.utils.github_api_tools import make_graphql_headers, normalize_github_pat
 from gittensor.validator import pat_storage
 from gittensor.validator.utils.github_validation import (
     validate_github_credentials,
@@ -52,8 +52,14 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
 
     uid = validator.metagraph.hotkeys.index(hotkey)
 
+    normalized_pat = normalize_github_pat(synapse.github_access_token)
+    if not normalized_pat:
+        return _reject('No Github PAT provided')
+
+    synapse.github_access_token = normalized_pat
+
     # 2. Validate PAT (checks it works, extracts github_id)
-    github_id, error = validate_github_credentials(uid, synapse.github_access_token)
+    github_id, error = validate_github_credentials(uid, normalized_pat)
     if error:
         return _reject(error)
 

--- a/gittensor/validator/utils/github_validation.py
+++ b/gittensor/validator/utils/github_validation.py
@@ -6,7 +6,11 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from gittensor.utils.github_api_tools import GitHubIdentityStatus, get_github_identity
+from gittensor.utils.github_api_tools import (
+    GitHubIdentityStatus,
+    get_github_identity,
+    normalize_github_pat,
+)
 
 
 @dataclass(frozen=True)
@@ -28,6 +32,7 @@ def validate_github_credentials_result(
     stored_github_id: Optional[str] = None,
 ) -> GitHubCredentialValidation:
     """Validate PAT and expose transient /user lookup failures to scoring."""
+    pat = normalize_github_pat(pat)
     if not pat:
         return GitHubCredentialValidation(None, f'No Github PAT provided by miner {uid}')
 

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -25,9 +25,19 @@ github_api_tools = pytest.importorskip(
 )
 
 get_github_identity = github_api_tools.get_github_identity
+normalize_github_pat = github_api_tools.normalize_github_pat
 find_prs_for_issue = github_api_tools.find_prs_for_issue
 execute_graphql_query = github_api_tools.execute_graphql_query
 check_github_issue_closed = github_api_tools.check_github_issue_closed
+
+
+class TestNormalizeGithubPat:
+    def test_strips_surrounding_whitespace(self):
+        assert normalize_github_pat('  ghp_abc  ') == 'ghp_abc'
+
+    def test_blank_after_strip_returns_none(self):
+        assert normalize_github_pat('   ') is None
+        assert normalize_github_pat(None) is None
 
 
 class TestOtherGitHubAPIFunctions:
@@ -48,10 +58,11 @@ class TestOtherGitHubAPIFunctions:
             mock_response_success,
         ]
 
-        result = get_github_identity('fake_token').github_id
+        result = get_github_identity('  fake_token  ').github_id
 
         assert result == '12345'
         assert mock_get.call_count == 3
+        assert mock_get.call_args.kwargs['headers']['Authorization'] == 'token fake_token'
 
     @patch('gittensor.utils.github_api_tools.requests.get')
     @patch('gittensor.utils.github_api_tools.time.sleep')

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -122,6 +122,17 @@ class TestHandlePatBroadcast:
         assert entry['uid'] == 1
         assert entry['github_id'] == 'github_42'
 
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_42', None))
+    def test_whitespace_padded_pat_is_normalized(self, mock_validate, mock_test_query, mock_validator):
+        synapse = _make_broadcast_synapse('hotkey_1', pat='  ghp_valid  \n')
+        result = _run(handle_pat_broadcast(mock_validator, synapse))
+
+        assert result.accepted is True
+        mock_validate.assert_called_once_with(1, 'ghp_valid')
+        entry = pat_storage.get_pat_by_uid(1)
+        assert entry['pat'] == 'ghp_valid'
+
     def test_unregistered_hotkey_rejected(self, mock_validator):
         synapse = _make_broadcast_synapse('unknown_hotkey')
         result = _run(handle_pat_broadcast(mock_validator, synapse))


### PR DESCRIPTION
## Summary

Normalize GitHub PATs by stripping leading and trailing whitespace before validation, storage, and API calls so tokens copied from `.env` files or secret managers are accepted.

## Related Issues

Closes #1392

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
