### PR TITLE
Update Taopedia article reward parameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -15,7 +15,21 @@
   "e35ventura/taopedia-articles": {
     "emission_share": 0.025,
     "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.0
+    "maintainer_cut": 0.0,
+    "additional_acceptable_branches": ["test"],
+    "trusted_label_pipeline": true,
+    "default_label_multiplier": 0.0,
+    "label_multipliers": {
+      "article": 1.0,
+      "correction": 1.25,
+      "image": 0.75,
+      "category": 0.5,
+      "other": 0.1
+    },
+    "eligibility": {
+      "min_credibility": 0.5,
+      "min_token_score_for_valid_issue": 0.0
+    }
   },
   "entrius/allways": {
     "emission_share": 0.05,


### PR DESCRIPTION
Configures Taopedia article rewards around the new trusted maintainer label pipeline.\n\nChanges for `e35ventura/taopedia-articles`:\n- count merged PRs into `test`\n- enable `trusted_label_pipeline`\n- set unlabeled/default multiplier to `0`\n- add article label multipliers\n- lower minimum credibility to `0.5`\n- set `min_token_score_for_valid_issue` to `0.0`\n\nValidation:\n- `uv run --extra dev pytest tests/validator/test_load_weights.py tests/validator/test_eligibility_resolver.py`