### PR TITLE
Register e35dev/podcast-design-canvas

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -341,5 +341,37 @@
       "type: test": 1.2
     },
     "maintainer_cut": 0.3
+  },
+  "e35dev/podcast-design-canvas": {
+    "emission_share": 0.301,
+    "issue_discovery_share": 0,
+    "maintainer_cut": 0,
+    "trusted_label_pipeline": true,
+    "default_label_multiplier": 0,
+    "label_multipliers": {
+      "episode-ingest": 3,
+      "preset-styles": 2.5,
+      "canvas-editor": 2.5,
+      "audio-captions": 2,
+      "contextual-visuals": 2,
+      "template-system": 1.75,
+      "export-publish": 1.75,
+      "product-polish": 1.5,
+      "bugfix": 1,
+      "infrastructure": 0.5
+    },
+    "eligibility": {
+      "min_credibility": 0.6,
+      "max_open_pr_threshold": 4
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 6,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1,
+        "min_multiplier": 0.02
+      }
+    }
   }
 }


### PR DESCRIPTION
Registers `e35dev/podcast-design-canvas` in the Gittensor master repository registry, targeting `test` (contributor work stays on the repo's own `main`).

- **emission_share: 0.301** — consumes the remaining headroom after the community rebalance (#1523), bringing total allocated emissions to **1.0**.
- `maintainer_cut: 0`
- `trusted_label_pipeline: true`, `default_label_multiplier: 0` (unlisted labels score 0)
- main-only (no `additional_acceptable_branches`)

Repo-maintainer label multipliers: `episode-ingest`, `preset-styles`, `canvas-editor`, `audio-captions`, `contextual-visuals`, `template-system`, `export-publish`, `product-polish`, `bugfix`, `infrastructure`.
