### PR TITLE
Tune Taopedia site label multipliers

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -36,17 +36,19 @@
     "trusted_label_pipeline": true,
     "default_label_multiplier": 0.0,
     "label_multipliers": {
-      "feature": 3.0,
-      "ui-ux": 2.0,
-      "bug": 0.625,
-      "security": 0.625,
-      "other": 0.1
+      "ui-ux": 5.0,
+      "feature": 2.0,
+      "bug": 0.35,
+      "security": 0.35,
+      "other": 0.05
     },
     "eligibility": {
-      "min_credibility": 0.6
+      "min_credibility": 0.6,
+      "max_open_pr_threshold": 4
     },
     "scoring": {
       "pr_lookback_days": 7,
+      "maintainer_issue_multiplier": 5.0,
       "time_decay": {
         "grace_period_hours": 6,
         "sigmoid_midpoint_days": 2,


### PR DESCRIPTION
## Summary
- Set Taopedia site `ui-ux` label multiplier to `5.0`.
- Lower Taopedia site `feature` label multiplier to `2.0`.
- Remove the Taopedia site `share-preview` label multiplier.
- Keep bug/security heavily discounted at `0.35` and other work at `0.05`.
- Cap Taopedia site open-PR spam threshold at `4`, so contributors can have up to four open Taopedia PRs before the open-PR spam penalty applies.
- Set Taopedia site `maintainer_issue_multiplier` to `5.0`, the current maximum accepted by the existing hyperparameter validator.

## Validation
- `.venv/bin/python -m pytest tests/validator/test_load_weights.py tests/validator/test_dynamic_open_pr_threshold.py tests/validator/test_eligibility_resolver.py -q`