### PR TITLE
fix(validator): key GitHub identity pin to hotkey, not UID slot

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -35,11 +35,14 @@ def _get_hotkey(synapse: bt.Synapse) -> str:
     return synapse.dendrite.hotkey
 
 
-def _github_identity_pin_error(uid: int, hotkey: str, github_id: Optional[str]) -> Optional[str]:
-    existing = pat_storage.get_pat_by_uid(uid)
-    if existing and existing.get('hotkey') == hotkey and existing.get('github_id'):
-        if existing['github_id'] != github_id:
-            return 'GitHub identity is locked for this hotkey. Deregister and re-register to change GitHub accounts.'
+def _github_identity_pin_error(hotkey: str, github_id: Optional[str]) -> Optional[str]:
+    # Pin is keyed on the stable hotkey, not the reusable UID slot, so a hotkey
+    # stays locked to its original GitHub account even after its old UID is
+    # taken over and it re-registers onto a different UID.
+    existing = pat_storage.get_pat_by_hotkey(hotkey)
+    pinned_github_id = existing.get('github_id') if existing else None
+    if pinned_github_id and pinned_github_id != '0' and pinned_github_id != github_id:
+        return 'GitHub identity is locked for this hotkey. Deregister and re-register to change GitHub accounts.'
     return None
 
 
@@ -71,7 +74,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
         return _reject(error)
 
     # 3. Enforce GitHub identity pinning — same hotkey cannot switch GitHub accounts
-    identity_error = _github_identity_pin_error(uid, hotkey, github_id)
+    identity_error = _github_identity_pin_error(hotkey, github_id)
     if identity_error:
         return _reject(identity_error)
 
@@ -80,7 +83,7 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
     if test_error:
         return _reject(f'PAT test query failed: {test_error}')
 
-    identity_error = _github_identity_pin_error(uid, hotkey, github_id)
+    identity_error = _github_identity_pin_error(hotkey, github_id)
     if identity_error:
         return _reject(identity_error)
 

--- a/gittensor/validator/pat_storage.py
+++ b/gittensor/validator/pat_storage.py
@@ -34,7 +34,14 @@ def load_all_pats() -> list[dict]:
 
 
 def save_pat(uid: int, hotkey: str, pat: str, github_id: str) -> None:
-    """Upsert a PAT entry by UID. Creates the file if needed."""
+    """Upsert a PAT entry, keyed by HOTKEY (one record per hotkey).
+
+    The record is keyed by the stable hotkey rather than the reusable UID slot
+    so a hotkey's GitHub identity pin survives UID churn. When this hotkey takes
+    over a UID that another hotkey used to occupy, the previous occupant's UID is
+    released (set to None) but its record — and therefore its identity pin — is
+    retained, so a displaced hotkey stays locked to its original GitHub account.
+    """
     with _lock:
         entries = _read_file()
 
@@ -46,8 +53,14 @@ def save_pat(uid: int, hotkey: str, pat: str, github_id: str) -> None:
             'stored_at': datetime.now(timezone.utc).isoformat(),
         }
 
+        # The UID slot now belongs to `hotkey`; release it from any other hotkey
+        # that previously occupied it, but keep that hotkey's identity pin.
+        for existing in entries:
+            if existing.get('uid') == uid and existing.get('hotkey') != hotkey:
+                existing['uid'] = None
+
         for i, existing in enumerate(entries):
-            if existing.get('uid') == uid:
+            if existing.get('hotkey') == hotkey:
                 entries[i] = entry
                 break
         else:
@@ -57,12 +70,33 @@ def save_pat(uid: int, hotkey: str, pat: str, github_id: str) -> None:
 
 
 def get_pat_by_uid(uid: int) -> Optional[dict]:
-    """Look up a single PAT entry by UID. Returns None if not found."""
+    """Look up the current occupant of a UID slot. Returns None if not found.
+
+    Released (detached) records carry uid=None, so they are never returned here.
+    """
     with _lock:
         for entry in _read_file():
             if entry.get('uid') == uid:
                 return entry
         return None
