### PR TITLE
Register e35dev/live-bittensor-emissions-leaderboard

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,19 +1,19 @@
 {
   "anderdc/social-media-manager": {
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0,
     "eligibility": {
-      "min_credibility": 0.0,
-      "min_issue_credibility": 0.0,
+      "min_credibility": 0,
+      "min_issue_credibility": 0,
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
     "emission_share": 0.005,
-    "fixed_base_score": 1.0,
-    "issue_discovery_share": 0.0,
+    "fixed_base_score": 1,
+    "issue_discovery_share": 0,
     "label_multipliers": {
-      "crown": 1.0
+      "crown": 1
     },
-    "maintainer_cut": 0.0,
+    "maintainer_cut": 0,
     "scoring": {
       "pr_lookback_days": 7
     },
@@ -26,18 +26,20 @@
   },
   "DPBG/Engram.AI": {
     "emission_share": 0.005,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0
   },
   "e35ventura/taopedia": {
     "emission_share": 0.025,
-    "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.0,
-    "additional_acceptable_branches": ["test"],
+    "issue_discovery_share": 0,
+    "maintainer_cut": 0,
+    "additional_acceptable_branches": [
+      "test"
+    ],
     "trusted_label_pipeline": true,
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0,
     "label_multipliers": {
-      "feature": 3.0,
-      "ui-ux": 2.0,
+      "feature": 3,
+      "ui-ux": 2,
       "bug": 0.625,
       "security": 0.625,
       "other": 0.1
@@ -50,20 +52,22 @@
       "time_decay": {
         "grace_period_hours": 6,
         "sigmoid_midpoint_days": 2,
-        "sigmoid_steepness": 1.0,
+        "sigmoid_steepness": 1,
         "min_multiplier": 0.02
       }
     }
   },
   "e35ventura/taopedia-articles": {
     "emission_share": 0.025,
-    "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.0,
-    "additional_acceptable_branches": ["test"],
+    "issue_discovery_share": 0,
+    "maintainer_cut": 0,
+    "additional_acceptable_branches": [
+      "test"
+    ],
     "trusted_label_pipeline": true,
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0,
     "label_multipliers": {
-      "article": 1.0,
+      "article": 1,
       "correction": 1.25,
       "image": 0.75,
       "category": 0.5,
@@ -71,7 +75,7 @@
     },
     "eligibility": {
       "min_credibility": 0.5,
-      "min_token_score_for_valid_issue": 0.0
+      "min_token_score_for_valid_issue": 0
     },
     "scoring": {
       "pr_lookback_days": 7,
@@ -85,13 +89,13 @@
   },
   "entrius/allways": {
     "emission_share": 0.04,
-    "issue_discovery_share": 1.0,
+    "issue_discovery_share": 1,
     "label_multipliers": {
       "bug": 1.25,
-      "enhancement": 1.0,
+      "enhancement": 1,
       "refactor": 0.25
     },
-    "maintainer_cut": 0.0,
+    "maintainer_cut": 0,
     "trusted_label_pipeline": true
   },
   "entrius/das-github-mirror": {
@@ -102,48 +106,48 @@
       "enhancement": 1.1,
       "refactor": 0.1
     },
-    "maintainer_cut": 0.0,
+    "maintainer_cut": 0,
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
     "emission_share": 0.07,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "bug": 1.1,
       "enhancement": 1.25,
       "feature": 1.5,
       "refactor": 0.25
     },
-    "maintainer_cut": 0.0,
+    "maintainer_cut": 0,
     "trusted_label_pipeline": true
   },
   "entrius/gittensor-ui": {
-    "emission_share": 0.0,
-    "issue_discovery_share": 0.0,
+    "emission_share": 0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "bug": 1.1,
-      "enhancement": 1.0,
+      "enhancement": 1,
       "feature": 1.25,
       "refactor": 0.5
     },
-    "maintainer_cut": 0.0,
+    "maintainer_cut": 0,
     "trusted_label_pipeline": true
   },
   "entrius/oc-1": {
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0,
     "eligibility": {
-      "min_credibility": 0.0,
-      "min_issue_credibility": 0.0,
+      "min_credibility": 0,
+      "min_issue_credibility": 0,
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.0,
-    "fixed_base_score": 1.0,
-    "issue_discovery_share": 0.0,
+    "emission_share": 0,
+    "fixed_base_score": 1,
+    "issue_discovery_share": 0,
     "label_multipliers": {
-      "benchmark-improvement": 1.0
+      "benchmark-improvement": 1
     },
-    "maintainer_cut": 0.0,
+    "maintainer_cut": 0,
     "trusted_label_pipeline": true
   },
   "Geniepod/genie-claw": {
@@ -152,7 +156,7 @@
       "max_open_pr_threshold": 2
     },
     "emission_share": 0.025,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "community-contribution": 0.2,
       "optimization": 0.8
@@ -161,13 +165,13 @@
   },
   "infiniflow/ragflow": {
     "emission_share": 0.055,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0
   },
   "JSONbored/awesome-claude": {
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0,
     "trusted_label_pipeline": true,
     "emission_share": 0.005,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "gittensor:bug": 0.5,
       "gittensor:feature": 1.25,
@@ -186,16 +190,16 @@
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 3,
-        "sigmoid_steepness": 1.0,
+        "sigmoid_steepness": 1,
         "min_multiplier": 0.05
       }
     }
   },
   "JSONbored/gittensory": {
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0,
     "trusted_label_pipeline": true,
     "emission_share": 0.013,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "gittensor:bug": 0.5,
       "gittensor:feature": 1.25,
@@ -214,16 +218,16 @@
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 3,
-        "sigmoid_steepness": 1.0,
+        "sigmoid_steepness": 1,
         "min_multiplier": 0.05
       }
     }
   },
   "JSONbored/metagraphed": {
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0,
     "trusted_label_pipeline": true,
     "emission_share": 0.0075,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "gittensor:bug": 0.5,
       "gittensor:feature": 1.5,
@@ -242,14 +246,14 @@
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 3,
-        "sigmoid_steepness": 1.0,
+        "sigmoid_steepness": 1,
         "min_multiplier": 0.05
       }
     }
   },
   "MkDev11/gittensor-hub": {
     "emission_share": 0.008,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "feature": 2,
       "whale": 20,
@@ -271,7 +275,7 @@
   },
   "vouchdev/vouch": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "feature": 1.5,
       "bug": 1.1
