### PR TITLE
fix(validator): pin scoring reference time for decay and PR lookback

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -2,6 +2,7 @@
 # Copyright © 2025 Entrius
 
 import asyncio
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
@@ -50,10 +51,16 @@ async def forward(self: 'Validator') -> None:
         master_repositories = load_master_repo_weights()
         programming_languages = load_programming_language_weights()
         token_config = load_token_config()
+        scoring_reference_time = datetime.now(timezone.utc)
 
         # 1. Score OSS contributions
         miner_evaluations, cached_uids, penalized_uids = await oss_contributions(
-            self, miner_uids, master_repositories, programming_languages, token_config
+            self,
+            miner_uids,
+            master_repositories,
+            programming_languages,
+            token_config,
+            scoring_reference_time=scoring_reference_time,
         )
 
         # 2. Score issue discovery
@@ -63,6 +70,7 @@ async def forward(self: 'Validator') -> None:
             programming_languages,
             token_config,
             evaluation_cache=self.evaluation_cache,
+            scoring_reference_time=scoring_reference_time,
         )
 
         # cached UIDs now have fresh issue-discovery fields — persist them
@@ -89,6 +97,7 @@ async def oss_contributions(
     master_repositories: Dict[str, RepositoryConfig],
     programming_languages: Dict,
     token_config,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> Tuple[Dict[int, MinerEvaluation], Set[int], Set[int]]:
     """Score OSS contributions and return miner evaluations + cached UIDs + penalized UIDs.
 
@@ -103,7 +112,12 @@ async def oss_contributions(
     bt.logging.info(f'Neurons to evaluate: {len(miner_uids)}')
 
     miner_evaluations, cached_uids, penalized_uids = await get_rewards(
-        self, miner_uids, master_repositories, programming_languages, token_config
+        self,
+        miner_uids,
+        master_repositories,
+        programming_languages,
+        token_config,
+        scoring_reference_time=scoring_reference_time,
     )
 
     return miner_evaluations, cached_uids, penalized_uids
@@ -115,6 +129,7 @@ async def issue_discovery(
     programming_languages: Dict,
     token_config,
     evaluation_cache: Optional[MinerEvaluationCache] = None,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> None:
     """Score issue discovery fields on miner evaluations.
 
@@ -128,6 +143,7 @@ async def issue_discovery(
         programming_languages,
         token_config,
         evaluation_cache=evaluation_cache,
+        scoring_reference_time=scoring_reference_time,
     )
 
 

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -133,6 +133,7 @@ async def run_issue_discovery(
     token_config: TokenConfig,
     client: Optional[MirrorClient] = None,
     evaluation_cache: Optional[MinerEvaluationCache] = None,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> None:
     """Score issue discovery. Mutates miner_evaluations.
 
@@ -154,7 +155,11 @@ async def run_issue_discovery(
         return
 
     client = client or MirrorClient()
-    now = datetime.now(timezone.utc)
+    now = scoring_reference_time if scoring_reference_time is not None else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
     # Each repo is windowed by its own pr_lookback_days; the mirror applies the
     # per-repo cutoffs server-side for the scoring fetch.
     since_by_repo = {
@@ -228,6 +233,7 @@ async def run_issue_discovery(
             token_config,
             open_counts=open_counts,
             canonical_pr_owners=canonical_pr_owners,
+            scoring_reference_time=now,
         )
         if complete:
             cacheable_uids.add(evaluation.uid)
@@ -433,6 +439,7 @@ async def _score_miner_issues(
     token_config: TokenConfig,
     open_counts: Dict[str, int],
     canonical_pr_owners: Dict[Tuple[str, int], Tuple[datetime, int, int]],
+    scoring_reference_time: Optional[datetime] = None,
 ) -> bool:
     """Classify + score one miner's mirror issues, per repository.
 
@@ -530,7 +537,13 @@ async def _score_miner_issues(
             )
             continue
 
-        adapted = _mirror_issue_for_scoring(issue, solving_pr, repo_config, base_score=cached.base_score)
+        adapted = _mirror_issue_for_scoring(
+            issue,
+            solving_pr,
+            repo_config,
+            base_score=cached.base_score,
+            scoring_reference_time=scoring_reference_time,
+        )
         if adapted is None:
             continue
 
@@ -781,6 +794,7 @@ def _mirror_issue_for_scoring(
     solving_pr: MirrorSolvingPR,
     repo_config: RepositoryConfig,
     base_score: float,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> Optional[Issue]:
     """Build a legacy ``Issue`` with discovery_* fields populated.
 
@@ -811,7 +825,12 @@ def _mirror_issue_for_scoring(
     scoring_cfg = resolve_scoring(repo_config.scoring)
     adapted.discovery_base_score = base_score
     adapted.discovery_time_decay_multiplier = round(
-        calculate_time_decay(solving_pr.merged_at, scoring_cfg.time_decay), 2
+        calculate_time_decay(
+            solving_pr.merged_at,
+            scoring_cfg.time_decay,
+            reference_time=scoring_reference_time,
+        ),
+        2,
     )
     adapted.discovery_review_quality_multiplier = round(
         calculate_issue_review_quality_multiplier(

--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -33,6 +33,7 @@ def load_miner_prs(
     eval_: MinerEvaluation,
     master_repositories: Dict[str, RepositoryConfig],
     client: Optional[MirrorClient] = None,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> None:
     """Populate eval_ with PRs fetched from the mirror service.
 
@@ -40,6 +41,8 @@ def load_miner_prs(
         eval_: MinerEvaluation to populate; must already have github_id set.
         master_repositories: repo configs to filter against.
         client: optional MirrorClient for dependency injection in tests.
+        scoring_reference_time: UTC anchor for per-repo lookback cutoffs; defaults
+            to wall clock when omitted (CLI / tests).
 
     On fetch failure both ``mirror_pr_fetch_failed`` and ``github_pr_fetch_failed``
     are set on the eval; the latter drives the cache-fallback path.
@@ -56,7 +59,11 @@ def load_miner_prs(
         return
 
     client = client or MirrorClient()
-    now = datetime.now(timezone.utc)
+    now = scoring_reference_time if scoring_reference_time is not None else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
     # Each repo is windowed by its own pr_lookback_days; the mirror applies the
     # per-repo cutoffs server-side and returns only in-window PRs.
     since_by_repo = {

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -25,6 +25,7 @@ import asyncio
 import math
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 import bittensor as bt
@@ -69,6 +70,7 @@ async def score_miner_prs(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     client: Optional[MirrorClient] = None,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> None:
     """Score all PRs on a MinerEvaluation.
 
@@ -99,7 +101,15 @@ async def score_miner_prs(
                 f'\n[{i}/{len(scored_prs)}] {label} PR #{scored.pr.pr_number} in {scored.pr.repo_full_name}'
             )
             try:
-                await score_pr(scored, eval_, master_repositories, programming_languages, token_config, client)
+                await score_pr(
+                    scored,
+                    eval_,
+                    master_repositories,
+                    programming_languages,
+                    token_config,
+                    client,
+                    scoring_reference_time=scoring_reference_time,
+                )
             except Exception as e:
                 bt.logging.warning(
                     f'UID {eval_.uid}: scoring failed for PR #{scored.pr.pr_number} in {scored.pr.repo_full_name}: {e}'
@@ -118,6 +128,7 @@ async def score_pr(
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
     client: MirrorClient,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> None:
     """Score a single PR. Populates ScoredPR scoring fields in place."""
     pr = scored.pr
@@ -176,7 +187,7 @@ async def score_pr(
         # eligibility and reporting gates keep their evidence signal.
         scored.base_score = repo_config.fixed_base_score
 
-    _calculate_pr_multipliers(scored, repo_config, scoring_cfg)
+    _calculate_pr_multipliers(scored, repo_config, scoring_cfg, scoring_reference_time=scoring_reference_time)
 
     if pr.state == 'MERGED':
         eval_.unique_repos_contributed_to.add(pr.repo_full_name)
@@ -364,7 +375,12 @@ def calculate_base_score_for_pr_files(
 # ============================================================================
 
 
-def _calculate_pr_multipliers(scored: ScoredPR, repo_config: RepositoryConfig, scoring_cfg: ResolvedScoring) -> None:
+def _calculate_pr_multipliers(
+    scored: ScoredPR,
+    repo_config: RepositoryConfig,
+    scoring_cfg: ResolvedScoring,
+    scoring_reference_time: Optional[datetime] = None,
+) -> None:
     """Compute time_decay, review_quality, label, and issue multipliers.
 
     Spam and credibility multipliers are deferred to ``finalize_miner_scores``
@@ -382,7 +398,10 @@ def _calculate_pr_multipliers(scored: ScoredPR, repo_config: RepositoryConfig, s
     if is_merged:
         assert pr.merged_at is not None, f'MERGED PR #{pr.pr_number} missing merged_at'
         scored.open_pr_spam_multiplier = 1.0  # finalized later with combined open-PR count
-        scored.time_decay_multiplier = round(calculate_time_decay(pr.merged_at, scoring_cfg.time_decay), 2)
+        scored.time_decay_multiplier = round(
+            calculate_time_decay(pr.merged_at, scoring_cfg.time_decay, reference_time=scoring_reference_time),
+            2,
+        )
         scored.review_quality_multiplier = round(
             calculate_review_quality_multiplier(
                 pr.review_summary.maintainer_changes_requested_count,

--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import bittensor as bt
@@ -33,6 +34,7 @@ async def evaluate_miners_pull_requests(
     token_config: TokenConfig,
     stale_hotkey: Optional[str] = None,
     stored_github_id: Optional[str] = None,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> MinerEvaluation:
     """
     Entry point from taking a miners response -> Get PRs -> Score PRs
@@ -46,6 +48,7 @@ async def evaluate_miners_pull_requests(
         token_config: Token-based scoring weights configuration
         stale_hotkey: If set, the UID has a stored PAT from this old hotkey (re-registration detected)
         stored_github_id: GitHub id recorded when the stored PAT was accepted
+        scoring_reference_time: UTC anchor for lookback windows and time decay
 
     Returns:
         MinerEvaluation: The object containing scores, valid_prs, etc.
@@ -69,9 +72,20 @@ async def evaluate_miners_pull_requests(
         return miner_eval
 
     with MirrorClient() as mirror_client:
-        await asyncio.to_thread(load_miner_prs, miner_eval, master_repositories, client=mirror_client)
+        await asyncio.to_thread(
+            load_miner_prs,
+            miner_eval,
+            master_repositories,
+            client=mirror_client,
+            scoring_reference_time=scoring_reference_time,
+        )
         await score_miner_prs(
-            miner_eval, master_repositories, programming_languages, token_config, client=mirror_client
+            miner_eval,
+            master_repositories,
+            programming_languages,
+            token_config,
+            client=mirror_client,
+            scoring_reference_time=scoring_reference_time,
         )
 
     bt.logging.info('*' * 50 + '\n')
@@ -84,6 +98,7 @@ async def get_rewards(
     master_repositories: Dict[str, RepositoryConfig],
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
+    scoring_reference_time: Optional[datetime] = None,
 ) -> Tuple[Dict[int, MinerEvaluation], Set[int], Set[int]]:
     """Score OSS contributions for all miners.
 
@@ -128,6 +143,7 @@ async def get_rewards(
             token_config,
             stale_hotkey=stale_hotkey,
             stored_github_id=stored_github_id,
+            scoring_reference_time=scoring_reference_time,
         )
         miner_evaluations[uid] = miner_evaluation
 

--- a/gittensor/validator/utils/datetime_utils.py
+++ b/gittensor/validator/utils/datetime_utils.py
@@ -30,9 +30,23 @@ def parse_optional_github_iso_to_utc(value: Optional[str]) -> Optional[datetime]
     return parse_github_iso_to_utc(value) if value else None
 
 
-def calculate_time_decay(merged_at: datetime, time_decay: ResolvedTimeDecay) -> float:
-    """Calculate sigmoid-based time decay multiplier from a merge timestamp."""
-    now = datetime.now(timezone.utc)
+def calculate_time_decay(
+    merged_at: datetime,
+    time_decay: ResolvedTimeDecay,
+    *,
+    reference_time: Optional[datetime] = None,
+) -> float:
+    """Calculate sigmoid-based time decay multiplier from a merge timestamp.
+
+    When ``reference_time`` is set (validator round anchor), every PR in the
+    round uses the same clock so decay and lookback windows stay consistent
+    across miners and scoring phases.
+    """
+    now = reference_time if reference_time is not None else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
     hours_since_merge = (now - merged_at).total_seconds() / SECONDS_PER_HOUR
 
     if hours_since_merge < time_decay.grace_period_hours:

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -229,6 +229,24 @@ class TestLookbackWindow:
         assert before - timedelta(days=30) <= since_by_repo['entrius/gittensor-ui'] <= after - timedelta(days=30)
         assert before - timedelta(days=60) <= since_by_repo['entrius/gittensor'] <= after - timedelta(days=60)
 
+    def test_scoring_reference_time_pins_since_by_repo(self):
+        """Two miners scored with the same anchor must send identical cutoffs."""
+        repos = _mirror_repos('entrius/gittensor-ui')
+        anchor = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+        expected_since = anchor - timedelta(days=30)
+
+        client_a = Mock()
+        client_a.get_miner_pulls.return_value = _build_response([])
+        load_miner_prs(_eval(), repos, client=client_a, scoring_reference_time=anchor)
+        since_a = client_a.get_miner_pulls.call_args.kwargs['since_by_repo']['entrius/gittensor-ui']
+
+        client_b = Mock()
+        client_b.get_miner_pulls.return_value = _build_response([])
+        load_miner_prs(_eval(), repos, client=client_b, scoring_reference_time=anchor)
+        since_b = client_b.get_miner_pulls.call_args.kwargs['since_by_repo']['entrius/gittensor-ui']
+
+        assert since_a == since_b == expected_since
+
 
 # ============================================================================
 # Error paths

--- a/tests/validator/utils/test_datetime_utils.py
+++ b/tests/validator/utils/test_datetime_utils.py
@@ -1,0 +1,37 @@
+"""Tests for scoring time-decay anchoring."""
+
+from datetime import datetime, timedelta, timezone
+
+from gittensor.validator.utils.datetime_utils import calculate_time_decay
+from gittensor.validator.utils.load_weights import ResolvedTimeDecay, resolve_time_decay
+
+
+def test_calculate_time_decay_uses_shared_reference_time():
+    """Same merged_at and reference_time must yield identical multipliers."""
+    time_decay = resolve_time_decay(None)
+    merged_at = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    reference = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+    first = calculate_time_decay(merged_at, time_decay, reference_time=reference)
+    second = calculate_time_decay(merged_at, time_decay, reference_time=reference)
+
+    assert first == second
+
+
+def test_calculate_time_decay_differs_when_reference_advances():
+    """Advancing the anchor changes decay — proves wall-clock drift is real."""
+    cfg = ResolvedTimeDecay(
+        grace_period_hours=12,
+        sigmoid_midpoint_days=10.0,
+        sigmoid_steepness=0.4,
+        min_multiplier=0.05,
+    )
+    merged_at = datetime(2026, 5, 20, 0, 0, tzinfo=timezone.utc)
+    early_ref = merged_at + timedelta(hours=13)
+    late_ref = merged_at + timedelta(hours=25)
+
+    early = calculate_time_decay(merged_at, cfg, reference_time=early_ref)
+    late = calculate_time_decay(merged_at, cfg, reference_time=late_ref)
+
+    assert early == 1.0
+    assert late < early

--- a/tests/validator/utils/test_datetime_utils.py
+++ b/tests/validator/utils/test_datetime_utils.py
@@ -27,11 +27,13 @@ def test_calculate_time_decay_differs_when_reference_advances():
         min_multiplier=0.05,
     )
     merged_at = datetime(2026, 5, 20, 0, 0, tzinfo=timezone.utc)
-    early_ref = merged_at + timedelta(hours=13)
-    late_ref = merged_at + timedelta(hours=25)
+    # Inside the 12h grace window → full multiplier.
+    inside_grace_ref = merged_at + timedelta(hours=6)
+    # Well past grace → sigmoid decay applies.
+    past_grace_ref = merged_at + timedelta(days=15)
 
-    early = calculate_time_decay(merged_at, cfg, reference_time=early_ref)
-    late = calculate_time_decay(merged_at, cfg, reference_time=late_ref)
+    inside_grace = calculate_time_decay(merged_at, cfg, reference_time=inside_grace_ref)
+    past_grace = calculate_time_decay(merged_at, cfg, reference_time=past_grace_ref)
 
-    assert early == 1.0
-    assert late < early
+    assert inside_grace == 1.0
+    assert past_grace < inside_grace


### PR DESCRIPTION
## Summary

Validator scoring used wall-clock time at each call site for (1) sigmoid time-decay multipliers and (2) per-repo PR lookback cutoffs sent to the mirror. Miners evaluated later in the same round could see a stricter lookback window and different decay than earlier UIDs; issue discovery already anchored one `now` per phase but OSS fetch did not.

This change captures a single `scoring_reference_time` at the start of each forward scoring step and threads it through `get_rewards`, `load_miner_prs`, `score_miner_prs`, `calculate_time_decay`, and `run_issue_discovery`. Optional parameters default to `None` so CLI/dev paths keep prior behavior when no anchor is passed.

## Related Issues

<!-- If you opened a GitHub issue, link it: Closes #NNNN -->
<!-- Related prior discussion: entrius/gittensor#1427 / PR #1428 (closed due to open-PR cap, not rejected on merit) -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

Added:
- `tests/validator/utils/test_datetime_utils.py` — same reference → identical decay; advancing reference changes decay
- `tests/validator/oss_contributions/mirror/test_load.py` — two loads with the same anchor send identical `since_by_repo`

```bash
uv run pytest tests/validator/utils/test_datetime_utils.py \
  tests/validator/oss_contributions/mirror/test_load.py::TestLookbackWindow::test_scoring_reference_time_pins_since_by_repo -q