### PR TITLE
feat(validator): add emission-blend round completion summary

### DIFF
--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -45,10 +45,21 @@ def blend_emission_pools(
     total_configured_share = sum(config.emission_share for config in master_repositories.values())
     recycle_share = max(0.0, 1.0 - total_configured_share) * OSS_EMISSION_SHARE
 
+    repos_allocated = 0
+    repos_fully_recycled = 0
+    maintainer_carve_out_total = 0.0
+    rewarded_uids: set[int] = set()
+
     for allocation in calculate_repo_emission_breakdown(
         miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo
     ):
         recycle_share += allocation.recycled_amount
+        if allocation.maintainer_rewards or allocation.pr_rewards or allocation.issue_discovery_rewards:
+            repos_allocated += 1
+        else:
+            repos_fully_recycled += 1
+        maintainer_carve_out_total += sum(allocation.maintainer_rewards.values())
+        rewarded_uids.update(allocation.maintainer_rewards, allocation.pr_rewards, allocation.issue_discovery_rewards)
         for uid, reward in allocation.maintainer_rewards.items():
             rewards[uid_index[uid]] += reward
         for uid, reward in allocation.pr_rewards.items():
@@ -71,6 +82,13 @@ def blend_emission_pools(
         rewards[recycle_idx] += recycle_share
         if recycle_share > EMISSION_SHARE_TOLERANCE:
             bt.logging.info(f'Recycling {recycle_share * 100:.0f}% unclaimed emissions from repo allocation')
+
+    bt.logging.info('')
+    bt.logging.info(
+        f'Emission blend complete | {repos_allocated} repos allocated | {repos_fully_recycled} fully recycled | '
+        f'{len(rewarded_uids)} miners rewarded | maintainer carve-out {maintainer_carve_out_total * 100:.1f}% | '
+        f'recycled {recycle_share * 100:.1f}%'
+    )
 
     return rewards
 


### PR DESCRIPTION
## Summary

The issue-discovery and OSS-scoring phases each close a scoring round with a one-line rollup (`Issue discovery complete | …` in `scan.py`, `OSS scoring complete | …` added in #1401), but the final phase — `blend_emission_pools`, which runs every round — returns silently, so a round ends with no record of how emissions were split. This adds the matching completion summary for the emission-blend phase so an operator can gauge a round at a glance.

Additive logging only: it accumulates four counters the allocation loop already computes — repos that paid out vs. fully recycled, distinct miners rewarded, total maintainer carve-out, and total recycled share — and prints one line before returning. No allocation logic runs differently and no miner's reward changes.

**Before** — the emission-blend phase ended at the recycle line, with no round-level summary:

```text
Recycling 12% unclaimed emissions from repo allocation
```

**After** — a single summary line now follows it (the counts below are from an example round, included to show the format — not real validator output):

```text
Recycling 12% unclaimed emissions from repo allocation

Emission blend complete | 9 repos allocated | 2 fully recycled | 47 miners rewarded | maintainer carve-out 1.8% | recycled 12.0%
```

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe below)

Enhancement — improves the existing emission-blend phase with a round-completion summary line. No behavior change.

## Testing

- [ ] Tests added/updated
- [x] Manually tested

No new functions, so no new tests; the existing `tests/validator/test_blend_emission_pools.py` (35) already covers the changed loop.

```console
$ pytest tests/validator/test_blend_emission_pools.py -q
...................................                                      [100%]
35 passed in 0.27s

$ ruff check gittensor/validator/emission_allocation.py
All checks passed!

$ ruff format --check gittensor/validator/emission_allocation.py
1 file already formatted
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
