### PR TITLE
fix(github): stop retrying permanent GraphQL client errors

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -84,13 +84,27 @@ def _is_rate_limited_response(response: requests.Response) -> bool:
         return True
     if response.status_code != 403:
         return False
-    if response.headers.get('x-ratelimit-remaining') == '0':
+    # Rate limits and abuse detection are transient: signalled by a Retry-After
+    # header, an exhausted budget, or a rate-limit/abuse message.
+    if response.headers.get('retry-after') or response.headers.get('x-ratelimit-remaining') == '0':
         return True
     try:
         message = str(response.json().get('message', '')).lower()
     except Exception:
         message = getattr(response, 'text', '').lower()
-    return 'rate limit' in message
+    return 'rate limit' in message or 'abuse' in message
+
+
+def _is_retryable_response(response: requests.Response) -> bool:
+    """Whether a non-200 response is transient and worth retrying.
+
+    Timeouts and rate limiting are transient; every other client error is
+    permanent, so the caller can fail fast instead of looping on backoff.
+    """
+    status = response.status_code
+    if status == 408 or _is_rate_limited_response(response):
+        return True
+    return not (400 <= status < 500)
 
 
 def get_github_identity(token: str) -> GitHubIdentityResult:
@@ -133,16 +147,7 @@ def get_github_identity(token: str) -> GitHubIdentityResult:
                     continue
                 return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
-            if response.status_code == 408 or _is_rate_limited_response(response):
-                bt.logging.warning(
-                    f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
-                )
-                if attempt < 5:
-                    time.sleep(2)
-                    continue
-                return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
-
-            if 400 <= response.status_code < 500:
+            if not _is_retryable_response(response):
                 bt.logging.warning(f'GitHub /user auth failed with status {response.status_code}')
                 return GitHubIdentityResult(None, GitHubIdentityStatus.INVALID_AUTH)
 
@@ -151,6 +156,8 @@ def get_github_identity(token: str) -> GitHubIdentityResult:
             )
             if attempt < 5:
                 time.sleep(2)
+                continue
+            return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
         except Exception as e:
             bt.logging.warning(f'Could not fetch GitHub user (attempt {attempt + 1}/6): {e}')
