### PR TITLE
fix(mirror): reject known cross-repo linked issues

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -86,6 +86,7 @@ class MirrorLinkedIssue:
     updated_at: Optional[datetime]
     is_transferred: bool
     solved_by_pr: Optional[int]
+    repository_full_name: Optional[str] = None
     labels: List[MirrorLabel] = field(default_factory=list)
 
     @classmethod
@@ -106,6 +107,9 @@ class MirrorLinkedIssue:
             updated_at=parse_optional_github_iso_to_utc(data.get('updated_at')),
             is_transferred=bool(data.get('is_transferred', False)),
             solved_by_pr=data.get('solved_by_pr'),
+            repository_full_name=(
+                data['repository_full_name'].lower() if data.get('repository_full_name') else None
+            ),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
         )
 

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -445,6 +445,7 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
     """Anti-gaming gates for issue → PR multiplier credit.
 
     - Reject transferred issues.
+    - Reject cross-repo issues when mirror provides issue repository identity.
     - Missing author / self-issue (uses github_id for immutability).
     - Issue created after the PR.
     - Any CLOSED issue must have state_reason=COMPLETED — NOT_PLANNED / reopened
@@ -461,6 +462,13 @@ def _is_valid_linked_issue(li: MirrorLinkedIssue, pr: MirrorPullRequest) -> bool
     """
     if li.is_transferred:
         bt.logging.warning(f'Skipping linked issue #{li.number} - transferred')
+        return False
+
+    if li.repository_full_name is not None and li.repository_full_name != pr.repo_full_name:
+        bt.logging.warning(
+            f'Skipping linked issue #{li.number} - cross-repo reference '
+            f'(issue in {li.repository_full_name}, PR in {pr.repo_full_name})'
+        )
         return False
 
     if li.author_github_id is None:

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -699,8 +699,9 @@ def _linked_issue(
     closed_at: str | None = '2026-04-18T10:00:00Z',
     author_association: str | None = 'CONTRIBUTOR',
     number: int = 50,
+    repository_full_name: str | None = None,
 ):
-    return {
+    data = {
         'number': number,
         'title': 't',
         'state': state,
@@ -714,6 +715,9 @@ def _linked_issue(
         'solved_by_pr': 100,
         'labels': [],
     }
+    if repository_full_name is not None:
+        data['repository_full_name'] = repository_full_name
+    return data
 
 
 class TestIssueMultiplier:
@@ -754,6 +758,22 @@ class TestLinkedIssueValidity:
         scored = ScoredPR(pr=_pr())
         li = MirrorLinkedIssue.from_dict(_linked_issue(is_transferred=True))
         assert _is_valid_linked_issue(li, scored.pr) is False
+
+    def test_cross_repo_linked_issue_blocks_when_repo_known(self):
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name='other-owner/other-repo'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+
+    def test_same_repo_linked_issue_passes_when_repo_known(self):
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name='Entrius/Gittensor-UI'))
+        assert _is_valid_linked_issue(li, scored.pr) is True
+
+    def test_missing_repo_identity_preserves_current_behavior(self):
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(repository_full_name=None))
+        assert li.repository_full_name is None
+        assert _is_valid_linked_issue(li, scored.pr) is True
 
     def test_missing_author_blocks(self):
         scored = ScoredPR(pr=_pr())


### PR DESCRIPTION
## Summary
- Add optional `repository_full_name` parsing to `MirrorLinkedIssue`, normalized to lowercase when present.
- Reject linked issues in `_is_valid_linked_issue` when the mirror reports a repository different from the PR repo.
- Preserve existing behavior for older mirror payloads where the linked issue repo identity is missing.

Fixes #1243

## Test plan
- `uv run --extra dev ruff check gittensor/utils/mirror/models.py gittensor/validator/oss_contributions/mirror/scoring.py tests/validator/oss_contributions/mirror/test_scoring.py`
- `uv run --extra dev pytest tests/validator/oss_contributions/mirror/test_scoring.py tests/validator/oss_contributions/mirror/test_adapters.py tests/validator/oss_contributions/mirror/test_classes_integration.py`

## Notes
This is the validator-side guard described in #1243. It fails open for missing `repository_full_name` so current mirror snapshots keep their existing issue multiplier behavior until das-github-mirror starts emitting the field.

Made with [Cursor](https://cursor.com)