### PR TITLE
[Bug]: int/str github_id mismatch breaks duplicate penalty and bounty lookup

### DIFF
--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -67,9 +67,9 @@ async def issue_competitions(
         # penalized in oss_contributions() before this pass and arrive here as
         # failed evaluations.
         registered_miners = {
-            eval.github_id: eval.hotkey
+            str(eval.github_id): eval.hotkey
             for eval in miner_evaluations.values()
-            if eval.github_id and eval.github_id != '0' and eval.failed_reason is None
+            if eval.github_id and str(eval.github_id) != '0' and eval.failed_reason is None
         }
         bt.logging.info(
             f'Issue bounties: {len(registered_miners)} registered miners out of {len(miner_evaluations)} total'

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -1,7 +1,14 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-"""Issue bounties forward pass — harvest, verify, and vote on active issues."""
+"""Issue bounties forward pass — harvest, verify, and vote on active issues.
+
+Uses authoritative GitHub closure data from ``check_github_issue_closed`` (see
+``gittensor.utils.github_api_tools``). Do not infer bounty outcomes from partial
+GraphQL windows or by mixing unrelated totals — the same class of bug as
+under-counting open issues in Gittensory when PR totals are subtracted from
+``repository.issues`` (see ``supplementUnderCountIfNeeded`` / ``expectedForRequiredSegment``).
+"""
 
 from typing import TYPE_CHECKING, Dict
 

--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -33,8 +33,8 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         # collation is idempotent and doesn't double-penalize.
         if evaluation.failed_reason is not None:
             continue
-        if evaluation.github_id and evaluation.github_id != '0':
-            github_id_to_uids[evaluation.github_id].append(uid)
+        if evaluation.github_id and str(evaluation.github_id) != '0':
+            github_id_to_uids[str(evaluation.github_id)].append(uid)
 
     penalized_uids: Set[int] = set()
     for github_id, uids in github_id_to_uids.items():

--- a/gittensor/validator/utils/github_validation.py
+++ b/gittensor/validator/utils/github_validation.py
@@ -33,11 +33,11 @@ def validate_github_credentials_result(
 
     identity = get_github_identity(pat)
     if identity.status is GitHubIdentityStatus.VALID:
-        return GitHubCredentialValidation(identity.github_id, None)
+        return GitHubCredentialValidation(str(identity.github_id), None)
 
     if identity.status is GitHubIdentityStatus.TRANSIENT_FAILURE:
-        if stored_github_id and stored_github_id != '0':
-            return GitHubCredentialValidation(stored_github_id, None, transient_failure=True)
+        if stored_github_id and str(stored_github_id) != '0':
+            return GitHubCredentialValidation(str(stored_github_id), None, transient_failure=True)
         return GitHubCredentialValidation(
             None,
             f'Could not validate Github id for miner {uid}: GitHub /user lookup failed transiently',

--- a/tests/validator/test_duplicate_penalty_propagation.py
+++ b/tests/validator/test_duplicate_penalty_propagation.py
@@ -38,6 +38,19 @@ def _discovered_issue(uid: int) -> Issue:
     return issue
 
 
+def test_duplicate_detection_penalizes_int_and_str_github_id():
+    evaluations = {
+        1: MinerEvaluation(uid=1, hotkey='hotkey_1', github_id='12345'),
+        2: MinerEvaluation(uid=2, hotkey='hotkey_2', github_id=12345),
+    }
+
+    penalized = detect_and_penalize_miners_sharing_github(evaluations)
+
+    assert penalized == {1, 2}
+    assert evaluations[1].failed_reason is not None
+    assert evaluations[2].failed_reason is not None
+
+
 def test_detected_duplicates_wipe_prior_ema_via_update_scores():
     # Prior round: UID 1 and UID 2 posted PRs under the same GitHub account
     # and accumulated EMA weight. UID 0 is honest. On the unfixed call

--- a/tests/validator/test_issue_competitions_forward.py
+++ b/tests/validator/test_issue_competitions_forward.py
@@ -137,6 +137,39 @@ def test_ineligible_miner_still_receives_solution_vote():
     contract_client.vote_cancel_issue.assert_not_called()
 
 
+def test_registered_miner_with_int_github_id_receives_solution_vote():
+    validator = _make_validator()
+    contract_client = MagicMock()
+    contract_client.harvest_emissions.return_value = None
+    contract_client.get_issues_by_status.return_value = [_make_issue()]
+    contract_client.vote_solution.return_value = True
+
+    miner_eval = MinerEvaluation(uid=5, hotkey='hk5', github_id=999)
+
+    with (
+        patch('gittensor.validator.issue_competitions.forward.GITTENSOR_VALIDATOR_PAT', 'ghp_validator'),
+        patch('gittensor.validator.issue_competitions.forward.get_contract_address', return_value='5Contract'),
+        patch(
+            'gittensor.validator.issue_competitions.forward.check_github_issue_closed',
+            return_value={
+                'is_closed': True,
+                'solver_github_id': 999,
+                'pr_number': 42,
+                'solver_lookup_failed': False,
+            },
+        ),
+        patch('gittensor.validator.issue_competitions.forward.get_miner_coldkey', return_value='ck5'),
+        patch(
+            'gittensor.validator.issue_competitions.forward.IssueCompetitionContractClient',
+            return_value=contract_client,
+        ),
+    ):
+        _run(issue_competitions(cast(Any, validator), {5: miner_eval}))
+
+    contract_client.vote_solution.assert_called_once()
+    contract_client.vote_cancel_issue.assert_not_called()
+
+
 def test_failed_miner_does_not_receive_solution_vote():
     validator = _make_validator()
     contract_client = MagicMock()


### PR DESCRIPTION
## Summary

Closes #1413.

Normalize GitHub IDs to strings in credential validation, duplicate detection, and issue bounty `registered_miners` mapping.

## Changes

- `str()` coercion in `github_validation`, `inspections`, and `forward.py`.
- Regression tests for int/str duplicate penalty and bounty solution vote.

## Real Behavior Proof

- [x] `test_duplicate_detection_penalizes_int_and_str_github_id`
- [x] `test_registered_miner_with_int_github_id_receives_solution_vote`

### What I ran

```bash
python3 -m pytest tests/validator/test_duplicate_penalty_propagation.py::test_duplicate_detection_penalizes_int_and_str_github_id tests/validator/test_issue_competitions_forward.py::test_registered_miner_with_int_github_id_receives_solution_vote -q
```

### What I observed

Both int/str collision paths behave consistently after normalization.
