### PR TITLE
Range-check label multipliers and fixed base score during registry load

### DIFF
--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -152,8 +152,8 @@ class RepositoryConfig:
             same fnmatch wildcard syntax as ``additional_acceptable_branches``.
         default_label_multiplier: Multiplier used when no configured label
             pattern matches. Defaults to neutral scoring.
-        fixed_base_score: Override for the PR base score. Expected
-            to be within [0.0, 100.0]; range is enforced by the live-config test.
+        fixed_base_score: Override for the PR base score. Must be within
+            [0.0, 100.0]; range is enforced at load time by ``_validate_label_configs``.
         eligibility: Per-repo overrides for the eligibility / spam knobs. Unset
             fields fall back to the global default constants — see
             ``resolve_eligibility``.
@@ -508,6 +508,47 @@ def _validate_scoring_configs(configs: Dict[str, RepositoryConfig]) -> None:
             )
 
 
+def _validate_label_configs(configs: Dict[str, RepositoryConfig]) -> None:
+    """Range-check every repo's label-multiplier and fixed-base-score config.
+
+    These feed straight into PR scoring (``label_multipliers`` →
+    ``resolve_highest_label_multiplier`` → ``_apply_score_multipliers``;
+    ``fixed_base_score`` → ``ScoredPR.base_score``) exactly like the issue-bonus
+    multipliers that ``_validate_scoring_configs`` already bounds. Without this,
+    a typo in a high-churn ``chore(weights)`` PR (e.g. ``5.0`` → ``50.0`` or a
+    stray ``-``) would silently distort live scoring instead of failing fast at
+    startup. Bounds mirror the live-config tests in ``test_load_weights.py``.
+    """
+    for repo_name, config in configs.items():
+        if config.fixed_base_score is not None:
+            value = config.fixed_base_score
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise RepositoryRegistryError(
+                    f'{repo_name} fixed_base_score must be a number, got {type(value).__name__}'
+                )
+            if not 0.0 <= float(value) <= 100.0:
+                raise RepositoryRegistryError(
+                    f'{repo_name} fixed_base_score must be within [0, 100], got {value}'
+                )
+        if not 0.0 <= config.default_label_multiplier <= 20.0:
+            raise RepositoryRegistryError(
+                f'{repo_name} default_label_multiplier must be within [0, 20], '
+                f'got {config.default_label_multiplier}'
+            )
+        if config.label_multipliers is not None:
+            if len(config.label_multipliers) > 10:
+                raise RepositoryRegistryError(
+                    f'{repo_name} label_multipliers must have <= 10 entries, '
+                    f'got {len(config.label_multipliers)}'
+                )
+            for pattern, multiplier in config.label_multipliers.items():
+                if not 0.0 <= multiplier <= 20.0:
+                    raise RepositoryRegistryError(
+                        f'{repo_name} label_multipliers[{pattern!r}] must be within [0, 20], '
+                        f'got {multiplier}'
+                    )
+
+
 def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
     """
     Load repository emission shares from the local JSON file.
@@ -563,6 +604,7 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
         _validate_emission_shares(normalized_data)
         _validate_eligibility_configs(normalized_data)
         _validate_scoring_configs(normalized_data)
+        _validate_label_configs(normalized_data)
 
         bt.logging.debug(f'Successfully loaded {len(normalized_data)} repository entries from {weights_file}')
         return normalized_data

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -320,6 +320,28 @@ class TestRepositoryConfigMirrorScoringFields:
         with pytest.raises(RepositoryRegistryError):
             lw.load_master_repo_weights()
 
+    @pytest.mark.parametrize(
+        'metadata',
+        [
+            {'emission_share': 0.5, 'fixed_base_score': -1.0},
+            {'emission_share': 0.5, 'fixed_base_score': 101.0},
+            {'emission_share': 0.5, 'fixed_base_score': 'oops'},
+            {'emission_share': 0.5, 'default_label_multiplier': -0.1},
+            {'emission_share': 0.5, 'default_label_multiplier': 25.0},
+            {'emission_share': 0.5, 'label_multipliers': {'kind/*': -1.0}},
+            {'emission_share': 0.5, 'label_multipliers': {'kind/*': 50.0}},
+            {'emission_share': 0.5, 'label_multipliers': {f'kind/{i}': 1.0 for i in range(11)}},
+        ],
+    )
+    def test_loader_rejects_out_of_range_label_configs(self, tmp_path, monkeypatch, metadata):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(json.dumps({'foo/bad': metadata}))
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        with pytest.raises(RepositoryRegistryError):
+            lw.load_master_repo_weights()
+
     def test_live_mirror_scoring_fields_have_valid_shape(self):
         """Loader passes scoring + eligibility fields through unchanged — CI fails
         when a bad value is committed to master_repositories.json."""


### PR DESCRIPTION
## Summary

`load_master_repo_weights()` already range-checks nearly every per-repo field through `_validate_eligibility_configs` and `_validate_scoring_configs`, failing fast at startup when a value is out of bounds. Three scoring fields were left out: `label_multipliers`, `default_label_multiplier`, and `fixed_base_score`. The last one was not even coerced to a number, so it was stored raw from JSON.

These fields drive live scoring. `label_multipliers` resolves through `resolve_highest_label_multiplier` and multiplies into a PR's earned score, while the structurally identical issue-bonus multipliers are already clamped to `[1, 5]`. `fixed_base_score` is assigned straight onto `ScoredPR.base_score`. Because `master_repositories.json` is the most edited file in the repo and almost every recent merge touches these exact fields, a single typo such as `5.0` becoming `50.0` would pass validation and quietly distort emissions, and a non-numeric `fixed_base_score` would later raise a `TypeError` that `score_pr` swallows, leaving the PR unscored.

This change adds `_validate_label_configs`, wired into the same load chain as the existing validators, so these fields fail fast like the rest of the registry. Bounds mirror the live-config assertions already present in the tests:

- `label_multipliers`: at most 10 entries, each value within `[0, 20]`
- `default_label_multiplier`: within `[0, 20]`
- `fixed_base_score`: a number (not a bool), within `[0, 100]`

The `[0, 20]` range is used rather than the issue-bonus `[1, 5]` because live configs legitimately use `0` and sub-1 multipliers, so the issue-bonus bounds would reject valid data. Every currently valid config keeps its behavior, and the `fixed_base_score` docstring now points at the load-time check instead of the test.

## Related Issues

Fixes #1399

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Parametrized rejection tests cover negative, over-cap, non-numeric, bool, and too-many-entries cases for all three fields. The live `master_repositories.json` loads cleanly through the full validation chain, confirming no valid config changes behavior.

```bash
uv run pytest tests/validator/test_load_weights.py -q
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
