### PR TITLE
[Bug]: Time-decay scoring uses wall clock causing validator drift

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -2,6 +2,7 @@
 # Copyright © 2025 Entrius
 
 import asyncio
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
@@ -17,6 +18,7 @@ from gittensor.validator.utils.config import (
     VALIDATOR_STEPS_INTERVAL,
     VALIDATOR_WAIT,
 )
+from gittensor.validator.utils.datetime_utils import set_scoring_reference_time
 from gittensor.validator.utils.load_weights import (
     RepositoryConfig,
     load_master_repo_weights,
@@ -46,6 +48,7 @@ async def forward(self: 'Validator') -> None:
     """
 
     if self.step % VALIDATOR_STEPS_INTERVAL == 0:
+        set_scoring_reference_time(datetime.now(timezone.utc))
         miner_uids = get_all_uids(self)
         master_repositories = load_master_repo_weights()
         programming_languages = load_programming_language_weights()

--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -30,9 +30,22 @@ def parse_optional_github_iso_to_utc(value: Optional[str]) -> Optional[datetime]
     return parse_github_iso_to_utc(value) if value else None
 
 
-def calculate_time_decay(merged_at: datetime, time_decay: ResolvedTimeDecay) -> float:
+_scoring_reference_time: Optional[datetime] = None
+
+
+def set_scoring_reference_time(now: Optional[datetime]) -> None:
+    """Pin the reference instant for one validator forward step."""
+    global _scoring_reference_time
+    _scoring_reference_time = now
+
+
+def calculate_time_decay(
+    merged_at: datetime,
+    time_decay: ResolvedTimeDecay,
+    reference_time: Optional[datetime] = None,
+) -> float:
     """Calculate sigmoid-based time decay multiplier from a merge timestamp."""
-    now = datetime.now(timezone.utc)
+    now = reference_time or _scoring_reference_time or datetime.now(timezone.utc)
     hours_since_merge = (now - merged_at).total_seconds() / SECONDS_PER_HOUR
 
     if hours_since_merge < time_decay.grace_period_hours:


### PR DESCRIPTION
## Summary

Closes #1427.

Pin a scoring reference time at the start of each validator forward step for time-decay calculations.

## Changes

- `gittensor/validator/utils/datetime_utils.py`: `set_scoring_reference_time` + anchored `calculate_time_decay`.
- `gittensor/validator/forward.py`: set anchor each scoring step.

## Test plan

- [ ] Unit test: same frozen reference yields identical decay multiplier.
