### PR TITLE
Update master_repositories scoring section

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -244,20 +244,21 @@
     "emission_share": 0.018,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "bug": 1.1,
-      "enhancement": 1.25,
-      "feature": 1.5,
+      "bug": 1.2,
+      "enhancement": 1.3,
+      "feature": 1.0,
       "refactor": 0.25,
-      "test": 1.2
+      "test": 1.0,
+      "support": 3
     },
     "scoring": {
       "standard_issue_multiplier": 1,
       "review_penalty_rate": 0.01,
       "pr_lookback_days": 15
     },
-    "maintainer_cut": 0.6,
+    "maintainer_cut": 0.4,
     "eligibility": {
-      "excessive_pr_penalty_base_threshold": 10
+      "excessive_pr_penalty_base_threshold": 5
     }
   },
   "seroperson/jvm-live-reload": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -227,6 +227,7 @@
       "open_pr_collateral_percent": 0.1,
       "review_penalty_rate": 0.2,
       "maintainer_issue_multiplier": 1.5,
+      "standard_issue_multiplier": 1,
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 14,
@@ -248,6 +249,11 @@
       "feature": 1.5,
       "refactor": 0.25,
       "test": 1.2
+    },
+    "scoring": {
+      "standard_issue_multiplier": 1,
+      "review_penalty_rate": 0.01,
+      "pr_lookback_days": 15
     },
     "maintainer_cut": 0.6,
     "eligibility": {


### PR DESCRIPTION
## Summary

Scam-prevention tune for `phase-rs/phase`. Two effects:

1. **Reshape label multipliers** to reward signal lanes (`bug`, `support`) and
   neutralize the two lanes that were being farmed (`feature`, `test`).
2. **Tighten anti-farming knobs**: shrink the maintainer carve-out and cut
   the excessive-PR penalty threshold in half.

### Diff at a glance

| Field | Before | After | Why |
|---|---|---|---|
| `label_multipliers.bug` | 1.10 | 1.20 | real bugfix work is the highest-value lane |
| `label_multipliers.enhancement` | 1.25 | 1.30 | small nudge |
| `label_multipliers.feature` | 1.50 | **1.00** | most farmed lane — drop to baseline |
| `label_multipliers.test` | 1.20 | **1.00** | test-only PRs were being scored above baseline |
| `label_multipliers.support` | — | **3.00** | new lane; `support` is a maintainer-applied signal, high-trust |
| `label_multipliers.refactor` | 0.25 | 0.25 | unchanged |
| `maintainer_cut` | 0.60 | **0.40** | shrink maintainer carve-out → larger contributor pool |
| `eligibility.excessive_pr_penalty_base_threshold` | 10 | **5** | tighter spam cap; penalty fires earlier |

### Also retained from the prior pass on this branch

`phase-rs/phase.scoring.standard_issue_multiplier = 1` and the explicit
`scoring` block (`review_penalty_rate: 0.01`, `pr_lookback_days: 15`)
already on the branch — kept as-is.

## Why now

Recent open-PR behavior on `phase-rs/phase` showed `feature`- and
`test`-labeled PRs accumulating disproportionate base-multiplied scores
while `bug`/`support` work was undervalued. The `maintainer_cut` at 60%
also left too small a contributor pool for the rebalanced label weights
to pay out meaningfully. Cutting `excessive_pr_penalty_base_threshold`
from 10 → 5 brings phase-rs/phase in line with other repos that have
faced similar PR-volume farming patterns.

## Related precedent

- #1452 (merged) — prior phase-rs/phase eligibility + `maintainer_cut`
  tune. Continues the same line of work.
- #1394 (merged) — initial `phase-rs/phase` label multipliers.

No open PR touches the `phase-rs/phase` block in
`master_repositories.json` (checked via local cache of 362 issues +
1115 PRs).

## Type of Change

- [x] Chore (weights / config)
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Testing

- Config schema validated by the existing master-repositories load tests.
- `uv run pytest` — green.
- `uv run ruff check` / `ruff format --check` — clean.

## Checklist

- [x] Single-purpose diff (weights config only)
- [x] Self-review completed
- [x] No code changes; pure config rebalance
