### PR TITLE
chore(weights): rebalance community emission shares

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,7 +7,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.004,
+    "emission_share": 0.005,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -34,8 +34,8 @@
     "label_multipliers": {
       "feature": 3.0,
       "ui-ux": 2.0,
-      "bug": 1.25,
-      "security": 1.25,
+      "bug": 0.625,
+      "security": 0.625,
       "other": 0.1
     },
     "eligibility": {
@@ -62,7 +62,7 @@
     }
   },
   "entrius/allways": {
-    "emission_share": 0.05,
+    "emission_share": 0.04,
     "issue_discovery_share": 1.0,
     "label_multipliers": {
       "bug": 1.25,
@@ -96,7 +96,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
-    "emission_share": 0.01,
+    "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,
@@ -128,7 +128,7 @@
     "eligibility": {
       "max_open_pr_threshold": 2
     },
-    "emission_share": 0.033,
+    "emission_share": 0.03,
     "issue_discovery_share": 0.0,
     "maintainer_cut": 0.3
   },
@@ -162,7 +162,7 @@
   },
   "JSONbored/gittensory": {
     "default_label_multiplier": 0.0,
-    "emission_share": 0.01,
+    "emission_share": 0.015,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 1.0,
@@ -179,6 +179,10 @@
         "min_multiplier": 0.05
       }
     }
