### PR TITLE
feat(cli): add `gitt miner ensure` and retry post broadcasts so PAT coverage self-heals

### DIFF
--- a/gittensor/cli/miner_commands/__init__.py
+++ b/gittensor/cli/miner_commands/__init__.py
@@ -7,12 +7,14 @@ Command structure:
     gitt miner (alias: m)     - Miner management commands
         post                     Broadcast GitHub PAT to validators
         check                    Check how many validators have your PAT
+        ensure                   Re-broadcast PAT only to validators missing it
         score                    Score GitHub entities through the production pipeline
 """
 
 import click
 
 from .check import miner_check
+from .ensure import miner_ensure
 from .post import miner_post
 from .score import score_command
 
@@ -25,6 +27,7 @@ def miner_group():
     Commands:
         post     Broadcast your GitHub PAT to validators
         check    Check how many validators have your PAT stored
+        ensure   Re-broadcast your PAT only to validators missing it (cron-safe)
         score    Run the validator scoring pipeline end-to-end for a single miner
     """
     pass
@@ -32,6 +35,7 @@ def miner_group():
 
 miner_group.add_command(miner_post, name='post')
 miner_group.add_command(miner_check, name='check')
+miner_group.add_command(miner_ensure, name='ensure')
 miner_group.add_command(score_command, name='score')
 
 

