### PR TITLE
Normalize GitHub IDs for miner matching

### DIFF
--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -67,7 +67,7 @@ async def issue_competitions(
         # penalized in oss_contributions() before this pass and arrive here as
         # failed evaluations.
         registered_miners = {
-            eval.github_id: eval.hotkey
+            str(eval.github_id): eval.hotkey
             for eval in miner_evaluations.values()
             if eval.github_id and eval.github_id != '0' and eval.failed_reason is None
         }

--- a/gittensor/validator/oss_contributions/inspections.py
+++ b/gittensor/validator/oss_contributions/inspections.py
@@ -34,7 +34,7 @@ def detect_and_penalize_miners_sharing_github(miner_evaluations: Dict[int, Miner
         if evaluation.failed_reason is not None:
             continue
         if evaluation.github_id and evaluation.github_id != '0':
-            github_id_to_uids[evaluation.github_id].append(uid)
+            github_id_to_uids[str(evaluation.github_id)].append(uid)
 
     penalized_uids: Set[int] = set()
     for github_id, uids in github_id_to_uids.items():

--- a/tests/validator/test_github_id_normalization.py
+++ b/tests/validator/test_github_id_normalization.py
@@ -1,0 +1,17 @@
+from gittensor.classes import MinerEvaluation
+from gittensor.validator.oss_contributions.inspections import detect_and_penalize_miners_sharing_github
+
+
+def test_duplicate_penalty_normalizes_github_id_types():
+    evaluations = {
+        1: MinerEvaluation(uid=1, hotkey='hotkey_1', github_id='12345'),
+        2: MinerEvaluation(uid=2, hotkey='hotkey_2', github_id=12345),
+        3: MinerEvaluation(uid=3, hotkey='hotkey_3', github_id='67890'),
+    }
+
+    penalized_uids = detect_and_penalize_miners_sharing_github(evaluations)
+
+    assert penalized_uids == {1, 2}
+    assert evaluations[1].failed_reason is not None
+    assert evaluations[2].failed_reason is not None
+    assert evaluations[3].failed_reason is None

--- a/tests/validator/test_issue_competitions_forward.py
+++ b/tests/validator/test_issue_competitions_forward.py
@@ -137,6 +137,39 @@ def test_ineligible_miner_still_receives_solution_vote():
     contract_client.vote_cancel_issue.assert_not_called()
 
 
+def test_int_github_id_miner_receives_solution_vote():
+    validator = _make_validator()
+    contract_client = MagicMock()
+    contract_client.harvest_emissions.return_value = None
+    contract_client.get_issues_by_status.return_value = [_make_issue()]
+    contract_client.vote_solution.return_value = True
+
+    miner_eval = MinerEvaluation(uid=5, hotkey='hk5', github_id=999)
+
+    with (
+        patch('gittensor.validator.issue_competitions.forward.GITTENSOR_VALIDATOR_PAT', 'ghp_validator'),
+        patch('gittensor.validator.issue_competitions.forward.get_contract_address', return_value='5Contract'),
+        patch(
+            'gittensor.validator.issue_competitions.forward.check_github_issue_closed',
+            return_value={
+                'is_closed': True,
+                'solver_github_id': '999',
+                'pr_number': 42,
+                'solver_lookup_failed': False,
+            },
+        ),
+        patch('gittensor.validator.issue_competitions.forward.get_miner_coldkey', return_value='ck5'),
+        patch(
+            'gittensor.validator.issue_competitions.forward.IssueCompetitionContractClient',
+            return_value=contract_client,
+        ),
+    ):
+        _run(issue_competitions(cast(Any, validator), {5: miner_eval}))
+
+    contract_client.vote_solution.assert_called_once()
+    contract_client.vote_cancel_issue.assert_not_called()
+
+
 def test_failed_miner_does_not_receive_solution_vote():
     validator = _make_validator()
     contract_client = MagicMock()


### PR DESCRIPTION
## Summary
- Normalize miner GitHub IDs to strings when building duplicate-detection buckets.
- Normalize issue-bounty registered miner lookup keys so int and string IDs match consistently.
- Add regressions for mixed int/string duplicate detection and bounty solver lookup.

Fixes #1413

## Tests
- PYTHONPATH=C:\\Users\\49159\\money-engine\\test_stubs;C:\\Users\\49159\\money-engine\\bounties\\gittensor .\\.venv\\Scripts\\python -m pytest tests\\validator\\test_github_id_normalization.py tests\\validator\\test_issue_competitions_forward.py::test_int_github_id_miner_receives_solution_vote -q
- .\\.venv\\Scripts\\python -m ruff check gittensor\\validator\\oss_contributions\\inspections.py gittensor\\validator\\issue_competitions\\forward.py tests\\validator\\test_github_id_normalization.py tests\\validator\\test_issue_competitions_forward.py

Note: full dependency install on this Windows host failed because bittensor native dependencies require the MSVC linker (link.exe), so the focused tests were run with a minimal import stub for external bittensor modules.