### PR TITLE
refactor: hoist gittensor.constants import out of get_contract_address

### DIFF
--- a/gittensor/utils/utils.py
+++ b/gittensor/utils/utils.py
@@ -4,6 +4,8 @@ GitTensor Utilities
 
 import os
 
+from gittensor.constants import CONTRACT_ADDRESS
+
 
 def backoff_seconds(attempt: int, base: int = 5, cap: int = 30) -> int:
     return min(base * (2**attempt), cap)
@@ -15,6 +17,4 @@ def get_contract_address() -> str:
     Returns:
         Contract address string (env var override or constants.py default)
     """
-    from gittensor.constants import CONTRACT_ADDRESS
-
     return os.environ.get('CONTRACT_ADDRESS') or CONTRACT_ADDRESS


### PR DESCRIPTION
## Summary

The `CONTRACT_ADDRESS` import in [`gittensor/utils/utils.py`](gittensor/utils/utils.py) was function-local inside `get_contract_address`, which is the only use of the name in this module. Moving it to module-level:

- matches the **imports-at-top** convention used everywhere else in `gittensor/`
- removes per-call import lookup overhead (`get_contract_address` is called on every validator forward pass for the issue-bounty contract)

Verified **no circular-import risk**: `gittensor.constants` only imports stdlib (`re`, `typing`) — there is no path back into `gittensor.utils.utils`.

```diff
 import os

+from gittensor.constants import CONTRACT_ADDRESS
+

 def backoff_seconds(attempt: int, base: int = 5, cap: int = 30) -> int:
     return min(base * (2**attempt), cap)


 def get_contract_address() -> str:
     """..."""
-    from gittensor.constants import CONTRACT_ADDRESS
-
     return os.environ.get('CONTRACT_ADDRESS') or CONTRACT_ADDRESS
```

Net: **+2 / -2 lines**, single file. No behaviour change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 913 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)