### PR TITLE
fix(cli): surface packed storage decode failures in issue list reads

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -666,9 +666,9 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
     storage directly. Works around substrate-interface Ink! 5 compatibility issues.
 
     Returns ``None`` only when the contract genuinely has no readable packed
-    storage at this address (no child key, no bytes, undersized payload).
-    RPC / decode failures propagate so callers can distinguish a failed read
-    from a clean "no storage yet" state.
+    storage at this address (no child key, no bytes).
+    RPC failures and non-empty payloads that fail to decode propagate so
+    callers can distinguish a failed read from a clean "no storage yet" state.
 
     Args:
         substrate: SubstrateInterface instance
@@ -697,8 +697,12 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
     packed = decode_packed_contract_storage(packed_bytes)
     if not packed:
         if verbose:
-            err_console.print(f'[dim]Debug: Packed storage too small ({len(packed_bytes)} < 74 bytes)[/dim]')
-        return None
+            err_console.print(
+                f'[dim]Debug: Failed to decode packed storage ({len(packed_bytes)} bytes returned)[/dim]'
+            )
+        raise RuntimeError(
+            f'Failed to decode packed contract storage ({len(packed_bytes)} bytes returned from chain)'
+        )
 
     return {
         'owner': substrate.ss58_encode(packed.owner.hex()),

--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -257,7 +257,7 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         )
         err_console.print(f'[dim]Sum of bounty amounts from {len(issues)} issue(s)[/dim]')
     except Exception as e:
-        handle_exception(as_json=as_json, message=str(e))
+        handle_exception(as_json=as_json, message=str(e), error_type='read_failed')
 
 
 @click.command('pending-harvest', cls=StyledCommand)

