### PR TITLE
fix: normalize github_id to str, prevent false cancel votes on truncated timelines

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -426,7 +426,7 @@ def _select_current_close_event(issue_data: Dict[str, Any]) -> Optional[Dict[str
     return None
 
 
-def _solver_from_closed_event(repo: str, event: Dict[str, Any]) -> tuple[Optional[int], Optional[int]]:
+def _solver_from_closed_event(repo: str, event: Dict[str, Any]) -> tuple[Optional[str], Optional[int]]:
     target_repo = repo.lower()
     closer = event.get('closer') or {}
     if closer.get('__typename') != 'PullRequest':
@@ -445,12 +445,17 @@ def _solver_from_closed_event(repo: str, event: Dict[str, Any]) -> tuple[Optiona
         return None, None
 
     author = closer.get('author') or {}
-    return author.get('databaseId'), closer.get('number')
+    raw_id = author.get('databaseId')
+    # Normalize to str so dict lookups against registered_miners (whose keys
+    # come from get_github_identity -> str) always match regardless of the
+    # JSON int/str ambiguity.  See entrius/gittensor#1413.
+    github_id = str(raw_id) if raw_id is not None else None
+    return github_id, closer.get('number')
 
 
 def find_solver_from_closure_event(
     repo: str, issue_number: int, token: str
-) -> Optional[tuple[Optional[int], Optional[int]]]:
+) -> Optional[tuple[Optional[str], Optional[int]]]:
     """Resolve the issue solver from GitHub's authoritative current close event.
 
     Cross-reference and ``closingIssuesReferences`` entries are declarations made
@@ -495,6 +500,24 @@ def find_solver_from_closure_event(
 
     close_event = _select_current_close_event(issue_data)
     if close_event is None:
+        # When the issue is closed (has closedAt) but we couldn't find the
+        # matching close event, the lookup may be indeterminate due to
+        # timeline truncation.  Return None (lookup failure) when there are
+        # completed close events in the timeline but none match closedAt
+        # (suggesting the authoritative event fell outside the window),
+        # so callers skip cancel votes on legitimately solved issues.
+        # See entrius/gittensor#1411.
+        closed_at = issue_data.get('closedAt')
+        if closed_at:
+            timeline_nodes = issue_data.get('timelineItems', {}).get('nodes', []) or []
+            has_completed = any(n and _is_completed_close_event(n) for n in timeline_nodes)
+            if has_completed:
+                # Completed events exist but none match closedAt — likely truncated
+                bt.logging.warning(
+                    f'Issue {repo}#{issue_number} has closedAt={closed_at} with '
+                    f'completed close events but none match (timeline possibly truncated)'
+                )
+                return None
         return None, None
 
     solver_github_id, pr_number = _solver_from_closed_event(f'{owner}/{name}', close_event)

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -66,8 +66,11 @@ async def issue_competitions(
         # evaluations are not valid payout targets. Duplicate GitHub IDs are
         # penalized in oss_contributions() before this pass and arrive here as
         # failed evaluations.
+        #
+        # Keys are normalized to str so lookups against solver_github_id
+        # (which may arrive as int from GraphQL) always match.  See #1413.
         registered_miners = {
-            eval.github_id: eval.hotkey
+            str(eval.github_id): eval.hotkey
             for eval in miner_evaluations.values()
             if eval.github_id and eval.github_id != '0' and eval.failed_reason is None
         }

--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -34,7 +34,9 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         if evaluation.failed_reason is not None:
             continue
         if evaluation.github_id and evaluation.github_id != '0':
-            github_id_to_uids[evaluation.github_id].append(uid)
+            # Normalize to str so duplicate detection works regardless of
+            # whether github_id was stored as int or str.  See #1413.
+            github_id_to_uids[str(evaluation.github_id)].append(uid)
 
     penalized_uids: Set[int] = set()
     for github_id, uids in github_id_to_uids.items():

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -316,7 +316,7 @@ class TestFindSolverFromClosureEvent:
 
         solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
 
-        assert solver_id == 42
+        assert solver_id == "42"
         assert pr_number == 14
         query = mock_graphql.call_args.kwargs['query']
         assert 'CLOSED_EVENT' in query
@@ -394,7 +394,7 @@ class TestFindSolverFromClosureEvent:
 
         solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
 
-        assert solver_id == 42
+        assert solver_id == "42"
         assert pr_number == 14
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
@@ -421,7 +421,7 @@ class TestFindSolverFromClosureEvent:
 
         solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
 
-        assert solver_id == 200
+        assert solver_id == "200"
         assert pr_number == 20
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
@@ -462,7 +462,7 @@ class TestFindSolverFromClosureEvent:
 
         solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
 
-        assert solver_id == 42
+        assert solver_id == "42"
         assert pr_number == 14
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
@@ -477,7 +477,7 @@ class TestFindSolverFromClosureEvent:
 
         solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
 
-        assert solver_id == 42
+        assert solver_id == "42"
         assert pr_number == 14
 
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
@@ -572,7 +572,7 @@ class TestCheckGithubIssueClosed:
 
         assert result == {
             'is_closed': True,
-            'solver_github_id': 999,
+            'solver_github_id': '999',
             'pr_number': 900,
             'solver_lookup_failed': False,
         }


### PR DESCRIPTION
## Summary

Normalizes `github_id` / `solver_github_id` to `str` at all boundaries to prevent int/str dict key mismatches, and returns a lookup-failure sentinel when a closed issue's authoritative close event is missing from the (possibly truncated) timeline.

Fixes #1413  
Fixes #1411

## Changes

### Bug #1413 — int/str github_id mismatch

**Root cause:** `_solver_from_closed_event()` returns `databaseId` directly from GraphQL as `int`, while `registered_miners` keys come from `get_github_identity()` → `str(user_id)`. Even though `forward.py` line 132 wraps the lookup in `str()`, the inconsistency is fragile and breaks duplicate detection in `inspections.py`.

**Fix:**
- `github_api_tools._solver_from_closed_event` — normalize `databaseId` to `str` at the source; update return type from `tuple[Optional[int], ...]` to `tuple[Optional[str], ...]`
- `forward.py` — `str()` normalize `registered_miners` dict keys  
- `inspections.py` — `str()` normalize `github_id_to_uids` dict keys

### Bug #1411 — false cancel votes on truncated timelines

**Root cause:** `_ISSUE_CLOSURE_QUERY` fetches only the last 20 `CLOSED_EVENT` nodes. On high-churn issues the current close event can fall outside that window. `_select_current_close_event` then returns `None`, `find_solver_from_closure_event` returns `(None, None)` (not a failure sentinel), and `forward.py` votes cancel on a legitimately solved bounty.

**Fix:** In `find_solver_from_closure_event`, when `close_event is None` but `closedAt` is set and completed close events exist in the timeline (meaning the authoritative event was truncated), return `None` (lookup failure) instead of `(None, None)`. This causes `forward.py` to skip the issue rather than cancel it.

## Testing

- All 34 tests in `tests/utils/test_github_api_tools.py` pass (updated 6 assertions from int to str)
- All 4 tests in `tests/validator/test_issue_competitions_forward.py` pass
- All 561 tests in `tests/validator/` pass