### PR TITLE
Tune JSONbored repo weights: maintainer cut, credibility, slop label

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -186,7 +186,8 @@
     "label_multipliers": {
       "gittensor:bug": 0.5,
       "gittensor:feature": 1.25,
-      "gittensor:priority": 1.75
+      "gittensor:priority": 1.75,
+      "slop": 0.0
     },
     "eligibility": {
       "min_credibility": 0.5
@@ -214,7 +215,8 @@
     "label_multipliers": {
       "gittensor:bug": 0.5,
       "gittensor:feature": 1.25,
-      "gittensor:priority": 1.75
+      "gittensor:priority": 1.75,
+      "slop": 0.0
     },
     "eligibility": {
       "min_credibility": 0.6
@@ -242,10 +244,11 @@
     "label_multipliers": {
       "gittensor:bug": 0.5,
       "gittensor:feature": 1.5,
-      "gittensor:priority": 2.5
+      "gittensor:priority": 2.5,
+      "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.5
+      "min_credibility": 0.6
     },
     "maintainer_cut": 0.5,
     "scoring": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -247,7 +247,7 @@
     "eligibility": {
       "min_credibility": 0.5
     },
-    "maintainer_cut": 0.25,
+    "maintainer_cut": 0.5,
     "scoring": {
       "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,


### PR DESCRIPTION
Tunes weights config for the three JSONbored repos. Based on current `test`; `emission_share` and unrelated fields untouched.

- **JSONbored/metagraphed**: `maintainer_cut` 0.25 → 0.5; `min_credibility` 0.5 → 0.6; add `slop` label (0x).
- **JSONbored/gittensory**: add `slop` label (0x). (credibility 0.6 and maintainer_cut 0.5 already on target.)
- **JSONbored/awesome-claude**: add `slop` label (0x). (credibility 0.5 and maintainer_cut 0.5 already on target.)

Net: all three share `maintainer_cut` 0.5 and a `slop` 0x multiplier; credibility 0.6 everywhere except awesome-claude (0.5). Single-file change to `master_repositories.json`.