--- a/gittensor/cli/miner_commands/ensure.py
+++ b/gittensor/cli/miner_commands/ensure.py
@@ -1,0 +1,215 @@
+# Entrius 2025
+
+"""gitt miner ensure — keep PAT coverage asserted across validator restarts."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+import click
+from rich.table import Table
+
+from gittensor.cli.issue_commands.helpers import NETWORK_CHOICE
+from gittensor.cli.miner_commands.helpers import (
+    DEFAULT_MIN_VALIDATOR_STAKE,
+    DEFAULT_MIN_VALIDATOR_VTRUST,
+    NETUID_DEFAULT,
+    _broadcast_pat_with_retry,
+    _connect_bittensor,
+    _error,
+    _load_config_value,
+    _pat_check_row_category,
+    _pat_post_row_category,
+    _print,
+    _probe_pat,
+    _render_skipped_validators,
+    _require_registered,
+    _require_validator_axons,
+    _resolve_endpoint,
+    _status,
+    console,
+)
+from gittensor.cli.miner_commands.post import _validate_pat_locally
+
+# Probe categories that mean "this validator does not currently hold a usable PAT
+# for us" and a re-broadcast should be attempted. 'valid' (has it) and
+# 'inconclusive' (has it, but a transient validator-side GitHub check) are left alone.
+_MISSING_CATEGORIES = {'no_pat', 'invalid_pat', 'no_response'}
+
+_RESULT_MARKUP = {
+    'accepted': '[green]✓ re-sent[/green]',
+    'rejected': '[red]✗ rejected[/red]',
+    'no_response': '[yellow]— no response[/yellow]',
+}
+
+
+def _ensure_cycle(dendrite, metagraph, *, min_vtrust, min_stake, retries, pat, json_mode):
+    """One coverage pass: probe, re-broadcast to validators missing a PAT, report.
+
+    Returns the list of uids still uncovered after the pass. Does not exit.
+    """
+    validator_axons, validator_uids, excluded = _require_validator_axons(
+        metagraph, json_mode, min_vtrust=min_vtrust, min_stake=min_stake
+    )
+    axon_by_uid = dict(zip(validator_uids, validator_axons))
+
+    with _status(f'[bold]Checking {len(validator_axons)} validators...'):
+        probe = _probe_pat(dendrite, validator_axons, validator_uids)
+    missing_uids = [r['uid'] for r in probe if _pat_check_row_category(r) in _MISSING_CATEGORIES]
+    already_valid = len(validator_uids) - len(missing_uids)
+
+    repost_results: list[dict] = []
+    if missing_uids:
+        with _status(f'[bold]Re-broadcasting to {len(missing_uids)} validator(s) missing your PAT...'):
+            repost_results = _broadcast_pat_with_retry(
+                dendrite, [axon_by_uid[u] for u in missing_uids], missing_uids, pat, retries=retries
+            )
+    still_missing = [r['uid'] for r in repost_results if r.get('accepted') is not True]
+    now_valid = already_valid + (len(missing_uids) - len(still_missing))
+
+    if json_mode:
+        click.echo(
+            json.dumps(
+                {
+                    'success': len(still_missing) == 0,
+                    'total_validators': len(validator_uids),
+                    'already_valid': already_valid,
+                    'reposted': len(missing_uids),
+                    'now_valid': now_valid,
+                    'still_missing': still_missing,
+                    'results': repost_results,
+                    'skipped': excluded,
+                },
+                indent=2,
+            )
+        )
+    else:
+        if not missing_uids:
+            console.print(f'[bold green]All {len(validator_uids)} validators already have a valid PAT.[/bold green]')
+        else:
+            table = Table(title='Re-broadcast (validators that were missing your PAT)')
+            table.add_column('UID', style='cyan', justify='right')
+            table.add_column('Validator', style='dim')
+            table.add_column('Result', justify='center')
+            for r in repost_results:
+                table.add_row(str(r['uid']), r['hotkey'], _RESULT_MARKUP[_pat_post_row_category(r)])
+            console.print(table)
+            console.print(f'\n[bold]{now_valid}/{len(validator_uids)} validators now have your PAT.[/bold]')
+            if still_missing:
+                console.print(f'[yellow]Still uncovered (unreachable this run): {still_missing}[/yellow]')
+        _render_skipped_validators(excluded, json_mode)
+
+    return still_missing
+
+
+@click.command()
+@click.option('--wallet', 'wallet_name', default=None, help='Bittensor wallet name.')
+@click.option('--hotkey', 'wallet_hotkey', default=None, help='Bittensor hotkey name.')
+@click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True)
+@click.option('--network', type=NETWORK_CHOICE, default=None, help='Network name (local, test, finney).')
+@click.option('--rpc-url', default=None, help='Subtensor RPC endpoint URL (overrides --network).')
+@click.option(
+    '--pat',
+    default=None,
+    envvar='GITTENSOR_MINER_PAT',
+    help='GitHub Personal Access Token. Falls back to GITTENSOR_MINER_PAT, then interactive prompt.',
+)
+@click.option(
+    '--min-vtrust',
+    type=float,
+    default=DEFAULT_MIN_VALIDATOR_VTRUST,
+    show_default=True,
+    help='Minimum validator_trust to consider.',
+)
+@click.option(
+    '--min-stake',
+    type=float,
+    default=DEFAULT_MIN_VALIDATOR_STAKE,
+    show_default=True,
+    help='Minimum validator stake (α) to consider.',
+)
+@click.option(
+    '--retries',
+    type=int,
+    default=2,
+    show_default=True,
+    help='Retries for validators that do not respond to the re-broadcast.',
+)
+@click.option(
+    '--watch',
+    type=int,
+    default=0,
+    show_default=True,
+    metavar='SECONDS',
+    help='Re-run every SECONDS so coverage self-heals without external cron (0 = run once).',
+)
+@click.option('--json', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
+def miner_ensure(
+    wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, retries, watch, json_mode
+):
+    """Ensure every eligible validator has a valid PAT — re-broadcasting only where missing.
+
+    A single `gitt miner post` is one-shot: once a validator loses its stored PAT
+    (e.g. it restarts without persistent storage), you are silently scored 0 by it
+    until you manually re-post. This command probes coverage and re-broadcasts your
+    PAT **only** to validators that are missing it (no PAT is sent to validators that
+    already have one), so it is cheap to run on a schedule (cron) and lets coverage
+    self-heal. Exits non-zero if any reachable validator is still uncovered afterward.
+
+    \b
+    Examples:
+        gitt miner ensure --wallet alice --hotkey default
+        gitt miner ensure --wallet alice --hotkey default --json   # for cron / monitoring
+    """
+    if not pat:
+        if json_mode:
+            _error('--pat flag or GITTENSOR_MINER_PAT environment variable is required for JSON mode.', json_mode)
+            sys.exit(1)
+        pat = click.prompt('Enter your GitHub Personal Access Token', hide_input=True)
+
+    with _status('[bold]Validating PAT...'):
+        github_login = _validate_pat_locally(pat)
+    if github_login is None:
+        _error('GitHub PAT is invalid or expired. Check your GITTENSOR_MINER_PAT.', json_mode)
+        sys.exit(1)
+    _print(f'[green]PAT is valid.[/green] GitHub account: [bold]@{github_login}[/bold]')
+
+    wallet_name = wallet_name or _load_config_value('wallet') or 'default'
+    wallet_hotkey = wallet_hotkey or _load_config_value('hotkey') or 'default'
+    ws_endpoint = _resolve_endpoint(network, rpc_url)
+    _print(f'[dim]Wallet: {wallet_name}/{wallet_hotkey} | Network: {ws_endpoint} | Netuid: {netuid}[/dim]')
+
+    with _status('[bold]Connecting to network...'):
+        try:
+            wallet, subtensor, metagraph, dendrite = _connect_bittensor(wallet_name, wallet_hotkey, ws_endpoint, netuid)
+        except Exception as e:
+            _error(f'Failed to initialize bittensor: {e}', json_mode)
+            sys.exit(1)
+
+    _require_registered(wallet, metagraph, netuid, json_mode)
+
+    cycle_kwargs = dict(min_vtrust=min_vtrust, min_stake=min_stake, retries=retries, pat=pat, json_mode=json_mode)
+
+    # Watch mode: re-assert coverage forever, re-syncing the metagraph each round so
+    # validators that (re)join the active set are picked up. Coverage self-heals
+    # without external cron. Transient failures (e.g. no eligible validators this
+    # round) are swallowed so the loop keeps running.
+    if watch > 0:
+        _print(f'[dim]Watch mode: re-asserting PAT coverage every {watch}s. Ctrl-C to stop.[/dim]')
+        try:
+            while True:
+                try:
+                    _ensure_cycle(dendrite, metagraph, **cycle_kwargs)
+                except SystemExit:
+                    pass
+                time.sleep(watch)
+                metagraph = subtensor.metagraph(netuid=netuid)
+        except KeyboardInterrupt:
+            sys.exit(0)
+
+    # One-shot (cron-friendly): non-zero exit if any reachable validator is still uncovered.
+    still_missing = _ensure_cycle(dendrite, metagraph, **cycle_kwargs)
+    if still_missing:
+        sys.exit(1)

--- a/gittensor/cli/miner_commands/helpers.py
+++ b/gittensor/cli/miner_commands/helpers.py
@@ -214,3 +214,93 @@ def _pat_post_aggregate_counts(results: list[dict[str, Any]]) -> dict[str, int]:
         'rejected': counts['rejected'],
         'no_response': counts['no_response'],
     }
+
+
+def _probe_pat(dendrite, axons: list, uids: list[int]) -> list[dict[str, Any]]:
+    """Send a PatCheckSynapse probe to each axon and return check-result rows.
+
+    No PAT is transmitted. Row shape matches `miner check`:
+    {uid, hotkey, has_pat, pat_valid, rejection_reason}.
+    """
+    import asyncio
+
+    from gittensor.synapses import PatCheckSynapse
+
+    synapse = PatCheckSynapse()
+
+    async def _check():
+        return await dendrite(axons=axons, synapse=synapse, deserialize=False, timeout=15.0)
+
+    responses = asyncio.run(_check())
+    results: list[dict[str, Any]] = []
+    for uid, axon, resp in zip(uids, axons, responses):
+        results.append(
+            {
+                'uid': uid,
+                'hotkey': axon.hotkey[:16] + '...',
+                'has_pat': getattr(resp, 'has_pat', None),
+                'pat_valid': getattr(resp, 'pat_valid', None),
+                'rejection_reason': getattr(resp, 'rejection_reason', None),
+            }
+        )
+    return results
+
+
+def _broadcast_pat_with_retry(
+    dendrite,
+    axons: list,
+    uids: list[int],
+    pat: str,
+    *,
+    retries: int = 2,
+    delay: float = 2.0,
+) -> list[dict[str, Any]]:
+    """Broadcast a PAT to validator axons, retrying ONLY those that did not respond.
+
+    A single broadcast is best-effort: a validator that is briefly unreachable
+    (mid-restart, transient network blip) returns no response and, without a
+    retry, is silently and permanently dropped until the next manual post. This
+    retries no-response validators up to ``retries`` times (an explicit
+    accept/reject is final), so transient unreachability does not become a silent
+    coverage gap.
+
+    Returns one row per uid (input order), shaped like `miner post`:
+    {uid, hotkey, accepted, rejection_reason, status_code}.
+    """
+    import asyncio
+    import time
+
+    from gittensor.synapses import PatBroadcastSynapse
+
+    final: dict[int, dict[str, Any]] = {}
+    pending: list[tuple[int, Any]] = list(zip(uids, axons))
+    for attempt in range(retries + 1):
+        if not pending:
+            break
+        cur_uids = [u for u, _ in pending]
+        cur_axons = [a for _, a in pending]
+        synapse = PatBroadcastSynapse(github_access_token=pat)
+
+        async def _broadcast(_axons=cur_axons, _synapse=synapse):
+            return await dendrite(axons=_axons, synapse=_synapse, deserialize=False, timeout=30.0)
+
+        responses = asyncio.run(_broadcast())
+        retry_next: list[tuple[int, Any]] = []
+        for (uid, axon), resp in zip(zip(cur_uids, cur_axons), responses):
+            accepted = getattr(resp, 'accepted', None)
+            reason = getattr(resp, 'rejection_reason', None)
+            status_code = getattr(resp.dendrite, 'status_code', None) if hasattr(resp, 'dendrite') else None
+            final[uid] = {
+                'uid': uid,
+                'hotkey': axon.hotkey[:16] + '...',
+                'accepted': accepted,
+                'rejection_reason': reason,
+                'status_code': status_code,
+            }
+            # Only a no-response (neither accepted nor explicitly rejected) is retried.
+            if accepted is None and reason is None:
+                retry_next.append((uid, axon))
+        pending = retry_next
+        if pending and attempt < retries:
+            time.sleep(delay)
+    return [final[u] for u in uids]

--- a/gittensor/cli/miner_commands/post.py
+++ b/gittensor/cli/miner_commands/post.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import sys
 
@@ -17,6 +16,7 @@ from gittensor.cli.miner_commands.helpers import (
     DEFAULT_MIN_VALIDATOR_STAKE,
     DEFAULT_MIN_VALIDATOR_VTRUST,
     NETUID_DEFAULT,
+    _broadcast_pat_with_retry,
     _connect_bittensor,
     _error,
     _load_config_value,
@@ -67,8 +67,15 @@ _PAT_POST_STATUS_MARKUP = {
     show_default=True,
     help='Minimum validator stake (α) to broadcast to.',
 )
+@click.option(
+    '--retries',
+    type=int,
+    default=2,
+    show_default=True,
+    help='Retries for validators that do not respond on the first broadcast.',
+)
 @click.option('--json', 'json_mode', is_flag=True, default=False, help='Output results as JSON.')
-def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, json_mode):
+def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vtrust, min_stake, retries, json_mode):
     """Broadcast your GitHub PAT to all validators on the network.
 
     Validators will validate your PAT (test GitHub API access),
