### PR TITLE
fix(validator): persist closed_at for closed pull requests

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -159,6 +159,7 @@ class PullRequest:
     title: str
     author_login: str
     merged_at: Optional[datetime]  # None for OPEN PRs
+    closed_at: Optional[datetime] = None  # Set when PR is CLOSED without merge
     created_at: datetime
 
     # PR state based fields

--- a/gittensor/validator/oss_contributions/mirror/adapters.py
+++ b/gittensor/validator/oss_contributions/mirror/adapters.py
@@ -98,6 +98,7 @@ def mirror_scored_pr_to_legacy_pull_request(
     - ``pr.body`` → ``PullRequest.description``
     - ``pr.head_sha`` → ``PullRequest.head_ref_oid``
     - ``pr.base_sha`` → ``PullRequest.base_ref_oid``
+    - ``pr.closed_at`` → ``PullRequest.closed_at``
     - state string ``MERGED|OPEN|CLOSED`` → ``PRState`` enum
 
     ``file_changes`` and ``issues`` are left as None on the resulting PullRequest
@@ -114,6 +115,7 @@ def mirror_scored_pr_to_legacy_pull_request(
         title=pr.title,
         author_login=pr.author_login,
         merged_at=pr.merged_at,
+        closed_at=pr.closed_at,
         created_at=pr.created_at,
         pr_state=PRState(pr.state),
         base_score=scored.base_score,

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -44,7 +44,7 @@ DO NOTHING
 BULK_UPSERT_PULL_REQUESTS = """
 INSERT INTO pull_requests (
     number, repository_full_name, uid, hotkey, github_id, title, author_login,
-    merged_at, pr_created_at, pr_state,
+    merged_at, closed_at, pr_created_at, pr_state,
     base_score, issue_multiplier,
     open_pr_spam_multiplier, time_decay_multiplier,
     credibility_multiplier, review_quality_multiplier, label_multiplier, label,
@@ -54,7 +54,7 @@ INSERT INTO pull_requests (
     token_score, structural_count, structural_score, leaf_count, leaf_score
 ) VALUES (
     %s, %s, %s, %s, %s, %s, %s,
-    %s, %s, %s,
+    %s, %s, %s, %s,
     %s, %s,
     %s, %s,
     %s, %s, %s, %s,
@@ -70,6 +70,7 @@ DO UPDATE SET
     title = EXCLUDED.title,
     author_login = EXCLUDED.author_login,
     merged_at = EXCLUDED.merged_at,
+    closed_at = EXCLUDED.closed_at,
     pr_state = EXCLUDED.pr_state,
     base_score = EXCLUDED.base_score,
     issue_multiplier = EXCLUDED.issue_multiplier,

--- a/gittensor/validator/storage/repository.py
+++ b/gittensor/validator/storage/repository.py
@@ -175,6 +175,7 @@ class Repository(BaseRepository):
                     pr.title,
                     pr.author_login,
                     pr.merged_at,
+                    pr.closed_at,
                     pr.created_at,
                     pr.pr_state.value,  # Convert PRState enum to string
                     pr.base_score,

--- a/tests/validator/oss_contributions/mirror/test_adapters.py
+++ b/tests/validator/oss_contributions/mirror/test_adapters.py
@@ -229,6 +229,8 @@ class TestMirrorScoredPrToLegacyPullRequest:
         scored = ScoredPR(pr=pr)
         adapted = mirror_scored_pr_to_legacy_pull_request(scored, 1, 'hk', 'gid')
         assert adapted.pr_state == PRState.CLOSED
+        assert adapted.closed_at == pr.closed_at
+        assert adapted.merged_at is None
 
     def test_changes_requested_count_from_review_summary(self):
         pr = _make_mirror_pr(maintainer_changes_requested=4)


### PR DESCRIPTION
## Summary

Closed (unmerged) pull requests were not retaining their closure timestamp during validator ingestion and persistence.

Although the mirror API provides a `closed_at` value, the validator adapter and database persistence layer only stored `merged_at`, `pr_created_at`, and `pr_state`. As a result, downstream consumers could not determine when a closed pull request actually became inactive.

This PR adds end-to-end persistence of `closed_at` within the validator storage pipeline, ensuring closure timestamps are available for downstream reporting, analytics, and UI consumption.

Fixes #1453 

## Changes

* Add `closed_at` to the `PullRequest` model
* Map `closed_at` from mirror payloads during PR adaptation
* Persist `closed_at` in `BULK_UPSERT_PULL_REQUESTS`
* Include `closed_at` in repository bulk storage operations
* Extend adapter test coverage to verify `closed_at` is preserved for closed PRs

## Why This Matters

Merged pull requests already expose a meaningful activity timestamp via `merged_at`, but closed pull requests did not expose an equivalent closure timestamp.

Persisting `closed_at` enables:

* Accurate tracking of closed PR activity
* Improved contributor and repository analytics
* Correct activity-window calculations
* Consistent lifecycle data between Issues and Pull Requests
* Future UI enhancements that display closure dates and durations

## Database Migration

This change requires the following schema migration:

```sql
ALTER TABLE pull_requests
ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ NULL;
```

The migration must be applied before or alongside deployment.

## Out of Scope

This PR only persists the data within the validator.

Follow-up changes are required in downstream repositories to surface the value:

* Dashboard API: expose `closed_at` as `closedAt`
* gittensor-ui: display closure date or duration for closed pull requests

## Test Plan

* [x] Verify `closed_at` is mapped from mirror payloads
* [x] Verify `closed_at` is included in bulk persistence operations
* [x] Verify CLOSED pull requests retain `closed_at`
* [x] Verify merged pull requests continue to use `merged_at` unchanged

```bash
uv run pytest tests/validator/oss_contributions/mirror/test_adapters.py -q

uv run pytest tests/validator/utils/test_storage_mirror.py -q
```
