### PR TITLE
chore: update tao-pulse-app repository hyperparams

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -5,7 +5,8 @@
   },
   "cogniax/tao-pulse-app": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.7,
+    "maintainer_cut": 0.4
   },
   "e35ventura/taopedia": {
     "emission_share": 0.025,


### PR DESCRIPTION
This PR updates the hyperparameters for cogniax/tao-pulse-app to better match the current needs of the repo.

Why:
- The repo is still in an early-stage app development phase.
- Maintainers are spending significant time on specification, product decisions, review, triage, and governance.
- High-quality issue discovery, feature ideas, and enhancement proposals are currently more valuable than raw PR volume.
- AI-generated PRs are relatively cheap to produce, but careful product thinking and maintainer judgment are not.