### PR TITLE
fix: ignore commented inline-test markers

### DIFF
--- a/gittensor/validator/utils/tree_sitter_scoring.py
+++ b/gittensor/validator/utils/tree_sitter_scoring.py
@@ -1,7 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 from collections import Counter
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple, Union
 
 import bittensor as bt
 from tree_sitter import Node, Parser, Tree
@@ -88,6 +88,58 @@ def parse_code(content: str, language: str) -> Optional[Tree]:
 # Leaf: ("leaf", node_type, text_bytes)
 NodeSignature = Union[Tuple[str, str], Tuple[str, str, bytes]]
 
+INLINE_TEST_LANGUAGES: Dict[str, str] = {
+    'rs': 'rust',
+    'zig': 'zig',
+    'd': 'd',
+}
+
+
+def _iter_nodes(root: Node) -> Iterator[Node]:
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        yield node
+        stack.extend(reversed(node.children))
+
+
+def _node_text(node: Node) -> str:
+    return (node.text or b'').decode('utf-8', errors='ignore')
+
+
+def _rust_attribute_text(node: Node) -> Optional[str]:
+    for child in node.children:
+        if child.type == 'attribute':
+            return _node_text(child).strip()
+    return None
+
+
+def _is_rust_inline_test_attribute(attribute_text: str) -> bool:
+    compact = ''.join(attribute_text.split())
+    attribute_head = compact.split('(', 1)[0]
+
+    return attribute_head == 'test' or attribute_head.endswith('::test') or compact == 'cfg(test)'
+
+
+def _has_rust_inline_tests(root: Node) -> bool:
+    for node in _iter_nodes(root):
+        if node.type not in {'attribute_item', 'inner_attribute_item'}:
+            continue
+
+        attribute_text = _rust_attribute_text(node)
+        if attribute_text and _is_rust_inline_test_attribute(attribute_text):
+            return True
+
+    return False
+
+
+def _has_zig_inline_tests(root: Node) -> bool:
+    return any(node.type == 'TestDecl' for node in _iter_nodes(root))
+
+
+def _has_d_inline_tests(root: Node) -> bool:
+    return any(node.type == 'unittest_declaration' for node in _iter_nodes(root))
+
 
 def collect_node_signatures(
     tree: Tree,
@@ -137,8 +189,9 @@ def collect_node_signatures(
 def has_inline_tests(content: str, extension: str) -> bool:
     """Check whether source code contains inline test markers.
 
-    Uses simple pattern matching to detect language-specific test constructs
-    that live inside production source files.  Currently supports:
+    Uses a regex prefilter followed by tree-sitter AST inspection so markers
+    inside comments or string literals are not treated as executable tests.
+    Currently supports:
     - Rust: ``#[cfg(test)]``, ``#![cfg(test)]``, ``#[test]``, ``#[tokio::test]``
     - Zig:  ``test "name" { ... }``, ``test { ... }``
     - D:    ``unittest { ... }``
@@ -146,7 +199,26 @@ def has_inline_tests(content: str, extension: str) -> bool:
     pattern = INLINE_TEST_PATTERNS.get(extension)
     if pattern is None:
         return False
-    return pattern.search(content) is not None
+    if pattern.search(content) is None:
+        return False
+
+    language = INLINE_TEST_LANGUAGES.get(extension)
+    if language is None:
+        return False
+
+    tree = parse_code(content, language)
+    if tree is None:
+        return False
+
+    root = tree.root_node
+    if extension == 'rs':
+        return _has_rust_inline_tests(root)
+    if extension == 'zig':
+        return _has_zig_inline_tests(root)
+    if extension == 'd':
+        return _has_d_inline_tests(root)
+
+    return False
 
 
 def score_tree_diff(

--- a/tests/validator/test_inline_test_detection.py
+++ b/tests/validator/test_inline_test_detection.py
@@ -57,9 +57,21 @@ def test_rust_test_in_doc_comment_not_detected():
     assert has_inline_tests(code, 'rs') is False
 
 
+def test_rust_test_in_block_comment_not_detected():
+    """#[test] inside a block comment must not trigger detection."""
+    code = 'fn prod() {}\n/*\n#[test]\nfn example() {}\n*/\n'
+    assert has_inline_tests(code, 'rs') is False
+
+
 def test_rust_test_in_string_not_detected():
     """#[test] inside a string literal must not trigger detection."""
     code = 'fn f() { let s = "#[test]"; }\n'
+    assert has_inline_tests(code, 'rs') is False
+
+
+def test_rust_test_in_raw_multiline_string_not_detected():
+    """#[test] inside a raw multiline string must not trigger detection."""
+    code = 'fn prod() {}\nlet s = r#"\n#[test]\nfn example() {}\n"#;\n'
     assert has_inline_tests(code, 'rs') is False
 
 
@@ -88,6 +100,12 @@ def test_zig_production_only_not_detected():
 def test_d_unittest_detected():
     code = 'int add(int a, int b) { return a + b; }\nunittest { assert(add(1,2) == 3); }\n'
     assert has_inline_tests(code, 'd') is True
+
+
+def test_d_unittest_in_block_comment_not_detected():
+    """unittest inside a block comment must not trigger detection."""
+    code = 'int prod() { return 1; }\n/*\nunittest { assert(true); }\n*/\n'
+    assert has_inline_tests(code, 'd') is False
 
 
 def test_d_production_only_not_detected():

--- a/tests/validator/test_token_scoring_integration.py
+++ b/tests/validator/test_token_scoring_integration.py
@@ -14,7 +14,7 @@ Run tests:
 
 import pytest
 
-from gittensor.classes import FileChange
+from gittensor.classes import FileChange, ScoringCategory
 from gittensor.utils.github_api_tools import FileContentPair
 from gittensor.validator.utils.load_weights import TokenConfig, load_programming_language_weights, load_token_config
 from gittensor.validator.utils.tree_sitter_scoring import calculate_token_score_from_file_changes, score_tree_diff
@@ -206,6 +206,51 @@ def process(data):
         print(f'  Structural: {breakdown.structural_count} = {breakdown.structural_score:.2f}')
         print(f'  Leaf: {breakdown.leaf_count} = {breakdown.leaf_score:.2f}')
         print(f'  Total: {breakdown.total_score:.2f}')
+
+    def test_rust_inline_test_marker_in_block_comment_scores_as_source(self, weights):
+        """
+        Test that docs/examples mentioning #[test] do not demote production edits.
+        """
+        old_content = 'fn prod() -> i32 { 1 }\n'
+        with_marker = 'fn prod() -> i32 { 2 }\n/*\n#[test]\nfn example() {}\n*/\n'
+        without_marker = 'fn prod() -> i32 { 2 }\n/*\nExample test function goes here.\n*/\n'
+        programming_languages = load_programming_language_weights()
+
+        marker_change = FileChange(
+            pr_number=1,
+            repository_full_name='owner/repo',
+            filename='src/lib.rs',
+            changes=2,
+            additions=1,
+            deletions=1,
+            status='modified',
+        )
+        marker_result = calculate_token_score_from_file_changes(
+            [marker_change],
+            {'src/lib.rs': FileContentPair(old_content=old_content, new_content=with_marker)},
+            weights,
+            programming_languages,
+        ).file_results[0]
+
+        control_change = FileChange(
+            pr_number=1,
+            repository_full_name='owner/repo',
+            filename='src/lib.rs',
+            changes=2,
+            additions=1,
+            deletions=1,
+            status='modified',
+        )
+        control_result = calculate_token_score_from_file_changes(
+            [control_change],
+            {'src/lib.rs': FileContentPair(old_content=old_content, new_content=without_marker)},
+            weights,
+            programming_languages,
+        ).file_results[0]
+
+        assert marker_result.category == ScoringCategory.SOURCE
+        assert marker_result.is_test_file is False
+        assert marker_result.score == pytest.approx(control_result.score)
 
     def test_typescript_file_scoring(self, weights):
         """


### PR DESCRIPTION
## Summary

close #1431  

Fix `has_inline_tests()` so Rust/Zig/D inline-test detection no longer treats markers inside comments or string literals as real tests.

The existing regex remains as a fast prefilter, but matches are now verified against tree-sitter AST nodes:

- Rust: `attribute_item` / `inner_attribute_item`
- Zig: `TestDecl`
- D: `unittest_declaration`

This preserves the current file-level inline-test demotion behavior while avoiding false positives from docs, examples, comments, and raw strings.

## Problem

`has_inline_tests()` regex-scanned raw source text. A production Rust file containing `#[test]` only inside a block comment or raw multiline string was classified as an inline-test file.

That caused `calculate_token_score_from_file_changes()` to demote the whole file to `ScoringCategory.TEST` and apply `TEST_FILE_CONTRIBUTION_WEIGHT = 0.05`.

## Validation

- `uv run pytest -q tests/validator/test_inline_test_detection.py`
- `uv run pytest -q tests/validator/test_token_scoring_integration.py tests/validator/test_inline_test_detection.py`
- `uv run pytest tests/ -v`
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push`

Result: full test suite passed, 914 tests.