### PR TITLE
chore(weights): rebalance community emission shares

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,8 +1,4 @@
 {
-  "aglover1221/product-data-extractor": {
-    "emission_share": 0.0,
-    "issue_discovery_share": 0.0
-  },
   "cogniax/tao-pulse-app": {
     "emission_share": 0.01,
     "issue_discovery_share": 0.7,
@@ -55,7 +51,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.1,
+    "emission_share": 0.09,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,
@@ -146,7 +142,7 @@
     }
   },
   "MkDev11/gittensor-hub": {
-    "emission_share": 0.02,
+    "emission_share": 0.012,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 2,
@@ -188,7 +184,7 @@
     "additional_acceptable_branches": ["test"]
   },
   "phase-rs/phase": {
-    "emission_share": 0.015,
+    "emission_share": 0.018,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,
@@ -203,7 +199,7 @@
     "issue_discovery_share": 0.0
   },
   "touchpilot/touchpilot": {
-    "emission_share": 0.025,
+    "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "maintainer_cut": 0.3
   },


### PR DESCRIPTION
Suggestive emission-share rebalance on realized progress since #1389 (merged 2026-05-28) and forward outlook. Subnet price 0.005285 TAO/ALPHA, TAO $219.29 (1.0 share ≈ $9,880/day). Default posture is HOLD; raises must clear the organic-pull gate, demotes require confirmed churn or a proven alt link (suspicion → partial trim, not floor).

## Rebalances
| repo | old | new | est. $/day (old→new) | type |
|---|---:|---:|---|---|
| phase-rs/phase | 0.01500 | 0.01800 | $148 → $178 | raise (analysis) |
| MkDev11/gittensor-hub | 0.02000 | 0.01200 | $198 → $119 | partial trim — suspected |
| touchpilot/touchpilot | 0.02500 | 0.00500 | $247 → $49 | floor — confirmed farming |
| entrius/gittensor | 0.10000 | 0.09000 | $988 → $889 | directed (core repo) |
| aglover1221/product-data-extractor | 0.00000 | removed | $0 → $0 | directed (delisted) |

Held (no change): infiniflow/ragflow 0.055, we-promise/sure 0.030, Geniepod/genie-claw 0.033, e35ventura/taopedia 0.025, e35ventura/taopedia-articles 0.025, seroperson/jvm-live-reload 0.011, vouchdev/vouch 0.010, cogniax/tao-pulse-app 0.010, JSONbored/gittensory 0.010, JSONbored/awesome-claude 0.005.

## Totals
- Previous: `0.43900` (headroom 0.56100)
- New: `0.40400` (headroom 0.59600)

## Why these changed

**phase-rs/phase — raise 0.015 → 0.018**
- Clears the organic-pull gate: 29 external (non-mining-cohort) contributors of 49 total — genuine outside adoption, not emission-manufactured activity.
- Sustained delivery slope, not a pre-rebalance burst: daily releases through v0.1.47 (2026-06-04); 19 eligible miners, all merged through real `matthewevans` APPROVED reviews.
- Caveat (against): 123★, niche/non-commercial — adoption ceiling is real, so the raise is modest, not aggressive.

**MkDev11/gittensor-hub — partial trim 0.020 → 0.012 (SUSPECTED shadow-mining, not confirmed)**
- Claim/evidence: maintainer MkDev11 merges contributor `bitloi`'s PRs with zero human review — all 18 of them — including PR #71 (+1,227 / 23 files) merged in **99 seconds** and PR #154 (+10,163 / 23 files) on bot comments only. bitloi is a 0-follower/no-name account and the repo's top earner (18 PRs + 8 issues).
- Not floored: the work is genuinely substantial source (real repositories-page redesign, treemap algorithm, real components — not churn), and bitloi earns independently-reviewed PRs elsewhere (ragflow). Churn basis is ruled out and the bitloi↔MkDev11 identity link is unproven.
- Action: meaningful trim sized to the suspicion + this note. Verifying the identity link next run; clears if independent review appears on contributor PRs, confirms (→ floor) if linked.

