### PR TITLE
fix(cli): resolve wallet/hotkey from config in vote, admin, and harvest commands

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -792,6 +792,11 @@ def _make_contract_client(contract_addr: str, ws_endpoint: str, wallet_name: str
 
     Returns (wallet, client). Lazy-imports bittensor and the contract client so
     that the top-level CLI remains importable without those heavy dependencies.
+
+    Wallet resolution order (mirrors ``issues register``):
+    1. Explicit CLI flags win (any value other than the Click default ``'default'``).
+    2. ``~/.gittensor/config.json`` ``wallet`` / ``hotkey`` keys.
+    3. Click defaults (``'default'`` / ``'default'``).
     """
     import bittensor as bt
 
@@ -799,7 +804,11 @@ def _make_contract_client(contract_addr: str, ws_endpoint: str, wallet_name: str
         IssueCompetitionContractClient,
     )
 
-    wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+    config = load_config()
+    effective_wallet = wallet_name if wallet_name != 'default' else config.get('wallet', wallet_name)
+    effective_hotkey = wallet_hotkey if wallet_hotkey != 'default' else config.get('hotkey', wallet_hotkey)
+
+    wallet = bt.Wallet(name=effective_wallet, hotkey=effective_hotkey)
     subtensor = bt.Subtensor(network=ws_endpoint)
     client = IssueCompetitionContractClient(
         contract_address=contract_addr,

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -243,15 +243,15 @@ def issue_register(
     '--wallet-name',
     '--wallet.name',
     '--wallet',
-    default='validator',
-    help='Wallet name',
+    default=None,
+    help='Wallet name (default: config wallet, then "validator")',
 )
 @click.option(
     '--wallet-hotkey',
     '--wallet.hotkey',
     '--hotkey',
-    default='default',
-    help='Hotkey name',
+    default=None,
+    help='Hotkey name (default: config hotkey, then "default")',
 )
 @click.option(
     '--network',
@@ -293,8 +293,13 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
         missing_contract_message='Contract address not configured. Set CONTRACT_ADDRESS env var or run ./up.sh --issues.',
     )
 
+    # CLI flags override config; fall back to config, then to command defaults.
+    config = load_config()
+    effective_wallet = wallet_name or config.get('wallet', 'validator')
+    effective_hotkey = wallet_hotkey or config.get('hotkey', 'default')
+
     print_network_header(network_name, contract_addr)
-    err_console.print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey}[/dim]\n')
+    err_console.print(f'[dim]Wallet: {effective_wallet}/{effective_hotkey}[/dim]\n')
 
     try:
         import bittensor as bt
@@ -304,7 +309,7 @@ def issue_harvest(wallet_name: str, wallet_hotkey: str, network: str, rpc_url: s
         )
 
         with err_console.status('[bold cyan]Loading wallet...', spinner='dots'):
-            wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
+            wallet = bt.Wallet(name=effective_wallet, hotkey=effective_hotkey)
             hotkey_addr = wallet.hotkey.ss58_address
         err_console.print(f'[green]Hotkey address:[/green] {hotkey_addr}')
 

--- a/tests/cli/test_wallet_config_resolution.py
+++ b/tests/cli/test_wallet_config_resolution.py
@@ -1,0 +1,157 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""_make_contract_client and harvest must resolve wallet/hotkey from config
+when explicit CLI flags are absent (issue #1424)."""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+
+def _config_patch(wallet: str, hotkey: str):
+    """Return a patch that injects a config with the given wallet/hotkey."""
+    return patch(
+        'gittensor.cli.issue_commands.helpers.load_config',
+        return_value={'wallet': wallet, 'hotkey': hotkey},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _make_contract_client
+# ---------------------------------------------------------------------------
+
+
+def test_make_contract_client_uses_config_wallet_when_cli_is_default(cli_root, runner):
+    """vote/admin commands should use config wallet when --wallet-name is not given."""
+    captured = {}
+
+    def _fake_make(contract_addr, ws_endpoint, wallet_name, wallet_hotkey):
+        captured['wallet_name'] = wallet_name
+        captured['wallet_hotkey'] = wallet_hotkey
+        fake_wallet = MagicMock()
+        fake_wallet.hotkey.ss58_address = '5Fake'
+        fake_client = MagicMock()
+        fake_client.cancel_vote.return_value = ('0xhash', None)
+        return fake_wallet, fake_client
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.vote._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        _config_patch('configured-wallet', 'configured-hotkey'),
+        patch('gittensor.cli.issue_commands.vote._make_contract_client', side_effect=_fake_make),
+    ):
+        runner.invoke(cli_root, ['vote', 'cancel', '1', 'dup', '--yes'])
+
+    assert captured.get('wallet_name') == 'default', \
+        'helpers._make_contract_client receives the raw Click default; resolution happens inside it'
+
+
+def test_make_contract_client_internal_resolves_config(tmp_path):
+    """_make_contract_client itself must resolve 'default' wallet to config wallet."""
+    from gittensor.cli.issue_commands.helpers import _make_contract_client
+
+    fake_bt_wallet = MagicMock()
+    fake_subtensor = MagicMock()
+    fake_client = MagicMock()
+
+    with (
+        patch('gittensor.cli.issue_commands.helpers.load_config',
+              return_value={'wallet': 'my-wallet', 'hotkey': 'my-hotkey'}),
+        patch('bittensor.Wallet', return_value=fake_bt_wallet) as wallet_cls,
+        patch('bittensor.Subtensor', return_value=fake_subtensor),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+    ):
+        _make_contract_client('5Addr', 'ws://x', 'default', 'default')
+
+    wallet_cls.assert_called_once_with(name='my-wallet', hotkey='my-hotkey')
+
+
+def test_make_contract_client_explicit_flag_wins_over_config():
+    """Explicit CLI wallet flag must override the config value."""
+    from gittensor.cli.issue_commands.helpers import _make_contract_client
+
+    fake_bt_wallet = MagicMock()
+    fake_subtensor = MagicMock()
+    fake_client = MagicMock()
+
+    with (
+        patch('gittensor.cli.issue_commands.helpers.load_config',
+              return_value={'wallet': 'config-wallet', 'hotkey': 'config-hotkey'}),
+        patch('bittensor.Wallet', return_value=fake_bt_wallet) as wallet_cls,
+        patch('bittensor.Subtensor', return_value=fake_subtensor),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+    ):
+        _make_contract_client('5Addr', 'ws://x', 'explicit-wallet', 'explicit-hotkey')
+
+    wallet_cls.assert_called_once_with(name='explicit-wallet', hotkey='explicit-hotkey')
+
+
+# ---------------------------------------------------------------------------
+# harvest
+# ---------------------------------------------------------------------------
+
+
+def test_harvest_uses_config_wallet_when_flags_absent(cli_root, runner):
+    """gitt harvest with no wallet flags should use config wallet/hotkey."""
+    fake_wallet = MagicMock()
+    fake_wallet.hotkey.ss58_address = '5Fake'
+    fake_client = MagicMock()
+    fake_client.harvest_emissions.return_value = {'tx_hash': '0xabc', 'success': True}
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.mutations.load_config',
+              return_value={'wallet': 'config-wallet', 'hotkey': 'config-hotkey'}),
+        patch('bittensor.Wallet', return_value=fake_wallet) as wallet_cls,
+        patch('bittensor.Subtensor', return_value=MagicMock()),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+    ):
+        runner.invoke(cli_root, ['harvest'], catch_exceptions=False)
+
+    wallet_cls.assert_called_once_with(name='config-wallet', hotkey='config-hotkey')
+
+
+def test_harvest_explicit_flag_wins_over_config(cli_root, runner):
+    """gitt harvest --wallet-name explicit must override config."""
+    fake_wallet = MagicMock()
+    fake_wallet.hotkey.ss58_address = '5Fake'
+    fake_client = MagicMock()
+    fake_client.harvest_emissions.return_value = {'tx_hash': '0xabc', 'success': True}
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('gittensor.cli.issue_commands.mutations.load_config',
+              return_value={'wallet': 'config-wallet', 'hotkey': 'config-hotkey'}),
+        patch('bittensor.Wallet', return_value=fake_wallet) as wallet_cls,
+        patch('bittensor.Subtensor', return_value=MagicMock()),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+    ):
+        runner.invoke(
+            cli_root,
+            ['harvest', '--wallet-name', 'explicit-wallet', '--wallet-hotkey', 'explicit-hotkey'],
+            catch_exceptions=False,
+        )
+
+    wallet_cls.assert_called_once_with(name='explicit-wallet', hotkey='explicit-hotkey')


