### PR TITLE
chore(weights): tune awesome-claude reward labels

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -93,12 +93,14 @@
     "issue_discovery_share": 0.0
   },
   "JSONbored/awesome-claude": {
+    "default_label_multiplier": 0.0,
     "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "feature": 1.5,
-      "bug": 1.1
+      "gittensor:feature": 1.0,
+      "gittensor:priority": 1.5
     },
+    "maintainer_cut": 0.3,
     "scoring": {
       "pr_lookback_days": 45,
       "open_pr_collateral_percent": 0.15,


### PR DESCRIPTION
## Summary
- Sets the Awesome Claude maintainer cut to 30%.
- Changes unmatched labels to a zero default multiplier.
- Replaces broad generic feature/bug reward labels with explicit Gittensor focus labels.

## What changed
- Added `default_label_multiplier: 0.0` for `JSONbored/awesome-claude`.
- Added `maintainer_cut: 0.3`.
- Replaced broad `feature` and `bug` multipliers with `gittensor:feature` and `gittensor:priority`.

## Why
- Keeps normal GitHub triage labels separate from Gittensor reward routing.
- Gives contributors clear positive labels to target while preventing unrelated PRs from receiving reward weight by default.

## Validation
- `uv run python` config load and label resolution smoke check.
- `uv run --with pytest pytest tests/validator/test_load_weights.py -q` passed: 137 tests.
- `git diff --check`.
