### PR TITLE
fix(classes): normalize MinerEvaluation github_id to str to prevent dict key mismatch

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -282,6 +282,10 @@ class MinerEvaluation:
     mirror_pr_fetch_failed: bool = False
     evaluation_timestamp: Optional[datetime] = None
 
+    def __post_init__(self):
+        if self.github_id is not None:
+            self.github_id = str(self.github_id)
+
     # Populated by gittensor.validator.oss_contributions.mirror.combine.combine.
     merged_prs: List['ScoredPR'] = field(default_factory=list)
     open_prs: List['ScoredPR'] = field(default_factory=list)


### PR DESCRIPTION
## Description

This PR addresses the issue raised in #1413 where a mismatch between `int` and `str` types for `github_id` causes identity splitting, duplicate false positives, or denied bounty payouts during dictionary key lookups.

### Changes Made:
- Added a `__post_init__` hook to the `MinerEvaluation` dataclass.
- Ensured that if a `github_id` is passed as an `int`, it is immediately cast to a `str` during initialization. This guarantees type consistency (`str`) across all validation and scoring pipelines, solving the `dict` key mismatch.

## Related Issues
Closes #1413

---
*Payout Address (Solana):* `6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp`