### PR TITLE
weights: add anderdc/social-media-manager (0.004)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,4 +1,21 @@
 {
+  "anderdc/social-media-manager": {
+    "default_label_multiplier": 0.0,
+    "eligibility": {
+      "min_credibility": 0.0,
+      "min_issue_credibility": 0.0,
+      "min_valid_merged_prs": 0,
+      "min_valid_solved_issues": 0
+    },
+    "emission_share": 0.004,
+    "fixed_base_score": 1.0,
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "crown": 1.0
+    },
+    "maintainer_cut": 0.0,
+    "trusted_label_pipeline": true
+  },
   "cogniax/tao-pulse-app": {
     "emission_share": 0.01,
     "issue_discovery_share": 0.7,
@@ -64,7 +81,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.09,
+    "emission_share": 0.08,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -14,6 +14,9 @@
       "crown": 1.0
     },
     "maintainer_cut": 0.0,
+    "scoring": {
+      "pr_lookback_days": 7
+    },
     "trusted_label_pipeline": true
   },
   "cogniax/tao-pulse-app": {


### PR DESCRIPTION
Adds `anderdc/social-media-manager` to the master repository list and rebalances to stay under the emission-share cap.

## Changes
- **Add `anderdc/social-media-manager`** at `emission_share: 0.004`. Config mirrors `entrius/oc-1` (flat-scored content repo):
  - `fixed_base_score: 1.0` — a tweet `.md` isn't scored by code-tokens; flat base per crowned post.
  - `label_multipliers: { crown: 1.0 }` + `default_label_multiplier: 0.0` — only the maintainer-applied `crown` label pays; everything else scores 0.
  - `trusted_label_pipeline: true` — the crown label is applied by the GitHub App (`xiao-xiao-mao`), surfacing as `actor_association=NULL`; without this flag the label is filtered out and the winner earns nothing (label_resolution.py, issue #911).
  - `maintainer_cut: 0.0` — full slice to the winning miner.
  - Lax eligibility (all 0) — matches the maintainer's gate-1 'live SN74 miner is the only bar' policy.
- **Trim `entrius/gittensor`** `0.09 -> 0.08` to make room.

Total `emission_share` across all repos: **0.398** (under 1.0).