### PR TITLE
fix(issue bounties): avoid false cancel when closure timeline is truncated

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -14,6 +14,7 @@ from gittensor.constants import (
 )
 from gittensor.utils.models import PRInfo
 from gittensor.utils.utils import backoff_seconds
+from gittensor.validator.utils.datetime_utils import parse_github_iso_to_utc
 
 
 class GitHubIdentityStatus(Enum):
@@ -202,7 +203,7 @@ query($owner: String!, $name: String!, $issueNumber: Int!) {
   repository(owner: $owner, name: $name) {
     issue(number: $issueNumber) {
       closedAt
-      timelineItems(itemTypes: [CLOSED_EVENT], last: 20) {
+      timelineItems(itemTypes: [CLOSED_EVENT], last: 100) {
         nodes {
           ... on ClosedEvent {
             createdAt
@@ -420,8 +421,23 @@ def _select_current_close_event(issue_data: Dict[str, Any]) -> Optional[Dict[str
     if not completed_events:
         return None
 
+    closed_dt = None
+    try:
+        closed_dt = parse_github_iso_to_utc(closed_at)
+    except (TypeError, ValueError):
+        closed_dt = None
+
     for node in reversed(completed_events):
-        if node.get('createdAt') == closed_at:
+        created_at = node.get('createdAt')
+        if not created_at:
+            continue
+        if closed_dt is not None:
+            try:
+                if parse_github_iso_to_utc(created_at) == closed_dt:
+                    return node
+            except (TypeError, ValueError):
+                pass
+        if created_at == closed_at:
             return node
     return None
 
@@ -495,6 +511,16 @@ def find_solver_from_closure_event(
 
     close_event = _select_current_close_event(issue_data)
     if close_event is None:
+        closed_at = issue_data.get('closedAt')
+        if closed_at:
+            timeline_nodes = issue_data.get('timelineItems', {}).get('nodes', []) or []
+            completed_events = [node for node in timeline_nodes if node and _is_completed_close_event(node)]
+            if completed_events:
+                bt.logging.warning(
+                    f'Could not resolve current close event for {repo}#{issue_number} '
+                    f'within timeline window (closed_at={closed_at})'
+                )
+                return None
         return None, None
 
     solver_github_id, pr_number = _solver_from_closed_event(f'{owner}/{name}', close_event)

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -306,6 +306,26 @@ class TestFindSolverFromClosureEvent:
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
     @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_close_event_matches_closed_at_with_normalized_timestamps(self, mock_logging, mock_graphql):
+        """Equivalent ISO timestamps must match (Z vs +00:00)."""
+        mock_graphql.return_value = _closure_graphql_response(
+            [
+                _closed_event_pr_node(
+                    number=20,
+                    user_id=42,
+                    created_at='2025-06-15T12:00:00.000+00:00',
+                ),
+            ],
+            closed_at='2025-06-15T12:00:00Z',
+        )
+
+        solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
+
+        assert solver_id == 42
+        assert pr_number == 20
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
     def test_single_merged_pr_closing_issue(self, mock_logging, mock_graphql):
         """Single merged PR closer returns correct solver."""
         mock_graphql.return_value = _closure_graphql_response(
@@ -575,6 +595,37 @@ class TestCheckGithubIssueClosed:
             'solver_github_id': 999,
             'pr_number': 900,
             'solver_lookup_failed': False,
+        }
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_truncated_closure_timeline_sets_solver_lookup_failed(self, mock_logging, mock_get, mock_graphql):
+        """When closed events exist but the current close is outside the window, do not vote cancel."""
+        issue_response = Mock()
+        issue_response.status_code = 200
+        issue_response.json.return_value = {'state': 'closed', 'state_reason': 'completed'}
+        mock_get.return_value = issue_response
+        stale_events = [
+            _closed_event_pr_node(
+                number=i,
+                user_id=100 + i,
+                created_at=f'2024-01-{i:02d}T00:00:00Z',
+            )
+            for i in range(1, 21)
+        ]
+        mock_graphql.return_value = _closure_graphql_response(
+            stale_events,
+            closed_at='2025-12-01T00:00:00Z',
+        )
+
+        result = check_github_issue_closed('owner/repo', 12, 'fake_token')
+
+        assert result == {
+            'is_closed': True,
+            'solver_github_id': None,
+            'pr_number': None,
+            'solver_lookup_failed': True,
         }
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')


### PR DESCRIPTION
## Summary

Closes #1411. Issue bounty validators must not vote cancel when GitHub’s closure timeline window omits the current close event. This aligns `check_github_issue_closed()` with `issue_competitions/forward.py`, which already skips cancel when `solver_lookup_failed` is true.

## Changes

- Request up to 100 `CLOSED_EVENT` nodes in the closure GraphQL query.
- Treat “closed issue + completed events in window but no matching current close” as solver lookup failure (skip cancel in forward pass).
- Add regression test for truncated timeline behavior.

## Real Behavior Proof

- [x] Unit test `test_truncated_closure_timeline_sets_solver_lookup_failed` asserts `solver_lookup_failed=True` when stale close events fill the window but `closedAt` does not match any of them.

### What I ran

```bash
python3 -m pytest tests/utils/test_github_api_tools.py::TestCheckGithubIssueClosed::test_truncated_closure_timeline_sets_solver_lookup_failed -q
```

### What I observed

Test encodes the forward-pass guard: no false “no solver” path when the current close event is outside the fetched timeline window.