@@ -355,7 +362,7 @@ def execute_graphql_query(
         query: The GraphQL query string
         variables: Query variables
         token: GitHub PAT for authentication
-        max_attempts: Maximum retry attempts (default 6)
+        max_attempts: Maximum retry attempts (default 8)
         timeout: Request timeout in seconds (default 30)
 
     Returns:
@@ -376,7 +383,14 @@ def execute_graphql_query(
             if response.status_code == 200:
                 return response.json()
 
-            # Retry on failure
+            # Permanent client errors can't be fixed by retrying — fail fast.
+            if not _is_retryable_response(response):
+                bt.logging.warning(
+                    f'GraphQL request failed with non-retryable status {response.status_code}: {response.text}'
+                )
+                return None
+
+            # Transient failure — retry with backoff.
             if attempt < (max_attempts - 1):
                 backoff_delay = backoff_seconds(attempt)
                 bt.logging.warning(

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -144,6 +144,110 @@ class TestExecuteGraphQLQueryRetryLogic:
         mock_sleep.assert_has_calls(expected_delays)
         assert mock_sleep.call_count == 7
 
+    @patch('gittensor.utils.github_api_tools.get_session')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_auth_failure_fails_fast_without_retry(self, mock_logging, mock_sleep, mock_get_session):
+        """A 401 (bad/revoked token) returns None immediately without burning the retry budget."""
+        mock_response = Mock(status_code=401, text='Bad credentials')
+        mock_session = Mock()
+        mock_session.post.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        result = execute_graphql_query('query {}', {}, 'bad_token', max_attempts=8)
+
+        assert result is None
+        mock_sleep.assert_not_called()
+        assert mock_session.post.call_count == 1
+
+    @patch('gittensor.utils.github_api_tools.get_session')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_forbidden_without_rate_limit_fails_fast(self, mock_logging, mock_sleep, mock_get_session):
+        """A 403 that is not a rate-limit signal is permanent and not retried."""
+        mock_response = Mock(status_code=403, text='Forbidden', headers={})
+        mock_response.json.return_value = {'message': 'Resource not accessible by personal access token'}
+        mock_session = Mock()
+        mock_session.post.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        result = execute_graphql_query('query {}', {}, 'token', max_attempts=8)
+
+        assert result is None
+        mock_sleep.assert_not_called()
+        assert mock_session.post.call_count == 1
+
+    @patch('gittensor.utils.github_api_tools.get_session')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_rate_limited_403_is_retried(self, mock_logging, mock_sleep, mock_get_session):
+        """A 403 rate-limit response is transient and retried to exhaustion."""
+        mock_response = Mock(status_code=403, text='rate limit exceeded', headers={'x-ratelimit-remaining': '0'})
+        mock_session = Mock()
+        mock_session.post.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        result = execute_graphql_query('query {}', {}, 'token', max_attempts=3)
+
+        assert result is None
+        assert mock_session.post.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch('gittensor.utils.github_api_tools.get_session')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_secondary_rate_limit_403_is_retried(self, mock_logging, mock_sleep, mock_get_session):
+        """A secondary rate limit / abuse-detection 403 (Retry-After header, no rate-limit
+        text) is transient and must keep being retried, not dropped by the fast-fail path."""
+        mock_response = Mock(
+            status_code=403,
+            text='You have triggered an abuse detection mechanism',
+            headers={'retry-after': '60'},
+        )
+        mock_response.json.return_value = {'message': 'You have triggered an abuse detection mechanism'}
+        mock_session = Mock()
+        mock_session.post.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        result = execute_graphql_query('query {}', {}, 'token', max_attempts=3)
+
+        assert result is None
+        assert mock_session.post.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch('gittensor.utils.github_api_tools.get_session')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_server_error_is_retried(self, mock_logging, mock_sleep, mock_get_session):
+        """A 5xx server error is transient and retried to exhaustion."""
+        mock_response = Mock(status_code=502, text='Bad Gateway')
+        mock_session = Mock()
+        mock_session.post.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        result = execute_graphql_query('query {}', {}, 'token', max_attempts=3)
+
+        assert result is None
+        assert mock_session.post.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch('gittensor.utils.github_api_tools.get_session')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_success_returns_parsed_json(self, mock_logging, mock_sleep, mock_get_session):
+        """A 200 returns the parsed body on the first attempt."""
+        mock_response = Mock(status_code=200)
+        mock_response.json.return_value = {'data': {'ok': True}}
+        mock_session = Mock()
+        mock_session.post.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        result = execute_graphql_query('query {}', {}, 'token', max_attempts=3)
+
+        assert result == {'data': {'ok': True}}
+        mock_sleep.assert_not_called()
+        assert mock_session.post.call_count == 1
+
 
 # ============================================================================
 # PR Discovery Fallback Tests


### PR DESCRIPTION
## Summary

`execute_graphql_query` retried on any response other than 200, so a permanent client failure such as bad credentials or forbidden access consumed the entire retry budget on backoff sleeps before returning `None`. No retry can change the outcome of those errors, and the REST helpers in the same module already fail fast on them.

This change adds a shared `_is_retryable_response` helper. Transient conditions (rate limiting, request timeout, and server errors) keep being retried with backoff, while permanent client errors return immediately with the real status logged. `get_github_identity` now reuses the same helper, which removes the duplicated status handling it carried before. `_is_rate_limited_response` also recognizes secondary rate limits and abuse detection through the `Retry-After` header or the response message, so those stay retryable.

## Related Issues

Fixes #1528 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

Added cases in `tests/utils/test_github_api_tools.py` covering fast fail on auth and forbidden responses, continued retries for rate limiting, secondary rate limits, abuse detection, and server errors, plus the success path. The full module suite and the related validator suites pass (94 tests).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)