### PR TITLE
fix(harvest): raise TreasuryReadError instead of returning 0 on chain failures

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -281,6 +281,7 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         from gittensor.validator.issue_competitions.contract_client import (
             IssueCompetitionContractClient,
         )
+        from gittensor.validator.issue_competitions.errors import TreasuryReadError
 
         with loading_context('Reading treasury and contract data...', as_json):
             subtensor = bt.Subtensor(network=ws_endpoint)
@@ -312,6 +313,8 @@ def issues_pending_harvest(network: str, rpc_url: str, contract: str, verbose: b
         console.print(f'[green]Treasury Stake:[/green] {format_alpha(treasury_stake, 4)} ALPHA')
         console.print(f'[green]Allocated to Bounties:[/green] {format_alpha(total_bounty_pool, 4)} ALPHA')
         console.print(f'[green]Pending Harvest:[/green] {format_alpha(pending_harvest, 4)} ALPHA')
+    except TreasuryReadError as e:
+        handle_exception(as_json=as_json, message=str(e), error_type='read_failed')
     except Exception as e:
         handle_exception(as_json=as_json, message=str(e))
 

--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -16,6 +16,7 @@ from async_substrate_interface.errors import ExtrinsicNotFound
 from bittensor_wallet import Keypair
 
 from gittensor.constants import MAX_ISSUE_ID
+from gittensor.validator.issue_competitions.errors import TreasuryReadError
 from gittensor.validator.issue_competitions.storage_utils import (
     ISSUES_MAPPING_ROOT_KEY,
     compute_ink5_lazy_key,
@@ -639,7 +640,7 @@ class IssueCompetitionContractClient:
 
         except Exception as e:
             bt.logging.error(f'Error fetching treasury stake: {e}')
-            return 0
+            raise TreasuryReadError(f'Treasury stake read failed: {e}') from e
 
     def get_last_harvest_block(self) -> int:
         """Query the block number of the last harvest."""

--- a/gittensor/validator/issue_competitions/errors.py
+++ b/gittensor/validator/issue_competitions/errors.py
@@ -1,0 +1,17 @@
+# The MIT License (MIT)
+# Copyright 2025 Entrius
+
+"""Lightweight exception types for issue-competition contract operations.
+
+Kept in a separate module so callers (CLI, tests) can import them without
+pulling in the heavy ``contract_client`` dependency tree.
+"""
+
+
+class TreasuryReadError(RuntimeError):
+    """Raised when the treasury stake cannot be read due to a chain or network error.
+
+    Distinct from a genuine zero-stake treasury, where ``get_treasury_stake``
+    returns ``0`` normally.  Callers (e.g. ``pending-harvest --json``) must
+    treat this as a read failure and emit ``success: false``.
+    """

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -67,6 +67,33 @@ def _ensure_fake_bittensor():
 _ensure_fake_bittensor()
 
 
+def _ensure_fake_async_substrate_interface():
+    """Provide a minimal async_substrate_interface stub when dependency is unavailable."""
+    if 'async_substrate_interface' in sys.modules:
+        return
+    try:
+        __import__('async_substrate_interface')
+        return
+    except ImportError:
+        pass
+
+    class _ExtrinsicNotFound(Exception):
+        pass
+
+    errors_mod = types.ModuleType('async_substrate_interface.errors')
+    errors_mod.ExtrinsicNotFound = _ExtrinsicNotFound  # type: ignore[attr-defined]
+
+    top_mod = types.ModuleType('async_substrate_interface')
+    top_mod.errors = errors_mod  # type: ignore[attr-defined]
+    top_mod.SubstrateInterface = object  # type: ignore[attr-defined]
+
+    sys.modules['async_substrate_interface'] = top_mod
+    sys.modules['async_substrate_interface.errors'] = errors_mod
+
+
+_ensure_fake_async_substrate_interface()
+
+
 def pytest_unconfigure(config):
     """Restore original bittensor module state after CLI test session."""
     del config

--- a/tests/cli/test_pending_harvest_read_error.py
+++ b/tests/cli/test_pending_harvest_read_error.py
@@ -1,0 +1,65 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""pending-harvest --json must emit success:false / error.type=read_failed when
+the treasury stake read fails, not success:true with treasury_stake_raw:0."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from gittensor.validator.issue_competitions.errors import TreasuryReadError
+
+
+def test_pending_harvest_json_reports_failure_on_treasury_read_error(cli_root, runner):
+    """TreasuryReadError → success:false, error.type=read_failed, exit non-zero."""
+    fake_subtensor = MagicMock()
+    fake_client = MagicMock()
+    fake_client.get_treasury_stake.side_effect = TreasuryReadError(
+        'Treasury stake read failed: ConnectionResetError'
+    )
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('bittensor.Subtensor', return_value=fake_subtensor),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+        patch('gittensor.cli.issue_commands.view._read_issues_from_child_storage', return_value=[]),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'pending-harvest', '--json'])
+
+    assert result.exit_code != 0, 'exit code must be non-zero on read failure'
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'
+
+
+def test_pending_harvest_json_succeeds_on_genuine_zero_stake(cli_root, runner):
+    """get_treasury_stake() returning 0 normally → success:true, pending_harvest_raw:0."""
+    fake_subtensor = MagicMock()
+    fake_client = MagicMock()
+    fake_client.get_treasury_stake.return_value = 0
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('bittensor.Subtensor', return_value=fake_subtensor),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+        patch('gittensor.cli.issue_commands.view._read_issues_from_child_storage', return_value=[]),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'pending-harvest', '--json'], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload['success'] is True
+    assert payload['treasury_stake_raw'] == 0
+    assert payload['pending_harvest_raw'] == 0


### PR DESCRIPTION
## Problem

`IssueCompetitionContractClient.get_treasury_stake()` (`contract_client.py:640-642`) catches all exceptions from the `SubtensorModule.Alpha` query and silently returns `0`:

```python
except Exception as e:
    bt.logging.error(f'Error fetching treasury stake: {e}')
    return 0   # ← transient error masked as "no stake"
```

`pending-harvest --json` then emits `success: true, treasury_stake_raw: 0`, making a transient network or RPC failure indistinguishable from a genuinely empty treasury. Closes #1449.

## Fix

### `gittensor/validator/issue_competitions/errors.py` (new)
Lightweight module containing only `TreasuryReadError(RuntimeError)` — no heavy imports, importable from CLI and tests without pulling in the contract-client dependency tree.

### `contract_client.py`
- Import `TreasuryReadError` from `errors.py`.
- Replace `except Exception → return 0` with `raise TreasuryReadError(...)`.
- Genuine zero-stake paths (packed storage returns `None`, Alpha returns null) are unaffected and still return `0`.

### `view.py`
Add an explicit `except TreasuryReadError` clause before the generic handler, passing `error_type="read_failed"` to `handle_exception`:
```json
{success: false, error: {type: read_failed, message: ...}}
```
with a non-zero exit code.

## Tests

`tests/cli/test_pending_harvest_read_error.py`:
- `TreasuryReadError` side-effect → `success: false`, `error.type == read_failed`, exit != 0
- Genuine `return 0` → `success: true`, `pending_harvest_raw: 0`, exit 0

`tests/cli/conftest.py`: add `async_substrate_interface` stub so tests can import from contract-client modules in environments where that package is absent.

Closes #1449
