### PR TITLE
chore: update touchpilot repository hyperparams

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -199,7 +199,8 @@
   },
   "touchpilot/touchpilot": {
     "emission_share": 0.025,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "maintainer_cut": 0.3
   },
   "we-promise/sure": {
     "emission_share": 0.03,


### PR DESCRIPTION
This PR updates the hyperparameters for touchpilot/touchpilot to better match the current needs of the repo.

Effective split:

30% maintainer rewards
70% PR rewards

Why:

The repo is still in an early-stage app development phase.
Maintainers are spending significant time on specification, product decisions, review, triage, and governance.