### PR TITLE
chore(weights): add cogniax/tao-pulse-app at 0.01 emission share

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -3,6 +3,10 @@
     "emission_share": 0.0,
     "issue_discovery_share": 0.0
   },
+  "cogniax/tao-pulse-app": {
+    "emission_share": 0.01,
+    "issue_discovery_share": 0.0
+  },
   "entrius/allways": {
     "emission_share": 0.05018,
     "issue_discovery_share": 1.0,


### PR DESCRIPTION
Adds [cogniax/tao-pulse-app](https://github.com/cogniax/tao-pulse-app) to the master repository list.

```json
"cogniax/tao-pulse-app": {
  "emission_share": 0.01,
  "issue_discovery_share": 0.0
}
```

Default community config: `emission_share` 0.01, `issue_discovery_share` 0.0, no label/scoring overrides.