### PR TITLE
chore(weights): rebalance shares, add sparkinfer, delist inactive repos

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,7 +7,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.005,
+    "emission_share": 0.004,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -20,16 +20,16 @@
     "trusted_label_pipeline": true
   },
   "cogniax/tao-pulse-app": {
-    "emission_share": 0.008,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.5,
     "maintainer_cut": 0.4
   },
   "DPBG/Engram.AI": {
-    "emission_share": 0.005,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0
   },
   "e35ventura/taopedia": {
-    "emission_share": 0.025,
+    "emission_share": 0.05,
     "issue_discovery_share": 0.0,
     "maintainer_cut": 0.0,
     "additional_acceptable_branches": ["test"],
@@ -161,9 +161,22 @@
     },
     "maintainer_cut": 0.3
   },
-  "infiniflow/ragflow": {
-    "emission_share": 0.055,
-    "issue_discovery_share": 0.0
+  "gittensor-ai-lab/sparkinfer": {
+    "default_label_multiplier": 0.0,
+    "eligibility": {
+      "min_credibility": 0.0,
+      "min_issue_credibility": 0.0,
+      "min_valid_merged_prs": 0,
+      "min_valid_solved_issues": 0
+    },
+    "emission_share": 0.1,
+    "fixed_base_score": 1.0,
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "benchmark-improvement": 1.0
+    },
+    "maintainer_cut": 0.0,
+    "trusted_label_pipeline": true
   },
   "JSONbored/awesome-claude": {
     "default_label_multiplier": 0.0,
@@ -196,7 +209,7 @@
   "JSONbored/gittensory": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.013,
+    "emission_share": 0.1,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.5,
@@ -224,7 +237,7 @@
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.0075,
+    "emission_share": 0.25,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.5,
@@ -250,7 +263,7 @@
     }
   },
   "MkDev11/gittensor-hub": {
-    "emission_share": 0.008,
+    "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 2,
@@ -272,7 +285,7 @@
     "maintainer_cut": 0.3
   },
   "vouchdev/vouch": {
-    "emission_share": 0.01,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -297,7 +310,7 @@
     "maintainer_cut": 0.5
   },
   "phase-rs/phase": {
-    "emission_share": 0.018,
+    "emission_share": 0.02,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,
@@ -317,12 +330,8 @@
       "excessive_pr_penalty_base_threshold": 10
     }
   },
-  "seroperson/jvm-live-reload": {
-    "emission_share": 0.005,
-    "issue_discovery_share": 0.0
-  },
   "touchpilot/touchpilot": {
-    "emission_share": 0.01,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "type: bug": 1.1,
@@ -332,42 +341,5 @@
       "type: test": 1.2
     },
     "maintainer_cut": 0.3
-  },
-  "we-promise/sure": {
-    "emission_share": 0.03,
-    "issue_discovery_share": 0.0,
-    "label_multipliers": {
-      "performance": 1.5,
-      "mobile/Flutter": 1.2
-    },
-    "maintainer_cut": 0.3
-  },
-  "e35dev/live-bittensor-emissions-leaderboard": {
-    "emission_share": 0.005,
-    "issue_discovery_share": 0,
-    "additional_acceptable_branches": [
-      "test"
-    ],
-    "trusted_label_pipeline": true,
-    "default_label_multiplier": 0,
-    "label_multipliers": {
-      "feature": 3,
-      "ui-ux": 2,
-      "bug": 0.625,
-      "security": 0.625,
-      "other": 0.1
-    },
-    "eligibility": {
-      "min_credibility": 0.6
-    },
-    "scoring": {
-      "pr_lookback_days": 7,
-      "time_decay": {
-        "grace_period_hours": 6,
-        "sigmoid_midpoint_days": 2,
-        "sigmoid_steepness": 1,
-        "min_multiplier": 0.02
-      }
-    }
   }
 }


### PR DESCRIPTION
Suggestive emission-share rebalance on realized progress since #1500 (merged 2026-06-18) and forward outlook, plus one addition (sparkinfer) and several delistings. Subnet price 0.00481 TAO/ALPHA, TAO $215.20.

**Baseline anchor for next run:** rebalance commit `c97bb55` (base `origin/test` @ `7bca4c7`).

## Rebalances
| repo | old | new | est. $/day (old→new) |
|---|---:|---:|---|
| gittensor-ai-lab/sparkinfer | 0.0 | 0.1 | $0 → $1,145 |
| JSONbored/metagraphed | 0.0075 | 0.25 | $86 → $2,864 |
| JSONbored/gittensory | 0.013 | 0.1 | $149 → $1,145 |
| phase-rs/phase | 0.018 | 0.02 | $206 → $229 |
| MkDev11/gittensor-hub | 0.008 | 0.005 | $92 → $57 |
| cogniax/tao-pulse-app | 0.008 | 0.0 | $92 → $0 |
| DPBG/Engram.AI | 0.005 | 0.0 | $57 → $0 |
| touchpilot/touchpilot | 0.01 | 0.0 | $115 → $0 |
| vouchdev/vouch | 0.01 | 0.0 | $115 → $0 |
| infiniflow/ragflow | 0.055 | delisted | $630 → $0 |
| seroperson/jvm-live-reload | 0.005 | delisted | $57 → $0 |
| we-promise/sure | 0.03 | delisted | $344 → $0 |
| e35dev/live-bittensor-emissions-leaderboard | 0.005 | delisted | $57 → $0 |

## Totals
- Previous: `0.3745` (headroom 0.6255)
- New: `0.6990` (headroom 0.3010)

## Added
- **gittensor-ai-lab/sparkinfer** — https://github.com/gittensor-ai-lab/sparkinfer — `0.10`, starting on `entrius/oc-1` default hyperparameters.

## Reduced — no social media presence / activity (kept listed at 0%)
- **cogniax/tao-pulse-app** — `0.008 → 0.0`
- **DPBG/Engram.AI** — `0.005 → 0.0`
- **touchpilot/touchpilot** — `0.01 → 0.0` — only a Discord server, no public-posting socials.
- **vouchdev/vouch** — `0.01 → 0.0`
- **MkDev11/gittensor-hub** — `0.008 → 0.005` — no social media presence/activity, and not responding to questions in the main Bittensor chat.

## Delisted — not aligned with gittensor and/or inactive
- **infiniflow/ragflow** — was `0.055`
- **seroperson/jvm-live-reload** — was `0.005`
- **we-promise/sure** — was `0.03`
- **e35dev/live-bittensor-emissions-leaderboard** — was `0.005`

## Increased
- **JSONbored/metagraphed** — `0.0075 → 0.25`
- **JSONbored/gittensory** — `0.013 → 0.1`
- **phase-rs/phase** — `0.018 → 0.02`

## Maintainer-owned (weights only)
- **anderdc/social-media-manager** — `0.005 → 0.004`
- **e35ventura/taopedia** — `0.025 → 0.05`
