### PR TITLE
feat(cli): add gitt miner advisor and gitt miner scan commands

### DIFF
--- a/gittensor/cli/miner_commands/__init__.py
+++ b/gittensor/cli/miner_commands/__init__.py
@@ -8,12 +8,16 @@ Command structure:
         post                     Broadcast GitHub PAT to validators
         check                    Check how many validators have your PAT
         score                    Score GitHub entities through the production pipeline
+        advisor                  Analyse scoring results and surface actionable recommendations
+        scan                     Discover high-value open issues across incentivised repos
 """
 
 import click
 
+from .advisor import advisor_command
 from .check import miner_check
 from .post import miner_post
+from .scan import scan_command
 from .score import score_command
 
 
@@ -26,6 +30,8 @@ def miner_group():
         post     Broadcast your GitHub PAT to validators
         check    Check how many validators have your PAT stored
         score    Run the validator scoring pipeline end-to-end for a single miner
+        advisor  Analyse scoring results and surface actionable recommendations
+        scan     Discover high-value open issues across incentivised repos
     """
     pass
 
@@ -33,6 +39,8 @@ def miner_group():
 miner_group.add_command(miner_post, name='post')
 miner_group.add_command(miner_check, name='check')
 miner_group.add_command(score_command, name='score')
+miner_group.add_command(advisor_command, name='advisor')
+miner_group.add_command(scan_command, name='scan')
 
 
 def register_miner_commands(cli):

