### PR TITLE
Fix duplicate validator scoring rounds with concurrent forwards

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -28,6 +28,28 @@ if TYPE_CHECKING:
     from neurons.validator import Validator
 
 
+async def _claim_scoring_round(self: 'Validator', step: int) -> bool:
+    """Claim the round-level scoring work for a validator step."""
+    if step % VALIDATOR_STEPS_INTERVAL != 0:
+        return False
+
+    async with self.lock:
+        if step == self._last_completed_scoring_round_step or step in self._active_scoring_round_steps:
+            bt.logging.debug(f'Scoring round for step {step} already claimed; skipping duplicate forward')
+            return False
+
+        self._active_scoring_round_steps.add(step)
+        return True
+
+
+async def _finish_scoring_round(self: 'Validator', step: int, completed: bool) -> None:
+    """Release a claimed scoring round and remember successful completion."""
+    async with self.lock:
+        self._active_scoring_round_steps.discard(step)
+        if completed:
+            self._last_completed_scoring_round_step = step
+
+
 async def forward(self: 'Validator') -> None:
     """Execute the validator's forward pass.
 
@@ -45,40 +67,46 @@ async def forward(self: 'Validator') -> None:
     - Recycle:              registry slack and inactive repo slices to UID 0
     """
 
-    if self.step % VALIDATOR_STEPS_INTERVAL == 0:
-        miner_uids = get_all_uids(self)
-        master_repositories = load_master_repo_weights()
-        programming_languages = load_programming_language_weights()
-        token_config = load_token_config()
+    step = self.step
+    if await _claim_scoring_round(self, step):
+        completed = False
+        try:
+            miner_uids = get_all_uids(self)
+            master_repositories = load_master_repo_weights()
+            programming_languages = load_programming_language_weights()
+            token_config = load_token_config()
 
-        # 1. Score OSS contributions
-        miner_evaluations, cached_uids, penalized_uids = await oss_contributions(
-            self, miner_uids, master_repositories, programming_languages, token_config
-        )
+            # 1. Score OSS contributions
+            miner_evaluations, cached_uids, penalized_uids = await oss_contributions(
+                self, miner_uids, master_repositories, programming_languages, token_config
+            )
 
-        # 2. Score issue discovery
-        await issue_discovery(
-            miner_evaluations,
-            master_repositories,
-            programming_languages,
-            token_config,
-            evaluation_cache=self.evaluation_cache,
-        )
+            # 2. Score issue discovery
+            await issue_discovery(
+                miner_evaluations,
+                master_repositories,
+                programming_languages,
+                token_config,
+                evaluation_cache=self.evaluation_cache,
+            )
 
-        # cached UIDs now have fresh issue-discovery fields — persist them
-        cached_uids.clear()
+            # cached UIDs now have fresh issue-discovery fields — persist them
+            cached_uids.clear()
 
-        # 3. Issue bounties verification
-        await issue_competitions(self, miner_evaluations)
+            # 3. Issue bounties verification
+            await issue_competitions(self, miner_evaluations)
 
-        # 4. Store all evaluations to DB (includes issue discovery fields)
-        await self.bulk_store_evaluation(miner_evaluations, master_repositories, skip_uids=cached_uids)
+            # 4. Store all evaluations to DB (includes issue discovery fields)
+            await self.bulk_store_evaluation(miner_evaluations, master_repositories, skip_uids=cached_uids)
 
-        # 5. Allocate repo-bounded emission shares into final rewards
-        maintainer_uids_by_repo = build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
-        rewards = blend_emission_pools(miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo)
+            # 5. Allocate repo-bounded emission shares into final rewards
+            maintainer_uids_by_repo = build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
+            rewards = blend_emission_pools(miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo)
 