### PR DESCRIPTION
## Problem

`_make_contract_client` (called by every `vote` and `admin` write command) creates the wallet from the raw Click defaults:

```python
wallet = bt.Wallet(name=wallet_name, hotkey=wallet_hotkey)
```

When the user does not pass `--wallet-name` / `--wallet-hotkey`, Click supplies `"default"`/`"default"`, ignoring any wallet/hotkey stored in `~/.gittensor/config.json`. `gitt harvest` has the same bug with its `"validator"`/`"default"` defaults.

Only `gitt issues register` (mutations.py:188-189) already resolved from config. Closes #1424.

## Fix

### `helpers.py` — `_make_contract_client`

Apply the same resolution pattern as `issues register`:

```python
config = load_config()
effective_wallet = wallet_name if wallet_name != "default" else config.get("wallet", wallet_name)
effective_hotkey = wallet_hotkey if wallet_hotkey != "default" else config.get("hotkey", wallet_hotkey)
wallet = bt.Wallet(name=effective_wallet, hotkey=effective_hotkey)
```

All eight `vote` / `admin` commands inherit the fix via the shared helper.

### `mutations.py` — `issue_harvest`

Change Click option defaults from `"validator"`/`"default"` to `None` (so explicit vs absent flags are distinguishable), then resolve with fallbacks:

```python
config = load_config()
effective_wallet = wallet_name or config.get("wallet", "validator")
effective_hotkey = wallet_hotkey or config.get("hotkey", "default")
```

## Tests

New `tests/cli/test_wallet_config_resolution.py` verifies:
- `_make_contract_client` passes the config wallet to `bt.Wallet` when CLI defaults are `"default"`
- Explicit CLI flags win over config values  
- `harvest` without flags uses the config wallet/hotkey
- `harvest` with explicit flags overrides config

Closes #1424
