### PR TITLE
fix(issue-discovery): gate solving PRs on branch eligibility

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -206,11 +206,16 @@ class MirrorSolvingPR:
     head_sha: Optional[str]
     base_sha: Optional[str]
     merge_base_sha: Optional[str]
+    base_ref: Optional[str]
+    head_ref: Optional[str]
+    head_repo_full_name: Optional[str]
+    default_branch: Optional[str]
     review_summary: MirrorReviewSummary
     labels: List[MirrorLabel] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict) -> 'MirrorSolvingPR':
+        head_repo = data.get('head_repo_full_name')
         return cls(
             pr_number=data['pr_number'],
             author_github_id=str(data['author_github_id']),
@@ -221,6 +226,10 @@ class MirrorSolvingPR:
             head_sha=data.get('head_sha'),
             base_sha=data.get('base_sha'),
             merge_base_sha=data.get('merge_base_sha'),
+            base_ref=data.get('base_ref'),
+            head_ref=data.get('head_ref'),
+            head_repo_full_name=head_repo.lower() if head_repo else None,
+            default_branch=data.get('default_branch'),
             review_summary=MirrorReviewSummary.from_dict(data.get('review_summary') or {}),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
         )

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -55,6 +55,7 @@ from gittensor.validator.oss_contributions.label_resolution import resolve_trust
 from gittensor.validator.oss_contributions.mirror.adapters import mirror_files_to_legacy
 from gittensor.validator.oss_contributions.mirror.scoring import (
     calculate_base_score_for_pr_files,
+    check_merged_branch_eligibility,
 )
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import (
@@ -214,7 +215,7 @@ async def run_issue_discovery(
 
         pending.append((evaluation, filtered, open_counts))
 
-    canonical_pr_owners = _build_canonical_pr_owners(pending)
+    canonical_pr_owners = _build_canonical_pr_owners(pending, mirror_repos)
     for evaluation, filtered, open_counts in pending:
         complete = await _score_miner_issues(
             evaluation,
@@ -327,6 +328,7 @@ def _restore_issue_discovery_from_cache(
 
 def _build_canonical_pr_owners(
     pending: List[Tuple[MinerEvaluation, List[MirrorIssue], Dict[str, int]]],
+    mirror_repos: Dict[str, RepositoryConfig],
 ) -> Dict[Tuple[str, int], Tuple[datetime, int, int]]:
     """Cross-miner one-issue-per-PR resolution.
 
@@ -339,7 +341,7 @@ def _build_canonical_pr_owners(
     canonical: Dict[Tuple[str, int], Tuple[datetime, int, int]] = {}
     for evaluation, issues, _ in pending:
         for issue in issues:
-            if _classify_issue(issue) != 'solved':
+            if _classify_issue(issue, mirror_repos.get(issue.repo_full_name)) != 'solved':
                 continue
             sp = issue.solving_pr
             assert sp is not None  # _classify_issue guarantees a solving_pr
@@ -457,7 +459,7 @@ async def _score_miner_issues(
         cfg = resolve_eligibility(repo_config.eligibility)
         acc = repo_acc.setdefault(issue.repo_full_name, _RepoIssueAcc())
 
-        classification = _classify_issue(issue)
+        classification = _classify_issue(issue, repo_config)
         if classification == 'not-solved-closed':
             acc.closed += 1
             continue
@@ -684,12 +686,15 @@ async def _resolve_solving_pr_score(
     return cached
 
 
-def _classify_issue(issue: MirrorIssue) -> str:
+def _classify_issue(issue: MirrorIssue, repo_config: Optional[RepositoryConfig]) -> str:
     """Return 'solved', 'not-solved-closed', or 'ignore' per anti-gaming gates.
 
     'ignore' = issue is open / transferred / has no scorable meaning at all.
     'not-solved-closed' = counts against credibility (closed but not solved).
     'solved' = counts toward solved metrics.
+
+    ``repo_config`` enables the branch-eligibility gate; when None (repo not in
+    the active mirror set) the branch check is skipped.
 
     Per-issue debug logs explain each classification so operators can debug
     "why didn't UID X get credit for issue Y?" without guessing.
@@ -724,6 +729,26 @@ def _classify_issue(issue: MirrorIssue) -> str:
             f'(solving PR #{sp.pr_number} state={sp.state}, not MERGED)'
         )
         return 'not-solved-closed'
+
+    # Branch-eligibility parity with OSS PR scoring: a solving PR merged into a
+    # non-acceptable branch must not earn discovery credit (the same PR would be
+    # rejected by _should_skip_merged_mirror_pr on the contribution path).
+    # Gate only when base_ref is present: the mirror began exposing branch
+    # metadata on the inline solving_pr after this field existed, so a null
+    # base_ref means pre-backfill data and falls through rather than blocking.
+    if repo_config is not None and sp.base_ref is not None:
+        skip, reason = check_merged_branch_eligibility(
+            pr_number=sp.pr_number,
+            repo_full_name=issue.repo_full_name,
+            base_ref=sp.base_ref,
+            head_ref=sp.head_ref,
+            head_repo_full_name=sp.head_repo_full_name,
+            default_branch=sp.default_branch,
+            repo_config=repo_config,
+        )
+        if skip:
+            bt.logging.debug(f'  issue #{issue.issue_number} ({issue.repo_full_name}): closed-not-solved ({reason})')
+            return 'not-solved-closed'
 
     if sp.edited_after_merge:
         bt.logging.debug(

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -189,6 +189,42 @@ async def score_pr(
 # ============================================================================
 
 
+def check_merged_branch_eligibility(
+    *,
+    pr_number: int,
+    repo_full_name: str,
+    base_ref: Optional[str],
+    head_ref: Optional[str],
+    head_repo_full_name: Optional[str],
+    default_branch: Optional[str],
+    repo_config: RepositoryConfig,
+) -> Tuple[bool, Optional[str]]:
+    """Branch-eligibility gate for a MERGED PR, shared by OSS PR scoring and
+    issue discovery so both reject the same non-acceptable-branch merges.
+
+    Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
+    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
+    check rather than false-positive-blocking on older data.
+    """
+    additional = repo_config.additional_acceptable_branches or []
+    acceptable = [default_branch or 'main'] + additional
+
+    # base_ref check.
+    if not branch_matches_pattern(base_ref or '', acceptable):
+        return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
+
+    # head_ref check — block PRs whose source branch is itself an acceptable
+    # branch. Only applies to same-repo PRs: fork branch names are arbitrary.
+    is_same_repo = head_repo_full_name is not None and head_repo_full_name == repo_full_name
+    if acceptable and head_ref and is_same_repo and branch_matches_pattern(head_ref, acceptable):
+        return True, (
+            f'PR #{pr_number} source branch {head_ref!r} is itself in '
+            f'acceptable branches — merging between acceptable branches not allowed'
+        )
+
+    return False, None
+
+
 def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfig) -> Tuple[bool, Optional[str]]:
     """Eligibility gate for MERGED PRs.
 
@@ -227,25 +263,15 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
         if pr.review_summary.approved_count == 0:
             return True, f'PR #{pr.pr_number} self-merged without external approval'
 
-    additional = repo_config.additional_acceptable_branches or []
-    default_branch = pr.default_branch or 'main'
-    acceptable = [default_branch] + additional
-
-    # base_ref check.
-    if not branch_matches_pattern(pr.base_ref or '', acceptable):
-        return True, (f'PR #{pr.pr_number} merged to {pr.base_ref!r} not in acceptable branches={acceptable}')
-
-    # head_ref check — block PRs whose source branch is itself an acceptable
-    # branch. Only applies to same-repo PRs: fork branch names are arbitrary.
-    # Falls through when head_ref or head_repo_full_name is missing (older data).
-    is_same_repo = pr.head_repo_full_name is not None and pr.head_repo_full_name == pr.repo_full_name
-    if acceptable and pr.head_ref and is_same_repo and branch_matches_pattern(pr.head_ref, acceptable):
-        return True, (
-            f'PR #{pr.pr_number} source branch {pr.head_ref!r} is itself in '
-            f'acceptable branches — merging between acceptable branches not allowed'
-        )
-
-    return False, None
+    return check_merged_branch_eligibility(
+        pr_number=pr.pr_number,
+        repo_full_name=pr.repo_full_name,
+        base_ref=pr.base_ref,
+        head_ref=pr.head_ref,
+        head_repo_full_name=pr.head_repo_full_name,
+        default_branch=pr.default_branch,
+        repo_config=repo_config,
+    )
 
 
 # ============================================================================

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -116,6 +116,10 @@ def _issue_dict(
     created_at: str = '2026-04-01T00:00:00Z',
     author_association: str = 'CONTRIBUTOR',
     solving_pr_labels: Optional[list] = None,
+    solving_pr_base_ref: Optional[str] = None,
+    solving_pr_head_ref: Optional[str] = None,
+    solving_pr_head_repo_full_name: Optional[str] = None,
+    solving_pr_default_branch: Optional[str] = None,
 ) -> dict:
     sp = None
     if solved_by_pr:
@@ -129,6 +133,10 @@ def _issue_dict(
             'head_sha': 'h',
             'base_sha': 'b',
             'merge_base_sha': 'mb',
+            'base_ref': solving_pr_base_ref,
+            'head_ref': solving_pr_head_ref,
+            'head_repo_full_name': solving_pr_head_repo_full_name,
+            'default_branch': solving_pr_default_branch,
             'labels': solving_pr_labels or [],
             'review_summary': {'maintainer_changes_requested_count': 0},
         }
@@ -181,58 +189,88 @@ def _run(coro):
 
 
 class TestClassifyIssue:
+    _RC = RepositoryConfig(emission_share=0.5)
+
     def test_clean_completed_merged_is_solved(self):
         issue = MirrorIssue.from_dict(_issue_dict())
-        assert _classify_issue(issue) == 'solved'
+        assert _classify_issue(issue, self._RC) == 'solved'
 
     def test_transferred_ignored(self):
         issue = MirrorIssue.from_dict(_issue_dict(is_transferred=True))
-        assert _classify_issue(issue) == 'ignore'
+        assert _classify_issue(issue, self._RC) == 'ignore'
 
     def test_open_issue_ignored(self):
         issue = MirrorIssue.from_dict(_issue_dict(state='OPEN', state_reason=None, solved_by_pr=None))
-        assert _classify_issue(issue) == 'ignore'
+        assert _classify_issue(issue, self._RC) == 'ignore'
 
     def test_not_planned_counts_as_closed(self):
         issue = MirrorIssue.from_dict(_issue_dict(state_reason='NOT_PLANNED'))
-        assert _classify_issue(issue) == 'not-solved-closed'
+        assert _classify_issue(issue, self._RC) == 'not-solved-closed'
 
     def test_null_state_reason_counts_as_closed(self):
         issue = MirrorIssue.from_dict(_issue_dict(state_reason=None, solved_by_pr=None))
-        assert _classify_issue(issue) == 'not-solved-closed'
+        assert _classify_issue(issue, self._RC) == 'not-solved-closed'
 
     def test_no_solving_pr_counts_as_closed(self):
         issue = MirrorIssue.from_dict(_issue_dict(solved_by_pr=None))
-        assert _classify_issue(issue) == 'not-solved-closed'
+        assert _classify_issue(issue, self._RC) == 'not-solved-closed'
 
     def test_solving_pr_not_merged_counts_as_closed(self):
         issue = MirrorIssue.from_dict(_issue_dict(solving_pr_state='OPEN'))
-        assert _classify_issue(issue) == 'not-solved-closed'
+        assert _classify_issue(issue, self._RC) == 'not-solved-closed'
 
     def test_solving_pr_edited_after_merge_counts_as_closed(self):
         issue = MirrorIssue.from_dict(_issue_dict(solving_pr_edited_after_merge=True))
-        assert _classify_issue(issue) == 'not-solved-closed'
+        assert _classify_issue(issue, self._RC) == 'not-solved-closed'
 
     def test_issue_edited_after_solving_pr_merge_counts_as_closed(self):
         # Anti-spec-rewrite: miner can't author a vague issue, then rewrite the
         # body after a third party's PR merges to retroactively claim discovery
         # credit for a fix they didn't anticipate.
         issue = MirrorIssue.from_dict(_issue_dict(last_edited_at='2026-04-18T10:00:01Z'))
-        assert _classify_issue(issue) == 'not-solved-closed'
+        assert _classify_issue(issue, self._RC) == 'not-solved-closed'
 
     def test_issue_edited_before_solving_pr_merge_is_solved(self):
         # Pre-merge edits are legitimate (sharpening the spec while the PR is
         # being written) and must NOT trip the gate.
         issue = MirrorIssue.from_dict(_issue_dict(last_edited_at='2026-04-17T10:00:00Z'))
-        assert _classify_issue(issue) == 'solved'
+        assert _classify_issue(issue, self._RC) == 'solved'
 
     def test_issue_never_edited_is_solved(self):
         issue = MirrorIssue.from_dict(_issue_dict(last_edited_at=None))
-        assert _classify_issue(issue) == 'solved'
+        assert _classify_issue(issue, self._RC) == 'solved'
 
     def test_missing_author_ignored(self):
         issue = MirrorIssue.from_dict(_issue_dict(author_github_id=None))
-        assert _classify_issue(issue) == 'ignore'
+        assert _classify_issue(issue, self._RC) == 'ignore'
+
+    def test_solving_pr_merged_to_default_branch_is_solved(self):
+        issue = MirrorIssue.from_dict(_issue_dict(solving_pr_base_ref='main', solving_pr_default_branch='main'))
+        assert _classify_issue(issue, self._RC) == 'solved'
+
+    def test_solving_pr_merged_to_nonscoring_branch_counts_as_closed(self):
+        # Parity with OSS PR scoring: a PR merged into a branch outside the
+        # acceptable set must not earn discovery credit.
+        issue = MirrorIssue.from_dict(
+            _issue_dict(solving_pr_base_ref='scratch-do-not-score', solving_pr_default_branch='main')
+        )
+        assert _classify_issue(issue, self._RC) == 'not-solved-closed'
+
+    def test_solving_pr_merged_to_additional_acceptable_branch_is_solved(self):
+        rc = RepositoryConfig(emission_share=0.5, additional_acceptable_branches=['develop'])
+        issue = MirrorIssue.from_dict(_issue_dict(solving_pr_base_ref='develop', solving_pr_default_branch='main'))
+        assert _classify_issue(issue, rc) == 'solved'
+
+    def test_missing_base_ref_falls_through_to_solved(self):
+        # Pre-backfill mirror data has no base_ref; the gate must not block it.
+        issue = MirrorIssue.from_dict(_issue_dict(solving_pr_base_ref=None))
+        assert _classify_issue(issue, self._RC) == 'solved'
+
+    def test_none_repo_config_skips_branch_gate(self):
+        issue = MirrorIssue.from_dict(
+            _issue_dict(solving_pr_base_ref='scratch-do-not-score', solving_pr_default_branch='main')
+        )
+        assert _classify_issue(issue, None) == 'solved'
 
 
 # ============================================================================
@@ -1210,7 +1248,9 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
+        canonical = _build_canonical_pr_owners(
+            [(e_a, [a_issue], {}), (e_b, [b_issue], {})], _mirror_repos('entrius/gittensor-ui')
+        )
 
         # Earlier-created issue (#50, uid 1) wins canonical for PR 100
         owner = canonical[('entrius/gittensor-ui', 100)]
@@ -1242,7 +1282,9 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
+        canonical = _build_canonical_pr_owners(
+            [(e_a, [a_issue], {}), (e_b, [b_issue], {})], _mirror_repos('entrius/gittensor-ui')
+        )
 
         owner = canonical[('entrius/gittensor-ui', 100)]
         assert owner[1] == 50  # lower issue_number wins
@@ -1274,7 +1316,9 @@ class TestCrossMinerOneIssuePerPr:
             )
         )
 
-        canonical = _build_canonical_pr_owners([(e_a, [a_issue], {}), (e_b, [b_issue], {})])
+        canonical = _build_canonical_pr_owners(
+            [(e_a, [a_issue], {}), (e_b, [b_issue], {})], _mirror_repos('entrius/gittensor-ui')
+        )
 
         owner = canonical[('entrius/gittensor-ui', 100)]
         assert owner[1] == 51  # B's issue claims canonical


### PR DESCRIPTION
## What

Issue discovery credits an issue as solved whenever its linked PR is `MERGED`, with no check on which branch the PR merged into. OSS PR scoring already rejects PRs merged to non-acceptable branches (`_should_skip_merged_mirror_pr`). The two paths disagreed, so a miner could merge a solving PR into a throwaway branch (e.g. `scratch-do-not-score`) and still earn discovery credit for the closed issue — a reward-integrity bypass of the repo branch restrictions.

## Change

- Extract the branch-eligibility logic from `_should_skip_merged_mirror_pr` into a shared `check_merged_branch_eligibility` helper (OSS path behavior unchanged — same checks, same messages).
- Apply that helper in `_classify_issue`, so a solving PR merged outside the acceptable branch set classifies as `not-solved-closed` instead of `solved`.
- Add `base_ref`, `head_ref`, `head_repo_full_name`, `default_branch` to `MirrorSolvingPR` so the gate has the branch metadata to read.

## Deploy ordering

The gate only fires when the solving PR carries `base_ref`. The mirror starts exposing branch metadata on the inline `solving_pr` in entrius/das-github-mirror#131; until that lands, `base_ref` is null and the gate falls through, scoring as before. So this is safe to deploy independently of, or before, the mirror change — the gate activates automatically once the mirror sends the field. Pairs with das-github-mirror#131 (addresses das-github-mirror#130).

## Tests

Added `_classify_issue` cases for default-branch (solved), non-scoring branch (not-solved-closed), additional-acceptable-branch (solved), missing `base_ref` fall-through (solved), and `None` repo_config (gate skipped). Full suite: 886 passed.