+
+
+def get_pat_by_hotkey(hotkey: str) -> Optional[dict]:
+    """Look up a hotkey's stored record, regardless of which UID slot it holds.
+
+    This is the source of truth for GitHub identity pinning: the binding follows
+    the stable hotkey, not the UID slot, so a hotkey cannot shed its pin by
+    cycling through deregistration and re-registration onto a fresh UID.
+    """
+    with _lock:
+        latest: Optional[dict] = None
+        for entry in _read_file():
+            if entry.get('hotkey') == hotkey and entry.get('github_id'):
+                # Defensive against legacy files with multiple records per hotkey:
+                # prefer the most recent one.
+                if latest is None or entry.get('stored_at', '') >= latest.get('stored_at', ''):
+                    latest = entry
+        return latest
 
 
 def _read_file() -> list[dict]:

--- a/tests/validator/test_pat_handler.py
+++ b/tests/validator/test_pat_handler.py
@@ -258,6 +258,33 @@ class TestHandlePatBroadcast:
         assert entry['github_id'] == 'github_99'
         assert entry['hotkey'] == 'hotkey_1'
 
+    @patch('gittensor.validator.pat_handler._test_pat_against_repo', return_value=None)
+    @patch('gittensor.validator.pat_handler.validate_github_credentials', return_value=('github_99', None))
+    def test_identity_pin_survives_uid_slot_reuse_and_reregistration(self, mock_validate, mock_test_query, mock_validator):
+        """A hotkey stays locked to its original GitHub id even after its old UID
+        slot is taken over by another hotkey and it re-registers on a new UID.
+
+        Regression for the UID-keyed identity-pin bypass: previously the pin was
+        looked up by UID slot, so reusing the slot erased the pin and let the
+        same hotkey switch GitHub accounts on re-registration.
+        """
+        # hotkey_1 originally pinned to github_42 at UID 1.
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_old', 'github_42')
+        # UID 1 is taken over by a throwaway hotkey (slot reused).
+        pat_storage.save_pat(1, 'throwaway', 'ghp_t', 'github_77')
+
+        # hotkey_1 re-registers and now occupies a different UID (index 2).
+        mock_validator.metagraph.hotkeys = ['hotkey_0', 'throwaway', 'hotkey_1']
+        mock_validator.metagraph.S = [100.0, 200.0, 300.0]
+
+        synapse = _make_broadcast_synapse('hotkey_1', pat='ghp_new_account')
+        result = _run(handle_pat_broadcast(mock_validator, synapse))
+
+        assert result.accepted is False
+        assert 'locked' in (result.rejection_reason or '').lower()
+        # The throwaway occupant of UID 1 is untouched.
+        assert pat_storage.get_pat_by_uid(1)['github_id'] == 'github_77'
+
 
 class TestHandlePatCheck:
     def test_test_query_call_does_not_block_event_loop(self, mock_validator):

--- a/tests/validator/test_pat_storage.py
+++ b/tests/validator/test_pat_storage.py
@@ -53,15 +53,24 @@ class TestSavePat:
         assert len(entries) == 1
         assert entries[0]['pat'] == 'ghp_new'
 
-    def test_save_upsert_replaces_hotkey_on_uid(self):
-        """When a new miner takes over a UID, save_pat overwrites the old entry."""
+    def test_save_releases_uid_but_retains_displaced_pin(self):
+        """When a new hotkey takes over a UID, the new hotkey becomes the slot's
+        occupant, but the displaced hotkey's record (and its identity pin) is
+        retained with its UID released to None."""
         pat_storage.save_pat(1, 'old_hotkey', 'ghp_old', 'user_old')
         pat_storage.save_pat(1, 'new_hotkey', 'ghp_new', 'user_new')
 
-        entries = pat_storage.load_all_pats()
-        assert len(entries) == 1
-        assert entries[0]['hotkey'] == 'new_hotkey'
-        assert entries[0]['pat'] == 'ghp_new'
+        # The UID slot now belongs to new_hotkey.
+        occupant = pat_storage.get_pat_by_uid(1)
+        assert occupant is not None
+        assert occupant['hotkey'] == 'new_hotkey'
+        assert occupant['pat'] == 'ghp_new'
+
+        # The displaced hotkey's identity pin survives (UID released to None).
+        displaced = pat_storage.get_pat_by_hotkey('old_hotkey')
+        assert displaced is not None
+        assert displaced['github_id'] == 'user_old'
+        assert displaced['uid'] is None
 
     def test_save_multiple_miners(self):
         pat_storage.save_pat(1, 'hotkey_1', 'ghp_a', 'user_a')
