### PR TITLE
Update Taopedia site hyperparameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,7 +7,20 @@
   "e35ventura/taopedia": {
     "emission_share": 0.025,
     "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.0
+    "maintainer_cut": 0.0,
+    "additional_acceptable_branches": ["test"],
+    "trusted_label_pipeline": true,
+    "default_label_multiplier": 0.0,
+    "label_multipliers": {
+      "feature": 3.0,
+      "ui-ux": 2.0,
+      "bug": 1.25,
+      "security": 1.25,
+      "other": 0.1
+    },
+    "eligibility": {
+      "min_credibility": 0.6
+    }
   },
   "e35ventura/taopedia-articles": {
     "emission_share": 0.025,


### PR DESCRIPTION
## Summary
- add trusted label-based scoring for e35ventura/taopedia
- set feature multiplier to 3.0 and ui-ux multiplier to 2.0
- set default unlabeled multiplier to 0.0 and keep min credibility at 0.6
- allow the test branch for Taopedia site contributions

## Tests
- uv run --extra dev pytest tests/validator/test_load_weights.py
- uv run --extra dev pytest tests/validator/test_label_multiplier.py tests/validator/oss_contributions/mirror/test_repo_config_fields.py