-        self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
+            self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))
+            completed = True
+        finally:
+            await _finish_scoring_round(self, step, completed=completed)
 
     await asyncio.sleep(VALIDATOR_WAIT)
 

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -78,6 +78,8 @@ class BaseValidatorNeuron(BaseNeuron):
         self.is_running: bool = False
         self.thread: Union[threading.Thread, None] = None
         self.lock = asyncio.Lock()
+        self._active_scoring_round_steps: set[int] = set()
+        self._last_completed_scoring_round_step: Union[int, None] = None
 
     def serve_axon(self):
         """Serve axon to enable external connections."""

--- a/tests/validator/test_concurrent_forward_scoring_guard.py
+++ b/tests/validator/test_concurrent_forward_scoring_guard.py
@@ -1,0 +1,159 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Regression tests for concurrent validator forwards sharing one step."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from gittensor.classes import MinerEvaluation
+from gittensor.validator import forward as forward_module
+from neurons.base.validator import BaseValidatorNeuron
+
+if TYPE_CHECKING:
+    from neurons.validator import Validator
+
+
+class _DummyValidator:
+    def __init__(self, step: int = 0, num_concurrent_forwards: int = 1):
+        self.step = step
+        self.config = SimpleNamespace(neuron=SimpleNamespace(num_concurrent_forwards=num_concurrent_forwards))
+        self.lock = asyncio.Lock()
+        self._active_scoring_round_steps: set[int] = set()
+        self._last_completed_scoring_round_step: int | None = None
+        self.evaluation_cache = object()
+        self.stored_evaluations = []
+        self.score_updates = []
+
+    async def forward(self):
+        return await forward_module.forward(cast('Validator', self))
+
+    async def bulk_store_evaluation(self, miner_evals, master_repositories, skip_uids=None):
+        self.stored_evaluations.append(
+            SimpleNamespace(
+                miner_evals=dict(miner_evals),
+                master_repositories=master_repositories,
+                skip_uids=set(skip_uids or set()),
+            )
+        )
+
+    def update_scores(self, rewards, uids, blacklisted_uids=None):
+        self.score_updates.append(
+            SimpleNamespace(
+                rewards=np.asarray(rewards).copy(),
+                uids=set(uids),
+                blacklisted_uids=list(blacklisted_uids or []),
+            )
+        )
+
+
+def _install_scoring_stubs(monkeypatch, oss_side_effect=None, penalized_uids=None):
+    miner_uids = {0, 1}
+    miner_evaluations = {
+        uid: MinerEvaluation(uid=uid, hotkey=f'hotkey_{uid}', github_id=str(uid)) for uid in miner_uids
+    }
+    rewards = np.array([0.25, 0.75])
+    oss_calls = []
+
+    async def fake_oss_contributions(*args):
+        oss_calls.append(args)
+        await asyncio.sleep(0)
+        if oss_side_effect is not None:
+            return await oss_side_effect(miner_evaluations)
+        return miner_evaluations, set(), set(penalized_uids or {1})
+
+    issue_discovery = AsyncMock(return_value=None)
+    issue_competitions = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(forward_module, 'VALIDATOR_WAIT', 0)
+    monkeypatch.setattr(forward_module, 'get_all_uids', lambda _validator: miner_uids)
+    monkeypatch.setattr(forward_module, 'load_master_repo_weights', lambda: {})
+    monkeypatch.setattr(forward_module, 'load_programming_language_weights', lambda: {})
+    monkeypatch.setattr(forward_module, 'load_token_config', lambda: SimpleNamespace(language_configs={}))
+    monkeypatch.setattr(forward_module, 'oss_contributions', fake_oss_contributions)
+    monkeypatch.setattr(forward_module, 'issue_discovery', issue_discovery)
+    monkeypatch.setattr(forward_module, 'issue_competitions', issue_competitions)
+    monkeypatch.setattr(forward_module, 'build_maintainer_uids_by_repo', lambda *_args: {})
+    monkeypatch.setattr(forward_module, 'blend_emission_pools', lambda *_args: rewards)
+
+    return SimpleNamespace(
+        miner_uids=miner_uids,
+        miner_evaluations=miner_evaluations,
+        rewards=rewards,
+        oss_calls=oss_calls,
+        issue_discovery=issue_discovery,
+        issue_competitions=issue_competitions,
+    )
+
+
+def test_concurrent_forward_runs_scoring_round_once_per_step(monkeypatch):
+    validator = _DummyValidator(step=0, num_concurrent_forwards=3)
+    stubs = _install_scoring_stubs(monkeypatch)
+
+    asyncio.run(BaseValidatorNeuron.concurrent_forward(cast(BaseValidatorNeuron, validator)))
+
+    assert len(stubs.oss_calls) == 1
+    assert stubs.issue_discovery.await_count == 1
+    assert stubs.issue_competitions.await_count == 1
+    assert len(validator.stored_evaluations) == 1
+    assert len(validator.score_updates) == 1
+
+    score_update = validator.score_updates[0]
+    assert score_update.uids == stubs.miner_uids
+    assert score_update.blacklisted_uids == [1]
+    np.testing.assert_allclose(score_update.rewards, stubs.rewards)
+    assert validator._active_scoring_round_steps == set()
+    assert validator._last_completed_scoring_round_step == 0
+
+
+def test_completed_scoring_round_does_not_block_later_interval(monkeypatch):
+    validator = _DummyValidator(step=0)
+    stubs = _install_scoring_stubs(monkeypatch)
+
+    async def run_forwards():
+        await validator.forward()
+        await validator.forward()
+
+        validator.step = forward_module.VALIDATOR_STEPS_INTERVAL
+        await validator.forward()
+
+    asyncio.run(run_forwards())
+
+    assert len(stubs.oss_calls) == 2
+    assert len(validator.score_updates) == 2
+    assert validator._active_scoring_round_steps == set()
+    assert validator._last_completed_scoring_round_step == forward_module.VALIDATOR_STEPS_INTERVAL
+
+
+def test_failed_scoring_round_can_be_retried_for_same_step(monkeypatch):
+    validator = _DummyValidator(step=0)
+    attempts = 0
+
+    async def flaky_oss_contributions(miner_evaluations):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError('scoring failed')
+        return miner_evaluations, set(), set()
+
+    _install_scoring_stubs(monkeypatch, oss_side_effect=flaky_oss_contributions, penalized_uids=set())
+
+    async def run_attempts():
+        with pytest.raises(RuntimeError, match='scoring failed'):
+            await validator.forward()
+        assert validator._active_scoring_round_steps == set()
+        assert validator._last_completed_scoring_round_step is None
+
+        await validator.forward()
+
+    asyncio.run(run_attempts())
+
+    assert attempts == 2
+    assert len(validator.score_updates) == 1
+    assert validator._active_scoring_round_steps == set()
+    assert validator._last_completed_scoring_round_step == 0


### PR DESCRIPTION
## Summary

Closes #1433.

Fixes duplicate validator scoring rounds when `--neuron.num_concurrent_forwards` is greater than `1`.

The validator now atomically claims round-level scoring work per validator step, so only one concurrent `forward()` can run the full scoring/update path for a given step. Duplicate concurrent forwards for the same active or completed scoring step skip the round-level side effects.

## Changes

- Added per-step scoring claim tracking to `BaseValidatorNeuron`
- Guarded the full scoring round in `gittensor/validator/forward.py`
- Released active scoring claims on failure so the same step can be retried
- Added regression tests for:
  - concurrent forwards scoring only once per step
  - later scoring intervals still running normally
  - failed scoring rounds being retryable

## Verification

```bash
uv run pytest tests/validator/test_concurrent_forward_scoring_guard.py -q
uv run ruff check .
uv run ruff format --check neurons/base/validator.py gittensor/validator/forward.py tests/validator/test_concurrent_forward_scoring_guard.py
uv run pyright
uv run pytest -q
uv run --extra dev vulture
git diff --check