### PR TITLE
chore(weights): tighten gittensory reward labels

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -128,19 +128,22 @@
     }
   },
   "JSONbored/gittensory": {
+    "default_label_multiplier": 0.0,
     "emission_share": 0.01,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "feature": 1.5
+      "gittensor:bug": 1.0,
+      "gittensor:feature": 1.25,
+      "gittensor:priority": 1.75
     },
-    "maintainer_cut": 0.3,
+    "maintainer_cut": 0.35,
     "scoring": {
       "pr_lookback_days": 45,
-      "maintainer_issue_multiplier": 1.75,
+      "maintainer_issue_multiplier": 2.0,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 14,
-        "min_multiplier": 0.1
+        "sigmoid_midpoint_days": 10,
+        "min_multiplier": 0.05
       }
     }
   },


### PR DESCRIPTION
## Summary
- tighten `JSONbored/gittensory` scoring around explicit namespaced reward labels
- set unmatched labels to `0.0` with `default_label_multiplier`
- update maintainer cut and repo-local scoring parameters for review-heavy direct PR work

## What changed
- Replace plain `feature` scoring with `gittensor:bug`, `gittensor:feature`, and `gittensor:priority`.
- Set `default_label_multiplier` to `0.0` so non-reward labels do not score by default.
- Increase `maintainer_cut` from `0.3` to `0.35`.
- Set `maintainer_issue_multiplier` to `2.0` and tighten the time-decay midpoint/floor to 10 days / `0.05`.

## Why
This keeps the repo's scoring surface narrow and explicit while preserving direct-PR-first contribution flow. `gittensor:priority` is reserved for maintainer-selected work that deserves an additional bonus.

## Validation
- `python -m json.tool gittensor/validator/weights/master_repositories.json >/dev/null`
- `git diff --check`
- `uv run --extra dev python -m pytest tests/validator/test_load_weights.py tests/validator/test_scoring_resolver.py tests/validator/test_blend_emission_pools.py tests/validator/test_maintainer_uids.py -q`
