### PR TITLE
Tune Taopedia repository scoring windows

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -44,6 +44,15 @@
     },
     "eligibility": {
       "min_credibility": 0.6
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 6,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1.0,
+        "min_multiplier": 0.02
+      }
     }
   },
   "e35ventura/taopedia-articles": {
@@ -63,6 +72,15 @@
     "eligibility": {
       "min_credibility": 0.5,
       "min_token_score_for_valid_issue": 0.0
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 3,
+        "sigmoid_midpoint_days": 1,
+        "sigmoid_steepness": 1.25,
+        "min_multiplier": 0.01
+      }
     }
   },
   "entrius/allways": {


### PR DESCRIPTION
## Summary
- set both Taopedia repositories to a 7-day PR scoring lookback
- add faster time decay for e35ventura/taopedia with a 2-day midpoint
- add more aggressive time decay for e35ventura/taopedia-articles with a 1-day midpoint

## Rationale
These settings make recent merged work matter more for Taopedia repos, encouraging faster PR throughput and more active development while keeping the site repo slightly less aggressive than the articles repo because visual/UI PRs can need maintainer review.

## Test
- uv run pytest tests/validator/test_load_weights.py