### PR TITLE
fix(validator): close MirrorClient session opened for issue discovery

### DIFF
--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -122,13 +122,15 @@ async def issue_discovery(
     inline ``solving_pr`` data, and a cross-miner cache of already-scored
     solving PRs so the base_score reflects real token scoring.
     """
-    await run_issue_discovery(
-        miner_evaluations,
-        master_repositories,
-        programming_languages,
-        token_config,
-        evaluation_cache=evaluation_cache,
-    )
+    with MirrorClient() as client:
+        await run_issue_discovery(
+            miner_evaluations,
+            master_repositories,
+            programming_languages,
+            token_config,
+            client=client,
+            evaluation_cache=evaluation_cache,
+        )
 
 
 def build_maintainer_uids_by_repo(


### PR DESCRIPTION
## Summary

`issue_discovery()` (`gittensor/validator/forward.py`) called `run_issue_discovery()` without a `client`, so the `client = client or MirrorClient()` fallback inside it created a new `MirrorClient` — and its underlying `requests.Session` — that was never closed. Issue discovery runs on every scoring round, so each round leaked the session's connection pool (open sockets).

This owns the client at the call site with `with MirrorClient() as client:` and passes it in, mirroring how `forward.build_maintainer_uids_by_repo` and `reward.evaluate_miner` already manage their `MirrorClient` lifetime. No behavior changes beyond the session now being released.

## Related Issues

No issue filed; self-contained resource-leak fix on the issue-discovery path, in the same vein as the per-PR content cleanup in #1456.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

Full gate run locally with `uv` (Python 3.12):

```
uv run ruff check / format         # clean
uv run pyright                     # 0 errors
uv run pytest tests/ -q            # 917 passed
```

No CLI output is affected (change is in `gittensor/validator/**`, not `gittensor/cli/**`), so no terminal evidence applies.

## Checklist

- [x] Code follows repository style (ruff lint + format clean)
- [x] Self-reviewed the diff (mirrors the existing `with MirrorClient() as client:` pattern in this file)
- [x] Tests pass (`uv run pytest tests/` — 917 passed) and pyright clean
- [x] No unrelated changes
