### PR TITLE
Tune `we-promise/sure` repo scoring parameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -166,6 +166,11 @@
   },
   "we-promise/sure": {
     "emission_share": 0.03,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "performance": 1.5,
+      "mobile/Flutter": 1.2
+    },
+    "maintainer_cut": 0.3
   }
 }


### PR DESCRIPTION
## Summary
- Tune the `we-promise/sure` repo scoring parameters for performance and mobile-oriented contributions.
- Just learning how things work with Gittensor, set up a PAT and looking for people truly interested in open source.