### PR TITLE
chore(weights): tune genie-claw maintainer config

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -71,8 +71,12 @@
     "trusted_label_pipeline": true
   },
   "Geniepod/genie-claw": {
+    "eligibility": {
+      "max_open_pr_threshold": 2
+    },
     "emission_share": 0.033,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "maintainer_cut": 0.3
   },
   "infiniflow/ragflow": {
     "emission_share": 0.055,


### PR DESCRIPTION
## Summary
- Add a `0.30` maintainer cut for `Geniepod/genie-claw`.
- Cap the repo's dynamic open-PR threshold at `2` via `eligibility.max_open_pr_threshold`.
- Leave `emission_share` and `issue_discovery_share` unchanged.

## Why
- Route a fixed maintainer carve-out for the existing `Geniepod/genie-claw` registry entry.
- Keep the open-PR allowance tight for this repo while retaining the rest of the eligibility defaults.

## Validation
- `jq empty gittensor/validator/weights/master_repositories.json`
- `git diff --check -- gittensor/validator/weights/master_repositories.json`
- `uv run --extra dev pytest tests/validator/test_load_weights.py -q` — 126 passed
