### PR TITLE
fix: preserve None sentinel from find_prs_for_issue on GraphQL failure

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -254,8 +254,14 @@ def fetch_open_issue_pull_requests(
     repository_full_name: str,
     issue_number: int,
     as_json: bool,
-) -> list:
-    """Fetch open PR submissions for a GitHub issue."""
+) -> Optional[list]:
+    """Fetch open PR submissions for a GitHub issue.
+
+    Returns:
+        A list of PRs (possibly empty) on success, or ``None`` if the GitHub
+        GraphQL lookup failed.  Callers must treat ``None`` as a lookup failure
+        rather than an empty submission list.
+    """
     token = os.environ.get('GITTENSOR_MINER_PAT') or ''
     if not token and not as_json:
         print_warning('No GitHub token found; set GITTENSOR_MINER_PAT to fetch GitHub issue submissions')
@@ -270,7 +276,7 @@ def fetch_open_issue_pull_requests(
                 token=token or None,
                 open_only=True,
             )
-            # Intentionally return GitHub tool output as-is (no CLI schema mapping yet).
+            # Propagate None (lookup failure) to caller rather than masking it.
             return prs
     except Exception as e:
         raise click.ClickException(f'Failed to fetch PR submissions from GitHub: {e}')

--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -82,6 +82,18 @@ def issues_submissions(
         handle_exception(as_json, str(e), click_error_type(e))
 
     if as_json:
+        if pull_requests is None:
+            # GraphQL lookup failed — surface as an explicit error rather than
+            # a false-success empty list (fixes #1492).
+            emit_json({
+                'success': False,
+                'error': 'github_lookup_failed',
+                'message': 'GitHub GraphQL lookup failed; submission count unavailable. Retry or check GITTENSOR_MINER_PAT.',
+                'issue_id': issue_id,
+                'repository': repo_name,
+                'issue_number': issue_number,
+            })
+            return
         submissions = [
             {
                 'number': pr.get('number'),

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -329,14 +329,24 @@ def find_prs_for_issue(
     issue_number: int,
     open_only: bool = True,
     token: Optional[str] = None,
-) -> List[PRInfo]:
-    """Find PRs that reference an issue via GraphQL cross-reference data."""
+) -> Optional[List[PRInfo]]:
+    """Find PRs that reference an issue via GraphQL cross-reference data.
+
+    Returns:
+        A list of PRs (possibly empty) on success, or ``None`` if the GraphQL
+        lookup failed (rate-limit, network error, missing payload, etc.).
+        Callers must distinguish ``None`` (lookup failed) from ``[]`` (no PRs).
+    """
     if token:
         try:
             prs = _search_issue_referencing_prs_graphql(repo, issue_number, token, open_only=open_only)
-            return prs or []
+            if prs is None:
+                bt.logging.debug(f'GraphQL PR lookup returned None for {repo}#{issue_number}')
+                return None
+            return prs
         except Exception as exc:
             bt.logging.debug(f'GraphQL PR fetch failed for {repo}#{issue_number}: {exc}')
+            return None
 
     return []
 


### PR DESCRIPTION
## Summary

Fixes #1492.

When `_search_issue_referencing_prs_graphql` returns `None` (rate-limit, network error, missing GraphQL payload), `find_prs_for_issue` was silently coercing it to `[]` via `prs or []`. This made a lookup failure indistinguishable from a genuinely empty submission list — downstream `gitt issues submissions --json` emitted `{"success": true, "submission_count": 0}` when GitHub lookup had actually failed.

## Changes

**`gittensor/utils/github_api_tools.py`**
- `find_prs_for_issue` now returns `None` on GraphQL failure (instead of `[]`)
- Returns `[]` only for the unauthenticated path (no token → always empty, not a failure)
- Return type updated to `Optional[List[PRInfo]]`

**`gittensor/cli/issue_commands/helpers.py`**
- `fetch_open_issue_pull_requests` propagates `None` to caller instead of masking it
- Return type updated to `Optional[list]`

**`gittensor/cli/issue_commands/submissions.py`**
- When `pull_requests is None`, emits `{"success": false, "error": "github_lookup_failed", ...}` instead of a false-success empty list
- Same error-payload pattern as #1357/#1358 for `gitt issues list`