+  },
+  "JSONbored/metagraphed": {
+    "emission_share": 0.0075,
+    "issue_discovery_share": 0.0
   },
   "MkDev11/gittensor-hub": {
     "emission_share": 0.012,
@@ -242,7 +246,7 @@
     }
   },
   "seroperson/jvm-live-reload": {
-    "emission_share": 0.011,
+    "emission_share": 0.008,
     "issue_discovery_share": 0.0
   },
   "touchpilot/touchpilot": {


### PR DESCRIPTION
Suggestive emission-share rebalance on realized progress since #1447 (merged 2026-06-04) and forward outlook. Subnet price 0.004575 TAO/ALPHA, TAO $213.67 (1.0 share ≈ $9,679/day; 0.001 share ≈ $9.68/day). Default posture is HOLD; raises must clear the organic-pull gate, demotes require confirmed churn or a proven alt link (suspicion → partial trim, not floor).

**Baseline anchor for next run:** this branch's rebalance commit is `210d005` (base `origin/test` @ `3686a3b`). Next rebalance should measure "progress since" from here and diff against the snapshot block at the bottom.

## Rebalances
| repo | old | new | est. $/day (old→new) | type |
|---|---:|---:|---|---|
| Geniepod/genie-claw | 0.0330 | 0.0300 | $319 → $290 | trim (analysis) |
| seroperson/jvm-live-reload | 0.0110 | 0.0080 | $106 → $77 | trim (analysis — pre-committed trigger) |
| JSONbored/gittensory | 0.0100 | 0.0150 | $97 → $145 | raise (directed) |
| JSONbored/metagraphed | — | 0.0075 | $0 → $73 | new listing (directed seed) |
| anderdc/social-media-manager | 0.0040 | 0.0050 | $39 → $48 | directed (protected) |
| entrius/allways | 0.0500 | 0.0400 | $484 → $387 | directed (protected) |
| entrius/gittensor-ui | 0.0100 | 0.0050 | $97 → $48 | directed (protected) |

Held (no change): infiniflow/ragflow 0.055, we-promise/sure 0.030, MkDev11/gittensor-hub 0.012, phase-rs/phase 0.018, JSONbored/awesome-claude 0.005, vouchdev/vouch 0.010, cogniax/tao-pulse-app 0.010, touchpilot/touchpilot 0.005 (floored last run), e35ventura/taopedia 0.025, e35ventura/taopedia-articles 0.025.

## Totals
- Previous (test): `0.3980` (headroom 0.6020)
- New: `0.3905` (headroom 0.6095)

## Why these changed — and what each owner is doing right / wrong

**Geniepod/genie-claw — trim 0.033 → 0.030**
- *What's wrong:* realized output went **backward** since the last rebalance — repo score fell **17 → 5**, eligible miners **9 → 7**, stars essentially flat (45 → 46), and there's been **no new release** since 2026-05-29 (still v1.0.0-alpha.10). At 0.033 the share was the most overweight in the set relative to delivered work (compare phase at 0.018 for a score of 1,600+).
- *What's right:* the engineering is genuine (13 commits since anchor, M1 Jetson harness near-done, most PRs reviewed by ai-hpc) — this is a real project, not a farm, which is why it's a **small trim, not a floor**.
- *How to move the share back up:* ship a release, land the Jetson milestone, and get repo score climbing again. Distant hardware-adoption path means stars/external pull will be the slow lever; delivered milestones are the fast one.

**seroperson/jvm-live-reload — trim 0.011 → 0.008**
- *What's wrong:* #1447 pre-committed the exact trigger — "trim if cadence stays flat next run" — and it stayed flat: 5 commits since anchor, **no release since v0.1.1 (2025-12-29, ~6 months)**, 2 eligible miners, repo score 0.
- *What's right:* legitimate independent OSS (Maven Central, clean maintainer merges, predates emissions) — it keeps a fair floor presence, not a demotion.
- *How to move up:* resume a release cadence; the share tracks active delivery, and a dormant-but-real library settles at a low hold.

**JSONbored/gittensory — raise 0.010 → 0.015 (directed)**
- *What's right:* the **deepest realized absorber in the community set** — repo score **1,772**, 8 eligible miners, 126 merged PRs, ~100 commits since anchor, mcp-v0.4.0 shipped 2026-06-02, with real human review (27% change-request rate).
- *What's still wrong (the honest caveat):* it **fails the organic-pull gate** — 4★, ~89% mining-cohort, only ~2 external contributors. #1447's gate explicitly *held* this raise for that reason.
- *Why it moves anyway:* this is a **directed forward bet on the MCP/tooling thesis**, kept deliberately small (+0.005) — not a gate-cleared raise. **To keep it (and earn more): external adoption must show up** — outside contributors, stars, downstream MCP usage. If stars/external stay flat next run, this reverses.

**JSONbored/metagraphed — new listing at 0.0075 (directed seed)**
- *What's right:* active new repo (operational metadata/health/schema discovery for Bittensor subnets) — ~100 commits and **client-v0.2.0 shipped 2026-06-11**; extends the same JSONbored tooling stack.
- *What's unproven:* 1★, 0 forks, **0 eligible miners / score 0** — nothing realized yet.
- *How it's judged:* a standard small seed, in line with other new entries. It earns or loses the share on next run's realized output; no track record yet means a modest start.

**Directed / protected-owner moves (not rebalance-logic outputs):**
- **anderdc/social-media-manager 0.004 → 0.005** — operator repo, minor directed bump.
- **entrius/allways 0.050 → 0.040** — core subnet repo; directed trim that recycles ~0.010 of headroom.
- **entrius/gittensor-ui 0.010 → 0.005** — core repo; directed trim.
- **e35ventura/taopedia label multipliers** — folds in #1466: bug & security 1.25 → 0.625 (directed hyperparameter tweak by the repo owner; feature/ui-ux remain the high-value categories). No emission_share change.

## Carried-forward watch — MkDev11/gittensor-hub (HELD 0.012, not changed)

#1447 trimmed this 0.020 → 0.012 on **suspected** shadow-mining (contributor `bitloi` rubber-stamped by maintainer `MkDev11` — e.g. PR #71 +1,227/23 files merged in 99 seconds, #154 +10,163 lines on bot comments only) and deferred the verdict to this run. This week's merge-graph archaeology:
- **bitloi went dormant** — still exactly 18 merged PRs, **zero new PRs since the anchor**. No fresh rubber-stamp evidence (neither confirms nor clears the alt suspicion).
- **The size-vs-time impossibility did not recur.** New contributors (`philluiz2323`, `enjoyandlove`) were merged with COMMENTED reviews over realistic 6h–6d windows — weak hygiene, *improved* over the bitloi pattern.
- MkDev11's own PRs (#220/#221/#223/#224) are self-merged with 0 reviews, but the validator **zeroes** those, so they earn nothing — not farming.
- **Verdict: hold at 0.012.** Identity link unproven (don't floor — work is genuine source, churn already ruled out); no APPROVED independent review yet (don't restore). *To recover toward 0.018–0.020: introduce real review gates (APPROVED reviews on contributor PRs). It floors only if `bitloi` resumes large no-review PRs and the alt link confirms.* Also watching `philluiz2323` as a possible new alt.

touchpilot/touchpilot remains **floored at 0.005** (confirmed churn-farming last run): 41 commits and score 558.5 this week but **still 0 external contributors and no release** — rehab condition (independent review + no churn-farming account) not yet met. *Restores when churn-farming stops and outside contribution appears.*

## State-of-affairs snapshot — 2026-06-11 (baseline for next run; commit `210d005`)

External-contributor counts marked *(c)* are carried from the 2026-06-04 baseline (all-time) where not recomputed this run.

### infiniflow/ragflow
- share: 0.055 | stars: 82,474 | forks: 9,514 | release: v0.26.0 (2026-06-11) | commits since anchor: 100+
- eligible miners: 21 | repo score: 352 | external non-cohort: 80/99 *(c)*
- state: pre-gittensor flagship OSS, huge organic adoption, rigorous review. Anchor — hold.
- flags: none | revisit: only on a strong sustained shift

### we-promise/sure
- share: 0.030 | stars: 8,634 | forks: 147 | release: v0.7.2-alpha.5 (2026-06-11) | commits since anchor: 57
- eligible miners: 7 | repo score: 298 | external non-cohort: 87/96 *(c)*
- state: pre-gittensor real product, clean maintainer review (jjmata). Anchor — hold.
- flags: none | revisit: anchor — hold

### Geniepod/genie-claw
- share: 0.030 (↓ from 0.033) | stars: 46 | forks: 39 | release: v1.0.0-alpha.10 (2026-05-29) | commits since anchor: 13
- eligible miners: 7 (↓9) | repo score: 5 (↓17) | external non-cohort: 4/18 *(c)*
- state: on-device AI harness; real engineering but realized output slipped this week, no release since anchor, distant hardware-adoption path.
- flags: output regression | revisit: restore if a release lands + score recovers; trim again if it keeps slipping

### phase-rs/phase
- share: 0.018 | stars: 132 | forks: 85 | release: v0.1.53 (2026-06-10) | commits since anchor: 100+
- eligible miners: 23 | repo score: 1,616 | external non-cohort: 29/49 *(c)*
- state: MTG rules engine; clears organic gate, clean matthewevans review, daily releases. Niche/non-commercial ceiling.
- flags: none | revisit: watch adoption; raise candidate if stars/external grow

### JSONbored/gittensory
- share: 0.015 (↑ from 0.010) | stars: 4 | forks: 28 | release: mcp-v0.4.0 (2026-06-02) | commits since anchor: 100+
- eligible miners: 8 | repo score: 1,772 | external non-cohort: ~2/18 *(c)*
- state: deepest absorber, genuine reviewed engineering, BUT fails organic gate (cohort-heavy, 4★). Raise is a directed tooling-thesis bet.
- flags: organic-gate fail (raise is directed) | revisit: reverse if external adoption stays flat

### JSONbored/metagraphed
- share: 0.0075 (NEW) | stars: 1 | forks: 0 | release: client-v0.2.0 (2026-06-11) | commits since anchor: 100+
- eligible miners: 0 | repo score: 0 | external non-cohort: n/a
- state: new subnet-metadata tooling (sibling to gittensory); active dev, no realized contribution yet.
- flags: unproven (seed) | revisit: judge on first realized output

### JSONbored/awesome-claude
- share: 0.005 | stars: 262 | forks: 72 | release: mcp-v0.3.0 (2026-06-07) | commits since anchor: 100+
- eligible miners: 10 | repo score: 298 | external non-cohort: 9/24 *(c)*
- state: awesome-list registry, agentic submission gate (legitimate model). Farm-prone surface handled by low weight + default_label_multiplier 0.
- flags: none | revisit: hold

### MkDev11/gittensor-hub
- share: 0.012 | stars: 17 | forks: 32 | release: seed (none) | commits since anchor: 9
- eligible miners: 5 | repo score: ~330 (bitloi 256) | external non-cohort: 4/13 *(c)*
- state: real frontend code; bitloi (suspected alt) went dormant, no new no-review mega-PRs; new contributors get COMMENTED (not APPROVED) review.
- flags: **SUSPECTED shadow-mining (bitloi↔MkDev11) — unconfirmed, dormant; watch philluiz2323** | revisit: floor if bitloi resumes + link confirms; restore toward 0.018–0.020 if APPROVED review appears

### vouchdev/vouch
- share: 0.010 | stars: 4 | forks: 23 | release: v0.1.0 (2026-05-26) | commits since anchor: 0
- eligible miners: 3 | repo score: 441 | external non-cohort: 2/7 *(c)*
- state: maintained by plind-junior (registerer; not a ring). **Went dormant this week (0 commits).**
- flags: dormant | revisit: trim candidate if cadence stays flat next run

### cogniax/tao-pulse-app
- share: 0.010 | stars: 22 | forks: 18 | release: v0.1.0 | commits since anchor: 21
- eligible miners: 1 (mvphanx) | repo score: 164 | external non-cohort: 3/3 *(c)*
- state: seasoned positively — crossed eligibility (0→1 miner, score 0→164), shipped first release. But single-contributor with a growing 23-PR open queue.
- flags: single-contributor + review-backlog risk | revisit: raise candidate if a 2nd/3rd eligible contributor appears and queue is reviewed down

### seroperson/jvm-live-reload
- share: 0.008 (↓ from 0.011) | stars: 28 | forks: 26 | release: v0.1.1 (2025-12-29) | commits since anchor: 5
- eligible miners: 2 | repo score: 0 | external non-cohort: 2/6 *(c)*
- state: legit independent OSS, but tapering — flat cadence triggered the pre-committed trim.
- flags: none | revisit: hold low until a release cadence resumes

### touchpilot/touchpilot
- share: 0.005 (FLOORED last run) | stars: 11 | forks: 29 | release: none | commits since anchor: 41
- eligible miners: 8 | repo score: 559 | external non-cohort: 0/11 *(c)*
- state: confirmed churn-farming (RenzoMXD net-zero churn, maintainer-merged in minutes); still 0 external contributors, no release.
- flags: **FLOORED — rehab not yet met** | revisit: restore when churn-farming stops and outside contribution appears

---

Protected-owner repos (entrius / anderdc / e35ventura / landyndev) are out of scope for the rebalance logic; their shares move only by directed change and they get no snapshot entry.

