### PR TITLE
fix(github): null-safe GraphQL nested field access

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -278,12 +278,12 @@ def _search_issue_referencing_prs_graphql(
         bt.logging.warning(f'GraphQL cross-reference query returned errors for {repo}#{issue_number}: {errors}')
         return None
 
-    issue_data = result.get('data', {}).get('repository', {}).get('issue')
+    issue_data = ((result.get('data') or {}).get('repository') or {}).get('issue')
     if issue_data is None:
         bt.logging.warning(f'GraphQL cross-reference response missing issue data for {repo}#{issue_number}')
         return None
 
-    timeline_nodes = issue_data.get('timelineItems', {}).get('nodes', [])
+    timeline_nodes = (issue_data.get('timelineItems') or {}).get('nodes', [])
 
     out: List[PRInfo] = []
     for node in timeline_nodes:
@@ -411,7 +411,7 @@ def _is_completed_close_event(node: Dict[str, Any]) -> bool:
 
 def _select_current_close_event(issue_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Return the ClosedEvent that represents the issue's current closure."""
-    timeline_nodes = issue_data.get('timelineItems', {}).get('nodes', []) or []
+    timeline_nodes = (issue_data.get('timelineItems') or {}).get('nodes', []) or []
     closed_at = issue_data.get('closedAt')
     if not closed_at:
         return None
@@ -488,7 +488,7 @@ def find_solver_from_closure_event(
         bt.logging.warning(f'GraphQL closure query returned errors for {repo}#{issue_number}: {errors}')
         return None
 
-    issue_data = result.get('data', {}).get('repository', {}).get('issue')
+    issue_data = ((result.get('data') or {}).get('repository') or {}).get('issue')
     if issue_data is None:
         bt.logging.warning(f'GraphQL closure response missing issue data for {repo}#{issue_number}')
         return None

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -531,6 +531,65 @@ class TestFindSolverFromClosureEvent:
             result = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
             assert result is None
 
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_timeline_items_returns_no_solver(self, mock_logging, mock_graphql):
+        mock_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'issue': {
+                        'closedAt': '2025-06-01T00:00:00Z',
+                        'timelineItems': None,
+                    },
+                },
+            },
+        }
+
+        solver_id, pr_number = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
+
+        assert solver_id is None
+        assert pr_number is None
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_data_returns_no_solver(self, mock_logging, mock_graphql):
+        mock_graphql.return_value = {'data': None}
+
+        result = find_solver_from_closure_event('owner/repo', 12, 'fake_token')
+
+        assert result is None
+
+
+_search_issue_referencing_prs_graphql = github_api_tools._search_issue_referencing_prs_graphql
+
+
+class TestSearchIssueReferencingPrsGraphqlNullFields:
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_timeline_items_returns_empty_list(self, mock_logging, mock_graphql):
+        mock_graphql.return_value = {
+            'data': {
+                'repository': {
+                    'issue': {
+                        'timelineItems': None,
+                    },
+                },
+            },
+        }
+
+        result = _search_issue_referencing_prs_graphql('owner/repo', 12, 'fake_token')
+
+        assert result == []
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_repository_returns_none(self, mock_logging, mock_graphql):
+        mock_graphql.return_value = {'data': {'repository': None}}
+
+        result = _search_issue_referencing_prs_graphql('owner/repo', 12, 'fake_token')
+
+        assert result is None
+
 
 class TestCheckGithubIssueClosed:
     """Test issue state checks keep API failures distinct from no-solver cases."""


### PR DESCRIPTION
## Summary
- Replace unsafe `obj.get('field', {}).get(...)` chains with `(obj or {})` null-safe access in GraphQL issue parsers
- Handle explicit GraphQL `null` for `data`, `repository`, and `timelineItems` without raising `AttributeError`
- Add regression tests for solver lookup and cross-reference search paths

## Related Issues
Fixes #1490

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added/updated unit tests in `tests/utils/test_github_api_tools.py`
- [x] Covers `find_solver_from_closure_event` with `data: null` and `timelineItems: null`
- [x] Covers `_search_issue_referencing_prs_graphql` with `repository: null` and `timelineItems: null`

## Checklist
- [x] Code follows repository conventions
- [x] Self-reviewed the diff
- [x] Focused change; no unrelated edits

