### PR TITLE
chore(weights): add label multipliers for phase-rs/phase

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -139,7 +139,14 @@
   },
   "phase-rs/phase": {
     "emission_share": 0.015,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "bug": 1.1,
+      "ai-contribution": 0,
+      "enhancement": 1.25,
+      "feature": 1.5,
+      "refactor": 0.25
+    }
   },
   "seroperson/jvm-live-reload": {
     "emission_share": 0.011,


### PR DESCRIPTION
`phase-rs/phase` was added to the repository whitelist in #1389 with only
`emission_share` and `issue_discovery_share`, so every merged PR scored at a
flat 1.0× regardless of label. This adds a `label_multipliers` block so phase
contributions are weighted by PR type, consistent with the other scored repos.

```json
"phase-rs/phase": {
  "emission_share": 0.015,
  "issue_discovery_share": 0.0,
  "label_multipliers": {
    "bug": 1.1,
    "ai-contribution": 0,
    "enhancement": 1.25,
    "feature": 1.5,
    "refactor": 0.25
  }
}
```

- Multiplier values follow the `entrius/gittensor` pattern
  (bug 1.1 / enhancement 1.25 / feature 1.5 / refactor 0.25).
- `ai-contribution: 0` zero-weights AI-labeled PRs.
- `emission_share` and `issue_discovery_share` are unchanged.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (scoring config)

## Testing

- JSON validated; repo count and all other entries unchanged.
- Single-file change to `gittensor/validator/weights/master_repositories.json`;
  no code paths affected.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
