### PR TITLE
Tune Taopedia repository scoring windows

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -44,6 +44,15 @@
     },
     "eligibility": {
       "min_credibility": 0.6
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 6,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1.0,
+        "min_multiplier": 0.02
+      }
     }
   },
   "e35ventura/taopedia-articles": {
@@ -63,6 +72,15 @@
     "eligibility": {
       "min_credibility": 0.5,
       "min_token_score_for_valid_issue": 0.0
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 3,
+        "sigmoid_midpoint_days": 1,
+        "sigmoid_steepness": 1.25,
+        "min_multiplier": 0.01
+      }
     }
   },
   "entrius/allways": {


### PR DESCRIPTION
## Weight Adjustment PR

### Changes Summary

| Metric | Total |
| -------------------- | ----- |
| Repositories Added | 0 |
| Repositories Removed | 0 |
| Weights Modified | 0 |
| Net Weight Change | 0 |

No emission weights are changed. This PR only adds per-repository scoring-window overrides for two existing Taopedia repositories.

### Justification

This updates the Taopedia repositories to reward more recent merged work more heavily and stimulate faster PR throughput.

- `e35ventura/taopedia`: sets a 7-day PR lookback with faster time decay using a 6-hour grace period, 2-day sigmoid midpoint, 1.0 steepness, and 0.02 minimum multiplier.
- `e35ventura/taopedia-articles`: sets a 7-day PR lookback with more aggressive time decay using a 3-hour grace period, 1-day sigmoid midpoint, 1.25 steepness, and 0.01 minimum multiplier.

The site repo uses a slightly less aggressive decay because UI/visual PRs can require maintainer review, while the articles repo can move faster through automated article review.

### Additional Acceptable Branches

- [x] No additional_acceptable_branches changes in this PR
- [ ] Proof of merged PR(s) provided above for all additional_acceptable_branches entries

### Testing

- `uv run pytest tests/validator/test_load_weights.py` (145 passed)

### Checklist

- [x] Changes summary table is filled in accurately
- [x] Net weight changes are justified in the Justification section
- [x] Added repositories have correct branch and initial weight (N/A, no repositories added)
