### PR TITLE
Fix merged PRs with a missing base_ref being dropped in OSS scoring

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -736,12 +736,9 @@ def _classify_issue(issue: MirrorIssue, repo_config: Optional[RepositoryConfig])
         return 'not-solved-closed'
 
     # Branch-eligibility parity with OSS PR scoring: a solving PR merged into a
-    # non-acceptable branch must not earn discovery credit (the same PR would be
-    # rejected by _should_skip_merged_mirror_pr on the contribution path).
-    # Gate only when base_ref is present: the mirror began exposing branch
-    # metadata on the inline solving_pr after this field existed, so a null
-    # base_ref means pre-backfill data and falls through rather than blocking.
-    if repo_config is not None and sp.base_ref is not None:
+    # non-acceptable branch must not earn discovery credit. The gate itself
+    # falls through on missing metadata (e.g. a null base_ref), so no guard here.
+    if repo_config is not None:
         skip, reason = check_merged_branch_eligibility(
             pr_number=sp.pr_number,
             repo_full_name=issue.repo_full_name,

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -207,14 +207,14 @@ def check_merged_branch_eligibility(
     issue discovery so both reject the same non-acceptable-branch merges.
 
     Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
-    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
-    check rather than false-positive-blocking on older data.
+    ``main``; missing ``base_ref``/``head_ref``/``head_repo_full_name`` skips the
+    corresponding check rather than false-positive-blocking on older data.
     """
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
-    # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    # base_ref check — skip when absent (pre-backfill data) rather than block.
+    if base_ref is not None and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable
@@ -251,8 +251,9 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
 
     When the mirror response is missing a field (older data predating the
     schema additions), some checks fall through rather than false-positive-
-    blocking. Concretely: missing ``head_ref`` or ``head_repo_full_name`` skips
-    the head_ref check. Missing ``default_branch`` falls back to ``main``.
+    blocking. Concretely: missing ``base_ref`` skips the base_ref check; missing
+    ``head_ref`` or ``head_repo_full_name`` skips the head_ref check; missing
+    ``default_branch`` falls back to ``main``.
     """
     pr = scored.pr
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -54,7 +54,7 @@ def _pr(
     author_login: str = 'bittoby',
     merged_by_login: str | None = 'anderdc',
     author_association: str = 'CONTRIBUTOR',
-    base_ref: str = 'main',
+    base_ref: str | None = 'main',
     head_ref: str | None = 'feature/foo',
     head_repo_full_name: str | None = 'entrius/gittensor-ui',
     default_branch: str | None = 'main',
@@ -211,6 +211,14 @@ class TestEligibilityGate:
         scored = ScoredPR(pr=_pr(base_ref='main', default_branch=None))
         skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
         assert skip is False
+
+    def test_missing_base_ref_falls_through(self):
+        # Pre-backfill mirror data has no base_ref; the gate must not block it
+        # (parity with the issue-discovery path, which already falls through).
+        scored = ScoredPR(pr=_pr(base_ref=None, default_branch='main'))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
+        assert skip is False
+        assert reason is None
 
     def test_head_ref_in_additional_blocks_same_repo(self):
         scored = ScoredPR(


### PR DESCRIPTION
## Summary

On the OSS contribution path, `check_merged_branch_eligibility` coerced a null `base_ref` to an empty string (`base_ref or ''`), and the empty string never matches an acceptable branch pattern. As a result, any merged PR with a missing `base_ref` was rejected as a non acceptable branch merge and dropped at load time, so the miner silently lost the score for that PR.

This is the missing `base_ref` side of the same gate touched by #958 and #963. #963 fixed the under blocking case by making the acceptable set fall back to `'main'` and dropping the `if acceptable` guard, which left the base ref check always running. The leftover `base_ref or ''` coercion then turned a null `base_ref` into an over blocking case. This change closes that gap.

The issue discovery path already guarded against a null `base_ref` and treated it as pre-backfill data that should fall through. The null handling now lives inside the shared `check_merged_branch_eligibility` so both paths behave identically, and the now redundant guard in the issue discovery path is removed so the logic lives in one place.

PRs that do carry a `base_ref` are unaffected: matches, mismatches, wildcards, and the default branch fallback all behave exactly as before, so the #958 fix is fully preserved.

## Related Issues

Closes #1525 
Relates to #958, #963

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `test_missing_base_ref_falls_through` on the OSS path, mirroring the existing issue discovery coverage. Verified that the new test fails against the original source and passes with the fix. The #958 regression test (`test_no_default_branch_no_additional_blocks_non_main_base_ref`) still passes, confirming non acceptable concrete base refs remain blocked. All 156 tests across the affected modules pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)