### PR TITLE
fix(cli): honor configured wallet/hotkey for vote/admin/harvest signing

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, T
 import click
 import requests
 from bittensor_wallet.utils import is_valid_ss58_address
+from click.core import ParameterSource
 from rich.console import Console
 
 from gittensor.cli.issue_commands.tables import build_pr_table
@@ -526,6 +527,29 @@ def load_config() -> Dict[str, Any]:
     return {}
 
 
+def resolve_wallet_config(
+    wallet_name: str,
+    wallet_hotkey: str,
+    *,
+    wallet_default: str = 'default',
+    hotkey_default: str = 'default',
+) -> Tuple[str, str]:
+    """Resolve wallet values against the CLI config file."""
+    ctx = click.get_current_context(silent=True)
+    config = load_config()
+
+    if ctx is None:
+        wallet_explicit = wallet_name != wallet_default
+        hotkey_explicit = wallet_hotkey != hotkey_default
+    else:
+        wallet_explicit = ctx.get_parameter_source('wallet_name') == ParameterSource.COMMANDLINE
+        hotkey_explicit = ctx.get_parameter_source('wallet_hotkey') == ParameterSource.COMMANDLINE
+
+    effective_wallet = wallet_name if wallet_explicit else config.get('wallet', wallet_default)
+    effective_hotkey = wallet_hotkey if hotkey_explicit else config.get('hotkey', hotkey_default)
+    return effective_wallet, effective_hotkey
+
+
 def get_contract_address(cli_value: str = '') -> str:
     """
     Get contract address.
@@ -799,7 +823,13 @@ def _make_contract_client(contract_addr: str, ws_endpoint: str, wallet_name: str
         IssueCompetitionContractClient,
     )
 
-    wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+    effective_wallet, effective_hotkey = resolve_wallet_config(
+        wallet_name,
+        wallet_hotkey,
+        wallet_default='default',
+        hotkey_default='default',
+    )
+    wallet = bt.Wallet(name=effective_wallet, hotkey=effective_hotkey)
     subtensor = bt.Subtensor(network=ws_endpoint)
     client = IssueCompetitionContractClient(
         contract_address=contract_addr,

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -24,6 +24,7 @@ from .helpers import (
     print_error,
     print_network_header,
     print_success,
+    resolve_wallet_config,
     validate_bounty_amount,
     validate_github_issue,
     validate_repository,
@@ -294,7 +295,14 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
     )
 
     print_network_header(network_name, contract_addr)
-    err_console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey}[/dim]\n')
+
+    effective_wallet, effective_hotkey = resolve_wallet_config(
+        wallet_name,
+        wallet_hotkey,
+        wallet_default='validator',
+        hotkey_default='default',
+    )
+    err_console.print(f'[dim]Wallet: {effective_wallet}/{effective_hotkey}[/dim]\n')
 
     try:
         import bittensor as bt
@@ -304,7 +312,7 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
         )
 
         with err_console.status('[bold cyan]Loading wallet...', spinner='dots'):
-            wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+            wallet = bt.Wallet(name=effective_wallet, hotkey=effective_hotkey)
             hotkey_addr = wallet.hotkey.ss58_address
         err_console.print(f'[green]Hotkey address:[/green] {hotkey_addr}')
 


### PR DESCRIPTION
## Summary

`gitt config set wallet/hotkey` writes canonical keys to `~/.gittensor/config.json`,
and `gitt issues register` already honors them when wallet flags are omitted. The
other signed issue-contract write commands did not — `gitt vote *`, `gitt admin *`,
and `gitt harvest` passed their raw Click defaults straight into `bt.Wallet(...)`, so
a user with a configured wallet/hotkey could silently sign with the wrong key (or fail
because the command's fallback wallet doesn't exist) for irreversible on-chain actions.

This is the wallet/hotkey member of the CLI config-priority family already fixed for
adjacent keys in #1035, #1200, and #1364.

Closes #1424 
## Affected commands

Shared `_make_contract_client(...)` path: `gitt vote solution`, `gitt vote cancel`,
`gitt admin cancel-issue`, `gitt admin payout-issue`, `gitt admin set-owner`,
`gitt admin set-treasury`, `gitt admin add-vali`, `gitt admin remove-vali`.

Inline wallet construction: `gitt harvest`.

## Fix

Adds a shared `resolve_wallet_config(...)` helper applying the documented priority:

1. Explicit `--wallet-name` / `--wallet-hotkey` CLI flags win.
2. `~/.gittensor/config.json` `wallet` / `hotkey` when the flag is omitted.
3. The command's own Click default otherwise.

Whether a flag was supplied is detected via Click's `ParameterSource`, **not** a
`!= "default"` comparison. This matters because `gitt harvest` carries a non-`"default"`
fallback (`validator`), so a value comparison would mistake that fallback for an explicit
value and never consult config — and only a parameter-source check lets an explicit
`--wallet default` win over config. A no-Click-context fallback (value comparison) keeps
the helper usable in direct unit calls.

Wired into:
- `_make_contract_client(...)` — the shared vote/admin path (`default/default` fallback).
- `gitt harvest` — inline construction (`validator/default` fallback); the displayed
  `Wallet:` line now reflects the resolved key.

`gitt issues register` is intentionally left unchanged — it already honors config and has
special `//Alice` local-dev handling.

## Tests

New `TestWalletConfigResolution` covering every scenario:
- vote/admin without flags use configured `wallet` / `hotkey`
- vote/admin explicit flags win
- explicit `--wallet default --hotkey default` still beats config
- vote/admin without config preserve `default/default`
- `harvest` without flags uses configured `wallet` / `hotkey`
- `harvest` without config preserves `validator/default`
- `harvest` explicit flags win
- direct (no-Click-context) fallback path

## Verification

- `uv run pytest tests/` → **918 passed** (+8 new)
- ruff lint + format, pyright (0 errors), vulture: all clean
- Verified end-to-end against a real `config.json` file-read path
