### PR TITLE
fix(validator): skip transient zero-pr storage writes

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -117,12 +117,20 @@ class Validator(BaseValidatorNeuron):
 
         skip_uids = skip_uids or set()
         successful_count = 0
-        skipped_count = 0
+        cached_skipped_count = 0
+        transient_skipped_count = 0
         failed_uids: List[int] = []
 
         for uid, evaluation in miner_evals.items():
             if uid in skip_uids:
-                skipped_count += 1
+                cached_skipped_count += 1
+                continue
+
+            if evaluation.should_use_cache_fallback:
+                transient_skipped_count += 1
+                bt.logging.warning(
+                    f'Skipping DB storage for UID {uid}: transient PR fetch failure with no cached evaluation available'
+                )
                 continue
 
             try:
@@ -141,8 +149,10 @@ class Validator(BaseValidatorNeuron):
         # Summary logging
         if successful_count > 0:
             bt.logging.success(f'Stored validation results for {successful_count} UIDs to DB')
-        if skipped_count > 0:
-            bt.logging.info(f'Skipped {skipped_count} UIDs (cached evaluations)')
+        if cached_skipped_count > 0:
+            bt.logging.info(f'Skipped {cached_skipped_count} UIDs (cached evaluations)')
+        if transient_skipped_count > 0:
+            bt.logging.info(f'Skipped {transient_skipped_count} UIDs (transient PR fetch failures without cache)')
         if failed_uids:
             bt.logging.warning(f'Failed to store {len(failed_uids)} UIDs: {failed_uids}')
 

