### PR TITLE
fix: deduplicate cross-referenced PRs in issue submissions timeline

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -286,6 +286,7 @@ def _search_issue_referencing_prs_graphql(
     timeline_nodes = issue_data.get('timelineItems', {}).get('nodes', [])
 
     out: List[PRInfo] = []
+    seen_pr_numbers: set[int] = set()
     for node in timeline_nodes:
         pr = node.get('source') or {}
         if not pr:
@@ -297,6 +298,9 @@ def _search_issue_referencing_prs_graphql(
 
         pr_number = pr.get('number')
         if not pr_number:
+            continue
+
+        if pr_number in seen_pr_numbers:
             continue
 
         state = _resolve_pr_state(pr.get('state', ''), merged=bool(pr.get('merged', False)))
@@ -319,6 +323,7 @@ def _search_issue_referencing_prs_graphql(
             'review_count': int(reviews.get('totalCount', 0) or 0),
             'closing_numbers': closing_numbers,
         }
+        seen_pr_numbers.add(pr_number)
         out.append(pr_info)
 
     return out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,15 @@
 Root pytest configuration shared across all test directories.
 """
 
+import sys
+from unittest.mock import MagicMock
+try:
+    import bittensor
+except ImportError:
+    mock_bittensor = MagicMock()
+    mock_bittensor.logging = MagicMock()
+    sys.modules['bittensor'] = mock_bittensor
+
 import pytest
 import requests
 

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -299,6 +299,28 @@ def _closed_event_non_pr_node(typename='Commit', state_reason='COMPLETED', creat
             '__typename': typename,
         },
     }
+class TestSearchIssueReferencingPRsGraphQL:
+    """Test suite for _search_issue_referencing_prs_graphql function."""
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_search_deduplicates_duplicate_prs(self, mock_logging, mock_graphql):
+        """Verify that duplicate referencing PRs in timeline nodes are deduplicated."""
+        mock_graphql.return_value = _graphql_response(
+            [
+                _pr_node(number=101, user_id=42),
+                _pr_node(number=101, user_id=42),  # Duplicate
+                _pr_node(number=102, user_id=43),
+            ]
+        )
+
+        result = github_api_tools._search_issue_referencing_prs_graphql(
+            'owner/repo', 12, 'fake_token'
+        )
+
+        assert len(result) == 2
+        assert result[0]['number'] == 101
+        assert result[1]['number'] == 102
 
 
 class TestFindSolverFromClosureEvent:


### PR DESCRIPTION
## Summary

Deduplicate PR numbers in cross-referenced timeline events (`CROSS_REFERENCED_EVENT`) to prevent the same PR from being listed multiple times and inflating the submission count.

## Related Issues

Closes #1446
/claim #1446

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