**touchpilot/touchpilot — floor 0.025 → 0.005 (CONFIRMED churn farming)**
- Lead miner `RenzoMXD` (25 PRs) lands net-zero "refactor" churn (additions ≈ deletions) merged by maintainer `tmimmanuel` in 1–8 minutes with zero approved reviews (e.g. #186 +396/−352 in 1 min; #175 +1010/−926 in 8 min). 0 external contributors (11/11 are mining cohort), 10★, no releases — fails the organic-pull gate outright.
- *Rehabilitation: this repo becomes eligible for higher emissions again once we observe the shadow-mining stop — independent review on contributor PRs and no maintainer-merged account drawing rewards via low-value churn. This is a reset, not a ban.*

**Directed (not analysis-driven):** entrius/gittensor 0.10 → 0.09 (core repo, per maintainer direction); aglover1221/product-data-extractor removed entirely (dead/abandoned, last push 2026-05-21, was already 0.0).

## State-of-affairs snapshot — 2026-06-04 (baseline for next run; ext contributors = all-time, first run)

### infiniflow/ragflow
- share: 0.055 | stars: 81,919 | forks: 9,433 | open issues: 3,284 | latest release: v0.25.6 (2026-05-27)
- eligible miners: 21 | repo score: 372 | external non-cohort contributors: 80/99
- roadmap: ROADMAP 2026 (#12241) + Go API rewrite — on track
- state: pre-gittensor flagship OSS, huge organic adoption, rigorous human+bot review. Anchor repo.
- flags: none | revisit: only on a strong sustained shift (anchor — hold)

### we-promise/sure
- share: 0.030 | stars: 8,511 | forks: 127 | open issues: 361 | latest release: v0.7.1 (2026-05-31)
- eligible miners: 7 | repo score: 266 | external non-cohort contributors: 87/96
- roadmap: dated release train, v0.7.2 due 2026-06-29 — delivering
- state: pre-gittensor real product (8.5k★), clean maintainer review (jjmata), miner PRs APPROVED. Anchor.
- flags: none | revisit: anchor — hold

### Geniepod/genie-claw
- share: 0.033 | stars: 45 | forks: 39 | open issues: 24 | latest release: none (v1.0.0-alpha.x workspace)
- eligible miners: 9 | repo score: 17 | external non-cohort contributors: 4/18
- roadmap: 9 milestones, M1 (Jetson harness) near-done — delivering near-term
- state: on-device AI harness; real engineering, most miner PRs reviewed by ai-hpc. Maintainer self-merges legit. Adoption path distant (hardware).
- flags: a few unreviewed miner PRs (#229 +926, 0 approvals); watch | revisit: cap concentration if it grows

### phase-rs/phase
- share: 0.018 (↑ from 0.015) | stars: 123 | forks: 76 | open issues: 592 | latest release: v0.1.47 (2026-06-04)
- eligible miners: 19 | repo score: 785 | external non-cohort contributors: 29/49
- roadmap: card-coverage backlog, daily releases — delivering hard
- state: MTG rules engine; clears organic gate (29 external), clean matthewevans review. Niche/non-commercial ceiling.
- flags: none | revisit: watch adoption — if stars/external stay flat, hold or trim back

### MkDev11/gittensor-hub
- share: 0.012 (↓ from 0.020) | stars: 17 | forks: 31 | open issues: 15 | latest release: seed-2026-05-15
- eligible miners: 4 | repo score: 269 | external non-cohort contributors: 4/13
- roadmap: dashboard UI; low velocity since anchor (~15 commits)
- state: real frontend/infra code but ZERO human-approved review; maintainer MkDev11 rubber-stamps bitloi's large PRs (99-sec / 10k-line merges).
- flags: **SUSPECTED shadow-mining (bitloi↔MkDev11) — unconfirmed; partial trim pending verification**
- revisit: NEXT RUN — confirm identity link → floor; independent review appears → restore

### vouchdev/vouch
- share: 0.010 | stars: 4 | forks: 21 | open issues: 54 | latest release: none
- eligible miners: 3 | repo score: 373 | external non-cohort contributors: 2/7
- roadmap: git-native review-gated KB; young
- state: maintained by plind-junior (registerer; GitHub owner = vouchdev). Sole merger = maintainer (NOT a ring), deltas span days, work genuine. No formal review = weak hygiene, not farming.
- flags: cleared (was suspected; plind = real maintainer) | revisit: don't raise until external pull appears

### JSONbored/gittensory
- share: 0.010 | stars: 4 | forks: 22 | open issues: 105 | latest release: mcp-v0.4.0 (2026-06-02)
- eligible miners: 10 | repo score: 2,299 | external non-cohort contributors: 2/18
- roadmap: API/UI/MCP tooling; shipping, real human review (27% change-request rate)
- state: genuine reviewed engineering BUT ~89% mining-cohort, 4★ — emission-manufactured, fails organic gate.
- flags: high score concentration (gate held the raise) | revisit: raise only when external adoption appears

### JSONbored/awesome-claude
- share: 0.005 | stars: 258 | forks: 62 | open issues: 99 | latest release: mcp-v0.2.0 (2026-05-17)
- eligible miners: 5 | repo score: 408 | external non-cohort contributors: 9/24
- roadmap: awesome-list registry; agentic submission gate
- state: bot review+merge is a legitimate model (not a demote reason). Farm-prone low-skill surface already handled by low weight + default_label_multiplier 0.
- flags: none (agentic gate OK) | revisit: hold

### cogniax/tao-pulse-app
- share: 0.010 | stars: 21 | forks: 14 | open issues: 47 | latest release: none
- eligible miners: 0 | repo score: 0 | external non-cohort contributors: 3/3
- roadmap: mobile Bittensor-signals app; polished, ~2wk old
- state: too young to judge; maintainer cogniax reviewing/merging. 19 open PRs queued.
- flags: none | revisit: let it season; reassess next run

### seroperson/jvm-live-reload
- share: 0.011 | stars: 28 | forks: 26 | open issues: 19 | latest release: v0.1.1 (2025-12-29)
- eligible miners: 2 | repo score: 0.1 | external non-cohort contributors: 2/6
- roadmap: JVM hot-reload lib, Maven Central releases; tapering
- state: legit independent OSS, clean maintainer merges, but low/tapering activity (2 commits since anchor).
- flags: none | revisit: trim if cadence stays flat next run

### touchpilot/touchpilot
- share: 0.005 (↓ from 0.025) | stars: 10 | forks: 23 | open issues: 19 | latest release: none
- eligible miners: 6 | repo score: 840 | external non-cohort contributors: 0/11
- roadmap: Android AI agent; milestone closes but MVP, no releases
- state: CONFIRMED churn farming — RenzoMXD net-zero refactor churn merged in minutes, 0 external contributors.
- flags: **FLOORED — confirmed shadow-mining; rehab path stated** | revisit: restore when churn-farming stops

### e35ventura/taopedia
- share: 0.025 | stars: 3 | forks: 9 | open issues: 29 | latest release: none
- eligible miners: 0 | repo score: 0 | external non-cohort contributors: 3/3
- roadmap: knowledge-base site shell
- state: dormant for contributors (0 eligible, 1 self-merged PR ever); maintainer-only. Held this cycle (out of analysis logic).
- flags: dormant | revisit: revisit contributor surface next run

### e35ventura/taopedia-articles
- share: 0.025 | stars: 8 | forks: 19 | open issues: 7 | latest release: none
- eligible miners: 6 | repo score: 6 | external non-cohort contributors: 4/12
- roadmap: content/articles pipeline (trusted_label_pipeline, default_label_multiplier 0)
- state: high PR throughput with ~43% rejection gate; MkDev11 ~37% concentration. Held this cycle (out of analysis logic).
- flags: contributor concentration | revisit: consider per-contributor cap

---

189 config/weights tests pass (136 in the load/routing suite re-run on this branch); JSON lints clean.
