### PR TITLE
chore(weights): move JSONbored repos to a 7-day lookback regime

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -165,6 +165,7 @@
   },
   "JSONbored/awesome-claude": {
     "default_label_multiplier": 0.0,
+    "trusted_label_pipeline": true,
     "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -173,23 +174,26 @@
       "gittensor:priority": 1.75
     },
     "eligibility": {
-      "min_credibility": 0.6
+      "min_credibility": 0.5
     },
     "maintainer_cut": 0.5,
     "scoring": {
-      "pr_lookback_days": 35,
+      "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
-      "maintainer_issue_multiplier": 1.66,
+      "standard_issue_multiplier": 1.1,
+      "maintainer_issue_multiplier": 1.5,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 14,
-        "min_multiplier": 0.1
+        "sigmoid_midpoint_days": 3,
+        "sigmoid_steepness": 1.0,
+        "min_multiplier": 0.05
       }
     }
   },
   "JSONbored/gittensory": {
     "default_label_multiplier": 0.0,
+    "trusted_label_pipeline": true,
     "emission_share": 0.015,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -198,23 +202,26 @@
       "gittensor:priority": 1.75
     },
     "eligibility": {
-      "min_credibility": 0.8
+      "min_credibility": 0.6
     },
     "maintainer_cut": 0.5,
     "scoring": {
-      "pr_lookback_days": 35,
+      "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
-      "maintainer_issue_multiplier": 1.66,
+      "standard_issue_multiplier": 1.1,
+      "maintainer_issue_multiplier": 1.5,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 14,
-        "min_multiplier": 0.1
+        "sigmoid_midpoint_days": 3,
+        "sigmoid_steepness": 1.0,
+        "min_multiplier": 0.05
       }
     }
   },
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
+    "trusted_label_pipeline": true,
     "emission_share": 0.0075,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -223,18 +230,20 @@
       "gittensor:priority": 2.5
     },
     "eligibility": {
-      "min_credibility": 0.6
+      "min_credibility": 0.5
     },
     "maintainer_cut": 0.25,
     "scoring": {
-      "pr_lookback_days": 35,
+      "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
-      "maintainer_issue_multiplier": 1.66,
+      "standard_issue_multiplier": 1.1,
+      "maintainer_issue_multiplier": 1.5,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 14,
-        "min_multiplier": 0.1
+        "sigmoid_midpoint_days": 3,
+        "sigmoid_steepness": 1.0,
+        "min_multiplier": 0.05
       }
     }
   },


### PR DESCRIPTION
## Summary

Tune the maintainer-controlled config for the three repos I maintain (`JSONbored/awesome-claude`, `JSONbored/gittensory`, `JSONbored/metagraphed`) to a 7-day contribution window, with the scoring curve and gates re-balanced to match. `emission_share` and `issue_discovery_share` are unchanged (subnet-controlled).

## Changes (all three repos)

- **`pr_lookback_days`: 35 → 7** — a weekly contribution window. Precedented in the registry: several repos (e.g. `e35ventura/taopedia`, `e35ventura/taopedia-articles`) already use a 7-day lookback.
- **`time_decay` recalibrated for the shorter window** so scoring decays smoothly across the week instead of cliff-cutting at day 7: `sigmoid_midpoint_days` 14 → 3, `sigmoid_steepness` → 1.0, `min_multiplier` 0.1 → 0.05. (Curve: full ~1 day → ~53% day 3 → ~7% day 7.)
- **Issue multipliers:** `standard_issue_multiplier` → 1.1, `maintainer_issue_multiplier` 1.66 → 1.5.
- **`eligibility.min_credibility`:** awesome-claude 0.6 → 0.5, gittensory 0.8 → 0.6, metagraphed 0.6 → 0.5 — relaxed to absorb the noisier credibility sample a 7-day window produces.
- **`trusted_label_pipeline`: true** on all three (accept authoritative/bot-applied labels).

## Unchanged
`maintainer_cut` (0.5 / 0.5 / 0.25), `label_multipliers`, `open_pr_collateral_percent` 0.2, `review_penalty_rate` 0.2, `grace_period_hours` 24, `emission_share`, `issue_discovery_share`.

## Validation
`uv run pytest tests/validator/test_load_weights.py` → **145 passed** (loader enforces all ranges: lookback, `[1,5]` issue multipliers, `[0,1]` credibility, time-decay bounds). Single-file change; JSON valid; total registry `emission_share` unchanged.
