### PR TITLE
chore(weights): relax awesome-claude credibility gate

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -115,6 +115,9 @@
       "gittensor:feature": 1.0,
       "gittensor:priority": 1.5
     },
+    "eligibility": {
+      "min_credibility": 0.6
+    },
     "maintainer_cut": 0.3,
     "scoring": {
       "pr_lookback_days": 45,


### PR DESCRIPTION
## Summary
- lower the per-repo PR credibility gate for JSONbored/awesome-claude to 60%
- keep the default merged PR count gate unchanged
- leave global eligibility defaults unchanged for every other repo

## Rationale
Awesome Claude now receives a high volume of content submissions and uses a reviewer-agent flow to help process them. That creates more PR churn than a typical code-only repo, and some contributors can accumulate closures from automated review decisions rather than from low-quality or bad-faith work.

Lowering this repo-specific credibility gate helps keep contributors fairly eligible for rewards during this interim period while the reviewer-agent flow is still settling and may encounter early edge cases. Credibility still affects scoring, so contributors with more closures remain naturally down-weighted without being excluded too aggressively.

## Testing
- `python -m json.tool gittensor/validator/weights/master_repositories.json >/dev/null`
- `git diff --check`