### PR TITLE
Update master_repositories scoring section

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -294,7 +294,7 @@
       "feature": 1.0,
       "refactor": 0.25,
       "test": 1.0,
-      "support": 3
+      "quality": 3
     },
     "scoring": {
       "standard_issue_multiplier": 1,
@@ -303,7 +303,7 @@
     },
     "maintainer_cut": 0.4,
     "eligibility": {
-      "excessive_pr_penalty_base_threshold": 5
+      "excessive_pr_penalty_base_threshold": 10
     }
   },
   "seroperson/jvm-live-reload": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -244,20 +244,21 @@
     "emission_share": 0.018,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "bug": 1.1,
-      "enhancement": 1.25,
-      "feature": 1.5,
+      "bug": 1.2,
+      "enhancement": 1.3,
+      "feature": 1.0,
       "refactor": 0.25,
-      "test": 1.2
+      "test": 1.0,
+      "support": 3
     },
     "scoring": {
       "standard_issue_multiplier": 1,
       "review_penalty_rate": 0.01,
       "pr_lookback_days": 15
     },
-    "maintainer_cut": 0.6,
+    "maintainer_cut": 0.4,
     "eligibility": {
-      "excessive_pr_penalty_base_threshold": 10
+      "excessive_pr_penalty_base_threshold": 5
     }
   },
   "seroperson/jvm-live-reload": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -227,6 +227,7 @@
       "open_pr_collateral_percent": 0.1,
       "review_penalty_rate": 0.2,
       "maintainer_issue_multiplier": 1.5,
+      "standard_issue_multiplier": 1,
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 14,
@@ -248,6 +249,11 @@
       "feature": 1.5,
       "refactor": 0.25,
       "test": 1.2
+    },
+    "scoring": {
+      "standard_issue_multiplier": 1,
+      "review_penalty_rate": 0.01,
+      "pr_lookback_days": 15
     },
     "maintainer_cut": 0.6,
     "eligibility": {


### PR DESCRIPTION
## Summary

Recreates #1484 against `entrius/gittensor:test` with the unresolved review feedback applied.

- Keeps the `phase-rs/phase` scoring and label multiplier changes from #1484.
- Renames the new high-trust label multiplier from `support` to `quality`.
- Leaves `eligibility.excessive_pr_penalty_base_threshold` at `10`.

## Review feedback applied

- Applied https://github.com/entrius/gittensor/pull/1484#discussion_r3431105573 (`support` -> `quality`).
- Applied https://github.com/entrius/gittensor/pull/1484#discussion_r3432159164 (`excessive_pr_penalty_base_threshold` -> `10`).

## Testing

- `uv run python -m json.tool gittensor/validator/weights/master_repositories.json`
- `uv run --extra dev pytest tests/validator/test_load_weights.py` (145 passed)
