### PR TITLE
Tune Taopedia site bug and security weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -34,8 +34,8 @@
     "label_multipliers": {
       "feature": 3.0,
       "ui-ux": 2.0,
-      "bug": 1.25,
-      "security": 1.25,
+      "bug": 0.625,
+      "security": 0.625,
       "other": 0.1
     },
     "eligibility": {


### PR DESCRIPTION
## Summary
- Cut `e35ventura/taopedia` bug multiplier from `1.25` to `0.625`
- Cut `e35ventura/taopedia` security multiplier from `1.25` to `0.625`

## Rationale
Feature and UI/UX work remain the primary high-value reward categories for the Taopedia site. Bug and security labels remain separate for classification/auditability, but both receive a lower multiplier to reduce reward pressure for small fixes and hardening cleanup.

## Validation
- Parsed `gittensor/validator/weights/master_repositories.json` as JSON
- `git diff --check` passed