### PR TITLE
feat(validator): add OSS-scoring round completion summary

### DIFF
--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -16,7 +16,7 @@ from gittensor.validator.oss_contributions.inspections import (
 )
 from gittensor.validator.oss_contributions.mirror.load import load_miner_prs
 from gittensor.validator.oss_contributions.mirror.scoring import score_miner_prs
-from gittensor.validator.oss_contributions.scoring import finalize_miner_scores
+from gittensor.validator.oss_contributions.scoring import finalize_miner_scores, log_oss_scoring_summary
 from gittensor.validator.utils.load_weights import LanguageConfig, RepositoryConfig, TokenConfig
 
 # NOTE: there was a circular import error, needed this if to resolve it
@@ -145,5 +145,7 @@ async def get_rewards(
 
     # Finalize scores: apply eligibility gate, credibility, collateral
     finalize_miner_scores(miner_evaluations, master_repositories)
+
+    log_oss_scoring_summary(miner_evaluations, cached_uids, penalized_uids)
 
     return miner_evaluations, cached_uids, penalized_uids

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -1,7 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 import bittensor as bt
 
@@ -111,6 +111,26 @@ def finalize_miner_scores(
         _roll_up_miner_totals(evaluation)
 
     bt.logging.info('Finalization complete.')
+
+
+def log_oss_scoring_summary(
+    miner_evaluations: Dict[int, MinerEvaluation],
+    cached_uids: Set[int],
+    penalized_uids: Set[int],
+) -> None:
+    """Emit a round-level OSS-scoring rollup, mirroring the issue-discovery summary.
+
+    Counts are derived after finalization so eligibility reflects the gated
+    result. Logging only — no scoring state is read back or mutated.
+    """
+    eligible = sum(1 for e in miner_evaluations.values() if e and e.is_eligible)
+    failed = sum(1 for e in miner_evaluations.values() if e and e.failed_reason is not None)
+    bt.logging.info('')
+    bt.logging.info(
+        f'OSS scoring complete | {len(miner_evaluations)} evaluated | {eligible} eligible | '
+        f'{len(penalized_uids)} penalized (duplicate github) | {len(cached_uids)} cache-fallback | '
+        f'{failed} failed validation'
+    )
 
 
 def _group_prs_by_repo(prs: List['ScoredPR']) -> Dict[str, List['ScoredPR']]:


### PR DESCRIPTION
## Summary

The issue-discovery phase closes each scoring round with a one-line summary (`Issue discovery complete | N processed | …` in `scan.py`), but the OSS-scoring phase logs only `Finalization complete.` with no round-level aggregate. This change adds the matching completion summary so an operator can gauge a scoring round at a glance.

Additive logging only: it reads `is_eligible` / `failed_reason` (already set during finalization) plus the `cached_uids` / `penalized_uids` sets that `get_rewards()` already holds. It only counts and prints values that already exist — no scoring logic runs, and no miner's score changes.

**Before** — the OSS-scoring phase ended here, with no round-level summary:

```text
Finalization complete.
```

**After** — a single summary line now follows it (the counts below are from an example round, included to show the format — not real validator output):

```text
Finalization complete.

OSS scoring complete | 40 evaluated | 22 eligible | 2 penalized (duplicate github) | 5 cache-fallback | 1 failed validation
```

## Related Issues

Closes #1400

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated
- [x] Manually tested

```console
$ pytest tests/validator/test_oss_scoring.py -v
collected 2 items

tests/validator/test_oss_scoring.py::TestLogOssScoringSummary::test_counts_each_category PASSED [ 50%]
tests/validator/test_oss_scoring.py::TestLogOssScoringSummary::test_empty_round_reports_zeros PASSED [100%]

============================== 2 passed in 0.12s ==============================

$ ruff check gittensor/validator/oss_contributions/scoring.py gittensor/validator/oss_contributions/reward.py tests/validator/test_oss_scoring.py
All checks passed!

$ ruff format --check gittensor/validator/oss_contributions/scoring.py gittensor/validator/oss_contributions/reward.py tests/validator/test_oss_scoring.py
3 files already formatted
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)