--- a/tests/cli/test_issues_list_json.py
+++ b/tests/cli/test_issues_list_json.py
@@ -153,6 +153,61 @@ def test_issues_list_json_deeper_storage_read_failure_returns_structured_error(c
     assert 'issue_count' not in payload
 
 
+def test_issues_list_json_packed_storage_decode_failure_returns_structured_error(cli_root, runner):
+    """When child storage returns bytes that fail to decode, `issues list --json` must not
+    emit `success: true, issue_count: 0` as if the contract were genuinely empty."""
+    fake_substrate = object()
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('async_substrate_interface.SubstrateInterface', return_value=fake_substrate),
+        patch(
+            'gittensor.cli.issue_commands.helpers.get_contract_child_storage_key',
+            return_value='0xchild',
+        ),
+        patch(
+            'gittensor.cli.issue_commands.helpers.read_contract_packed_storage_bytes',
+            return_value=b'\x00' * 73,
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list', '--json'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'
+    assert 'Failed to decode packed contract storage' in payload['error']['message']
+    assert 'issue_count' not in payload
+
+
+def test_issues_list_human_packed_storage_decode_failure_exits_non_zero(cli_root, runner):
+    """Human mode must exit non-zero and not print `No issues found.` when decode fails."""
+    fake_substrate = object()
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('async_substrate_interface.SubstrateInterface', return_value=fake_substrate),
+        patch(
+            'gittensor.cli.issue_commands.helpers.get_contract_child_storage_key',
+            return_value='0xchild',
+        ),
+        patch(
+            'gittensor.cli.issue_commands.helpers.read_contract_packed_storage_bytes',
+            return_value=b'\x00' * 73,
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'list'], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert 'No issues found' not in result.output
+    assert 'Failed to decode packed contract storage' in result.output
+
+
 def test_issues_list_json_missing_dependency_emits_install_hint(cli_root, runner):
     """A missing-dependency ImportError must surface a structured error with the install hint,
     distinct from a generic read failure."""

--- a/tests/cli/test_pending_harvest_single_connection.py
+++ b/tests/cli/test_pending_harvest_single_connection.py
@@ -91,3 +91,62 @@ def test_pending_harvest_json_empty_treasury_still_succeeds(cli_root, runner):
     assert payload['treasury_stake_raw'] == 0
     assert payload['allocated_bounties_raw'] == 1_000_000_000
     assert payload['pending_harvest_raw'] == 0
+
+
+def test_pending_harvest_json_packed_storage_decode_failure_returns_read_failed(cli_root, runner):
+    """When issue storage decode fails, pending-harvest must not overstate harvestable alpha."""
+    fake_subtensor = MagicMock()
+    fake_client = MagicMock()
+    fake_client.get_treasury_stake.return_value = 5_000_000_000
+
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('bittensor.Subtensor', return_value=fake_subtensor),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+        patch(
+            'gittensor.cli.issue_commands.view._read_issues_from_child_storage',
+            side_effect=RuntimeError('Failed to decode packed contract storage (73 bytes returned from chain)'),
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'pending-harvest', '--json'], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'
+    assert 'Failed to decode packed contract storage' in payload['error']['message']
+    assert 'pending_harvest_raw' not in payload
+
+
+def test_bounty_pool_json_packed_storage_decode_failure_returns_read_failed(cli_root, runner):
+    """When packed storage decode fails, bounty-pool --json must not report a zero pool."""
+    fake_substrate = object()
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch('async_substrate_interface.SubstrateInterface', return_value=fake_substrate),
+        patch(
+            'gittensor.cli.issue_commands.helpers.get_contract_child_storage_key',
+            return_value='0xchild',
+        ),
+        patch(
+            'gittensor.cli.issue_commands.helpers.read_contract_packed_storage_bytes',
+            return_value=b'\x00' * 73,
+        ),
+    ):
+        result = runner.invoke(cli_root, ['issues', 'bounty-pool', '--json'], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'
+    assert 'Failed to decode packed contract storage' in payload['error']['message']
+    assert 'total_bounty_pool_raw' not in payload


### PR DESCRIPTION
## Summary

When contract child storage returns bytes that fail to decode, `_read_contract_packed_storage` previously returned `None`, and `_read_issues_from_child_storage` treated that as an empty issue list. Downstream CLI commands then reported success with zero values instead of a read failure.

This extends the same read-failure hardening pattern as #1450 (treasury read failures in `pending-harvest`) to packed storage decode failures for issue-list reads.

Closes #<ISSUE_NUMBER>

## Problem

If `read_contract_packed_storage_bytes` returns non-empty bytes that `decode_packed_contract_storage` cannot decode (e.g. truncated/corrupt payload), the CLI silently treated the contract as empty:

- `gitt issues list --json` → `{success: true, issue_count: 0}`
- `gitt issues bounty-pool --json` → `{success: true, total_bounty_pool_raw: 0}`
- `gitt issues pending-harvest --json` → inflated `pending_harvest_raw` (treasury stake minus zero allocated bounties)

This makes RPC/storage decode failures indistinguishable from a genuinely empty contract for scripts parsing JSON or checking exit codes.

## Solution

- Raise `RuntimeError` from `_read_contract_packed_storage` when bytes are returned but decoding fails, instead of returning `None`.
- Use `error_type='read_failed'` for `issues bounty-pool` exception handling (consistent with `issues list` and `issues pending-harvest`).
- A genuinely empty contract (no child key, no bytes, or `next_issue_id <= 1`) still returns `[]` and succeeds as before.

## Files changed

- `gittensor/cli/issue_commands/helpers.py` — propagate decode failures
- `gittensor/cli/issue_commands/view.py` — `read_failed` error type for bounty-pool
- `tests/cli/test_issues_list_json.py` — JSON + human mode regression tests
- `tests/cli/test_pending_harvest_single_connection.py` — pending-harvest + bounty-pool regression tests

## Test plan

- [x] `uv run python -m pytest tests/cli/test_issues_list_json.py -q`
- [x] `uv run python -m pytest tests/cli/test_pending_harvest_single_connection.py -q`
- [x] Verified decode failure emits `success: false`, `error.type == "read_failed"`, non-zero exit
- [x] Verified genuinely empty contract still emits `success: true, issue_count: 0`