### PR TITLE
fix(cli): raise on packed storage decode failure instead of silently returning empty list

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -695,10 +695,11 @@ def _read_contract_packed_storage(substrate, contract_addr: str, verbose: bool =
         err_console.print(f'[dim]Debug: Packed storage data length = {len(packed_bytes)} bytes[/dim]')
 
     packed = decode_packed_contract_storage(packed_bytes)
-    if not packed:
-        if verbose:
-            err_console.print(f'[dim]Debug: Packed storage too small ({len(packed_bytes)} < 74 bytes)[/dim]')
-        return None
+    if packed is None:
+        raise RuntimeError(
+            f'Contract packed storage decode failed for {contract_addr}: '
+            f'{len(packed_bytes)} bytes is below the minimum layout size'
+        )
 
     return {
         'owner': substrate.ss58_encode(packed.owner.hex()),


### PR DESCRIPTION
## Summary

Fixes #1494

When  returns  (buffer too small or corrupt data),  was returning , which  collapsed to . Callers then silently saw no issues instead of receiving an error signal.

## Changes

- Changed the  guard to  and raised  with a descriptive message including the contract address and byte count
- This ensures decode failures are visible rather than silently swallowed

## Testing

The fix raises  on corrupt/undersized packed storage buffers instead of silently returning an empty issue list.