@@ -100,6 +109,32 @@ class TestGetPatByUid:
     def test_get_missing(self):
         entry = pat_storage.get_pat_by_uid(999)
         assert entry is None
+
+
+class TestGetPatByHotkey:
+    def test_get_existing(self):
+        pat_storage.save_pat(1, 'hotkey_1', 'ghp_abc', 'user_1')
+        entry = pat_storage.get_pat_by_hotkey('hotkey_1')
+        assert entry is not None
+        assert entry['github_id'] == 'user_1'
+
+    def test_get_missing(self):
+        assert pat_storage.get_pat_by_hotkey('never_seen') is None
+
+    def test_pin_follows_hotkey_across_uid_reuse_and_reregistration(self):
+        """A hotkey's pin must be findable even after its old UID slot is taken
+        over and it later re-registers on a different UID."""
+        pat_storage.save_pat(1, 'victim', 'ghp_v', 'github_42')
+        # UID 1 reused by a throwaway hotkey.
+        pat_storage.save_pat(1, 'throwaway', 'ghp_t', 'github_77')
+        # victim re-registers on a fresh UID.
+        pat_storage.save_pat(5, 'victim', 'ghp_v2', 'github_42')
+
+        assert pat_storage.get_pat_by_uid(1)['hotkey'] == 'throwaway'
+        pin = pat_storage.get_pat_by_hotkey('victim')
+        assert pin is not None
+        assert pin['github_id'] == 'github_42'
+        assert pin['uid'] == 5
 
 
 class TestConcurrency:


### PR DESCRIPTION
## Summary

Fixes #1444. The validator's GitHub identity-pinning guarantee is documented as **permanent and per-hotkey**, but the pin was keyed on the **reusable UID slot** rather than the stable hotkey. The lock only held while a hotkey kept its original UID: once that slot was taken over by another hotkey (normal deregistration/churn), `save_pat`'s upsert-by-UID erased the displaced hotkey's record, and on re-registration onto a fresh UID the **same hotkey** could bind a **different** GitHub account — exactly what the spec says requires a new hotkey.

## Changes

- **`pat_storage.save_pat`** now upserts **by hotkey** (one record per hotkey). When a hotkey takes over a UID, the previous occupant's UID is **released** (`uid → None`) but its record — and therefore its identity pin — is **retained**.
- **`pat_storage.get_pat_by_hotkey`** (new) is the source of truth for pinning: the binding follows the stable hotkey, so a hotkey cannot shed its pin by cycling deregistration → re-registration.
- **`pat_storage.get_pat_by_uid`** still returns the current slot occupant (released records carry `uid=None`), so the scoring snapshot (`reward.py`) and `handle_pat_check` are unaffected.
- **`pat_handler._github_identity_pin_error`** now looks the pin up by hotkey (and ignores the `'0'` sentinel).

After the fix, a hotkey re-registering on a new UID stays locked to its original GitHub id; legitimate flows (PAT rotation with the same identity, a genuinely new hotkey on a recycled UID) still pass.

## Tests

- `test_pat_storage.py`: rewrote `test_save_upsert_replaces_hotkey_on_uid` (it encoded the buggy overwrite) into `test_save_releases_uid_but_retains_displaced_pin`; added a `TestGetPatByHotkey` class incl. pin-survives-UID-reuse-and-reregistration.
- `test_pat_handler.py`: added `test_identity_pin_survives_uid_slot_reuse_and_reregistration` (regression). Existing pin/rotation/new-miner/concurrent-recheck tests still hold.

## Notes

Scoped intentionally to the per-hotkey pin (the clear spec violation). A broadcast-time global `github_id`-uniqueness lock was deliberately left out: duplicate-account detection already zeroes miners sharing a GitHub account at scoring time, and such a lock would risk permanently locking out a user who lost access to an old hotkey.