@@ -290,12 +294,14 @@
     "eligibility": {
       "excessive_pr_penalty_base_threshold": 3
     },
-    "additional_acceptable_branches": ["test"],
+    "additional_acceptable_branches": [
+      "test"
+    ],
     "maintainer_cut": 0.5
   },
   "phase-rs/phase": {
     "emission_share": 0.018,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "bug": 1.1,
       "enhancement": 1.25,
@@ -310,11 +316,11 @@
   },
   "seroperson/jvm-live-reload": {
     "emission_share": 0.005,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0
   },
   "touchpilot/touchpilot": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "type: bug": 1.1,
       "type: enhancement": 1.25,
@@ -326,11 +332,39 @@
   },
   "we-promise/sure": {
     "emission_share": 0.03,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0,
     "label_multipliers": {
       "performance": 1.5,
       "mobile/Flutter": 1.2
     },
     "maintainer_cut": 0.3
+  },
+  "e35dev/live-bittensor-emissions-leaderboard": {
+    "emission_share": 0.005,
+    "issue_discovery_share": 0,
+    "additional_acceptable_branches": [
+      "test"
+    ],
+    "trusted_label_pipeline": true,
+    "default_label_multiplier": 0,
+    "label_multipliers": {
+      "feature": 3,
+      "ui-ux": 2,
+      "bug": 0.625,
+      "security": 0.625,
+      "other": 0.1
+    },
+    "eligibility": {
+      "min_credibility": 0.6
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 6,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1,
+        "min_multiplier": 0.02
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds `e35dev/live-bittensor-emissions-leaderboard` to the Gittensor master repository registry.