### PR TITLE
Add e35ventura/taopedia and e35ventura/taopedia-articles to master repository list

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,8 +7,18 @@
     "emission_share": 0.01,
     "issue_discovery_share": 0.0
   },
+  "e35ventura/taopedia": {
+    "emission_share": 0.025,
+    "issue_discovery_share": 0.0,
+    "maintainer_cut": 0.0
+  },
+  "e35ventura/taopedia-articles": {
+    "emission_share": 0.025,
+    "issue_discovery_share": 0.0,
+    "maintainer_cut": 0.0
+  },
   "entrius/allways": {
-    "emission_share": 0.05018,
+    "emission_share": 0.05,
     "issue_discovery_share": 1.0,
     "label_multipliers": {
       "bug": 1.25,
@@ -19,7 +29,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/das-github-mirror": {
-    "emission_share": 0.006,
+    "emission_share": 0.005,
     "issue_discovery_share": 0.5,
     "label_multipliers": {
       "bug": 1.25,
@@ -30,7 +40,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.10127,
+    "emission_share": 0.1,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,


### PR DESCRIPTION
Adds two repos with default config:

- `e35ventura/taopedia` — https://github.com/e35ventura/taopedia — emission_share 0.025
- `e35ventura/taopedia-articles` — https://github.com/e35ventura/taopedia-articles — emission_share 0.025