### PR TITLE
Register e35dev/podcast-design-canvas

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -369,5 +369,37 @@
         "min_multiplier": 0.02
       }
     }
+  },
+  "e35dev/podcast-design-canvas": {
+    "emission_share": 0.05,
+    "issue_discovery_share": 0,
+    "maintainer_cut": 0,
+    "trusted_label_pipeline": true,
+    "default_label_multiplier": 0,
+    "label_multipliers": {
+      "episode-ingest": 3,
+      "preset-styles": 2.5,
+      "canvas-editor": 2.5,
+      "audio-captions": 2,
+      "contextual-visuals": 2,
+      "template-system": 1.75,
+      "export-publish": 1.75,
+      "product-polish": 1.5,
+      "bugfix": 1,
+      "infrastructure": 0.5
+    },
+    "eligibility": {
+      "min_credibility": 0.6,
+      "max_open_pr_threshold": 4
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 6,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1,
+        "min_multiplier": 0.02
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds `e35dev/podcast-design-canvas` to the Gittensor master repository registry.

This update follows the Gittensor contribution path by targeting the PR at `test`, while keeping Podcast Design Canvas contributor work on its own `main` branch.

Builder Loops maintainer policy for Podcast Design Canvas:

- sets `emission_share` to 5%
- sets `maintainer_cut` to 0
- uses trusted repo-specific labels from the maintainer policy
- leaves unlisted labels at the default multiplier of 0
- does not add `additional_acceptable_branches`, so the registered product repo remains main-only unless a real extra product branch is introduced later

The label multipliers match the current repo-maintainer labels: `episode-ingest`, `preset-styles`, `canvas-editor`, `audio-captions`, `contextual-visuals`, `template-system`, `export-publish`, `product-polish`, `bugfix`, and `infrastructure`.
