### PR TITLE
chore(weights): add touchpilot label multipliers

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -206,6 +206,13 @@
   "touchpilot/touchpilot": {
     "emission_share": 0.005,
     "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "type: bug": 1.1,
+      "type: enhancement": 1.25,
+      "type: feature": 1.5,
+      "type: refactor": 0.25,
+      "type: test": 1.2
+    },
     "maintainer_cut": 0.3
   },
   "we-promise/sure": {


### PR DESCRIPTION
## Summary
- add label multipliers for touchpilot/touchpilot
- use the exact type-prefixed labels emitted by TouchPilot's PR labeler
- keep existing emission share and maintainer cut unchanged

## Multipliers
- type: bug: 1.1
- type: enhancement: 1.25
- type: feature: 1.5
- type: refactor: 0.25
- type: test: 1.2

## Validation
- python3 -m json.tool gittensor/validator/weights/master_repositories.json
- uv run --extra dev pytest tests/validator/test_load_weights.py -q