### PR TITLE
fix(credibility): use weighted ratio for round-level credibility rollup

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -621,7 +621,8 @@ def _roll_up_issue_totals(evaluation: MinerEvaluation) -> None:
     evaluation.issue_token_score = round(sum(re.issue_token_score for re in repo_evals), 2)
     evaluation.issue_discovery_score = round(sum(re.issue_discovery_score for re in repo_evals), 2)
     evaluation.is_issue_eligible = any(re.is_issue_eligible for re in repo_evals)
-    evaluation.issue_credibility = max((re.issue_credibility for re in repo_evals), default=0.0)
+    _attempts = evaluation.total_solved_issues + evaluation.total_closed_issues
+    evaluation.issue_credibility = evaluation.total_solved_issues / _attempts if _attempts > 0 else 0.0
 
 
 async def _resolve_solving_pr_score(

--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -203,7 +203,10 @@ def _roll_up_miner_totals(evaluation: MinerEvaluation) -> None:
     evaluation.total_leaf_score = sum(re.total_leaf_score for re in repo_evals)
     evaluation.total_nodes_scored = sum(re.total_nodes_scored for re in repo_evals)
     evaluation.is_eligible = any(re.is_eligible for re in repo_evals)
-    evaluation.credibility = max((re.credibility for re in repo_evals), default=0.0)
+    _total_merged = sum(re.total_merged_prs for re in repo_evals)
+    _total_closed = sum(re.total_closed_prs for re in repo_evals)
+    _attempts = _total_merged + _total_closed
+    evaluation.credibility = _total_merged / _attempts if _attempts > 0 else 0.0
     evaluation.unique_repos_count = len(evaluation.unique_repos_contributed_to)
 
     eligible_repos = sum(1 for re in repo_evals if re.is_eligible)

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -1919,3 +1919,56 @@ class TestLabelPolicyIssueDiscovery:
         assert ev_unlabeled.issue_discovery_score > 0.0
         assert ev_labeled.issue_discovery_score < ev_unlabeled.issue_discovery_score
         assert all(i.discovery_label_multiplier == pytest.approx(0.25) for i in ev_labeled.issue_discovery_issues)
+
+
+# ===========================================================================
+# Credibility rollup
+# ===========================================================================
+
+
+_roll_up_issue_totals = scan_module._roll_up_issue_totals
+
+
+def _repo_eval_issues(repo: str, solved: int, closed: int) -> RepoEvaluation:
+    re = RepoEvaluation(repository_full_name=repo)
+    re.total_solved_issues = solved
+    re.total_closed_issues = closed
+    return re
+
+
+class TestRollUpIssueTotals:
+    """_roll_up_issue_totals: issue_credibility uses weighted ratio, not max()."""
+
+    def test_multi_repo_weighted_ratio(self):
+        """One perfect micro-repo must not inflate credibility to 1.0."""
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {
+            'a/a': _repo_eval_issues('a/a', solved=1, closed=0),   # per-repo 1.0
+            'b/b': _repo_eval_issues('b/b', solved=2, closed=8),   # per-repo 0.20
+            'c/c': _repo_eval_issues('c/c', solved=3, closed=12),  # per-repo 0.20
+        }
+        _roll_up_issue_totals(ev)
+        # true weighted = 6 / (6+20) ≈ 0.23  (old max() would give 1.0)
+        assert ev.issue_credibility == pytest.approx(6 / 26)
+        assert ev.issue_credibility < 0.5
+
+    def test_zero_attempts_yields_zero(self):
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {'a/a': _repo_eval_issues('a/a', solved=0, closed=0)}
+        _roll_up_issue_totals(ev)
+        assert ev.issue_credibility == 0.0
+
+    def test_single_repo_matches_ratio(self):
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {'a/a': _repo_eval_issues('a/a', solved=8, closed=2)}
+        _roll_up_issue_totals(ev)
+        assert ev.issue_credibility == pytest.approx(0.8)
+
+    def test_all_solved_yields_one(self):
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {
+            'a/a': _repo_eval_issues('a/a', solved=5, closed=0),
+            'b/b': _repo_eval_issues('b/b', solved=3, closed=0),
+        }
+        _roll_up_issue_totals(ev)
+        assert ev.issue_credibility == pytest.approx(1.0)

--- a/tests/validator/oss_contributions/test_credibility_rollup.py
+++ b/tests/validator/oss_contributions/test_credibility_rollup.py
@@ -1,0 +1,65 @@
+"""Tests for _roll_up_miner_totals: credibility must use weighted ratio, not max().
+
+Issue #1438: using max() across per-repo credibility values lets a miner with
+one perfect micro-repo report round-level credibility of 1.0 regardless of how
+many PRs were rejected across their other repos.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+scoring_module = pytest.importorskip(
+    'gittensor.validator.oss_contributions.scoring',
+    reason='Requires gittensor oss_contributions subpackage',
+)
+classes = pytest.importorskip('gittensor.classes')
+
+_roll_up_miner_totals = scoring_module._roll_up_miner_totals
+MinerEvaluation = classes.MinerEvaluation
+RepoEvaluation = classes.RepoEvaluation
+
+
+def _repo_eval(repo: str, merged: int, closed: int) -> RepoEvaluation:
+    re = RepoEvaluation(repository_full_name=repo)
+    re.total_merged_prs = merged
+    re.total_closed_prs = closed
+    return re
+
+
+class TestRollUpMinerTotalsCredibility:
+    """_roll_up_miner_totals: credibility is weighted ratio across all repos, not max()."""
+
+    def test_multi_repo_weighted_ratio(self):
+        """One perfect micro-repo must not inflate credibility to 1.0."""
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {
+            'a/a': _repo_eval('a/a', merged=1, closed=0),   # per-repo 1.0
+            'b/b': _repo_eval('b/b', merged=2, closed=8),   # per-repo 0.20
+            'c/c': _repo_eval('c/c', merged=3, closed=12),  # per-repo 0.20
+        }
+        _roll_up_miner_totals(ev)
+        # true weighted = 6 / (6+20) ≈ 0.23  (old max() would give 1.0)
+        assert ev.credibility == pytest.approx(6 / 26)
+        assert ev.credibility < 0.5
+
+    def test_zero_attempts_yields_zero(self):
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {'a/a': _repo_eval('a/a', merged=0, closed=0)}
+        _roll_up_miner_totals(ev)
+        assert ev.credibility == 0.0
+
+    def test_single_repo_matches_ratio(self):
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {'a/a': _repo_eval('a/a', merged=8, closed=2)}
+        _roll_up_miner_totals(ev)
+        assert ev.credibility == pytest.approx(0.8)
+
+    def test_all_merged_yields_one(self):
+        ev = MinerEvaluation(uid=1, hotkey='hk')
+        ev.repo_evaluations = {
+            'a/a': _repo_eval('a/a', merged=5, closed=0),
+            'b/b': _repo_eval('b/b', merged=3, closed=0),
+        }
+        _roll_up_miner_totals(ev)
+        assert ev.credibility == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Fixes #1438.

Both `_roll_up_miner_totals` (`oss_contributions/scoring.py:206`) and `_roll_up_issue_totals` (`issue_discovery/scan.py:624`) used `max()` to aggregate per-repo credibility into the round-level scalar. A miner with one trivial micro-repo (`1 merged, 0 closed`) reported `credibility = 1.0` regardless of how many PRs were rejected across all other repos — an exploitable inflation of the quality signal.

### Root cause

```python
# before (both functions)
evaluation.credibility = max((re.credibility for re in repo_evals), default=0.0)
evaluation.issue_credibility = max((re.issue_credibility for re in repo_evals), default=0.0)
```

`max()` picks the best single-repo value. True round-level credibility is the weighted ratio across all attempts.

### Fix

Replace both `max()` calls with a weighted ratio using the merged/solved and closed counters that are already summed on the lines immediately above:

```python
# oss_contributions/scoring.py — _roll_up_miner_totals
_total_merged = sum(re.total_merged_prs for re in repo_evals)
_total_closed = sum(re.total_closed_prs for re in repo_evals)
_attempts = _total_merged + _total_closed
evaluation.credibility = _total_merged / _attempts if _attempts > 0 else 0.0

# issue_discovery/scan.py — _roll_up_issue_totals
_attempts = evaluation.total_solved_issues + evaluation.total_closed_issues
evaluation.issue_credibility = evaluation.total_solved_issues / _attempts if _attempts > 0 else 0.0
```

For the issue body's example miner (`1+2+3 = 6` merged, `0+8+12 = 20` closed): old result `1.0`, fixed result `6/26 ≈ 0.23`.

### Tests

- `tests/validator/oss_contributions/test_credibility_rollup.py` (new) — 4 cases for `_roll_up_miner_totals`: multi-repo weighted ratio, zero attempts, single repo, all-passing
- `tests/validator/issue_discovery/test_scan.py` — `TestRollUpIssueTotals` (new class, 4 cases) for `_roll_up_issue_totals`, same coverage

## Checklist

- [x] Two-line fix, one in each affected rollup function
- [x] No change to per-repo credibility calculation or gate logic
- [x] Regression tests for the exact gaming scenario described in #1438
- [x] Zero-attempts edge case covered (returns `0.0`, not a division error)