### PR TITLE
fix(cli): propagate GraphQL failures in find_prs_for_issue instead of returning empty list

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -332,11 +332,12 @@ def find_prs_for_issue(
 ) -> List[PRInfo]:
     """Find PRs that reference an issue via GraphQL cross-reference data."""
     if token:
-        try:
-            prs = _search_issue_referencing_prs_graphql(repo, issue_number, token, open_only=open_only)
-            return prs or []
-        except Exception as exc:
-            bt.logging.debug(f'GraphQL PR fetch failed for {repo}#{issue_number}: {exc}')
+        prs = _search_issue_referencing_prs_graphql(repo, issue_number, token, open_only=open_only)
+        if prs is None:
+            raise RuntimeError(
+                f'GraphQL cross-reference lookup failed for {repo}#{issue_number}; check logs'
+            )
+        return prs
 
     return []
 


### PR DESCRIPTION
## Summary

Fixes #1492: when `_search_issue_referencing_prs_graphql` returns `None` (rate limit, network error, GraphQL errors, or missing issue payload), `find_prs_for_issue` now raises `RuntimeError` instead of collapsing `None` to `[]`.

This surfaces the failure to callers (e.g. `fetch_open_issue_pull_requests` re-raises as `click.ClickException`) rather than silently reporting zero submissions.

## Related Issues
Fixes #1492

## Type of Change
- [x] Bug fix

## Testing
- `uv run ruff check gittensor/utils/github_api_tools.py`
- `uv run pytest tests/test_classes.py tests/cli/ -q --ignore=tests/cli/test_cli_helpers.py --ignore=tests/cli/test_cli_json_error_output.py` (pre-existing failures in those files)