### PR TITLE
refactor: hoist 'from math import prod' out of calculate_open_pr_collateral_score

### DIFF
--- a/gittensor/validator/oss_contributions/scoring.py
+++ b/gittensor/validator/oss_contributions/scoring.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
+from math import prod
 from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 import bittensor as bt
@@ -247,8 +248,6 @@ def calculate_open_pr_collateral_score(pr: 'ScoredPR', scoring: ResolvedScoring)
     NOT applicable: time_decay (merge-based), credibility_multiplier (merge-based),
                     open_pr_spam (not for collateral)
     """
-    from math import prod
-
     multipliers = {
         'issue': pr.issue_multiplier,
         'label': pr.label_multiplier,


### PR DESCRIPTION
## Summary

The `math.prod` import in [`gittensor/validator/oss_contributions/scoring.py`](gittensor/validator/oss_contributions/scoring.py#L250) is function-local inside `calculate_open_pr_collateral_score`, which is the only use of the name in this module.

[`gittensor/classes.py:6`](gittensor/classes.py#L6) already imports `from math import prod` at module-level for the same purpose (per-PR score multiplier composition), so this brings `scoring.py` in line with the established in-codebase pattern.

`calculate_open_pr_collateral_score` runs for **every open PR in every scoring round** — the per-call import lookup is on a validator hot path. Hoisting removes that overhead and matches the imports-at-top convention used everywhere else in the module.

Verified **no circular-import risk**: `math` is stdlib.

```diff
+from math import prod
 from typing import TYPE_CHECKING, Dict, List, Optional, Set

 import bittensor as bt
 ...

 def calculate_open_pr_collateral_score(pr: 'ScoredPR', scoring: ResolvedScoring) -> float:
     """..."""
-    from math import prod
-
     multipliers = {
```

Net: **+1 / -2 lines**, single file. No behaviour change.

Same shape as just-merged #1436 (hoist `gittensor.constants` import out of `get_contract_address`).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- `pytest tests/` — all 913 tests pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)