@@ -86,8 +93,6 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         gitt miner post --wallet alice --hotkey default
         gitt miner post --wallet alice --hotkey default --network test
     """
-    from gittensor.synapses import PatBroadcastSynapse
-
     if not pat:
         if json_mode:
             _error('--pat flag or GITTENSOR_MINER_PAT environment variable is required for JSON mode.', json_mode)
@@ -127,35 +132,10 @@ def miner_post(wallet_name, wallet_hotkey, netuid, network, rpc_url, pat, min_vt
         metagraph, json_mode, min_vtrust=min_vtrust, min_stake=min_stake
     )
 
-    # 5. Broadcast
-    synapse = PatBroadcastSynapse(github_access_token=pat)
-
-    async def _broadcast():
-        return await dendrite(
-            axons=validator_axons,
-            synapse=synapse,
-            deserialize=False,
-            timeout=30.0,
-        )
-
+    # 5. Broadcast — retry validators that don't respond so a transient blip isn't
+    #    a silent, permanent coverage gap.
     with _status(f'[bold]Broadcasting to {len(validator_axons)} validators...'):
-        responses = asyncio.run(_broadcast())
-
-    # 6. Collect results
-    results = []
-    for uid, axon, resp in zip(validator_uids, validator_axons, responses):
-        accepted = getattr(resp, 'accepted', None)
-        reason = getattr(resp, 'rejection_reason', None)
-        status_code = getattr(resp.dendrite, 'status_code', None) if hasattr(resp, 'dendrite') else None
-        results.append(
-            {
-                'uid': uid,
-                'hotkey': axon.hotkey[:16] + '...',
-                'accepted': accepted,
-                'rejection_reason': reason,
-                'status_code': status_code,
-            }
-        )
+        results = _broadcast_pat_with_retry(dendrite, validator_axons, validator_uids, pat, retries=retries)
 
     counts = _pat_post_aggregate_counts(results)
     accepted_count = counts['accepted']

--- a/tests/cli/test_miner_commands.py
+++ b/tests/cli/test_miner_commands.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from gittensor import __version__
 from gittensor.cli.main import cli
 from gittensor.cli.miner_commands.helpers import (
+    _broadcast_pat_with_retry,
     _get_validator_axons,
     _pat_check_aggregate_counts,
     _pat_post_aggregate_counts,
@@ -90,15 +91,18 @@ class TestMinerPost:
         )
         metagraph.hotkeys = ['5MinerHotkey']
         wallet = SimpleNamespace(hotkey=SimpleNamespace(ss58_address='5MinerHotkey'))
-        responses = [
-            SimpleNamespace(accepted=True, rejection_reason=None, dendrite=SimpleNamespace(status_code=200)),
-            SimpleNamespace(accepted=False, rejection_reason='denied', dendrite=SimpleNamespace(status_code=403)),
-            SimpleNamespace(accepted=None, rejection_reason=None, dendrite=SimpleNamespace(status_code=None)),
-        ]
+        resp_by_hotkey = {
+            '5Hk00': SimpleNamespace(accepted=True, rejection_reason=None, dendrite=SimpleNamespace(status_code=200)),
+            '5Hk01': SimpleNamespace(
+                accepted=False, rejection_reason='denied', dendrite=SimpleNamespace(status_code=403)
+            ),
+            '5Hk02': SimpleNamespace(accepted=None, rejection_reason=None, dendrite=SimpleNamespace(status_code=None)),
+        }
 
         class FakeDendrite:
-            async def __call__(self, **kwargs):
-                return responses
+            # Axon-aware so a no-response validator stays no-response across retries.
+            async def __call__(self, *, axons, **kwargs):
+                return [resp_by_hotkey[a.hotkey] for a in axons]
 
         with (
             patch('gittensor.cli.miner_commands.post._validate_pat_locally', return_value='testuser'),
@@ -374,3 +378,192 @@ class TestPatPostAggregateCounts:
         counts = _pat_post_aggregate_counts(results)
         assert counts['rejected'] == 1
         assert counts['no_response'] == 1
+
+
+def _post_resp(accepted, reason=None, status=None):
+    return SimpleNamespace(accepted=accepted, rejection_reason=reason, dendrite=SimpleNamespace(status_code=status))
+
+
+class TestBroadcastWithRetry:
+    """`_broadcast_pat_with_retry` retries ONLY no-response validators, so a transient
+    blip during one broadcast is not a silent, permanent coverage gap."""
+
+    def test_retries_only_the_no_response_validator(self):
+        axons = [SimpleNamespace(hotkey='5Hk00accepts'), SimpleNamespace(hotkey='5Hk01flaky')]
+        uids = [10, 20]
+        calls = []
+
+        class FakeDendrite:
+            def __init__(self):
+                self.n = 0
+
+            async def __call__(self, *, axons, **kw):
+                calls.append([a.hotkey for a in axons])
+                self.n += 1
+                if self.n == 1:
+                    return [_post_resp(True, status=200), _post_resp(None)]  # uid20: no response
+                return [_post_resp(True, status=200)]  # uid20 accepts on retry
+
+        results = _broadcast_pat_with_retry(FakeDendrite(), axons, uids, 'ghp_x', retries=2, delay=0)
+        assert len(calls) == 2  # the no-response validator was retried
+        assert calls[1] == ['5Hk01flaky']  # ONLY the no-response one was retried
+        by_uid = {r['uid']: r for r in results}
+        assert by_uid[10]['accepted'] is True
+        assert by_uid[20]['accepted'] is True  # eventually delivered
+
+    def test_explicit_rejection_is_final(self):
+        axons = [SimpleNamespace(hotkey='5Hk00rejects')]
+        calls = []
+
+        class FakeDendrite:
+            async def __call__(self, *, axons, **kw):
+                calls.append(1)
+                return [_post_resp(False, reason='denied', status=403)]
+
+        results = _broadcast_pat_with_retry(FakeDendrite(), axons, [10], 'ghp_x', retries=3, delay=0)
+        assert len(calls) == 1  # a rejection is not retried
+        assert results[0]['accepted'] is False
+
+    def test_persistent_no_response_is_surfaced_not_hidden(self):
+        axons = [SimpleNamespace(hotkey='5Hk00down')]
+        calls = []
+
+        class FakeDendrite:
+            async def __call__(self, *, axons, **kw):
+                calls.append(1)
+                return [_post_resp(None)]
+
+        results = _broadcast_pat_with_retry(FakeDendrite(), axons, [10], 'ghp_x', retries=2, delay=0)
+        assert len(calls) == 3  # initial attempt + 2 retries
+        assert results[0]['accepted'] is None  # still uncovered — reported, not silently dropped
+
+
+class TestMinerEnsure:
+    def test_help_text(self, runner):
+        result = runner.invoke(cli, ['miner', 'ensure', '--help'])
+        assert result.exit_code == 0
+        assert 'missing' in result.output.lower()
+
+    def test_ensure_alias(self, runner):
+        result = runner.invoke(cli, ['m', 'ensure', '--help'])
+        assert result.exit_code == 0
+
+    def test_reposts_only_to_validators_missing_pat(self, runner, monkeypatch):
+        monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+        # 3 validators: uid0 valid, uid1 missing (no_pat), uid2 valid.
+        metagraph = _fake_metagraph([(0.9, True, 50_000.0), (0.8, True, 40_000.0), (0.7, True, 30_000.0)])
+        metagraph.hotkeys = ['5MinerHotkey']
+        wallet = SimpleNamespace(hotkey=SimpleNamespace(ss58_address='5MinerHotkey'))
+        broadcast_targets = []
+
+        def check_resp(has_pat, pat_valid):
+            return SimpleNamespace(has_pat=has_pat, pat_valid=pat_valid, rejection_reason=None)
+
+        class FakeDendrite:
+            async def __call__(self, *, axons, synapse, **kw):
+                if type(synapse).__name__ == 'PatCheckSynapse':
+                    by = {
+                        '5Hk00': check_resp(True, True),
+                        '5Hk01': check_resp(False, False),
+                        '5Hk02': check_resp(True, True),
+                    }
+                    return [by[a.hotkey] for a in axons]
+                broadcast_targets.append([a.hotkey for a in axons])
+                return [_post_resp(True, status=200) for _ in axons]
+
+        with (
+            patch('gittensor.cli.miner_commands.ensure._validate_pat_locally', return_value='testuser'),
+            patch(
+                'gittensor.cli.miner_commands.ensure._connect_bittensor',
+                return_value=(wallet, object(), metagraph, FakeDendrite()),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ['miner', 'ensure', '--json', '--pat', 'ghp_x', '--wallet', 't', '--hotkey', 't']
+            )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload['success'] is True
+        assert payload['total_validators'] == 3
+        assert payload['already_valid'] == 2
+        assert payload['reposted'] == 1
+        assert payload['now_valid'] == 3
+        assert payload['still_missing'] == []
+        # Re-broadcast went ONLY to the missing validator, never to the two that had it.
+        assert broadcast_targets == [['5Hk01']]
+
+    def test_exits_nonzero_when_a_validator_stays_uncovered(self, runner, monkeypatch):
+        monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+        metagraph = _fake_metagraph([(0.9, True, 50_000.0)])
+        metagraph.hotkeys = ['5MinerHotkey']
+        wallet = SimpleNamespace(hotkey=SimpleNamespace(ss58_address='5MinerHotkey'))
+
+        class FakeDendrite:
+            async def __call__(self, *, axons, synapse, **kw):
+                if type(synapse).__name__ == 'PatCheckSynapse':
+                    return [SimpleNamespace(has_pat=False, pat_valid=False, rejection_reason=None) for _ in axons]
+                return [_post_resp(None) for _ in axons]  # unreachable for the re-broadcast too
+
+        with (
+            patch('gittensor.cli.miner_commands.ensure._validate_pat_locally', return_value='testuser'),
+            patch(
+                'gittensor.cli.miner_commands.ensure._connect_bittensor',
+                return_value=(wallet, object(), metagraph, FakeDendrite()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ['miner', 'ensure', '--json', '--pat', 'ghp_x', '--wallet', 't', '--hotkey', 't', '--retries', '1'],
+            )
+        assert result.exit_code != 0
+        payload = json.loads(result.stdout)
+        assert payload['success'] is False
+        assert payload['still_missing'] == [0]
+
+    def test_watch_loops_and_resyncs_metagraph(self, runner, monkeypatch):
+        monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+        metagraph = _fake_metagraph([(0.9, True, 50_000.0)])
+        metagraph.hotkeys = ['5MinerHotkey']
+        wallet = SimpleNamespace(hotkey=SimpleNamespace(ss58_address='5MinerHotkey'))
+        probes = []
+
+        class FakeSubtensor:
+            def __init__(self):
+                self.metagraph_calls = 0
+
+            def metagraph(self, netuid=None):
+                self.metagraph_calls += 1
+                return metagraph
+
+        subtensor = FakeSubtensor()
+
+        class FakeDendrite:
+            async def __call__(self, *, axons, synapse, **kw):
+                if type(synapse).__name__ == 'PatCheckSynapse':
+                    probes.append(1)
+                    return [SimpleNamespace(has_pat=True, pat_valid=True, rejection_reason=None) for _ in axons]
+                return [_post_resp(True, status=200) for _ in axons]
+
+        class FakeSleep:
+            def __init__(self):
+                self.n = 0
+
+            def __call__(self, _seconds):
+                self.n += 1
+                if self.n >= 2:  # let two cycles run, then stop like Ctrl-C
+                    raise KeyboardInterrupt
+
+        with (
+            patch('gittensor.cli.miner_commands.ensure._validate_pat_locally', return_value='testuser'),
+            patch(
+                'gittensor.cli.miner_commands.ensure._connect_bittensor',
+                return_value=(wallet, subtensor, metagraph, FakeDendrite()),
+            ),
+            patch('gittensor.cli.miner_commands.ensure.time.sleep', FakeSleep()),
+        ):
+            result = runner.invoke(
+                cli, ['miner', 'ensure', '--json', '--watch', '30', '--pat', 'ghp_x', '--wallet', 't', '--hotkey', 't']
+            )
+        assert result.exit_code == 0  # Ctrl-C / KeyboardInterrupt exits cleanly
+        assert len(probes) == 2  # ran two coverage cycles
+        assert subtensor.metagraph_calls == 1  # re-synced the metagraph between cycles


### PR DESCRIPTION
Fixes #1481

> Targets `test`. Verified against `origin/test` @ `1c813f5` (2026-06-15); full suite green (`uv run pytest tests/` → 945 passed), ruff lint + format clean.

## Summary

A miner's PAT coverage silently and permanently erodes. `gitt miner post` is a one-shot, best-effort broadcast: a validator briefly unreachable during it is silently dropped — no retry, and the command still reports success. And once any validator loses its stored PAT (e.g. it restarts without persistent `./data`), there is **no mechanism to restore coverage** — the miner is scored 0 by that validator every round until they remember to manually re-post. (Root cause, live evidence, and two runnable reproductions in #1481.)

This makes coverage **reliable** and **self-healing**, miner-side only:

- **`gitt miner post` now retries** validators that don't respond (`--retries`, default 2), so a transient blip during the broadcast isn't a silent, permanent coverage gap. An explicit accept/reject is final; only no-responses are retried.
- **New `gitt miner ensure`** — probes current coverage, then re-broadcasts the PAT **only** to validators that are missing a valid one (**no PAT is sent to validators that already have it**). It's cheap and non-spammy, safe to run on a schedule (cron), and exits non-zero if any reachable validator is still uncovered. Running it after a validator restart restores coverage automatically instead of silently de-scoring the miner. `--watch SECONDS` runs it as a self-healing loop (re-syncing the metagraph each round to pick up validators that (re)join), so coverage recovers without external cron.
- Shared `_probe_pat` / `_broadcast_pat_with_retry` helpers; `post` is refactored onto the latter (net −39 lines there).

This aligns with the existing "miner must re-post" remedy (surfaced in `inspections.py` when a validator has no stored PAT) by making it reliable and automatable, and with the transient-failure-resilience already adopted in #931 / #932 / #1107 (a transient/operational event must not cause a permanent wrong outcome).

## Behavior

`gitt miner ensure --json` (validator UID 1 was missing; UIDs 0 and 2 already had a valid PAT):

```json
{ "success": true, "total_validators": 3, "already_valid": 2,
  "reposted": 1, "now_valid": 3, "still_missing": [], "results": [ ... ], "skipped": [] }
```
Only the missing validator is re-sent the PAT; the two that already had it are untouched. Exits non-zero (for cron/alerting) if any reachable validator stays uncovered.

## Tests

`tests/cli/test_miner_commands.py`:
- `_broadcast_pat_with_retry`: retries **only** no-response validators; an explicit rejection is final (not retried); a persistent no-response is surfaced in the result, not silently dropped.
- `gitt miner ensure`: re-broadcasts to exactly the validators missing a PAT and never to the ones that have it; exits non-zero when a validator stays uncovered.
- `--watch`: loops the coverage cycle, re-syncs the metagraph between rounds, and exits cleanly on `KeyboardInterrupt`.
- Updated the existing `post` JSON-envelope test so its dendrite mock is axon-aware (a no-response validator stays no-response across retries — previously the mock returned fixed responses regardless of axons).

```
uv run pytest tests/      -> 945 passed
ruff check / ruff format  -> clean   (vulture clean on changed files)
```

## Notes

- Targets `test`. Miner-side CLI only — no validator or contract changes.
- Re-running `ensure` on a schedule is cheap: it sends no PAT to validators that already hold a valid one.
