### PR TITLE
fix(github_id): Normalize github_id to string

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -171,7 +171,7 @@ def build_maintainer_uids_by_repo(
                 )
                 continue
             uids = sorted(
-                {github_id_to_uid[m.github_id] for m in response.maintainers if m.github_id in github_id_to_uid}
+                {github_id_to_uid[str(m.github_id)] for m in response.maintainers if str(m.github_id) in github_id_to_uid}
             )
             if uids:
                 result[repo_name] = uids

--- a/gittensor/validator/issue_competitions/forward.py
+++ b/gittensor/validator/issue_competitions/forward.py
@@ -67,9 +67,9 @@ async def issue_competitions(
         # penalized in oss_contributions() before this pass and arrive here as
         # failed evaluations.
         registered_miners = {
-            eval.github_id: eval.hotkey
+            str(eval.github_id): eval.hotkey
             for eval in miner_evaluations.values()
-            if eval.github_id and eval.github_id != '0' and eval.failed_reason is None
+            if eval.github_id and str(eval.github_id) != '0' and eval.failed_reason is None
         }
         bt.logging.info(
             f'Issue bounties: {len(registered_miners)} registered miners out of {len(miner_evaluations)} total'

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -188,7 +188,7 @@ async def run_issue_discovery(
 
         try:
             response = await asyncio.to_thread(
-                client.get_miner_issues, evaluation.github_id, since_by_repo=since_by_repo
+                client.get_miner_issues, str(evaluation.github_id), since_by_repo=since_by_repo
             )
         except MirrorRequestError as e:
             bt.logging.warning(f'├─ UID {uid}: issue fetch failed ({e}) — skipped this miner')
@@ -197,7 +197,7 @@ async def run_issue_discovery(
             continue
 
         try:
-            current_response = await asyncio.to_thread(client.get_miner_issues, evaluation.github_id)
+            current_response = await asyncio.to_thread(client.get_miner_issues, str(evaluation.github_id))
         except MirrorRequestError as e:
             open_counts = _fallback_open_issue_counts(evaluation, evaluation_cache, response.issues, enabled_names)
             bt.logging.warning(f'├─ UID {uid}: open-issue count fetch failed ({e}) — using fallback open counts')
@@ -312,7 +312,7 @@ def _restore_issue_discovery_from_cache(
     if evaluation_cache is None:
         return False
 
-    cached = evaluation_cache.get(evaluation.uid, evaluation.hotkey, evaluation.github_id or '')
+    cached = evaluation_cache.get(evaluation.uid, evaluation.hotkey, str(evaluation.github_id) or '')
     if cached is None:
         bt.logging.warning(f'├─ UID {evaluation.uid}: no cached issue-discovery evaluation available')
         return False
@@ -345,7 +345,7 @@ def _build_canonical_pr_owners(
                 continue
             sp = issue.solving_pr
             assert sp is not None  # _classify_issue guarantees a solving_pr
-            if issue.author_github_id == sp.author_github_id:
+            if str(issue.author_github_id) == str(sp.author_github_id):
                 continue
             key = (issue.repo_full_name, sp.pr_number)
             marker = (issue.created_at or _FAR_FUTURE, issue.issue_number, evaluation.uid)
@@ -379,7 +379,7 @@ def _fallback_open_issue_counts(
     """
     cached = None
     if evaluation_cache is not None:
-        cached = evaluation_cache.get(evaluation.uid, evaluation.hotkey, evaluation.github_id or '')
+        cached = evaluation_cache.get(evaluation.uid, evaluation.hotkey, str(evaluation.github_id) or '')
 
     if cached is not None:
         counts = {

--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -60,7 +60,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     # 3. Enforce GitHub identity pinning — same hotkey cannot switch GitHub accounts
     existing = pat_storage.get_pat_by_uid(uid)
     if existing and existing.get('hotkey') == hotkey and existing.get('github_id'):
-        if existing['github_id'] != github_id:
+        if existing['github_id'] != str(github_id):
             return _reject(
                 'GitHub identity is locked for this hotkey. Deregister and re-register to change GitHub accounts.'
             )
@@ -71,7 +71,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
         return _reject(f'PAT test query failed: {test_error}')
 
     # 5. Store PAT (github_id guaranteed non-None after validate_github_credentials success)
-    pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=github_id or '0')
+    pat_storage.save_pat(uid=uid, hotkey=hotkey, pat=synapse.github_access_token, github_id=str(github_id) or '0')
 
     # Clear PAT from response so it isn't echoed back
     synapse.github_access_token = ''
@@ -121,7 +121,7 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
     synapse.has_pat = True
 
     # Re-validate the stored PAT
-    validation = validate_github_credentials_result(uid, entry['pat'], stored_github_id=entry.get('github_id'))
+    validation = validate_github_credentials_result(uid, entry['pat'], stored_github_id=str(entry.get('github_id')))
     if validation.transient_failure:
         synapse.pat_valid = None
         synapse.rejection_reason = 'GitHub API temporarily unavailable; retry the check in a few minutes.'

--- a/gittensor/validator/pat_storage.py
+++ b/gittensor/validator/pat_storage.py
@@ -20,6 +20,17 @@ PATS_FILE = Path(__file__).resolve().parents[2] / 'data' / 'miner_pats.json'
 _lock = threading.Lock()
 
 
+def _normalize_github_id(github_id) -> str:
+    return str(github_id)
+
+
+def _normalize_entry(entry: dict) -> dict:
+    github_id = entry.get('github_id')
+    if github_id is not None:
+        entry = {**entry, 'github_id': _normalize_github_id(github_id)}
+    return entry
+
+
 def ensure_pats_file() -> None:
     """Create the PATs file with an empty list if it doesn't exist. Called on validator boot."""
     with _lock:
@@ -42,7 +53,7 @@ def save_pat(uid: int, hotkey: str, pat: str, github_id: str) -> None:
             'uid': uid,
             'hotkey': hotkey,
             'pat': pat,
-            'github_id': github_id,
+            'github_id': _normalize_github_id(github_id),
             'stored_at': datetime.now(timezone.utc).isoformat(),
         }
 
@@ -61,7 +72,7 @@ def get_pat_by_uid(uid: int) -> Optional[dict]:
     with _lock:
         for entry in _read_file():
             if entry.get('uid') == uid:
-                return entry
+                return _normalize_entry(entry)
         return None
 
 
@@ -70,7 +81,7 @@ def _read_file() -> list[dict]:
     if not PATS_FILE.exists():
         return []
     try:
-        return json.loads(PATS_FILE.read_text())
+        return [_normalize_entry(e) for e in json.loads(PATS_FILE.read_text())]
     except (json.JSONDecodeError, OSError):
         return []
 

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -1,5 +1,15 @@
 # Storage Queries - Only SET/INSERT operations for writing data
 
+from typing import Any, Optional
+
+
+def normalize_github_id(github_id: Any) -> Optional[str]:
+    """Cast github_id to str for SQL parameters, dict keys, and comparisons."""
+    if github_id is None:
+        return None
+    return str(github_id)
+
+
 # Cleanup Queries - Remove stale data when a miner re-registers on a new uid/hotkey
 CLEANUP_STALE_MINER_EVALUATIONS = """
 DELETE FROM miner_evaluations


### PR DESCRIPTION
This PR fixes a bug where github_id was being treated as both an int and a string, leading to inconsistencies. This PR normalizes all github_id values to strings to ensure consistent behavior. I was unable to run the tests locally due to a Python version mismatch (my environment is 3.11.2, but the project requires >=3.12). However, I am confident that these changes are correct as they are simple type normalizations.