### PR TITLE
fix(scoring): gate valid merged PRs on source token score

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -120,7 +120,7 @@ INLINE_TEST_PATTERNS: Dict[str, re.Pattern] = {
 # Eligibility Gate (OSS Contributions)
 # =============================================================================
 # Per-repo defaults — each repo may override these in master_repositories.json.
-MIN_VALID_MERGED_PRS = 3  # minimum "valid" merged PRs (token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE) to receive score
+MIN_VALID_MERGED_PRS = 3  # minimum "valid" merged PRs (source_token_score >= MIN_TOKEN_SCORE_FOR_BASE_SCORE) to receive score
 MIN_CREDIBILITY = 0.80  # minimum credibility ratio to receive score
 
 # =============================================================================

--- a/gittensor/validator/oss_contributions/credibility.py
+++ b/gittensor/validator/oss_contributions/credibility.py
@@ -29,8 +29,12 @@ def check_eligibility(
 
     Gate requires:
     1. At least ``cfg.min_valid_merged_prs`` merged PRs with
-       ``token_score >= cfg.min_token_score_for_base_score``
+       ``source_token_score >= cfg.min_token_score_for_base_score``
     2. At least ``cfg.min_credibility`` credibility
+
+    Validity keys off ``source_token_score`` (SOURCE-only) so it matches the
+    base-score gate; the aggregate ``token_score`` (SOURCE + TEST) must not let
+    test content flip a PR to "valid" without earning a source base score.
 
     Returns:
         (is_eligible, credibility, reason)
@@ -38,7 +42,7 @@ def check_eligibility(
     """
     credibility = calculate_credibility(merged_prs, closed_prs)
 
-    valid_merged_count = sum(1 for pr in merged_prs if pr.token_score >= cfg.min_token_score_for_base_score)
+    valid_merged_count = sum(1 for pr in merged_prs if pr.source_token_score >= cfg.min_token_score_for_base_score)
 
     if valid_merged_count < cfg.min_valid_merged_prs:
         return False, credibility, f'{valid_merged_count}/{cfg.min_valid_merged_prs} valid merged PRs'

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -41,7 +41,8 @@ class ScoredPR:
 
     # Token scoring breakdown (populated when files are tokenized)
     code_density: float = 0.0
-    token_score: float = 0.0
+    token_score: float = 0.0  # all-category aggregate (SOURCE + TEST)
+    source_token_score: float = 0.0  # SOURCE-only; what the eligibility gate uses
     structural_count: int = 0
     structural_score: float = 0.0
     leaf_count: int = 0

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -162,6 +162,7 @@ async def score_pr(
                 ).min_token_score_for_base_score,
             )
             scored.token_score = result.token_score
+            scored.source_token_score = result.source_token_score
             scored.structural_count = result.structural_count
             scored.structural_score = result.structural_score
             scored.leaf_count = result.leaf_count
@@ -265,7 +266,8 @@ class BaseScoreResult:
     """
 
     base_score: float
-    token_score: float
+    token_score: float  # all-category aggregate (SOURCE + TEST)
+    source_token_score: float  # SOURCE-only; gates base score and eligibility
     structural_count: int
     structural_score: float
     leaf_count: int
@@ -341,6 +343,7 @@ def calculate_base_score_for_pr_files(
     return BaseScoreResult(
         base_score=base_score,
         token_score=token_score,
+        source_token_score=source_token_score,
         structural_count=structural_count,
         structural_score=structural_score,
         leaf_count=leaf_count,

--- a/tests/validator/oss_contributions/mirror/test_base_score_helper.py
+++ b/tests/validator/oss_contributions/mirror/test_base_score_helper.py
@@ -72,6 +72,7 @@ class TestResultShape:
         for field_name in [
             'base_score',
             'token_score',
+            'source_token_score',
             'structural_count',
             'structural_score',
             'leaf_count',
@@ -120,6 +121,7 @@ class TestPerRepoMinTokenScoreOverride:
             min_token_score_for_base_score=3.0,
         )
         assert result.base_score > 0.0
+        assert result.source_token_score == pytest.approx(4.0)
 
     def test_higher_per_repo_threshold_zeroes_pr(self, monkeypatch):
         # token_score = 7 would pass default (5), but stricter per-repo override (10) zeroes it.

--- a/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
+++ b/tests/validator/oss_contributions/mirror/test_repo_config_fields.py
@@ -7,6 +7,8 @@ penalizes another.
 
 from __future__ import annotations
 
+from typing import Optional
+
 from gittensor.classes import MinerEvaluation
 from gittensor.utils.mirror.models import MirrorPullRequest
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
@@ -53,10 +55,18 @@ def _mirror_pr(repo: str, number: int, state: str = 'MERGED') -> ScoredPR:
     return ScoredPR(pr=pr)
 
 
-def _merged(repo: str, number: int, base: float = 10.0, token: float = 10.0) -> ScoredPR:
+def _merged(
+    repo: str,
+    number: int,
+    base: float = 10.0,
+    token: float = 10.0,
+    source_token: Optional[float] = None,
+) -> ScoredPR:
     pr = _mirror_pr(repo, number)
     pr.base_score = base
     pr.token_score = token
+    # Eligibility gates on source_token_score; default it to the aggregate.
+    pr.source_token_score = token if source_token is None else source_token
     return pr
 
 
@@ -81,6 +91,22 @@ def test_eligibility_does_not_pool_across_repos():
     assert all(pr.earned_score == 0.0 for pr in repo_b)
     assert evaluation.total_score == 30.0
     assert evaluation.is_eligible is True  # eligible in at least one repo
+
+
+def test_validity_gate_keys_off_source_not_aggregate_token_score():
+    """A merged PR is "valid" only if its SOURCE score clears the threshold, not
+    the SOURCE+TEST aggregate — so the validity gate matches the base-score gate.
+    """
+    # Aggregate (10) clears the default threshold (5), but SOURCE (4) does not.
+    over_aggregate_under_source = [_merged('foo/a', n, token=10.0, source_token=4.0) for n in range(1, 4)]
+
+    evaluation = MinerEvaluation(uid=1, hotkey='hotkey', github_id='218712309')
+    evaluation.merged_prs = over_aggregate_under_source
+
+    finalize_miner_scores({1: evaluation}, {'foo/a': _gate_repo()})
+
+    # None of the three are "valid" → below min_valid_merged_prs → ineligible.
+    assert evaluation.repo_evaluations['foo/a'].is_eligible is False
 
 
 def test_zeroed_thresholds_repo_has_no_gate():

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -405,6 +405,7 @@ class TestFixedBaseScore:
             lambda *args, **kwargs: scoring_module.BaseScoreResult(
                 base_score=99.0,
                 token_score=42.0,
+                source_token_score=42.0,
                 structural_count=2,
                 structural_score=20.0,
                 leaf_count=3,
@@ -477,6 +478,7 @@ class TestFixedBaseScore:
             lambda *args, **kwargs: scoring_module.BaseScoreResult(
                 base_score=0.25,
                 token_score=100.0,
+                source_token_score=100.0,
                 structural_count=1,
                 structural_score=100.0,
                 leaf_count=0,


### PR DESCRIPTION
## Summary

The OSS scoring path measured one threshold constant against two different quantities. The base-score gate in `calculate_base_score_for_pr_files` keyed off the SOURCE-only token score, while the eligibility "valid merged PR" gate in `check_eligibility` keyed off `pr.token_score`, the all-category aggregate (`SOURCE + TEST`). As a result a merged PR could earn zero source base score yet still count toward `min_valid_merged_prs`, the gate that unlocks all scoring for a repository. A near-threshold source PR plus a small test file was enough to flip a PR from "not valid" to "valid".

This change makes validity match the base-score gate:

- `BaseScoreResult` now returns `source_token_score` (already computed inside the helper, so no extra work).
- `ScoredPR` stores `source_token_score` alongside the aggregate `token_score`, set during `score_pr`.
- `check_eligibility` counts a merged PR as valid only when its `source_token_score` clears the threshold.
- The constant comment and the `check_eligibility` docstring now describe the actual behavior.

The aggregate `token_score` is still kept for reporting rollups, the storage adapter, and the issue discovery cache, so both fields remain in use. The issue discovery path is intentionally untouched: it gates on a separate constant (`min_token_score_for_valid_issue`) compared consistently against the aggregate, so it has no internal mismatch.

## Related Issues

Fixes #1396

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `test_validity_gate_keys_off_source_not_aggregate_token_score`, which confirms a repo of merged PRs that pass the aggregate threshold but fail the SOURCE threshold is ineligible. Updated the `_merged` test helper to set the gating field, extended the base-score helper test to assert `source_token_score` is surfaced, and updated the `BaseScoreResult` stubs in `test_scoring.py`. The eligibility gate logic was verified directly: SOURCE-fail rows produce an ineligible result and SOURCE-pass rows produce an eligible one.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
