### PR TITLE
fix(cli): tag bounty-pool and admin-info contract read failures as read_failed

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -257,7 +257,9 @@ def issues_bounty_pool(network: str, rpc_url: str, contract: str, verbose: bool,
         )
         err_console.print(f'[dim]Sum of bounty amounts from {len(issues)} issue(s)[/dim]')
     except Exception as e:
-        handle_exception(as_json=as_json, message=str(e))
+        handle_exception(
+            as_json=as_json, message=f'Error reading bounty pool from contract: {e}', error_type='read_failed'
+        )
 
 
 @click.command('pending-harvest', cls=StyledCommand)
@@ -363,4 +365,6 @@ def admin_info(network: str, rpc_url: str, contract: str, verbose: bool, as_json
             err_console.print('[dim]Try running with --verbose to see debug details.[/dim]')
             raise SystemExit(1)
     except Exception as e:
-        handle_exception(as_json=as_json, message=str(e))
+        handle_exception(
+            as_json=as_json, message=f'Error reading contract configuration: {e}', error_type='read_failed'
+        )

--- a/tests/cli/test_cli_json_error_output.py
+++ b/tests/cli/test_cli_json_error_output.py
@@ -50,6 +50,38 @@ def test_cli_commands_emit_json_on_exception(cli_root, runner, argv):
     assert FORCED_MESSAGE in payload['error']['message']
 
 
+@pytest.mark.parametrize(
+    'argv,message_fragment',
+    [
+        (['issues', 'bounty-pool', '--json'], 'Error reading bounty pool from contract'),
+        (['admin', 'info', '--json'], 'Error reading contract configuration'),
+    ],
+)
+def test_read_only_commands_tag_contract_read_failures_as_read_failed(cli_root, runner, argv, message_fragment):
+    """Contract read failures from `bounty-pool` and `admin info` must surface as
+    `error.type == "read_failed"` so JSON consumers can distinguish a contract
+    read failure from a generic CLI error, matching `pending-harvest` and `vote list`.
+    """
+    with (
+        patch(
+            'gittensor.cli.issue_commands.view._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'test'),
+        ),
+        patch(
+            'async_substrate_interface.SubstrateInterface',
+            side_effect=RuntimeError(FORCED_MESSAGE),
+        ),
+    ):
+        result = runner.invoke(cli_root, argv, catch_exceptions=False)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'read_failed'
+    assert message_fragment in payload['error']['message']
+    assert FORCED_MESSAGE in payload['error']['message']
+
+
 def test_admin_info_emits_json_on_soft_read_failure(cli_root, runner):
     """`admin info --json` must emit structured JSON when packed storage read returns None."""
     with (


### PR DESCRIPTION
## Summary

`gitt issues bounty-pool --json` and `gitt admin info --json` previously surfaced contract read failures with the default `error.type == "cli_error"`, while their sibling read commands tag the same class of failure as `read_failed`:

| Command | error_type on contract read failure (before this PR) |
|---|---|
| `gitt issues list --json` | `read_failed` |
| `gitt issues pending-harvest --json` | `read_failed` (from #1450) |
| `gitt vote list --json` | `read_failed` (from #1472) |
| `gitt issues bounty-pool --json` | `cli_error` (default) |
| `gitt admin info --json` | `cli_error` (default) |

JSON consumers (validators, dashboards, scripts) calling these two commands could not programmatically distinguish a contract read failure from any other CLI error. This PR closes that gap by routing both exception paths through the canonical `read_failed` envelope, matching the pattern already established by #1450 and #1472.

## Changes

- `gittensor/cli/issue_commands/view.py`
  - `issues_bounty_pool`: outer `except Exception` now uses `error_type='read_failed'` with prefix `'Error reading bounty pool from contract: '`.
  - `admin_info`: outer `except Exception` now uses `error_type='read_failed'` with prefix `'Error reading contract configuration: '`. The existing soft-fail path inside the function already tagged this as `read_failed`; this change makes the hard-fail path consistent.
- `tests/cli/test_cli_json_error_output.py`: parametrized regression test asserts `error.type == 'read_failed'` and the new prefix for both commands when `SubstrateInterface` raises during contract read.

No behavioral change for the happy path or for the existing soft-fail path inside `admin_info`.

## Before / After

`gitt issues bounty-pool --json` against an unreachable endpoint (simulated by `SubstrateInterface` raising):

Before:
```json
{
  "success": false,
  "error": {
    "type": "cli_error",
    "message": "forced test failure for json-error assertion"
  }
}
```

After:
```json
{
  "success": false,
  "error": {
    "type": "read_failed",
    "message": "Error reading bounty pool from contract: forced test failure for json-error assertion"
  }
}
```

Same shape for `gitt admin info --json` with prefix `'Error reading contract configuration: '`.

## Type of Change

- [x] Bug fix (consistency / API contract gap)
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [x] Tests added/updated
- [x] Manually verified via `pytest`

Checks run locally inside `.venv`:

```bash
ruff check gittensor/cli/issue_commands/view.py tests/cli/test_cli_json_error_output.py
ruff format --check gittensor/cli/issue_commands/view.py tests/cli/test_cli_json_error_output.py
python -m pytest tests/cli/test_cli_json_error_output.py tests/cli/test_pending_harvest_single_connection.py tests/cli/test_vote_list_json.py tests/cli/test_issues_list_json.py -q
python -m pytest -q   # full suite: 947 passed
```

All checks clean; full suite passes (947 tests).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)