--- a/tests/validator/test_bulk_store_evaluation.py
+++ b/tests/validator/test_bulk_store_evaluation.py
@@ -1,0 +1,53 @@
+"""Regression tests for validator evaluation storage guards."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+classes = pytest.importorskip('gittensor.classes')
+validator_module = pytest.importorskip('neurons.validator')
+
+MinerEvaluation = classes.MinerEvaluation
+Validator = validator_module.Validator
+
+
+class _FakeStorage:
+    def __init__(self):
+        self.stored = []
+
+    def store_evaluation(self, evaluation, master_repositories):
+        self.stored.append(evaluation)
+        return SimpleNamespace(success=True, errors=[], stored_counts={})
+
+
+def _run_bulk_store(storage, miner_evals):
+    self_obj = SimpleNamespace(db_storage=storage)
+    asyncio.run(Validator.bulk_store_evaluation(self_obj, miner_evals, {'entrius/gittensor': object()}))
+
+
+def test_transient_identity_failure_without_cache_is_not_stored_as_zero_pr_eval():
+    """A transient GitHub /user failure is not authoritative PR state.
+
+    If cache fallback cannot restore a prior PR-bearing evaluation, the zero-PR
+    placeholder must not overwrite last-good DB rows.
+    """
+    storage = _FakeStorage()
+    evaluation = MinerEvaluation(uid=29, hotkey='hk', github_id='49853598')
+    evaluation.github_pr_fetch_failed = True
+
+    _run_bulk_store(storage, {29: evaluation})
+
+    assert storage.stored == []
+
+
+def test_successful_zero_pr_evaluation_still_stores():
+    """Legitimate zero-PR miners still need DB rows; only fetch failures skip."""
+    storage = _FakeStorage()
+    evaluation = MinerEvaluation(uid=30, hotkey='hk', github_id='12345')
+
+    _run_bulk_store(storage, {30: evaluation})
+
+    assert storage.stored == [evaluation]


### PR DESCRIPTION
## Summary

Prevent transient GitHub identity / PR-fetch placeholder evaluations from overwriting DB rows as authoritative zero-PR evaluations when no in-memory cache fallback is available.

This is a narrow follow-up to #932. #932 correctly lets transient GitHub `/user` failures use cache fallback when a validator has a usable in-memory cache entry. If a validator has restarted, or otherwise has no PR-bearing cache entry for the miner, the transient placeholder can still reach DB storage with `total_prs=0`.

## Production evidence

This failure shape is active in validator-side PAT checks:

- The miner has a stored PAT on all 7 serving validators.
- Each validator reports `has_pat: true`.
- Each validator reports `pat_valid: null`, not `false`.
- Each validator reports `GitHub API temporarily unavailable; retry the check in a few minutes.`

That means this is not an invalid/revoked PAT case. It is the transient GitHub identity-check path that prior fixes intentionally treat as inconclusive / cache-fallback-eligible.


Concrete active repro: UID 29 on subnet 74 currently shows this path via `gitt miner check`:

- all 7 serving validators report `has_pat: true`
- all 7 report `pat_valid: null`, not `false`
- all 7 return `GitHub API temporarily unavailable; retry the check in a few minutes.`

That is the transient identity-check path this PR guards. It is not an invalid PAT case, and it is active in production rather than only a synthetic test fixture.

Public validator logs also showed the same shape during scoring:

- PAT broadcast/check accepted the stored GitHub identity.
- Later `/user` identity revalidation failed with repeated transient `403` responses across all retry attempts.
- The validator logged transient identity failure and skipped PR loading.
- On validators without a usable in-memory PR cache, the evaluation remained a zero-PR placeholder.
- That placeholder was still eligible for DB storage through `bulk_store_evaluation`.

## Code path

Current behavior:

1. `validate_github_credentials` can return a stored GitHub id with `transient_failure=True`.
2. `validate_response_and_initialize_miner_evaluation` sets `github_pr_fetch_failed=True` and leaves `failed_reason=None`.
3. `evaluate_miners_pull_requests` short-circuits before loading PRs, so the evaluation has `total_prs=0`.
4. `store_or_use_cached_evaluation` can restore a cached evaluation only when a PR-bearing in-memory cache entry exists.
5. If no such cache exists, `bulk_store_evaluation` still stores the transient zero-PR placeholder.

This PR adds the missing storage guard: if `evaluation.should_use_cache_fallback` is still true at DB-storage time, skip storing that non-authoritative placeholder.

## Historical context

This intentionally follows the prior cache-fallback decisions rather than changing policy broadly:

- #931 / #932: transient GitHub `/user` failures should use cache fallback instead of becoming invalid PAT failures.
- #515 / #516: legitimate successful zero-PR miners must still store as zero.
- #904 / #905: auth/scope/PAT failures must fail closed and must not restore stale cache.
- #596 / #600 and #1039 / #1040: authoritative duplicate-penalty zeroing must still persist.
- #922 / #1052 / #1105: fresh issue-discovery updates normally need persistence, so skip behavior must remain narrow.
- #1106 / #1107 and #1406 / #1407: transient PAT checks should surface as inconclusive rather than invalid/no-response.
- #1307: do not add another cache freshness layer or expand fallback complexity.

The new guard only applies to transient placeholder evaluations where `should_use_cache_fallback` remains true. It does not skip successful zero-PR evaluations or permanent invalid-auth failures.

## Tradeoff

DB storage runs after issue discovery. If issue-discovery fields were refreshed in the same round for the same miner, this skip also avoids writing those fresh DB fields.

That is deliberate for this narrow path: preserving last-good DB state is safer than mixing fresh issue fields with non-authoritative zero PR fields from a transient GitHub identity / PR fetch failure.

## What changed

- Skip DB storage in `Validator.bulk_store_evaluation` when an evaluation still has `should_use_cache_fallback=True`.
- Log transient-placeholder skips separately from normal cached-evaluation skips.
- Add regression tests proving:
  - transient GitHub identity failure without cache does not store a zero-PR DB row
  - successful zero-PR evaluations still store normally

## Validation

- `python -m pytest tests/validator/test_bulk_store_evaluation.py tests/validator/test_github_identity_fallback.py tests/validator/test_store_or_use_cached_evaluation.py tests/validator/oss_contributions/mirror/test_routing.py -q`
- `python -m pytest tests/validator -q`
- `python -m pytest -q`
- `ruff check gittensor/ neurons/ tests/`

Full test suite passed: 915 tests. Validator suite passed: 565 tests.
