### PR TITLE
chore(weights): update JSONbored repository hyperparameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -150,18 +150,19 @@
     "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:feature": 1.0,
-      "gittensor:priority": 1.5
+      "gittensor:bug": 0.5,
+      "gittensor:feature": 1.25,
+      "gittensor:priority": 1.75
     },
     "eligibility": {
       "min_credibility": 0.6
     },
-    "maintainer_cut": 0.3,
+    "maintainer_cut": 0.5,
     "scoring": {
-      "pr_lookback_days": 45,
-      "open_pr_collateral_percent": 0.15,
+      "pr_lookback_days": 35,
+      "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
-      "maintainer_issue_multiplier": 1.75,
+      "maintainer_issue_multiplier": 1.66,
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 14,
@@ -174,24 +175,50 @@
     "emission_share": 0.015,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:bug": 1.0,
+      "gittensor:bug": 0.5,
       "gittensor:feature": 1.25,
       "gittensor:priority": 1.75
     },
-    "maintainer_cut": 0.35,
+    "eligibility": {
+      "min_credibility": 0.8
+    },
+    "maintainer_cut": 0.5,
     "scoring": {
-      "pr_lookback_days": 45,
-      "maintainer_issue_multiplier": 2.0,
+      "pr_lookback_days": 35,
+      "open_pr_collateral_percent": 0.2,
+      "review_penalty_rate": 0.2,
+      "maintainer_issue_multiplier": 1.66,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 10,
-        "min_multiplier": 0.05
+        "sigmoid_midpoint_days": 14,
+        "min_multiplier": 0.1
       }
     }
   },
   "JSONbored/metagraphed": {
+    "default_label_multiplier": 0.0,
     "emission_share": 0.0075,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "gittensor:bug": 0.5,
+      "gittensor:feature": 1.5,
+      "gittensor:priority": 2.5
+    },
+    "eligibility": {
+      "min_credibility": 0.6
+    },
+    "maintainer_cut": 0.25,
+    "scoring": {
+      "pr_lookback_days": 35,
+      "open_pr_collateral_percent": 0.2,
+      "review_penalty_rate": 0.2,
+      "maintainer_issue_multiplier": 1.66,
+      "time_decay": {
+        "grace_period_hours": 24,
+        "sigmoid_midpoint_days": 14,
+        "min_multiplier": 0.1
+      }
+    }
   },
   "MkDev11/gittensor-hub": {
     "emission_share": 0.012,


### PR DESCRIPTION
## Summary

Tune the maintainer-controlled config for the three repos I maintain (`JSONbored/awesome-claude`, `JSONbored/gittensory`, `JSONbored/metagraphed`): set maintainer cuts, settle on one label scheme, and align the scoring/eligibility knobs. `emission_share` and `issue_discovery_share` are left untouched (subnet-controlled).

## Changes

**`maintainer_cut`** (fraction of the repo's emission slice routed to the maintainer neuron; validated `[0, 1]`):

| repo | before | after |
|---|---|---|
| `awesome-claude` | 0.30 | **0.50** |
| `gittensory` | 0.35 | **0.50** |
| `metagraphed` | (unset → 0.0) | **0.25** |

`metagraphed` is kept lower to route more emission to miners.

**`label_multipliers`** — drop the unused `gittensor:bonus`; standardize on three labels. `metagraphed` is weighted higher than the other two to attract contributions. `trusted_label_pipeline` stays off, so only **maintainer-applied** labels count:

| label | awesome-claude / gittensory | metagraphed |
|---|---|---|
| `gittensor:priority` | 1.75 | 2.5 |
| `gittensor:feature` | 1.25 | 1.5 |
| `gittensor:bug` | 0.5 | 0.5 |

`default_label_multiplier` is `0.0` on all three (scoring is label-curated — an unlabeled PR scores 0).

**`eligibility.min_credibility`:** `awesome-claude` 0.6, `gittensory` 0.8, `metagraphed` 0.6.

**`scoring`** (identical across all three):

| field | value |
|---|---|
| `pr_lookback_days` | 35 |
| `open_pr_collateral_percent` | 0.2 |
| `review_penalty_rate` | 0.2 |
| `maintainer_issue_multiplier` | 1.66 |
| `time_decay` | 24h grace / 14d midpoint / 0.1 floor |

## Not changed
- `emission_share` (0.005 / 0.015 / 0.0075) and `issue_discovery_share` (0.0) — subnet-controlled. Total registry `emission_share` unchanged.
- `trusted_label_pipeline` left off (default).

## Validation
- `uv run pytest tests/validator/test_load_weights.py` → **145 passed** (the registry loader enforces every range: `maintainer_cut ∈ [0,1]`, `maintainer_issue_multiplier ∈ [1,5]`, eligibility/scoring/time-decay bounds).
- `uv run pytest tests/` → **937 passed**.
- Single-file change; JSON valid.
