### PR TITLE
[Bug]: REST closed issues without state_reason skip GraphQL solver lookup

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -534,16 +534,18 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
             return {'is_closed': False}
 
         state_reason = data.get('state_reason')
-        if not isinstance(state_reason, str) or state_reason.strip().lower() != 'completed':
-            bt.logging.info(
-                f'Issue closed on GitHub but not completed: {repo}#{issue_number} state_reason={state_reason}'
-            )
-            return {
-                'is_closed': True,
-                'solver_github_id': None,
-                'pr_number': None,
-                'solver_lookup_failed': False,
-            }
+        if isinstance(state_reason, str):
+            normalized_reason = state_reason.strip().lower()
+            if normalized_reason in ('not_planned', 'duplicate', 'transferred'):
+                bt.logging.info(
+                    f'Issue closed on GitHub but not completed: {repo}#{issue_number} state_reason={state_reason}'
+                )
+                return {
+                    'is_closed': True,
+                    'solver_github_id': None,
+                    'pr_number': None,
+                    'solver_lookup_failed': False,
+                }
 
         bt.logging.debug(f'Finding solver for {repo}#{issue_number}')
         solver_lookup = find_solver_from_closure_event(repo, issue_number, token)

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -602,8 +602,6 @@ class TestCheckGithubIssueClosed:
             {'state': 'closed', 'state_reason': 'not_planned'},
             {'state': 'closed', 'state_reason': 'duplicate'},
             {'state': 'closed', 'state_reason': 'transferred'},
-            {'state': 'closed', 'state_reason': None},
-            {'state': 'closed'},
         ],
     )
     @patch('gittensor.utils.github_api_tools.execute_graphql_query')
@@ -624,3 +622,27 @@ class TestCheckGithubIssueClosed:
             'solver_lookup_failed': False,
         }
         mock_graphql.assert_not_called()
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_closed_without_state_reason_attributions_solver(self, mock_logging, mock_get, mock_graphql):
+        issue_response = Mock()
+        issue_response.status_code = 200
+        issue_response.json.return_value = {'state': 'closed'}
+        mock_get.return_value = issue_response
+        mock_graphql.return_value = _closure_graphql_response(
+            [
+                _closed_event_pr_node(number=900, user_id=999),
+            ]
+        )
+
+        result = check_github_issue_closed('owner/repo', 12, 'fake_token')
+
+        assert result == {
+            'is_closed': True,
+            'solver_github_id': 999,
+            'pr_number': 900,
+            'solver_lookup_failed': False,
+        }
+        mock_graphql.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #1422.

Only skip GraphQL solver lookup for explicit non-completion `state_reason` values; when REST omits `state_reason`, still call `find_solver_from_closure_event()`.

## Changes

- `gittensor/utils/github_api_tools.py`: narrow early-return to `not_planned` / `duplicate` / `transferred`.
- `tests/utils/test_github_api_tools.py`: `test_closed_without_state_reason_attributions_solver`.

## Real Behavior Proof

- [x] `test_closed_without_state_reason_attributions_solver`

### What I ran

```bash
python3 -m pytest tests/utils/test_github_api_tools.py::TestCheckGithubIssueClosed::test_closed_without_state_reason_attributions_solver -q
```

### What I observed

GraphQL closure query runs and returns solver `999` / PR `900` when REST has no `state_reason`.

## Test plan

- [ ] `python3 -m pytest tests/utils/test_github_api_tools.py -q`
