### PR TITLE
perf(validator): free per-PR file content after scoring

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -167,6 +167,10 @@ async def score_pr(
             scored.leaf_score = result.leaf_score
             scored.total_nodes_scored = result.total_nodes_scored
             scored.base_score = result.base_score
+
+            for scored_file in files:
+                scored_file.head_content = None
+                scored_file.base_content = None
         elif not has_fixed_base:
             bt.logging.warning(f'No files returned for PR #{pr.pr_number}')
             return


### PR DESCRIPTION
## Summary

`score_pr` attaches each PR's full source text to its `ScoredPR` via `scored.files` — `MirrorFile.head_content` / `base_content`, up to ~1 MB per file. That content is only needed transiently to compute the tree-diff scalar scores (token/structural/leaf counts + base score), but it currently stays attached to every `ScoredPR` and is held across **all** miners in `miner_evaluations` for the entire scoring round.

This frees the heavy text as soon as the scalar scores are extracted, keeping only the lightweight file metadata (filename / additions / deletions). The persistent cache already does exactly this — `_scored_mirror_pr_for_cache` sets `files = None` (`classes.py`); this just applies the same treatment to the live round dict.

**Effect:** peak scoring-round memory drops from roughly `miners × PRs × files × content` down to metadata + a single PR's content at a time, with no change to scoring output.

## Why it's safe

The file content is consumed entirely within `score_pr` (the `file_contents` dict built by `mirror_files_to_legacy` and passed to `calculate_base_score_for_pr_files`). Nothing downstream reads `head_content` / `base_content` after that point:

- `_calculate_pr_multipliers` reads only PR metadata + scalar scores
- `finalize_miner_scores` operates on scalar scores
- `bulk_store_evaluation` → `get_all_file_changes` reads only file **metadata** (discards content)

## Type of Change

- [x] Performance / optimization

## Testing

- [x] Existing mirror scoring tests pass (72 passed)