### PR TITLE
chore(weights): tune phase-rs/phase and vouchdev/vouch eligibility and maintainer cut

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -197,7 +197,10 @@
       "refactor": 0.25,
       "test": 1.2
     },
-    "maintainer_cut": 0.5
+    "maintainer_cut": 0.5,
+    "eligibility": {
+      "excessive_pr_penalty_base_threshold": 10
+    }
   },
   "seroperson/jvm-live-reload": {
     "emission_share": 0.011,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -200,7 +200,7 @@
       "refactor": 0.25,
       "test": 1.2
     },
-    "maintainer_cut": 0.5,
+    "maintainer_cut": 0.6,
     "eligibility": {
       "excessive_pr_penalty_base_threshold": 10
     }

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -184,6 +184,9 @@
         "min_multiplier": 0.1
       }
     },
+    "eligibility": {
+      "excessive_pr_penalty_base_threshold": 3
+    },
     "additional_acceptable_branches": ["test"],
     "maintainer_cut": 0.5
   },


### PR DESCRIPTION
Three small per-repo overrides on `master_repositories.json`:

- **`phase-rs/phase` `eligibility.excessive_pr_penalty_base_threshold: 10`** — phase has high PR throughput; the default threshold of 2 (`gittensor/constants.py:172`) caused the binary `open_pr_spam` multiplier (`scoring.py:72-80`) to zero merged-PR earnings whenever a contributor sat with even a few open PRs in flight. Raising the base to 10 lifts the threshold to `min(10 + floor(token_score/300), 30)` and lets active contributors carry their typical open-PR queue without losing the round.

- **`vouchdev/vouch` `eligibility.excessive_pr_penalty_base_threshold: 3`** — modest +1 over the default (2 → 3) to match vouch's actual cadence; not as aggressive as phase since the throughput is lower.

- **`phase-rs/phase` `maintainer_cut: 0.5 → 0.6`** — small increase to phase's maintainer carve-out.

## Changes

```json
"phase-rs/phase": {
  ...
  "maintainer_cut": 0.6,
  "eligibility": {
    "excessive_pr_penalty_base_threshold": 10
  }
},
"vouchdev/vouch": {
  ...
  "eligibility": {
    "excessive_pr_penalty_base_threshold": 3
  },
  ...
}
```

Note: `excessive_pr_penalty_base_threshold` must be nested under `eligibility` — it's a field of `RepoEligibilityConfig` (`gittensor/validator/utils/load_weights.py:61`); a top-level placement is silently ignored, not rejected. Pattern matches the existing `Geniepod/genie-claw` override.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (weights/config)

## Testing

- JSON validated; loader exercised — `resolve_eligibility(p.eligibility).excessive_pr_penalty_base_threshold` returns 10 for phase and 3 for vouch.
- `uv run pytest` — 913 passed.
- `uv run pyright` / `ruff check` / `ruff format --check` / `vulture` — clean.
- Per-PR scoring math unchanged; only the per-repo eligibility threshold and maintainer carve-out shift.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
