### PR TITLE
fix(mirror): honor state_reason=TRANSFERRED in transferred gate

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -21,6 +21,21 @@ from gittensor.validator.utils.datetime_utils import (
 )
 
 
+def _parse_mirror_state_reason(value: Optional[str]) -> Optional[str]:
+    """Normalize mirror/GitHub state_reason to uppercase for gate comparisons."""
+    if value is None:
+        return None
+    normalized = str(value).strip().upper()
+    return normalized or None
+
+
+def _mirror_is_transferred(data: dict, state_reason: Optional[str]) -> bool:
+    """True when mirror marks transfer explicitly or GitHub state_reason says TRANSFERRED."""
+    if bool(data.get('is_transferred', False)):
+        return True
+    return state_reason == 'TRANSFERRED'
+
+
 @dataclass
 class MirrorLabel:
     """A label applied to a PR or issue, with the actor who applied it.
@@ -94,17 +109,18 @@ class MirrorLinkedIssue:
         # str-typed field so downstream `==` comparisons with author_github_id
         # from MirrorPullRequest don't silently mismatch on type.
         author_github_id = data.get('author_github_id')
+        state_reason = _parse_mirror_state_reason(data.get('state_reason'))
         return cls(
             number=data['number'],
             title=data.get('title', ''),
             state=data['state'],
-            state_reason=data.get('state_reason'),
+            state_reason=state_reason,
             author_github_id=str(author_github_id) if author_github_id is not None else None,
             author_association=data.get('author_association'),
             created_at=parse_optional_github_iso_to_utc(data.get('created_at')),
             closed_at=parse_optional_github_iso_to_utc(data.get('closed_at')),
             updated_at=parse_optional_github_iso_to_utc(data.get('updated_at')),
-            is_transferred=bool(data.get('is_transferred', False)),
+            is_transferred=_mirror_is_transferred(data, state_reason),
             solved_by_pr=data.get('solved_by_pr'),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
         )
@@ -265,12 +281,13 @@ class MirrorIssue:
     def from_dict(cls, data: dict) -> 'MirrorIssue':
         solving_pr_raw = data.get('solving_pr')
         author_github_id = data.get('author_github_id')
+        state_reason = _parse_mirror_state_reason(data.get('state_reason'))
         return cls(
             repo_full_name=data['repo_full_name'].lower(),
             issue_number=data['issue_number'],
             title=data.get('title', ''),
             state=data['state'],
-            state_reason=data.get('state_reason'),
+            state_reason=state_reason,
             author_github_id=str(author_github_id) if author_github_id is not None else None,
             author_login=data.get('author_login'),
             author_association=data.get('author_association'),
@@ -278,7 +295,7 @@ class MirrorIssue:
             closed_at=parse_optional_github_iso_to_utc(data.get('closed_at')),
             updated_at=parse_optional_github_iso_to_utc(data.get('updated_at')),
             last_edited_at=parse_optional_github_iso_to_utc(data.get('last_edited_at')),
-            is_transferred=bool(data.get('is_transferred', False)),
+            is_transferred=_mirror_is_transferred(data, state_reason),
             solved_by_pr=data.get('solved_by_pr'),
             labels=[MirrorLabel.from_dict(label) for label in data.get('labels') or []],
             solving_pr=MirrorSolvingPR.from_dict(solving_pr_raw) if solving_pr_raw else None,

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -272,6 +272,17 @@ class TestMirrorLinkedIssue:
         li = MirrorLinkedIssue.from_dict(linked_issue_dict)
         assert li.labels == []
 
+    def test_state_reason_transferred_sets_is_transferred_when_flag_false(self, linked_issue_dict):
+        linked_issue_dict['is_transferred'] = False
+        linked_issue_dict['state_reason'] = 'TRANSFERRED'
+        li = MirrorLinkedIssue.from_dict(linked_issue_dict)
+        assert li.is_transferred is True
+
+    def test_lowercase_state_reason_normalized(self, linked_issue_dict):
+        linked_issue_dict['state_reason'] = 'completed'
+        li = MirrorLinkedIssue.from_dict(linked_issue_dict)
+        assert li.state_reason == 'COMPLETED'
+
 
 # ============================================================================
 # MirrorPullRequest
@@ -390,6 +401,13 @@ class TestMirrorIssue:
         issue = MirrorIssue.from_dict(issue_dict)
         assert issue.solving_pr is None
         assert issue.solved_by_pr is None
+
+    def test_state_reason_transferred_sets_is_transferred_when_flag_false(self, issue_dict):
+        issue_dict['is_transferred'] = False
+        issue_dict['state_reason'] = 'transferred'
+        issue = MirrorIssue.from_dict(issue_dict)
+        assert issue.state_reason == 'TRANSFERRED'
+        assert issue.is_transferred is True
 
     def test_missing_solving_pr_key_treated_as_none(self, issue_dict):
         del issue_dict['solving_pr']

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -199,6 +199,10 @@ class TestClassifyIssue:
         issue = MirrorIssue.from_dict(_issue_dict(is_transferred=True))
         assert _classify_issue(issue, self._RC) == 'ignore'
 
+    def test_state_reason_transferred_ignored_when_flag_false(self):
+        issue = MirrorIssue.from_dict(_issue_dict(is_transferred=False, state_reason='TRANSFERRED'))
+        assert _classify_issue(issue, self._RC) == 'ignore'
+
     def test_open_issue_ignored(self):
         issue = MirrorIssue.from_dict(_issue_dict(state='OPEN', state_reason=None, solved_by_pr=None))
         assert _classify_issue(issue, self._RC) == 'ignore'

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -754,6 +754,11 @@ class TestLinkedIssueValidity:
         li = MirrorLinkedIssue.from_dict(_linked_issue(is_transferred=True))
         assert _is_valid_linked_issue(li, scored.pr) is False
 
+    def test_state_reason_transferred_blocks_when_flag_false(self):
+        scored = ScoredPR(pr=_pr())
+        li = MirrorLinkedIssue.from_dict(_linked_issue(is_transferred=False, state_reason='TRANSFERRED'))
+        assert _is_valid_linked_issue(li, scored.pr) is False
+
     def test_missing_author_blocks(self):
         scored = ScoredPR(pr=_pr())
         li = MirrorLinkedIssue.from_dict(_linked_issue(author_github_id=None))


### PR DESCRIPTION
## Summary
- Normalize mirror `state_reason` to uppercase at parse time
- Derive `is_transferred` from either the mirror boolean **or** `state_reason == TRANSFERRED`
- Add regression tests for linked issues and issue-discovery classification

## Related Issues
Fixes #1488

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added/updated unit tests
- [x] Manual review of mirror model parsing and downstream gate behavior

Test coverage:
- `tests/utils/test_mirror_models.py` — parse-time normalization + transferred derivation
- `tests/validator/oss_contributions/mirror/test_scoring.py` — `_is_valid_linked_issue` blocks transferred via `state_reason`
- `tests/validator/issue_discovery/test_scan.py` — `_classify_issue` ignores transferred via `state_reason`

## Checklist
- [x] Code follows repository conventions
- [x] Self-reviewed the diff
- [x] Focused change; no unrelated edits
