### PR TITLE
chore(weights): rebalance community emission shares

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -20,7 +20,7 @@
     "trusted_label_pipeline": true
   },
   "cogniax/tao-pulse-app": {
-    "emission_share": 0.01,
+    "emission_share": 0.008,
     "issue_discovery_share": 0.5,
     "maintainer_cut": 0.4
   },
@@ -106,7 +106,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.08,
+    "emission_share": 0.07,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,
@@ -118,7 +118,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
-    "emission_share": 0.005,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.1,
@@ -151,7 +151,7 @@
     "eligibility": {
       "max_open_pr_threshold": 2
     },
-    "emission_share": 0.03,
+    "emission_share": 0.025,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "community-contribution": 0.2,
@@ -194,7 +194,7 @@
   "JSONbored/gittensory": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.015,
+    "emission_share": 0.013,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.5,
@@ -248,7 +248,7 @@
     }
   },
   "MkDev11/gittensor-hub": {
-    "emission_share": 0.012,
+    "emission_share": 0.008,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 2,
@@ -309,11 +309,11 @@
     }
   },
   "seroperson/jvm-live-reload": {
-    "emission_share": 0.008,
+    "emission_share": 0.005,
     "issue_discovery_share": 0.0
   },
   "touchpilot/touchpilot": {
-    "emission_share": 0.005,
+    "emission_share": 0.01,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "type: bug": 1.1,


### PR DESCRIPTION
Suggestive emission-share rebalance on realized progress since #1469 (merged 2026-06-15) and forward outlook. Subnet price 0.004555 TAO/ALPHA, TAO $231.10 (1.0 share ≈ $11,263/day; 0.001 share ≈ $11.26/day). Default posture is HOLD; the window since the anchor is only ~3 days, so moves are limited to fired pre-committed triggers, a cleared rehabilitation, and a strengthened farming suspicion.

**Baseline anchor for next run:** rebalance commit `e6c1e1c` (base `origin/test` @ `e75df41`). Next run pins "progress since" to this commit and diffs against the snapshot block below.

## Rebalances
| repo | old | new | est. $/day (old→new) | type |
|---|---:|---:|---|---|
| touchpilot/touchpilot | 0.0050 | 0.0100 | $56 → $113 | restore (rehab met) |
| Geniepod/genie-claw | 0.0300 | 0.0250 | $338 → $282 | trim (pre-committed trigger) |
| JSONbored/gittensory | 0.0150 | 0.0130 | $169 → $146 | trim (directed bet, partial) |
| MkDev11/gittensor-hub | 0.0120 | 0.0080 | $135 → $90 | trim (suspicion strengthened) |
| cogniax/tao-pulse-app | 0.0100 | 0.0080 | $113 → $90 | trim (stalled) |
| seroperson/jvm-live-reload | 0.0080 | 0.0050 | $90 → $56 | trim to floor (dormant) |
| entrius/gittensor | 0.0800 | 0.0700 | $901 → $788 | directed (protected) |
| entrius/gittensor-ui | 0.0050 | 0.0000 | $56 → $0 | directed (protected) |

Held (no change): infiniflow/ragflow 0.055, we-promise/sure 0.030, phase-rs/phase 0.018, JSONbored/metagraphed 0.0075, JSONbored/awesome-claude 0.005, vouchdev/vouch 0.010, DPBG/Engram.AI 0.005.

## Totals
- Previous: `0.3955` (headroom 0.6045)
- New: `0.3695` (headroom 0.6305)

Trimmed share flows back to the recycle remainder; it does not dilute other repos.

## Why these changed

**touchpilot/touchpilot — restore 0.005 → 0.010 (rehabilitation met)**
- Last run's rehab condition — *"restores when churn-farming stops and outside contribution appears"* — is now satisfied. The confirmed churn account `RenzoMXD` filed PRs #275–280 (06-14) that were **closed unmerged / rejected** (last merge was pre-floor #186 on 06-04). Merges since the anchor now carry real **APPROVED** reviews with CHANGES_REQUESTED cycles (#285 +381/−282, #259 +1,056/−206 multi-round, #243), on net-additive genuine Kotlin source — no churn signature.
- Genuine external contributors appeared (andriypolanski, jonathanchang31, Asukaminato0612, YB0y); open issues 0 → 12; 9 eligible miners; 15 commits since anchor. Restored to parity with vouch.
- **Conditional — release-or-demote:** still **no tagged release**. If touchpilot does not show concrete progress toward an initial release by the next rebalance, it gets demoted again. Restore is the reward for stopping the exploit; sustaining it requires shipping.

**Geniepod/genie-claw — trim 0.030 → 0.025**
- #1469 pre-committed *"trim again if it keeps slipping."* It slipped hard: repo score **5 → 0.41**, eligible miners **7 → 4**, only **3 commits**, and **no new release** (still v1.0.0-alpha.10 from 05-29). At 0.030 the share was absorbing almost nothing.
- The engineering is genuine (bittoby's PRs carry APPROVED reviews, merged by a separate account ai-hpc — not self-merged), so this is a small trim, not a floor. Restores if a release lands and score recovers.

**JSONbored/gittensory — trim 0.015 → 0.013 (directed bet, partial walk-back)**
- #1469's raise was an explicitly conditional directed bet: *"If stars/external stay flat next run, this reverses."* **Stars are flat at 4**, still ~cohort-heavy (8 eligible, ~2 external), so the organic-pull gate remains failed and the pre-commitment applies.
- The trigger we're waiting on is **outside usage** (stars / external contributors / downstream MCP adoption) — a soft, slow-moving signal — not a farming finding, and the realized output is still deep and genuinely reviewed (score 1,617; oktofeesh1's PRs went through CHANGES_REQUESTED → APPROVED). So this is a partial walk-back, not a full reversal: the share steps down toward (not all the way back to) the pre-bet level, leaving room to re-raise quickly once external adoption shows up, and to step down further if it stays flat.

**MkDev11/gittensor-hub — trim 0.012 → 0.008 (suspicion strengthened; not floored)**
- The carried-forward bitloi↔MkDev11 double-dip suspicion strengthened. **PR #231 (+13,100/−1,229 across 25 files, opened→merged in 87 minutes, reviews `[COMMENTED, COMMENTED]` — zero APPROVED)** merged 06-12 and now **dominates the repo score: bitloi 1,211 of 1,243 total.** A 13k-line first-party-source PR cannot be reviewed in 87 minutes — textbook size-vs-time impossibility + author≠merger + zero-approval signature. Review hygiene did not improve (philluiz2323 PRs also COMMENTED-only).
- **Not floored:** the 13k lines are genuine first-party Next.js source (not churn/vendored/generated), and the alt identity link is still circumstantial (bitloi: 2021, 0/0 followers, no bio; MkDev11: "Merge King Developer", both 56 repos) — not proven. Per the graduated response, that's a meaningful trim + verify, not a floor. **Floors next run if the alt link confirms or another no-review mega-PR lands.** Also watching `philluiz2323` (fresh 2026-03 account, 0/0 followers, now eligible on both gittensor-hub and touchpilot).

**cogniax/tao-pulse-app — trim 0.010 → 0.008 (stalled)**
- Every axis of #1469's "seasoned positively" thesis reversed: still a **single eligible contributor** (mvphanx — no 2nd/3rd appeared), repo score **164 → 93**, **no new release** (v0.1.0 from 05-27), and the external **24-PR queue is unprocessed with backlog to 2026-05-29** (grew 23 → 24). The only merges since anchor were 2 PRs the maintainer authored himself (#95, #93). The share is routing to one maintainer who isn't reviewing the queue rather than absorbing external work.
- Not a floor (not farming — self-merges are zeroed by the validator anyway, and he's the legit maintainer). Watch flag: mvphanx is simultaneously maintainer (cut 0.4) and sole eligible miner.
- **Conditional — release-or-demote (same lane as touchpilot):** if there's no progress toward an initial release and the review queue stays ignored by the next rebalance, it drops further toward the floor.

**seroperson/jvm-live-reload — trim 0.008 → 0.005 (floor; dormant)**
- #1469 set a "low hold until a release cadence resumes." It did not resume — still **v0.1.1 (2025-12-29, ~6 months)**, 2 commits, eligible miners **2 → 1**, near-zero score (21). A recycling share on a dormant project.
- Legit independent OSS (Maven Central, MIT, predates emissions), so it drops to the registry floor — kept on, not delisted — and climbs back the moment a release lands.

**Directed / protected-owner moves (not rebalance-logic outputs):**
- **entrius/gittensor 0.080 → 0.070** and **entrius/gittensor-ui 0.005 → 0.000** — directed trims by the owner. Lowered because development on these products is nearing completion; the freed share recycles into the remainder.

## Carried-forward watch
- **MkDev11/gittensor-hub** — suspected bitloi↔MkDev11 shadow-mining; trimmed this run on the strengthened evidence above. Verdict still pending an identity-link confirmation; floors if confirmed or if another no-review mega-PR lands.
- **vouchdev/vouch (HELD 0.010)** — last run's dormancy flagged a trim trigger; cadence **resumed** (~8 merges 06-15→17, score 441 → 461, genuine net-additive work, plind-junior the registerer merging everyone is the sanctioned pattern). Cleared — hold.
- **DPBG/Engram.AI (HELD 0.005)** — added 2026-06-15 on a 3–4 week probation; only ~3 days in. No fresh-account lint padding since listing, one genuine externally-reviewed PR (#51), real Phase-2 roadmap appeared — but 0 eligible miners / 0 score and a maintainer self-merge burst on listing day. Too early; judged on its probation window.

## State-of-affairs snapshot — 2026-06-18 (baseline for next run; commit `e6c1e1c`)

### infiniflow/ragflow
- share: 0.055 | stars: 83,129 | forks: 9,620 | open issues: 2,635 | latest release: v0.26.1 (2026-06-17)
- eligible miners: 22 | repo score (sum): 160.9 | external (non-cohort) contributors: ~80 (KevinHuSh, cike8899, writinwaters, JinHai-CN, yongtenglei…)
- roadmap: continuous releases (v0.26.x) — on track
- state: pre-gittensor flagship OSS, huge organic adoption, rigorous review. Anchor — hold.
- flags: none | revisit: only on a strong sustained shift

### we-promise/sure
- share: 0.030 | stars: 8,721 | forks: 172 | open issues: 223 | latest release: v0.7.2-alpha.7 (2026-06-15)
- eligible miners: 7 | repo score (sum): 204.3 | external (non-cohort) contributors: ~87 (jjmata, zachgoll, Shpigford, sokie, gariasf…)
- roadmap: steady alpha cadence (alpha.5→alpha.7) — on track
- state: pre-gittensor real product, clean maintainer review (jjmata). Anchor — hold.
- flags: none | revisit: anchor — hold

### phase-rs/phase
- share: 0.018 | stars: 135 | forks: 87 | open issues: 446 | latest release: v0.1.59 (2026-06-17)
- eligible miners: 22 | repo score (sum): 1,725.5 | external (non-cohort) contributors: ~29 (matthewevans, mike-theDude, Whovencroft, ntindle, AgilErck…)
- roadmap: daily releases (v0.1.54→v0.1.59 since baseline) — on track
- state: MTG rules engine; clears organic gate, clean matthewevans review, sustained daily delivery. Niche/non-commercial ceiling. Raise candidate if external growth accelerates.
- flags: none | revisit: raise if stars/external accelerate

### Geniepod/genie-claw
- share: 0.025 (↓ from 0.030) | stars: 48 | forks: 40 | open issues: 10 | latest release: v1.0.0-alpha.10 (2026-05-29)
- eligible miners: 4 (↓7) | repo score (sum): 0.41 (↓5) | external (non-cohort) contributors: ~6 (ai-hpc, enjoyandlove, statxc, greatjourney589…)
- roadmap: M1 Jetson harness — stalled (no release since anchor)
- state: on-device AI harness; real reviewed engineering (ai-hpc merges with APPROVED) but realized output collapsed this window.
- flags: output regression | revisit: restore if a release lands + score recovers; trim again if it keeps slipping

### JSONbored/gittensory
- share: 0.013 (↓ from 0.015) | stars: 4 | forks: 30 | open issues: 52 | latest release: mcp-v0.6.0 (2026-06-14)
- eligible miners: 8 | repo score (sum): 1,617 | external (non-cohort) contributors: ~2 (cohort-heavy)
- roadmap: MCP tooling (mcp-v0.5.0/0.6.0) — delivering
- state: deepest genuine absorber, real CHANGES_REQUESTED→APPROVED review on miner PRs, BUT fails organic gate (4★, cohort-heavy). Directed bet reversed per pre-commitment.
- flags: organic-gate fail | revisit: re-raise only if external adoption (stars/outside contributors/downstream MCP usage) shows up

### JSONbored/metagraphed
- share: 0.0075 | stars: 2 | forks: 5 | open issues: 145 | latest release: python-v0.3.0 (2026-06-17)
- eligible miners: 1 (oktofeesh1) | repo score (sum): 112 | external (non-cohort) contributors: ~2 (bot/maintainer-heavy)
- roadmap: platform/python/client releases — delivering
- state: subnet-metadata tooling (sibling to gittensory); seed produced first realized output (0→112) but single cohort contributor, no organic pull. Hold.
- flags: seed, no organic pull | revisit: raise only with a 2nd contributor + external adoption

### JSONbored/awesome-claude
- share: 0.005 | stars: 265 | forks: 79 | open issues: 50 | latest release: mcp-v0.3.1 (2026-06-14)
- eligible miners: 11 | repo score (sum): 156.2 | external (non-cohort) contributors: ~3 human (dpdanpittman, kriptoburak, Desel72) + agentic gate
- roadmap: mcp-v0.3.x — on track
- state: awesome-list registry, agentic submission gate (legitimate model). Farm-prone surface handled by low weight + default_label_multiplier 0.
- flags: none | revisit: hold

### MkDev11/gittensor-hub
- share: 0.008 (↓ from 0.012) | stars: 17 | forks: 33 | open issues: 0 | latest release: none (seed)
- eligible miners: 5 | repo score (sum): 1,243 (bitloi 1,211) | external (non-cohort) contributors: ~4
- roadmap: none (seed) — dormant since 06-12
- state: real frontend source, BUT score is 96% one suspect account's unreviewable 13k-line/87-min/0-approval PR (#231). Trimmed on strengthened double-dip suspicion.
- flags: **SUSPECTED shadow-mining (bitloi↔MkDev11) — strengthened, alt link unproven; watch philluiz2323** | revisit: FLOOR if alt link confirms or another no-review mega-PR lands; restore toward 0.012 if APPROVED independent review appears

### vouchdev/vouch
- share: 0.010 | stars: 4 | forks: 26 | open issues: 81 | latest release: v0.1.0 (2026-05-26)
- eligible miners: 4 (↑3) | repo score (sum): 460.6 | external (non-cohort) contributors: ~2 (Yurii214 + cohort)
- roadmap: post-v0.1.0 feature work — active
- state: maintained by plind-junior (registerer; merging everyone is normal, not a ring). Cadence resumed; genuine net-additive work.
- flags: dormancy cleared | revisit: hold; trim if cadence stalls again

### cogniax/tao-pulse-app
- share: 0.008 (↓ from 0.010) | stars: 22 | forks: 19 | open issues: 40 | latest release: v0.1.0 (2026-05-27)
- eligible miners: 1 (mvphanx) | repo score (sum): 93.5 | external (non-cohort) contributors: ~2 (owldev127, pragnaahh)
- roadmap: none shipped since v0.1.0 — stalled
- state: single-contributor; maintainer self-merges his own PRs while a 24-PR external queue (backlog to 05-29) rots. Output declining.
- flags: stale review queue; maintainer=sole eligible miner (watch) | revisit: **release-or-demote** — drops toward floor if no release progress and queue still ignored next run

### seroperson/jvm-live-reload
- share: 0.005 (↓ from 0.008, floor) | stars: 28 | forks: 29 | open issues: 19 | latest release: v0.1.1 (2025-12-29)
- eligible miners: 1 (↓2) | repo score (sum): 21.4 | external (non-cohort) contributors: ~2 (Desel72 + cohort)
- roadmap: none — dormant (~6 months no release)
- state: legit independent OSS (Maven Central, predates emissions); release cadence never resumed → floored.
- flags: dormant | revisit: restore off floor when a release cadence resumes

### touchpilot/touchpilot
- share: 0.010 (↑ from 0.005, restored) | stars: 11 | forks: 29 | open issues: 12 | latest release: none
- eligible miners: 9 | repo score (sum): 368 | external (non-cohort) contributors: ~4 (andriypolanski, jonathanchang31, Asukaminato0612, YB0y)
- roadmap: no tagged release yet — **conditional**
- state: rehab met — churn account RenzoMXD now rejected, merges carry APPROVED + CHANGES_REQUESTED cycles on genuine Kotlin source, external contributors appeared. Restored off floor.
- flags: no release yet (release-or-demote next run) | revisit: **demote again if no progress toward an initial release by next rebalance**

### DPBG/Engram.AI
- share: 0.005 | stars: 3 | forks: 11 | open issues: 8 | latest release: none
- eligible miners: 0 | repo score (sum): 0 | external (non-cohort) contributors: ~1 reviewed (kiannidev #51)
- roadmap: Phase 2 epic (8 typed issues) — newly posted
- state: added 2026-06-15 on 3–4 week probation; no fresh-account lint padding since listing, one genuine reviewed PR, real roadmap appeared, but no realized output yet.
- flags: probation (manufactured day-1 optics history) | revisit: judge on first realized output at end of probation window (~early July)

---

Protected-owner repos (entrius / anderdc / e35ventura / landyndev) are out of scope for the rebalance logic; their shares move only by directed change (this run: entrius/gittensor and entrius/gittensor-ui, nearing-completion trims) and they get no snapshot entry.