--- a/gittensor/cli/miner_commands/advisor.py
+++ b/gittensor/cli/miner_commands/advisor.py
@@ -1,0 +1,433 @@
+# Entrius 2025
+
+"""gitt miner advisor — Analyse scoring results and surface actionable recommendations.
+
+Runs the same validator pipeline as ``gitt miner score`` but, instead of
+dumping raw numbers, interprets them and tells the miner exactly what to do
+next to maximise their reward.
+
+Categories of advice produced:
+- CRITICAL  Eligibility blockers — fix these or earn nothing in a repo
+- WARNING   Active penalties cutting your score right now
+- TIP       Multiplier opportunities you are not yet using
+- INFO      Context useful for planning (time decay, label opportunities, etc.)
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional, cast
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from gittensor.cli.miner_commands.helpers import (
+    PIPELINE_DEV_HOTKEY,
+    PIPELINE_DEV_UID,
+    LocalValidatorStub,
+    drain_logs,
+    override_pats_file,
+    _error,
+)
+from gittensor.validator.oss_contributions.scoring import calculate_open_pr_threshold
+from gittensor.validator.utils.load_weights import (
+    RepositoryConfig,
+    resolve_eligibility,
+    resolve_scoring,
+)
+
+console = Console()
+
+
+# ---------------------------------------------------------------------------
+# Advice model
+# ---------------------------------------------------------------------------
+
+
+class Severity(Enum):
+    CRITICAL = "CRITICAL"
+    WARNING = "WARNING"
+    TIP = "TIP"
+    INFO = "INFO"
+
+
+_SEVERITY_STYLE = {
+    Severity.CRITICAL: "bold red",
+    Severity.WARNING: "yellow",
+    Severity.TIP: "bold cyan",
+    Severity.INFO: "dim",
+}
+
+_SEVERITY_ICON = {
+    Severity.CRITICAL: "✗",
+    Severity.WARNING: "⚠",
+    Severity.TIP: "★",
+    Severity.INFO: "·",
+}
+
+
+@dataclass
+class Advice:
+    severity: Severity
+    repo: Optional[str]
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Analysis helpers
+# ---------------------------------------------------------------------------
+
+
+def _days_since(dt: datetime) -> float:
+    return (datetime.now(timezone.utc) - dt).total_seconds() / 86400
+
+
+def _analyse(
+    miner_eval: Any,
+    master_repositories: Dict[str, RepositoryConfig],
+    rewards_payload: Dict[str, Any],
+) -> List[Advice]:
+    """Derive a list of Advice objects from a completed MinerEvaluation."""
+    advice: List[Advice] = []
+
+    if miner_eval.failed_reason:
+        advice.append(
+            Advice(
+                Severity.CRITICAL,
+                None,
+                f"Identity validation failed: {miner_eval.failed_reason}. "
+                "Register a valid GitHub PAT with: gitt miner post",
+            )
+        )
+        return advice
+
+    for repo_name, repo_config in sorted(master_repositories.items(), key=lambda x: -x[1].emission_share):
+        if repo_config.emission_share <= 0:
+            continue
+
+        repo_eval = miner_eval.repo_evaluations.get(repo_name)
+        merged = [pr for pr in miner_eval.merged_prs if pr.pr.repo_full_name.lower() == repo_name]
+        closed = [pr for pr in miner_eval.closed_prs if pr.pr.repo_full_name.lower() == repo_name]
+        open_prs = [pr for pr in miner_eval.open_prs if pr.pr.repo_full_name.lower() == repo_name]
+
+        elig_cfg = resolve_eligibility(repo_config.eligibility)
+        scoring_cfg = resolve_scoring(repo_config.scoring)
+
+        merged_count = len(merged)
+        closed_count = len(closed)
+        open_count = len(open_prs)
+        total_attempts = merged_count + closed_count
+        credibility = merged_count / total_attempts if total_attempts > 0 else 0.0
+
+        # --- eligibility gate ---
+        if merged_count < elig_cfg.min_valid_merged_prs:
+            need = elig_cfg.min_valid_merged_prs - merged_count
+            advice.append(
+                Advice(
+                    Severity.CRITICAL,
+                    repo_name,
+                    f"Need {need} more merged PR(s) to unlock scoring "
+                    f"(have {merged_count}/{elig_cfg.min_valid_merged_prs}). "
+                    f"emission_share={repo_config.emission_share:.1%}",
+                )
+            )
+        elif credibility < elig_cfg.min_credibility:
+            advice.append(
+                Advice(
+                    Severity.CRITICAL,
+                    repo_name,
+                    f"Credibility {credibility:.0%} below minimum {elig_cfg.min_credibility:.0%} "
+                    f"(merged={merged_count}, closed={closed_count}). "
+                    "Avoid submitting PRs that are likely to be closed without merging.",
+                )
+            )
+
+        # --- open-PR spam penalty ---
+        total_token_score = sum(pr.token_score for pr in merged)
+        spam_threshold = calculate_open_pr_threshold(elig_cfg, total_token_score)
+        if open_count > spam_threshold:
+            advice.append(
+                Advice(
+                    Severity.WARNING,
+                    repo_name,
+                    f"Open PR spam penalty active: {open_count} open PRs > threshold {spam_threshold}. "
+                    "ALL earned scores for this repo are zeroed. "
+                    f"Close {open_count - spam_threshold} open PR(s) to restore scoring.",
+                )
+            )
+        elif open_count == spam_threshold and spam_threshold > 0:
+            advice.append(
+                Advice(
+                    Severity.WARNING,
+                    repo_name,
+                    f"At the open-PR limit ({open_count}/{spam_threshold}). "
+                    "One more open PR will zero all earned scores for this repo.",
+                )
+            )
+
+        # --- time decay on merged PRs ---
+        for spr in merged:
+            if spr.pr.merged_at is None:
+                continue
+            days = _days_since(spr.pr.merged_at)
+            midpoint = scoring_cfg.time_decay.sigmoid_midpoint_days
+            if days >= midpoint:
+                decay = spr.time_decay_multiplier
+                advice.append(
+                    Advice(
+                        Severity.WARNING,
+                        repo_name,
+                        f"PR #{spr.pr.pr_number} is {days:.0f}d old "
+                        f"(time decay={decay:.2f}x, midpoint={midpoint:.0f}d). "
+                        "Score will continue to drop — open a new PR to replace it.",
+                    )
+                )
+            elif days >= scoring_cfg.time_decay.grace_period_hours / 24 * 3:
+                decay = spr.time_decay_multiplier
+                if decay < 0.9:
+                    advice.append(
+                        Advice(
+                            Severity.INFO,
+                            repo_name,
+                            f"PR #{spr.pr.pr_number} is {days:.0f}d old (time decay={decay:.2f}x). "
+                            "Consider submitting new PRs before this decays further.",
+                        )
+                    )
+
+        # --- review quality penalty ---
+        for spr in merged:
+            if spr.review_quality_multiplier < 1.0:
+                penalty_pct = (1.0 - spr.review_quality_multiplier) * 100
+                advice.append(
+                    Advice(
+                        Severity.WARNING,
+                        repo_name,
+                        f"PR #{spr.pr.pr_number} has review quality penalty "
+                        f"({penalty_pct:.0f}% deduction from CHANGES_REQUESTED reviews). "
+                        "Address maintainer feedback thoroughly before submitting.",
+                    )
+                )
+
+        # --- issue multiplier opportunity ---
+        if repo_eval and repo_eval.is_eligible:
+            prs_without_issue = [spr for spr in merged if spr.issue_multiplier <= 1.0]
+            if prs_without_issue:
+                advice.append(
+                    Advice(
+                        Severity.TIP,
+                        repo_name,
+                        f"{len(prs_without_issue)} merged PR(s) lack an issue link "
+                        f"(standard multiplier=1.33x, maintainer issue=1.66x). "
+                        "Find open issues in this repo and link your next PR to one.",
+                    )
+                )
+
+        # --- label multiplier opportunity ---
+        if repo_config.label_multipliers and repo_eval and repo_eval.is_eligible:
+            best_label = max(repo_config.label_multipliers.items(), key=lambda x: x[1])
+            if best_label[1] > 1.0:
+                prs_without_label = [
+                    spr for spr in merged if spr.label is None or spr.label_multiplier <= 1.0
+                ]
+                if prs_without_label:
+                    advice.append(
+                        Advice(
+                            Severity.TIP,
+                            repo_name,
+                            f"Best scoring label for this repo: '{best_label[0]}' ({best_label[1]:.2f}x). "
+                            f"{len(prs_without_label)} merged PR(s) are not benefiting from a label. "
+                            "Ask maintainers to apply scoring labels to eligible PRs.",
+                        )
+                    )
+
+        # --- issue discovery opportunity ---
+        if repo_config.issue_discovery_share > 0 and repo_eval:
+            if repo_eval.issue_discovery_score <= 0 and repo_eval.is_eligible:
+                advice.append(
+                    Advice(
+                        Severity.TIP,
+                        repo_name,
+                        f"Issue discovery earns {repo_config.issue_discovery_share:.0%} of this repo's "
+                        "emission slice but your score is 0. "
+                        "Open high-quality issues in this repo to earn discovery rewards.",
+                    )
+                )
+
+    # ------------------------------------------------------------------ #
+    # Global / cross-repo observations
+    # ------------------------------------------------------------------ #
+
+    untouched_high_value = [
+        (name, cfg)
+        for name, cfg in sorted(master_repositories.items(), key=lambda x: -x[1].emission_share)
+        if cfg.emission_share >= 0.04
+        and name not in miner_eval.unique_repos_contributed_to
+        and cfg.emission_share > 0
+    ]
+    if untouched_high_value:
+        repos_str = ", ".join(
+            f"{name} ({cfg.emission_share:.1%})" for name, cfg in untouched_high_value[:3]
+        )
+        advice.append(
+            Advice(
+                Severity.TIP,
+                None,
+                f"High-value repos with no contributions yet: {repos_str}. "
+                "Diversifying across multiple repos increases total reward.",
+            )
+        )
+
+    if miner_eval.issue_discovery_score <= 0:
+        discovery_repos = [
+            name
+            for name, cfg in master_repositories.items()
+            if cfg.issue_discovery_share > 0 and cfg.emission_share > 0
+        ]
+        if discovery_repos:
+            advice.append(
+                Advice(
+                    Severity.TIP,
+                    None,
+                    f"Issue discovery score is 0 across all repos. "
+                    f"{len(discovery_repos)} repo(s) allocate emission to issue discovery. "
+                    "Opening issues that get solved by other contributors earns extra rewards.",
+                )
+            )
+
+    return advice
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_advice(advice_list: List[Advice], miner_eval: Any, reward: float) -> None:
+    console.print()
+    console.print(
+        Panel(
+            f"[bold]GitHub ID:[/bold] {miner_eval.github_id}  "
+            f"[bold]Blended reward:[/bold] [bold green]{reward:.6f}[/bold green]  "
+            f"[bold]Eligible repos:[/bold] "
+            + str(sum(1 for re in miner_eval.repo_evaluations.values() if re.is_eligible)),
+            title="Miner Advisor",
+            expand=False,
+        )
+    )
+
+    if not advice_list:
+        console.print("[bold green]No issues found. Your setup looks optimal.[/bold green]")
+        return
+
+    order = [Severity.CRITICAL, Severity.WARNING, Severity.TIP, Severity.INFO]
+    for sev in order:
+        items = [a for a in advice_list if a.severity == sev]
+        if not items:
+            continue
+
+        table = Table(
+            title=f"{_SEVERITY_ICON[sev]}  {sev.value}",
+            title_style=_SEVERITY_STYLE[sev],
+            show_header=True,
+            show_lines=True,
+        )
+        table.add_column("Repo", style="cyan", no_wrap=True, min_width=28)
+        table.add_column("Recommendation", overflow="fold")
+
+        for a in items:
+            table.add_row(a.repo or "(global)", a.message)
+
+        console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+@click.command(name="advisor")
+@click.option(
+    "--pat",
+    default=None,
+    envvar="GITTENSOR_MINER_PAT",
+    help="GitHub Personal Access Token. Uses GITTENSOR_MINER_PAT env if unset.",
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(["warning", "info", "debug", "trace"]),
+    default="warning",
+    show_default=True,
+    help="Bittensor log verbosity.",
+)
+def advisor_command(pat: Optional[str], log_level: str) -> None:
+    """Analyse your scoring results and surface actionable recommendations.
+
+    Runs the full validator scoring pipeline locally (no subtensor, wallet, or
+    DB required), then interprets the output to tell you exactly what to do
+    next to maximise your reward.
+
+    \\b
+    Advice categories:
+        CRITICAL  Eligibility blockers — fix these or earn nothing
+        WARNING   Active penalties cutting your score right now
+        TIP       Multiplier opportunities you are not yet using
+        INFO      Context useful for planning
+
+    \\b
+    Examples:
+        gitt miner advisor --pat ghp_xxxxx
+        GITTENSOR_MINER_PAT=ghp_xxxxx gitt miner advisor
+    """
+    import asyncio
+    import bittensor as bt
+
+    from gittensor.validator.emission_allocation import blend_emission_pools
+    from gittensor.validator.forward import build_maintainer_uids_by_repo, issue_discovery, oss_contributions
+    from gittensor.validator.utils.load_weights import (
+        load_master_repo_weights,
+        load_programming_language_weights,
+        load_token_config,
+    )
+
+    if not pat:
+        _error("--pat flag or GITTENSOR_MINER_PAT environment variable is required.", False)
+        sys.exit(1)
+
+    getattr(bt.logging, f"set_{log_level}")()
+
+    stub = LocalValidatorStub()
+    miner_uids = {PIPELINE_DEV_UID}
+
+    with console.status("[bold cyan]Loading weights…", spinner="dots"):
+        master_repositories = load_master_repo_weights()
+        programming_languages = load_programming_language_weights()
+        token_config = load_token_config()
+
+    pat_snapshot = [{"uid": PIPELINE_DEV_UID, "hotkey": PIPELINE_DEV_HOTKEY, "pat": pat}]
+
+    async def _run():
+        with override_pats_file(pat_snapshot):
+            miner_evaluations, _, _ = await oss_contributions(
+                cast(Any, stub), miner_uids, master_repositories, programming_languages, token_config
+            )
+            await issue_discovery(miner_evaluations, master_repositories, programming_languages, token_config)
+        maintainer_uids_by_repo = build_maintainer_uids_by_repo(
+            miner_evaluations, master_repositories, miner_uids
+        )
+        rewards = blend_emission_pools(
+            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo
+        )
+        return miner_evaluations[PIPELINE_DEV_UID], float(rewards[0])
+
+    with console.status("[bold cyan]Running validator pipeline…", spinner="dots"):
+        miner_eval, reward = asyncio.run(_run())
+
+    drain_logs()
+
+    advice = _analyse(miner_eval, master_repositories, {"blended_final": reward})
+    _render_advice(miner_eval=miner_eval, advice_list=advice, reward=reward)

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from collections import Counter
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import Any, Dict, Iterator, Set
 
 from rich.console import Console
 from rich.table import Table
@@ -214,3 +218,71 @@ def _pat_post_aggregate_counts(results: list[dict[str, Any]]) -> dict[str, int]:
         'rejected': counts['rejected'],
         'no_response': counts['no_response'],
     }
+
+
+# ---------------------------------------------------------------------------
+# Shared pipeline utilities (used by score, advisor, scan)
+# ---------------------------------------------------------------------------
+
+#: UID used when running the validator pipeline locally without a real metagraph.
+PIPELINE_DEV_UID: int = 1
+#: Hotkey placeholder for local pipeline runs.
+PIPELINE_DEV_HOTKEY: str = 'dev'
+
+
+class LocalValidatorStub:
+    """Minimal validator stub for running the scoring pipeline locally.
+
+    Satisfies the duck-type surface used by ``oss_contributions`` and
+    ``issue_discovery``: a ``metagraph`` with a ``hotkeys`` dict, and a
+    no-op ``store_or_use_cached_evaluation``.
+    """
+
+    def __init__(self, uid: int = PIPELINE_DEV_UID, hotkey: str = PIPELINE_DEV_HOTKEY) -> None:
+        self.metagraph = SimpleNamespace(hotkeys={uid: hotkey})
+
+    def store_or_use_cached_evaluation(self, miner_evaluations: Dict) -> Set[int]:
+        return set()
+
+
+@contextmanager
+def override_pats_file(snapshot: list) -> Iterator[None]:
+    """Temporarily redirect ``pat_storage.PATS_FILE`` to an in-memory fixture.
+
+    Allows running the scoring pipeline against an injected PAT without
+    touching the real PAT storage file on disk.
+    """
+    from gittensor.validator import pat_storage
+
+    original = pat_storage.PATS_FILE
+    with TemporaryDirectory() as tmp:
+        fake = Path(tmp) / 'miner_pats.json'
+        fake.write_text(json.dumps(snapshot))
+        pat_storage.PATS_FILE = fake
+        try:
+            yield
+        finally:
+            pat_storage.PATS_FILE = original
+
+
+def drain_logs() -> None:
+    """Stop bittensor log production and wait for the async writer to drain.
+
+    bittensor logs through a queue consumed by a background worker thread.
+    ``queue.empty()`` only tells us nothing more is *enqueued*; the worker may
+    still be inside ``write()`` for the last record.  The grace tick covers
+    that race so the final lines are not truncated by a fast process exit.
+    """
+    import bittensor as bt
+
+    if bt.logging.current_state_value == 'Warning':
+        bt.logging.set_warning(on=False)
+    bt.logging.off()
+    queue = bt.logging.get_queue()
+    if not queue.empty():
+        deadline = time.monotonic() + 2.0
+        while not queue.empty() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        time.sleep(0.1)
+    sys.stderr.flush()
+    sys.stdout.flush()

--- a/gittensor/cli/miner_commands/scan.py
+++ b/gittensor/cli/miner_commands/scan.py
@@ -1,0 +1,503 @@
+# Entrius 2025
+
+"""gitt miner scan — Discover high-value open issues across incentivised repositories.
+
+For every repo in master_repositories.json the command fetches open GitHub
+issues, scores each one by expected TAO opportunity, and surfaces a ranked
+action list so the miner can focus effort where the reward is highest.
+
+Opportunity score formula
+─────────────────────────
+  opportunity = emission_share
+              × potential_issue_multiplier   (1.66 if maintainer-authored, else 1.33)
+              × label_bonus                  (best matching label multiplier, or 1.0)
+              × competition_factor           (1.0 no competing PR, 0.4 has one)
+              × freshness_factor             (1.0 if ≤14d old, decays to 0.3 at 60d)
+
+Higher = more TAO for the same PR effort.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+import click
+import requests
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+from gittensor.cli.miner_commands.helpers import (
+    PIPELINE_DEV_HOTKEY,
+    PIPELINE_DEV_UID,
+    LocalValidatorStub,
+    override_pats_file,
+    _error,
+)
+from gittensor.constants import (
+    BASE_GITHUB_API_URL,
+    GITHUB_HTTP_TIMEOUT_SECONDS,
+    MAINTAINER_ASSOCIATIONS,
+)
+from gittensor.utils.github_api_tools import make_headers
+
+console = Console()
+err = Console(stderr=True)
+
+# Maximum issues fetched per repo (1 API page = 30 items)
+_ISSUES_PER_REPO = 30
+# Repos with emission_share below this are skipped to save API calls
+_MIN_EMISSION_SHARE = 0.005
+# How many top opportunities to display
+_TOP_N = 30
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Opportunity:
+    repo: str
+    issue_number: int
+    title: str
+    url: str
+    author_association: str
+    labels: List[str]
+    created_at: datetime
+    comments: int
+    has_competing_pr: bool
+    emission_share: float
+    issue_discovery_share: float
+    opportunity_score: float
+    potential_multiplier: float
+    label_bonus: float
+    competition_factor: float
+    freshness_factor: float
+    tip: str = ""
+
+
+# ---------------------------------------------------------------------------
+# GitHub REST helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_open_issues(
+    session: requests.Session,
+    repo: str,
+    per_page: int = _ISSUES_PER_REPO,
+) -> List[Dict]:
+    """Fetch the most recently updated open issues for a repo (1 page)."""
+    url = f"{BASE_GITHUB_API_URL}/repos/{repo}/issues"
+    try:
+        resp = session.get(
+            url,
+            params={"state": "open", "per_page": per_page, "sort": "updated", "direction": "desc"},
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
+        )
+        if resp.status_code == 404:
+            return []
+        if resp.status_code == 403:
+            remaining = resp.headers.get("x-ratelimit-remaining", "?")
+            err.print(f"[yellow]Rate-limited or no access for {repo} (remaining={remaining})[/yellow]")
+            if remaining == "0":
+                reset = int(resp.headers.get("x-ratelimit-reset", time.time() + 60))
+                wait = max(1, reset - int(time.time()))
+                err.print(f"[yellow]Rate limit reset in {wait}s. Waiting…[/yellow]")
+                time.sleep(min(wait, 60))
+            return []
+        resp.raise_for_status()
+        # GitHub returns PRs in the issues endpoint; filter them out
+        return [i for i in resp.json() if "pull_request" not in i]
+    except requests.RequestException as exc:
+        err.print(f"[dim]Could not fetch issues for {repo}: {exc}[/dim]")
+        return []
+
+
+def _check_competing_prs(session: requests.Session, repo: str, issue_number: int) -> bool:
+    """Return True if any open PR in the repo references this issue number."""
+    search_query = f"repo:{repo} is:pr is:open #{issue_number}"
+    try:
+        resp = session.get(
+            f"{BASE_GITHUB_API_URL}/search/issues",
+            params={"q": search_query, "per_page": 1},
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
+        )
+        if resp.status_code != 200:
+            return False
+        return resp.json().get("total_count", 0) > 0
+    except requests.RequestException:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+
+def _potential_issue_multiplier(author_association: str, repo_cfg) -> float:
+    """Return the likely issue multiplier if this issue is solved."""
+    from gittensor.validator.utils.load_weights import resolve_scoring
+
+    scoring = resolve_scoring(repo_cfg.scoring)
+    if author_association in MAINTAINER_ASSOCIATIONS:
+        return scoring.maintainer_issue_multiplier
+    return scoring.standard_issue_multiplier
+
+
+def _best_label_bonus(issue_labels: List[str], repo_cfg) -> Tuple[float, str]:
+    """Return (best_multiplier, label_name) from the repo's label_multipliers config."""
+    if not repo_cfg.label_multipliers or not issue_labels:
+        return 1.0, ""
+    best = 1.0
+    best_name = ""
+    for label in issue_labels:
+        lval = repo_cfg.label_multipliers.get(label)
+        if lval is not None and lval > best:
+            best = lval
+            best_name = label
+    return best, best_name
+
+
+def _freshness_factor(created_at: datetime) -> float:
+    """Issues older than 60 days decay; very fresh issues are prioritised."""
+    days = (datetime.now(timezone.utc) - created_at).total_seconds() / 86400
+    if days <= 14:
+        return 1.0
+    # Sigmoid decay: 0.5 at 30 days, 0.3 floor at 60+ days
+    raw = 1.0 / (1.0 + math.exp(0.15 * (days - 30)))
+    return max(0.3, raw)
+
+
+def _parse_dt(iso: Optional[str]) -> Optional[datetime]:
+    if not iso:
+        return None
+    s = iso.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _score_issue(
+    repo: str,
+    raw: Dict,
+    repo_cfg,
+    check_prs: bool,
+    session: requests.Session,
+) -> Optional[Opportunity]:
+    """Compute an Opportunity for a single GitHub issue dict."""
+    issue_number = raw.get("number")
+    title = raw.get("title", "")
+    url = raw.get("html_url", f"https://github.com/{repo}/issues/{issue_number}")
+    author_assoc = (raw.get("author_association") or "NONE").upper()
+    labels = [lbl["name"] for lbl in (raw.get("labels") or [])]
+    comments = raw.get("comments", 0)
+    created_at = _parse_dt(raw.get("created_at"))
+    if created_at is None:
+        return None
+
+    # default_label_multiplier=0.0 means only labelled issues score → skip unlabelled
+    if repo_cfg.default_label_multiplier == 0.0 and not labels:
+        return None
+
+    has_competing = False
+    if check_prs:
+        has_competing = _check_competing_prs(session, repo, issue_number)
+
+    pot_mult = _potential_issue_multiplier(author_assoc, repo_cfg)
+    label_bonus, label_name = _best_label_bonus(labels, repo_cfg)
+    comp_factor = 0.4 if has_competing else 1.0
+    fresh = _freshness_factor(created_at)
+
+    score = repo_cfg.emission_share * pot_mult * label_bonus * comp_factor * fresh
+
+    # Build human-readable tip
+    tips = []
+    if author_assoc in MAINTAINER_ASSOCIATIONS:
+        tips.append(f"maintainer issue → {pot_mult:.2f}x")
+    if label_name:
+        tips.append(f"label '{label_name}' → {label_bonus:.2f}x")
+    if has_competing:
+        tips.append("competing PR exists")
+    tip = " | ".join(tips) if tips else ""
+
+    return Opportunity(
+        repo=repo,
+        issue_number=issue_number,
+        title=title[:72],
+        url=url,
+        author_association=author_assoc,
+        labels=labels,
+        created_at=created_at,
+        comments=comments,
+        has_competing_pr=has_competing,
+        emission_share=repo_cfg.emission_share,
+        issue_discovery_share=repo_cfg.issue_discovery_share,
+        opportunity_score=score,
+        potential_multiplier=pot_mult,
+        label_bonus=label_bonus,
+        competition_factor=comp_factor,
+        freshness_factor=fresh,
+        tip=tip,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Eligibility gap helper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EligibilityGap:
+    repo: str
+    emission_share: float
+    have_merged: int
+    need_merged: int
+    credibility: float
+    min_credibility: float
+
+
+def _eligibility_gaps(miner_eval, master_repositories: Dict) -> List[EligibilityGap]:
+    """Return repos where the miner is not yet eligible but close (within 3 PRs)."""
+    from gittensor.validator.utils.load_weights import resolve_eligibility
+
+    gaps: List[EligibilityGap] = []
+    for repo_name, cfg in master_repositories.items():
+        if cfg.emission_share <= 0:
+            continue
+        elig = resolve_eligibility(cfg.eligibility)
+        merged = [pr for pr in miner_eval.merged_prs if pr.pr.repo_full_name.lower() == repo_name]
+        closed = [pr for pr in miner_eval.closed_prs if pr.pr.repo_full_name.lower() == repo_name]
+        n_merged = len(merged)
+        n_closed = len(closed)
+        total = n_merged + n_closed
+        cred = n_merged / total if total > 0 else 0.0
+
+        missing_prs = elig.min_valid_merged_prs - n_merged
+        cred_ok = cred >= elig.min_credibility or total == 0
+
+        if missing_prs > 0 and missing_prs <= 3:
+            gaps.append(
+                EligibilityGap(
+                    repo=repo_name,
+                    emission_share=cfg.emission_share,
+                    have_merged=n_merged,
+                    need_merged=elig.min_valid_merged_prs,
+                    credibility=cred,
+                    min_credibility=elig.min_credibility,
+                )
+            )
+    return sorted(gaps, key=lambda g: -g.emission_share)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_opportunities(opps: List[Opportunity], top_n: int) -> None:
+    shown = opps[:top_n]
+    if not shown:
+        console.print("[yellow]No open issues found in incentivised repos.[/yellow]")
+        return
+
+    table = Table(
+        title=f"Top {len(shown)} Issue Opportunities",
+        show_lines=True,
+    )
+    table.add_column("#", justify="right", style="dim", no_wrap=True)
+    table.add_column("Score", justify="right", style="bold green", no_wrap=True)
+    table.add_column("Repo", style="cyan", no_wrap=True)
+    table.add_column("Issue", no_wrap=False)
+    table.add_column("Labels", style="magenta", no_wrap=True)
+    table.add_column("Mult", justify="right", no_wrap=True)
+    table.add_column("Compete", justify="center", no_wrap=True)
+    table.add_column("Age(d)", justify="right", no_wrap=True)
+    table.add_column("Tip", style="dim", no_wrap=False)
+
+    for rank, opp in enumerate(shown, start=1):
+        age_days = (datetime.now(timezone.utc) - opp.created_at).total_seconds() / 86400
+        compete_str = (
+            Text("✗ yes", style="red") if opp.has_competing_pr else Text("✓ free", style="green")
+        )
+        issue_cell = f"#{opp.issue_number} {opp.title}"
+        table.add_row(
+            str(rank),
+            f"{opp.opportunity_score:.4f}",
+            opp.repo,
+            issue_cell,
+            ", ".join(opp.labels) or "-",
+            f"{opp.potential_multiplier:.2f}x",
+            compete_str,
+            f"{age_days:.0f}",
+            opp.tip or "-",
+        )
+
+    console.print(table)
+    console.print(
+        "\n[dim]Score = emission_share × issue_multiplier × label_bonus × competition × freshness[/dim]"
+    )
+
+
+def _render_gaps(gaps: List[EligibilityGap]) -> None:
+    if not gaps:
+        return
+    table = Table(title="Almost Eligible (≤3 PRs away)", show_lines=False)
+    table.add_column("Repo", style="cyan")
+    table.add_column("Emission", justify="right")
+    table.add_column("Merged", justify="right")
+    table.add_column("Need", justify="right")
+    table.add_column("Credibility", justify="right")
+
+    for g in gaps:
+        cred_style = "green" if g.credibility >= g.min_credibility else "red"
+        table.add_row(
+            g.repo,
+            f"{g.emission_share:.1%}",
+            str(g.have_merged),
+            str(g.need_merged),
+            f"[{cred_style}]{g.credibility:.0%}[/{cred_style}]",
+        )
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+@click.command(name="scan")
+@click.option(
+    "--pat",
+    default=None,
+    envvar="GITTENSOR_MINER_PAT",
+    help="GitHub Personal Access Token. Uses GITTENSOR_MINER_PAT env if unset.",
+)
+@click.option(
+    "--top",
+    type=int,
+    default=_TOP_N,
+    show_default=True,
+    help="Number of top opportunities to display.",
+)
+@click.option(
+    "--min-emission",
+    type=float,
+    default=_MIN_EMISSION_SHARE,
+    show_default=True,
+    help="Skip repos with emission_share below this value.",
+)
+@click.option(
+    "--check-prs",
+    is_flag=True,
+    default=False,
+    help="Check each issue for competing open PRs (slower — uses extra API calls).",
+)
+@click.option(
+    "--gaps",
+    is_flag=True,
+    default=False,
+    help="Also show repos where you are ≤3 PRs from becoming eligible (requires --score-pat).",
+)
+def scan_command(
+    pat: Optional[str],
+    top: int,
+    min_emission: float,
+    check_prs: bool,
+    gaps: bool,
+) -> None:
+    """Discover high-value open issues across incentivised repositories.
+
+    Scans every repo in master_repositories.json and ranks open GitHub issues
+    by opportunity score so you know exactly where to focus your next PR.
+
+    \\b
+    Opportunity score:
+        emission_share × issue_multiplier × label_bonus × competition × freshness
+
+    \\b
+    Examples:
+        gitt miner scan --pat ghp_xxxxx
+        gitt miner scan --pat ghp_xxxxx --check-prs --top 20
+        GITTENSOR_MINER_PAT=ghp_xxxxx gitt miner scan --min-emission 0.03
+    """
+    if not pat:
+        _error("--pat flag or GITTENSOR_MINER_PAT environment variable is required.", False)
+        sys.exit(1)
+
+    from gittensor.validator.utils.load_weights import load_master_repo_weights
+
+    with console.status("[bold cyan]Loading repository registry…", spinner="dots"):
+        master_repositories = load_master_repo_weights()
+
+    target_repos = {
+        name: cfg
+        for name, cfg in sorted(master_repositories.items(), key=lambda x: -x[1].emission_share)
+        if cfg.emission_share >= min_emission
+    }
+
+    err.print(
+        f"[dim]Scanning {len(target_repos)} repos "
+        f"(emission_share ≥ {min_emission:.1%}) …[/dim]"
+    )
+
+    session = requests.Session()
+    session.headers.update(make_headers(pat))
+
+    opportunities: List[Opportunity] = []
+
+    with console.status("[bold cyan]Fetching open issues…", spinner="dots") as status:
+        for repo, cfg in target_repos.items():
+            status.update(f"[bold cyan]Fetching issues: {repo}[/bold cyan]")
+            raw_issues = _fetch_open_issues(session, repo)
+            for raw in raw_issues:
+                opp = _score_issue(repo, raw, cfg, check_prs, session)
+                if opp is not None:
+                    opportunities.append(opp)
+
+    opportunities.sort(key=lambda o: -o.opportunity_score)
+    console.print()
+    _render_opportunities(opportunities, top)
+
+    if gaps:
+        import asyncio
+        from typing import Any, cast
+
+        import bittensor as bt
+
+        from gittensor.validator.forward import oss_contributions
+        from gittensor.validator.utils.load_weights import (
+            load_programming_language_weights,
+            load_token_config,
+        )
+
+        bt.logging.set_warning()
+
+        with console.status("[bold cyan]Running scoring pipeline for eligibility gaps…", spinner="dots"):
+            langs = load_programming_language_weights()
+            token_cfg = load_token_config()
+            stub = LocalValidatorStub()
+            snapshot = [{"uid": PIPELINE_DEV_UID, "hotkey": PIPELINE_DEV_HOTKEY, "pat": pat}]
+
+            async def _run():
+                with override_pats_file(snapshot):
+                    evals, _, _ = await oss_contributions(
+                        cast(Any, stub), {PIPELINE_DEV_UID}, master_repositories, langs, token_cfg
+                    )
+                return evals[PIPELINE_DEV_UID]
+
+            miner_eval = asyncio.run(_run())
+
+        gap_list = _eligibility_gaps(miner_eval, target_repos)
+        console.print()
+        _render_gaps(gap_list)

--- a/gittensor/cli/miner_commands/score.py
+++ b/gittensor/cli/miner_commands/score.py
@@ -10,27 +10,30 @@ from __future__ import annotations
 import dataclasses
 import json
 import sys
-from contextlib import contextmanager
 from enum import Enum
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Dict, Iterator, NoReturn, Optional, Set, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional, Set, Tuple, cast
 
 import click
 from rich.console import Console
 from rich.table import Table
 
 from gittensor.cli.json_output import emit_json
-from gittensor.cli.miner_commands.helpers import _error
+from gittensor.cli.miner_commands.helpers import (
+    PIPELINE_DEV_HOTKEY,
+    PIPELINE_DEV_UID,
+    LocalValidatorStub,
+    drain_logs,
+    override_pats_file,
+    _error,
+)
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
 
 console = Console()
 
-_DEV_UID = 1
-_DEV_HOTKEY = 'dev'
+_DEV_UID = PIPELINE_DEV_UID
+_DEV_HOTKEY = PIPELINE_DEV_HOTKEY
 
 
 def _die(msg: str, json_mode: bool) -> NoReturn:
@@ -47,15 +50,6 @@ def _resolve_pat(cli_pat: Optional[str], json_mode: bool) -> str:
 def _round(x: float) -> float:
     return round(x, 4)
 
-
-class _StubValidator:
-    """Stub `self` with no tensor, wallet, axon, wandb, and DB connection."""
-
-    def __init__(self, uid: int, hotkey: str):
-        self.metagraph = SimpleNamespace(hotkeys={uid: hotkey})
-
-    def store_or_use_cached_evaluation(self, miner_evaluations: Dict) -> Set[int]:
-        return set()
 
 
 _EVAL_SKIP: frozenset = frozenset(
@@ -256,60 +250,11 @@ def _render_table(payload: Dict[str, Any]) -> None:
         console.print(pr_table)
 
 
-@contextmanager
-def _override_pats_file(snapshot: list) -> Iterator[None]:
-    """Point pat_storage at a tempfile holding our injected PAT snapshot."""
-    from gittensor.validator import pat_storage
-
-    original = pat_storage.PATS_FILE
-    with TemporaryDirectory() as tmp:
-        fake = Path(tmp) / 'miner_pats.json'
-        fake.write_text(json.dumps(snapshot))
-        pat_storage.PATS_FILE = fake
-        try:
-            yield
-        finally:
-            pat_storage.PATS_FILE = original
-
-
 def _apply_log_level(level: str) -> None:
-    """Configure bittensor's logger. The dev tool bypasses BaseNeuron, which is
-    where production normally calls `bt.logging.set_config`, so the level stays
-    at the default (warning) unless we set it ourselves.
-    """
+    """Configure bittensor's logger for a local pipeline run."""
     import bittensor as bt
 
     getattr(bt.logging, f'set_{level}')()
-
-
-def _drain_logs() -> None:
-    """Stop log production and wait for the async stderr writer to drain.
-
-    bittensor logs through a queue consumed by a background worker thread.
-    `queue.empty()` only tells us nothing more is *enqueued*; the worker may
-    still be inside `write()` for the last record. The grace tick covers that
-    race so the final lines aren't truncated by a fast process exit.
-    """
-    import time
-
-    import bittensor as bt
-
-    # bittensor's LoggingMachine defines disable_logging transitions from
-    # Trace/Debug/Default/Disabled/Info but NOT from Warning (only
-    # `disable_warning = Warning.to(Default)` exists), so a bare `off()` raises
-    # TransitionNotAllowed when --log-level is warning. Step Warning down to
-    # Default first; from Default the disable_logging transition is defined.
-    if bt.logging.current_state_value == 'Warning':
-        bt.logging.set_warning(on=False)
-    bt.logging.off()
-    queue = bt.logging.get_queue()
-    if not queue.empty():
-        deadline = time.monotonic() + 2.0
-        while not queue.empty() and time.monotonic() < deadline:
-            time.sleep(0.05)
-        time.sleep(0.1)
-    sys.stderr.flush()
-    sys.stdout.flush()
 
 
 @click.command(name='score')
@@ -357,7 +302,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
 
     # `oss_contributions` is typed as taking a real `Validator`; the stub fulfils
     # the surface that function actually uses (metagraph.hotkeys, the cache hook).
-    stub = cast('Validator', _StubValidator(_DEV_UID, _DEV_HOTKEY))
+    stub = cast('Validator', LocalValidatorStub(_DEV_UID, _DEV_HOTKEY))
     miner_uids = {_DEV_UID}
 
     if json_mode:
@@ -373,7 +318,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
     pat_snapshot = [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': resolved_pat}]
 
     async def _run() -> Dict[str, Any]:
-        with _override_pats_file(pat_snapshot):
+        with override_pats_file(pat_snapshot):
             miner_evaluations, _, _ = await oss_contributions(
                 stub, miner_uids, master_repositories, programming_languages, token_config
             )
@@ -399,7 +344,7 @@ def score_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
         console.print('[bold cyan]Running validator pipeline...[/bold cyan]')
     payload = asyncio.run(_run())
 
-    _drain_logs()
+    drain_logs()
 
     if json_mode:
         emit_json(payload)

--- a/tests/cli/test_miner_advisor.py
+++ b/tests/cli/test_miner_advisor.py
@@ -1,0 +1,318 @@
+# Entrius 2025
+
+"""Tests for `gitt miner advisor`."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from gittensor.cli.main import cli
+from gittensor.cli.miner_commands.advisor import Severity, _analyse
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _make_eval(
+    uid: int = 1,
+    hotkey: str = "dev",
+    github_id: str = "42",
+    failed_reason=None,
+    **overrides,
+):
+    from gittensor.classes import MinerEvaluation
+
+    ev = MinerEvaluation(uid=uid, hotkey=hotkey, github_id=github_id, failed_reason=failed_reason)
+    for k, v in overrides.items():
+        setattr(ev, k, v)
+    return ev
+
+
+def _minimal_repo_configs() -> Dict:
+    """One high-value repo with no per-repo overrides."""
+    from gittensor.validator.utils.load_weights import RepositoryConfig
+
+    return {
+        "entrius/gittensor": RepositoryConfig(
+            emission_share=0.09,
+            issue_discovery_share=0.0,
+            label_multipliers={"feature": 1.5, "bug": 1.1},
+            trusted_label_pipeline=True,
+        )
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _analyse
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyse:
+    def test_failed_identity_returns_critical(self):
+        ev = _make_eval(failed_reason="PAT invalid")
+        advice = _analyse(ev, _minimal_repo_configs(), {})
+        assert any(a.severity == Severity.CRITICAL for a in advice)
+        assert any("PAT" in a.message or "failed" in a.message.lower() for a in advice)
+
+    def test_no_merged_prs_returns_critical(self):
+        ev = _make_eval()
+        advice = _analyse(ev, _minimal_repo_configs(), {})
+        criticals = [a for a in advice if a.severity == Severity.CRITICAL]
+        assert criticals, "Expected CRITICAL advice when miner has 0 merged PRs"
+        assert any("entrius/gittensor" in (a.repo or "") for a in criticals)
+
+    def test_eligible_miner_no_issues_linked_returns_tip(self):
+        """A miner who is eligible but has no issue-linked PRs should get a TIP."""
+        from gittensor.classes import MinerEvaluation, RepoEvaluation
+        from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
+        from gittensor.utils.mirror.models import MirrorPullRequest
+
+        ev = _make_eval()
+
+        # Build 3 merged ScoredPRs with issue_multiplier=1.0 (no linked issue)
+        for i in range(1, 4):
+            pr = MagicMock(spec=MirrorPullRequest)
+            pr.pr_number = i
+            pr.repo_full_name = "entrius/gittensor"
+            pr.state = "MERGED"
+            pr.merged_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+            pr.author_association = "CONTRIBUTOR"
+
+            spr = MagicMock(spec=ScoredPR)
+            spr.pr = pr
+            spr.issue_multiplier = 1.0
+            spr.label = None
+            spr.label_multiplier = 1.0
+            spr.time_decay_multiplier = 0.95
+            spr.review_quality_multiplier = 1.0
+            spr.token_score = 50.0
+            ev.merged_prs.append(spr)
+
+        ev.unique_repos_contributed_to.add("entrius/gittensor")
+
+        repo_eval = RepoEvaluation(
+            repository_full_name="entrius/gittensor",
+            total_merged_prs=3,
+            total_open_prs=0,
+            total_closed_prs=0,
+        )
+        repo_eval.is_eligible = True
+        repo_eval.credibility = 1.0
+        repo_eval.total_score = 45.0
+        repo_eval.issue_discovery_score = 0.0
+        ev.repo_evaluations["entrius/gittensor"] = repo_eval
+
+        advice = _analyse(ev, _minimal_repo_configs(), {})
+        tips = [a for a in advice if a.severity == Severity.TIP and a.repo == "entrius/gittensor"]
+        assert tips, "Expected TIP about missing issue links"
+        assert any("issue" in a.message.lower() for a in tips)
+
+    def test_open_pr_spam_penalty_warning(self):
+        """Exceeding the open-PR threshold should produce a WARNING."""
+        from gittensor.classes import MinerEvaluation, RepoEvaluation
+        from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
+        from gittensor.utils.mirror.models import MirrorPullRequest
+
+        ev = _make_eval()
+
+        # 3 merged PRs to pass eligibility
+        for i in range(1, 4):
+            pr = MagicMock(spec=MirrorPullRequest)
+            pr.pr_number = i
+            pr.repo_full_name = "entrius/gittensor"
+            pr.state = "MERGED"
+            pr.merged_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+            spr = MagicMock(spec=ScoredPR)
+            spr.pr = pr
+            spr.issue_multiplier = 1.0
+            spr.label = None
+            spr.label_multiplier = 1.0
+            spr.time_decay_multiplier = 1.0
+            spr.review_quality_multiplier = 1.0
+            spr.token_score = 10.0
+            ev.merged_prs.append(spr)
+
+        # 5 open PRs — exceeds default threshold of 2
+        for i in range(10, 15):
+            pr = MagicMock(spec=MirrorPullRequest)
+            pr.pr_number = i
+            pr.repo_full_name = "entrius/gittensor"
+            pr.state = "OPEN"
+            spr = MagicMock(spec=ScoredPR)
+            spr.pr = pr
+            ev.open_prs.append(spr)
+
+        ev.unique_repos_contributed_to.add("entrius/gittensor")
+        repo_eval = RepoEvaluation(
+            repository_full_name="entrius/gittensor",
+            total_merged_prs=3,
+            total_open_prs=5,
+            total_closed_prs=0,
+        )
+        repo_eval.is_eligible = True
+        repo_eval.credibility = 1.0
+        repo_eval.total_score = 0.0  # zeroed by spam penalty
+        repo_eval.issue_discovery_score = 0.0
+        ev.repo_evaluations["entrius/gittensor"] = repo_eval
+
+        advice = _analyse(ev, _minimal_repo_configs(), {})
+        warnings = [a for a in advice if a.severity == Severity.WARNING and a.repo == "entrius/gittensor"]
+        assert warnings, "Expected WARNING about open PR spam"
+        assert any("spam" in a.message.lower() or "open pr" in a.message.lower() for a in warnings)
+
+    def test_credibility_below_threshold_returns_critical(self):
+        """Credibility below min_credibility should block eligibility and produce CRITICAL."""
+        from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
+        from gittensor.utils.mirror.models import MirrorPullRequest
+
+        ev = _make_eval()
+
+        # 3 merged PRs + 10 closed PRs → credibility = 3/13 ≈ 0.23, below 0.80
+        for i in range(1, 4):
+            pr = MagicMock(spec=MirrorPullRequest)
+            pr.pr_number = i
+            pr.repo_full_name = "entrius/gittensor"
+            pr.state = "MERGED"
+            pr.merged_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+            spr = MagicMock(spec=ScoredPR)
+            spr.pr = pr
+            spr.issue_multiplier = 1.0
+            spr.label = None
+            spr.label_multiplier = 1.0
+            spr.time_decay_multiplier = 1.0
+            spr.review_quality_multiplier = 1.0
+            spr.token_score = 10.0
+            ev.merged_prs.append(spr)
+
+        for i in range(100, 110):
+            pr = MagicMock(spec=MirrorPullRequest)
+            pr.pr_number = i
+            pr.repo_full_name = "entrius/gittensor"
+            pr.state = "CLOSED"
+            spr = MagicMock(spec=ScoredPR)
+            spr.pr = pr
+            ev.closed_prs.append(spr)
+
+        advice = _analyse(ev, _minimal_repo_configs(), {})
+        criticals = [a for a in advice if a.severity == Severity.CRITICAL and a.repo == "entrius/gittensor"]
+        assert criticals, "Expected CRITICAL for low credibility"
+        assert any("credib" in a.message.lower() for a in criticals)
+
+    def test_high_value_untouched_repo_returns_tip(self):
+        """Repos with ≥4% emission_share the miner has never touched should generate a TIP."""
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        repos = {
+            "entrius/gittensor": RepositoryConfig(emission_share=0.09, issue_discovery_share=0.0),
+            "infiniflow/ragflow": RepositoryConfig(emission_share=0.055, issue_discovery_share=0.0),
+        }
+        ev = _make_eval()
+        # miner contributed to only one repo
+        ev.unique_repos_contributed_to.add("entrius/gittensor")
+
+        advice = _analyse(ev, repos, {})
+        tips = [a for a in advice if a.severity == Severity.TIP and a.repo is None]
+        assert any("ragflow" in a.message for a in tips), (
+            "Expected TIP mentioning the untouched high-value repo"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration-level CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisorCli:
+    def _patch_pipeline(self, ev, blended: float = 0.0):
+        repos = _minimal_repo_configs()
+        miner_evaluations = {1: ev}
+        final_rewards = np.array([blended])
+
+        oss_mock = AsyncMock(return_value=(miner_evaluations, set(), set()))
+        issue_mock = AsyncMock(return_value=None)
+        blend_mock = MagicMock(return_value=final_rewards)
+        build_mock = MagicMock(return_value={})
+        load_repos_mock = MagicMock(return_value=repos)
+        load_langs_mock = MagicMock(return_value={})
+        load_token_mock = MagicMock(return_value=MagicMock(language_configs={}))
+
+        return {
+            "oss": oss_mock,
+            "issue": issue_mock,
+            "blend": blend_mock,
+            "build": build_mock,
+            "load_repos": load_repos_mock,
+            "load_langs": load_langs_mock,
+            "load_token": load_token_mock,
+        }
+
+    def test_missing_pat_exits_nonzero(self, runner: CliRunner):
+        result = runner.invoke(cli, ["miner", "advisor"])
+        assert result.exit_code != 0
+
+    def test_failed_identity_shows_critical(self, runner: CliRunner):
+        ev = _make_eval(failed_reason="PAT invalid or expired")
+        mocks = self._patch_pipeline(ev)
+
+        with (
+            patch("gittensor.validator.forward.oss_contributions", mocks["oss"]),
+            patch("gittensor.validator.forward.issue_discovery", mocks["issue"]),
+            patch("gittensor.validator.emission_allocation.blend_emission_pools", mocks["blend"]),
+            patch("gittensor.validator.forward.build_maintainer_uids_by_repo", mocks["build"]),
+            patch(
+                "gittensor.validator.utils.load_weights.load_master_repo_weights",
+                mocks["load_repos"],
+            ),
+            patch(
+                "gittensor.validator.utils.load_weights.load_programming_language_weights",
+                mocks["load_langs"],
+            ),
+            patch(
+                "gittensor.validator.utils.load_weights.load_token_config",
+                mocks["load_token"],
+            ),
+        ):
+            result = runner.invoke(cli, ["miner", "advisor", "--pat", "ghp_test"])
+
+        assert result.exit_code == 0
+        assert "CRITICAL" in result.output
+
+    def test_eligible_miner_output_contains_panel(self, runner: CliRunner):
+        ev = _make_eval()
+        mocks = self._patch_pipeline(ev, blended=0.05)
+
+        with (
+            patch("gittensor.validator.forward.oss_contributions", mocks["oss"]),
+            patch("gittensor.validator.forward.issue_discovery", mocks["issue"]),
+            patch("gittensor.validator.emission_allocation.blend_emission_pools", mocks["blend"]),
+            patch("gittensor.validator.forward.build_maintainer_uids_by_repo", mocks["build"]),
+            patch(
+                "gittensor.validator.utils.load_weights.load_master_repo_weights",
+                mocks["load_repos"],
+            ),
+            patch(
+                "gittensor.validator.utils.load_weights.load_programming_language_weights",
+                mocks["load_langs"],
+            ),
+            patch(
+                "gittensor.validator.utils.load_weights.load_token_config",
+                mocks["load_token"],
+            ),
+        ):
+            result = runner.invoke(cli, ["miner", "advisor", "--pat", "ghp_test"])
+
+        assert result.exit_code == 0
+        assert "Miner Advisor" in result.output

--- a/tests/cli/test_miner_scan.py
+++ b/tests/cli/test_miner_scan.py
@@ -1,0 +1,288 @@
+# Entrius 2025
+
+"""Tests for `gitt miner scan`."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gittensor.cli.main import cli
+from gittensor.cli.miner_commands.scan import (
+    Opportunity,
+    _best_label_bonus,
+    _check_competing_prs,
+    _fetch_open_issues,
+    _freshness_factor,
+    _parse_dt,
+    _potential_issue_multiplier,
+    _score_issue,
+)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _repo_cfg(emission_share=0.09, label_multipliers=None, default_label_multiplier=1.0):
+    from gittensor.validator.utils.load_weights import RepositoryConfig
+
+    return RepositoryConfig(
+        emission_share=emission_share,
+        issue_discovery_share=0.0,
+        label_multipliers=label_multipliers,
+        default_label_multiplier=default_label_multiplier,
+    )
+
+
+def _raw_issue(number=1, title="Fix the bug", author_association="NONE", labels=None, created_at="2026-05-01T00:00:00Z", comments=0):
+    return {
+        "number": number,
+        "title": title,
+        "html_url": f"https://github.com/test/repo/issues/{number}",
+        "author_association": author_association,
+        "labels": [{"name": l} for l in (labels or [])],
+        "created_at": created_at,
+        "comments": comments,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit: _parse_dt
+# ---------------------------------------------------------------------------
+
+class TestParseDt:
+    def test_z_suffix(self):
+        dt = _parse_dt("2026-05-01T12:00:00Z")
+        assert dt is not None
+        assert dt.tzinfo is not None
+        assert dt.year == 2026
+
+    def test_none_returns_none(self):
+        assert _parse_dt(None) is None
+
+    def test_invalid_returns_none(self):
+        assert _parse_dt("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: _freshness_factor
+# ---------------------------------------------------------------------------
+
+class TestFreshnessFactor:
+    def test_very_fresh_issue_scores_one(self):
+        dt = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0)
+        # 0 days old
+        assert _freshness_factor(dt) == 1.0
+
+    def test_14_days_old_is_full(self):
+        from datetime import timedelta
+        dt = datetime.now(timezone.utc) - timedelta(days=13)
+        assert _freshness_factor(dt) == 1.0
+
+    def test_60_days_old_hits_floor(self):
+        from datetime import timedelta
+        dt = datetime.now(timezone.utc) - timedelta(days=60)
+        assert _freshness_factor(dt) == pytest.approx(0.3, abs=0.05)
+
+    def test_30_days_old_is_roughly_half(self):
+        from datetime import timedelta
+        dt = datetime.now(timezone.utc) - timedelta(days=30)
+        f = _freshness_factor(dt)
+        assert 0.3 <= f <= 0.7
+
+
+# ---------------------------------------------------------------------------
+# Unit: _best_label_bonus
+# ---------------------------------------------------------------------------
+
+class TestBestLabelBonus:
+    def test_matching_label_returns_multiplier(self):
+        cfg = _repo_cfg(label_multipliers={"feature": 1.5, "bug": 1.1})
+        bonus, name = _best_label_bonus(["feature"], cfg)
+        assert bonus == pytest.approx(1.5)
+        assert name == "feature"
+
+    def test_no_label_multipliers_returns_one(self):
+        cfg = _repo_cfg()
+        bonus, name = _best_label_bonus(["feature"], cfg)
+        assert bonus == 1.0
+        assert name == ""
+
+    def test_no_matching_label_returns_one(self):
+        cfg = _repo_cfg(label_multipliers={"feature": 1.5})
+        bonus, name = _best_label_bonus(["bug"], cfg)
+        assert bonus == 1.0
+        assert name == ""
+
+    def test_picks_best_when_multiple(self):
+        cfg = _repo_cfg(label_multipliers={"feature": 1.5, "bug": 1.1})
+        bonus, name = _best_label_bonus(["bug", "feature"], cfg)
+        assert bonus == pytest.approx(1.5)
+        assert name == "feature"
+
+
+# ---------------------------------------------------------------------------
+# Unit: _potential_issue_multiplier
+# ---------------------------------------------------------------------------
+
+class TestPotentialIssueMultiplier:
+    def test_none_association_gives_standard(self):
+        cfg = _repo_cfg()
+        mult = _potential_issue_multiplier("NONE", cfg)
+        assert mult == pytest.approx(1.33)
+
+    def test_owner_gives_maintainer(self):
+        cfg = _repo_cfg()
+        mult = _potential_issue_multiplier("OWNER", cfg)
+        assert mult == pytest.approx(1.66)
+
+    def test_member_gives_maintainer(self):
+        cfg = _repo_cfg()
+        mult = _potential_issue_multiplier("MEMBER", cfg)
+        assert mult == pytest.approx(1.66)
+
+
+# ---------------------------------------------------------------------------
+# Unit: _score_issue
+# ---------------------------------------------------------------------------
+
+class TestScoreIssue:
+    def test_basic_scoring(self):
+        cfg = _repo_cfg(emission_share=0.09)
+        raw = _raw_issue(created_at="2026-06-01T00:00:00Z")
+        session = MagicMock()
+        opp = _score_issue("test/repo", raw, cfg, check_prs=False, session=session)
+        assert opp is not None
+        assert opp.repo == "test/repo"
+        assert opp.issue_number == 1
+        assert opp.opportunity_score > 0
+        # score = 0.09 * 1.33 * 1.0 * 1.0 * freshness
+        assert opp.opportunity_score <= 0.09 * 1.33 * 1.0 + 1e-6
+
+    def test_default_label_multiplier_zero_skips_unlabelled(self):
+        cfg = _repo_cfg(default_label_multiplier=0.0, label_multipliers={"feature": 1.0})
+        raw = _raw_issue(labels=[])  # no labels
+        session = MagicMock()
+        opp = _score_issue("test/repo", raw, cfg, check_prs=False, session=session)
+        assert opp is None
+
+    def test_default_label_multiplier_zero_keeps_labelled(self):
+        cfg = _repo_cfg(default_label_multiplier=0.0, label_multipliers={"feature": 1.0})
+        raw = _raw_issue(labels=["feature"])
+        session = MagicMock()
+        opp = _score_issue("test/repo", raw, cfg, check_prs=False, session=session)
+        assert opp is not None
+
+    def test_competing_pr_reduces_score(self):
+        cfg = _repo_cfg(emission_share=0.09)
+        raw = _raw_issue(created_at="2026-06-01T00:00:00Z")
+        session = MagicMock()
+
+        # Without competing PR
+        opp_free = _score_issue("test/repo", raw, cfg, check_prs=False, session=session)
+
+        # With competing PR injected via mock
+        with patch("gittensor.cli.miner_commands.scan._check_competing_prs", return_value=True):
+            opp_compete = _score_issue("test/repo", raw, cfg, check_prs=True, session=session)
+
+        assert opp_compete is not None
+        assert opp_free is not None
+        assert opp_compete.opportunity_score < opp_free.opportunity_score
+
+    def test_maintainer_issue_scores_higher(self):
+        cfg = _repo_cfg(emission_share=0.09)
+        raw_standard = _raw_issue(author_association="NONE", created_at="2026-06-01T00:00:00Z")
+        raw_maintainer = _raw_issue(author_association="OWNER", created_at="2026-06-01T00:00:00Z")
+        session = MagicMock()
+        opp_std = _score_issue("t/r", raw_standard, cfg, check_prs=False, session=session)
+        opp_mnt = _score_issue("t/r", raw_maintainer, cfg, check_prs=False, session=session)
+        assert opp_mnt is not None and opp_std is not None
+        assert opp_mnt.opportunity_score > opp_std.opportunity_score
+
+
+# ---------------------------------------------------------------------------
+# Unit: _fetch_open_issues
+# ---------------------------------------------------------------------------
+
+class TestFetchOpenIssues:
+    def test_filters_pull_requests(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            {"number": 1, "title": "Issue", "pull_request": {}},  # PR — should be filtered
+            {"number": 2, "title": "Real issue"},                  # real issue
+        ]
+        session = MagicMock()
+        session.get.return_value = mock_resp
+        issues = _fetch_open_issues(session, "test/repo")
+        assert len(issues) == 1
+        assert issues[0]["number"] == 2
+
+    def test_404_returns_empty(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        session = MagicMock()
+        session.get.return_value = mock_resp
+        assert _fetch_open_issues(session, "nonexistent/repo") == []
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+class TestScanCli:
+    def test_missing_pat_exits_nonzero(self, runner: CliRunner):
+        result = runner.invoke(cli, ["miner", "scan"])
+        assert result.exit_code != 0
+
+    def test_scan_shows_table(self, runner: CliRunner):
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        repos = {
+            "entrius/gittensor": RepositoryConfig(
+                emission_share=0.09,
+                issue_discovery_share=0.0,
+                label_multipliers={"feature": 1.5},
+            )
+        }
+        issues = [
+            {
+                "number": 42,
+                "title": "Add dark mode support",
+                "html_url": "https://github.com/entrius/gittensor/issues/42",
+                "author_association": "NONE",
+                "labels": [{"name": "feature"}],
+                "created_at": "2026-06-01T00:00:00Z",
+                "comments": 3,
+            }
+        ]
+
+        with (
+            patch("gittensor.validator.utils.load_weights.load_master_repo_weights", return_value=repos),
+            patch("gittensor.cli.miner_commands.scan._fetch_open_issues", return_value=issues),
+        ):
+            result = runner.invoke(cli, ["miner", "scan", "--pat", "ghp_test"])
+
+        assert result.exit_code == 0, result.output
+        assert "entrius/gittensor" in result.output
+        assert "feature" in result.output
+        assert "Issue Opportunities" in result.output
+
+    def test_scan_no_issues_shows_message(self, runner: CliRunner):
+        from gittensor.validator.utils.load_weights import RepositoryConfig
+
+        repos = {"test/repo": RepositoryConfig(emission_share=0.05, issue_discovery_share=0.0)}
+
+        with (
+            patch("gittensor.validator.utils.load_weights.load_master_repo_weights", return_value=repos),
+            patch("gittensor.cli.miner_commands.scan._fetch_open_issues", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["miner", "scan", "--pat", "ghp_test"])
+
+        assert result.exit_code == 0
+        assert "No open issues" in result.output


### PR DESCRIPTION
Closes #1460

## Summary

Adds two new `gitt miner` subcommands that help miners understand their score and find the best GitHub issues to target next.

## New commands

### `gitt miner advisor`

Runs the full validator scoring pipeline locally (no subtensor/wallet/DB required) and interprets the output into ranked, actionable advice:

```
$ gitt miner advisor --pat ghp_xxxx

✗  CRITICAL
┌────────────────────────────┬──────────────────────────────────────────────────────┐
│ Repo                       │ Recommendation                                       │
├────────────────────────────┼──────────────────────────────────────────────────────┤
│ infiniflow/ragflow         │ Need 2 more merged PR(s) to unlock scoring …         │
└────────────────────────────┴──────────────────────────────────────────────────────┘
⚠  WARNING  ★  TIP  ·  INFO
```

Advice categories:
- **CRITICAL** — eligibility blockers (merged PR count, credibility below threshold)
- **WARNING** — active penalties (open-PR spam threshold, time decay past midpoint, review quality deduction)
- **TIP** — multiplier opportunities (missing issue links, unused label multipliers, zero issue-discovery score)
- **INFO** — context for planning (decay trajectory, untouched high-value repos)

### `gitt miner scan`

Scans every repo in `master_repositories.json`, fetches open GitHub issues, and ranks them by TAO opportunity score:

```
opportunity = emission_share × issue_multiplier × label_bonus × competition_factor × freshness_factor
```

```
$ gitt miner scan --pat ghp_xxxx --check-prs

Top 15 Issue Opportunities
┌────────┬──────────────────────┬──────────────────────────────┬───────┬──────────┐
│ Score  │ Repo                 │ Issue                        │ Mult  │ Compete  │
├────────┼──────────────────────┼──────────────────────────────┼───────┼──────────┤
│ 0.1791 │ entrius/gittensor    │ #1420 Stale is_admin flag …  │ 1.33x │ ✓ free   │
└────────┴──────────────────────┴──────────────────────────────┴───────┴──────────┘
```

Flags:
- `--check-prs` — calls GitHub Search API to flag issues that already have a competing open PR
- `--gaps` — runs the scoring pipeline to surface repos within 3 PRs of eligibility unlock
- `--min-emission FLOAT` — skip low-value repos (default 0.5%)
- `--top N` — how many results to show (default 30)

## Refactor: shared pipeline utilities

The three local-pipeline commands (`score`, `advisor`, `scan`) each previously embedded their own copies of `_StubValidator` / `_override_pats_file` / `_drain_logs`. These are consolidated in `helpers.py`:

| Symbol | Purpose |
|---|---|
| `LocalValidatorStub` | Minimal validator stub for local pipeline runs |
| `override_pats_file(snapshot)` | Context manager: inject a test PAT without touching disk storage |
| `drain_logs()` | Stop bittensor log production and wait for the async writer to drain |
| `PIPELINE_DEV_UID` / `PIPELINE_DEV_HOTKEY` | Shared constants |

`score.py` is updated to import from `helpers.py` (net −71 lines).

## Tests

| File | Tests | Coverage |
|---|---|---|
| `tests/cli/test_miner_advisor.py` | 9 | `_analyse` (6 unit), CLI integration (3) |
| `tests/cli/test_miner_scan.py` | 24 | `_parse_dt`, `_freshness_factor`, `_best_label_bonus`, `_potential_issue_multiplier`, `_score_issue`, `_fetch_open_issues`, CLI smoke |

All 946 existing tests continue to pass.

## Checklist
- [x] New commands registered in `miner_group` (`__init__.py`)
- [x] All heavy imports deferred inside command body (keeps `--help` fast)
- [x] No subtensor / wallet / DB touched during local pipeline run
- [x] `uv run --with pytest python -m pytest tests/ -q` → 946 passed
