### PR TITLE
fix(validator): close GitHub API sessions to stop connection-pool leaks

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -108,56 +108,58 @@ def get_github_identity(token: str) -> GitHubIdentityResult:
         return GitHubIdentityResult(None, GitHubIdentityStatus.INVALID_AUTH)
 
     session = get_session(token)
+    try:
+        # Retry logic for timeout issues
+        for attempt in range(6):
+            try:
+                response = session.get(f'{BASE_GITHUB_API_URL}/user', timeout=GITHUB_HTTP_TIMEOUT_SECONDS)
+                if response.status_code == 200:
+                    try:
+                        user_data: Dict[str, Any] = response.json()
+                    except Exception as e:
+                        bt.logging.warning(f'Failed to parse GitHub /user JSON response: {e}')
+                        if attempt < 5:
+                            time.sleep(2)
+                            continue
+                        return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
-    # Retry logic for timeout issues
-    for attempt in range(6):
-        try:
-            response = session.get(f'{BASE_GITHUB_API_URL}/user', timeout=GITHUB_HTTP_TIMEOUT_SECONDS)
-            if response.status_code == 200:
-                try:
-                    user_data: Dict[str, Any] = response.json()
-                except Exception as e:
-                    bt.logging.warning(f'Failed to parse GitHub /user JSON response: {e}')
+                    user_id = user_data.get('id')
+                    if user_id is not None:
+                        return GitHubIdentityResult(str(user_id), GitHubIdentityStatus.VALID)
+
+                    bt.logging.warning(f'GitHub /user response missing id (attempt {attempt + 1}/6)')
                     if attempt < 5:
                         time.sleep(2)
                         continue
                     return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
-                user_id = user_data.get('id')
-                if user_id is not None:
-                    return GitHubIdentityResult(str(user_id), GitHubIdentityStatus.VALID)
+                if response.status_code == 408 or _is_rate_limited_response(response):
+                    bt.logging.warning(
+                        f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
+                    )
+                    if attempt < 5:
+                        time.sleep(2)
+                        continue
+                    return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
-                bt.logging.warning(f'GitHub /user response missing id (attempt {attempt + 1}/6)')
-                if attempt < 5:
-                    time.sleep(2)
-                    continue
-                return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+                if 400 <= response.status_code < 500:
+                    bt.logging.warning(f'GitHub /user auth failed with status {response.status_code}')
+                    return GitHubIdentityResult(None, GitHubIdentityStatus.INVALID_AUTH)
 
-            if response.status_code == 408 or _is_rate_limited_response(response):
                 bt.logging.warning(
                     f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
                 )
                 if attempt < 5:
                     time.sleep(2)
-                    continue
-                return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
-            if 400 <= response.status_code < 500:
-                bt.logging.warning(f'GitHub /user auth failed with status {response.status_code}')
-                return GitHubIdentityResult(None, GitHubIdentityStatus.INVALID_AUTH)
+            except Exception as e:
+                bt.logging.warning(f'Could not fetch GitHub user (attempt {attempt + 1}/6): {e}')
+                if attempt < 5:  # Don't sleep on last attempt
+                    time.sleep(2)
 
-            bt.logging.warning(
-                f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
-            )
-            if attempt < 5:
-                time.sleep(2)
-
-        except Exception as e:
-            bt.logging.warning(f'Could not fetch GitHub user (attempt {attempt + 1}/6): {e}')
-            if attempt < 5:  # Don't sleep on last attempt
-                time.sleep(2)
-
-    return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+        return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+    finally:
+        session.close()
 
 
 # GraphQL fragment used by issue submissions / PR discovery.
