### PR TITLE
chore(weights): tune gittensory hyperparameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -95,7 +95,20 @@
   },
   "JSONbored/gittensory": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "feature": 1.5
+    },
+    "maintainer_cut": 0.3,
+    "scoring": {
+      "pr_lookback_days": 45,
+      "maintainer_issue_multiplier": 1.75,
+      "time_decay": {
+        "grace_period_hours": 24,
+        "sigmoid_midpoint_days": 14,
+        "min_multiplier": 0.1
+      }
+    }
   },
   "MkDev11/gittensor-hub": {
     "emission_share": 0.02,


### PR DESCRIPTION
## Summary
- add repo-local scoring hyperparameters for `JSONbored/gittensory`
- add a single `feature` label multiplier for substantial shipped functionality
- add a maintainer cut for the repo's review and curation workload

## Changes
- Keeps `emission_share` unchanged at `0.01`.
- Keeps `issue_discovery_share` unchanged at `0.0`.
- Adds `feature: 1.5` as the only label multiplier.
- Adds `maintainer_cut: 0.3`.
- Adds a 45-day PR lookback and slower time-decay profile for review-heavy work.

## Rationale
Gittensory is intended to stay direct-PR-first for now. The label policy keeps the scoring surface narrow and focused on substantial feature work, while the maintainer cut accounts for the review and triage burden of keeping the repo useful for Gittensor contributors and maintainers.

## Validation
- `git diff --check`
- `uv run --extra dev python -m pytest tests/validator/test_load_weights.py tests/validator/test_scoring_resolver.py tests/validator/test_blend_emission_pools.py tests/validator/test_maintainer_uids.py`
