### PR TITLE
fix(github): match close events with normalized timestamps

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -14,6 +14,7 @@ from gittensor.constants import (
 )
 from gittensor.utils.models import PRInfo
 from gittensor.utils.utils import backoff_seconds
+from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
 
 
 class GitHubIdentityStatus(Enum):
@@ -420,8 +421,23 @@ def _select_current_close_event(issue_data: Dict[str, Any]) -> Optional[Dict[str
     if not completed_events:
         return None
 
+    closed_dt = None
+    try:
+        closed_dt = parse_github_iso_to_utc(closed_at)
+    except (TypeError, ValueError):
+        closed_dt = None
+
     for node in reversed(completed_events):
-        if node.get('createdAt') == closed_at:
+        created_at = node.get('createdAt')
+        if not created_at:
+            continue
+        if closed_dt is not None:
+            try:
+                if parse_github_iso_to_utc(created_at) == closed_dt:
+                    return node
+            except (TypeError, ValueError):
+                pass
+        if created_at == closed_at:
             return node
     return None
 

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -306,6 +306,26 @@ class TestFindSolverFromClosureEvent:
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
     @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_close_event_matches_closed_at_with_normalized_timestamps(self, mock_logging, mock_graphql):
+        """Equivalent ISO timestamps must match (Z vs +00:00)."""
+        mock_graphql.return_value = _closure_graphql_response(
+            [
+                _closed_event_pr_node(
+                    number=20,
+                    user_id=42,
+                    created_at='2025-06-15T12:00:00.000+00:00',
+                ),
+            ],
+            closed_at='2025-06-15T12:00:00Z',
+        )
+
+        solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
+
+        assert solver_id == 42
+        assert pr_number == 20
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
     def test_single_merged_pr_closing_issue(self, mock_logging, mock_graphql):
         """Single merged PR closer returns correct solver."""
         mock_graphql.return_value = _closure_graphql_response(


### PR DESCRIPTION
## Summary

Closes #1404. Match issue close events using normalized UTC timestamps from `parse_github_iso_to_utc`, not raw string equality.

## Changes

- `gittensor/utils/github_api_tools.py`: `_select_current_close_event`
- `tests/utils/test_github_api_tools.py`: regression for `Z` vs `+00:00` formats

## Test plan

- [x] `pytest tests/utils/test_github_api_tools.py -k normalized_timestamps`