@@ -361,45 +363,48 @@ def execute_graphql_query(
     Returns:
         Parsed JSON response data, or None if all attempts failed
     """
-    session = get_session(token)
     headers = make_graphql_headers(token)
 
-    for attempt in range(max_attempts):
-        try:
-            response = session.post(
-                f'{BASE_GITHUB_API_URL}/graphql',
-                headers=headers,
-                json={'query': query, 'variables': variables},
-                timeout=timeout,
-            )
-
-            if response.status_code == 200:
-                return response.json()
-
-            # Retry on failure
-            if attempt < (max_attempts - 1):
-                backoff_delay = backoff_seconds(attempt)
-                bt.logging.warning(
-                    f'GraphQL request failed with status {response.status_code} '
-                    f'(attempt {attempt + 1}/{max_attempts}), retrying in {backoff_delay}s...'
-                )
-                time.sleep(backoff_delay)
-            else:
-                bt.logging.error(
-                    f'GraphQL request failed with status {response.status_code} '
-                    f'after {max_attempts} attempts: {response.text}'
+    session = get_session(token)
+    try:
+        for attempt in range(max_attempts):
+            try:
+                response = session.post(
+                    f'{BASE_GITHUB_API_URL}/graphql',
+                    headers=headers,
+                    json={'query': query, 'variables': variables},
+                    timeout=timeout,
                 )
 
-        except requests.exceptions.RequestException as e:
-            if attempt < (max_attempts - 1):
-                backoff_delay = backoff_seconds(attempt)
-                bt.logging.warning(
-                    f'GraphQL request exception (attempt {attempt + 1}/{max_attempts}), '
-                    f'retrying in {backoff_delay}s: {e}'
-                )
-                time.sleep(backoff_delay)
-            else:
-                bt.logging.error(f'GraphQL request failed after {max_attempts} attempts: {e}')
+                if response.status_code == 200:
+                    return response.json()
+
+                # Retry on failure
+                if attempt < (max_attempts - 1):
+                    backoff_delay = backoff_seconds(attempt)
+                    bt.logging.warning(
+                        f'GraphQL request failed with status {response.status_code} '
+                        f'(attempt {attempt + 1}/{max_attempts}), retrying in {backoff_delay}s...'
+                    )
+                    time.sleep(backoff_delay)
+                else:
+                    bt.logging.error(
+                        f'GraphQL request failed with status {response.status_code} '
+                        f'after {max_attempts} attempts: {response.text}'
+                    )
+
+            except requests.exceptions.RequestException as e:
+                if attempt < (max_attempts - 1):
+                    backoff_delay = backoff_seconds(attempt)
+                    bt.logging.warning(
+                        f'GraphQL request exception (attempt {attempt + 1}/{max_attempts}), '
+                        f'retrying in {backoff_delay}s: {e}'
+                    )
+                    time.sleep(backoff_delay)
+                else:
+                    bt.logging.error(f'GraphQL request failed after {max_attempts} attempts: {e}')
+    finally:
+        session.close()
 
     return None
 
@@ -566,6 +571,8 @@ def check_github_issue_closed(repo: str, issue_number: int, token: str) -> Optio
     except Exception as e:
         bt.logging.error(f'Error checking GitHub issue {repo}#{issue_number}: {e}')
         return None
+    finally:
+        session.close()
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,9 @@ class _ForwardingSession:
             kwargs['headers'] = dict(self.headers)
         return requests.post(*args, **kwargs)
 
+    def close(self):
+        """Mirror requests.Session.close so callers can release the session."""
+
 
 @pytest.fixture(autouse=True)
 def _forward_github_sessions(monkeypatch):


### PR DESCRIPTION
## Summary

`get_github_identity`, `execute_graphql_query`, and `check_github_issue_closed` in `gittensor/utils/github_api_tools.py` each open a `requests.Session` via `get_session()` but never close it. Every PAT validation, GraphQL query, and issue-closure check therefore leaks the session's underlying `urllib3` connection pool (open sockets) for the life of the process. On a validator these run continuously, once per miner, so the leaked pools accumulate over time.

This wraps each session in `try/finally` (matching the `try/except` that already surrounds `check_github_issue_closed`) so the session is closed on every return and exception path. No control flow or return values change — only session lifetime.

## Related Issues

No issue filed; this is a self-contained resource-leak fix in the validator's GitHub API helpers, in the same vein as the per-PR content cleanup in #1456.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- Added a `close()` shim to the `_ForwardingSession` proxy in `tests/conftest.py` so it mirrors `requests.Session` now that callers release the session. (Not a test-only change — it accompanies the code fix.)
- Full gate run locally with `uv` (Python 3.12):

```
uv run pre-commit run --all-files                        # ruff lint + format: Passed
SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push  # pyright + vulture: Passed
uv run pytest tests/ -q                                  # 917 passed
```

No CLI output is affected (change is in `gittensor/utils/**`, not `gittensor/cli/**`), so no terminal evidence applies.

## Checklist

- [x] Code follows repository style (ruff lint + format clean)
- [x] Self-reviewed the diff (the large line count is re-indentation from the `try/finally` wrap, not logic changes)
- [x] Tests pass (`uv run pytest tests/` — 917 passed) and pyright/vulture clean
- [x] No unrelated changes
