### PR TITLE
sparkinfer: map label_multipliers to the repo's eval:* labels; set maintainer_cut 0.30

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -173,9 +173,16 @@
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "benchmark-improvement": 1.0
+      "eval:XL": 4.0,
+      "eval:L": 2.5,
+      "eval:M": 1.5,
+      "eval:S": 1.0,
+      "eval:XS": 0.5,
+      "eval:BASELINE": 1.0,
+      "eval:none": 0.0,
+      "eval:REJECT": 0.0
     },
-    "maintainer_cut": 0.0,
+    "maintainer_cut": 0.3,
     "trusted_label_pipeline": true
   },
   "JSONbored/awesome-claude": {


### PR DESCRIPTION
## What

Two changes to the `gittensor-ai-lab/sparkinfer` entry in `master_repositories.json`.

**1. `label_multipliers` — align with the labels the repo's PR-eval bot actually applies.**

The repo's eval bot labels each merged PR `eval:<tier>` by its measured speedup tier over the live performance frontier. The current entry configures only `benchmark-improvement`, which the bot never applies — so with `default_label_multiplier: 0.0`, every merged PR currently resolves to a 0 multiplier. This maps the real labels:

| label | multiplier | meaning |
|---|--:|---|
| `eval:XL` | 4.0 | largest verified frontier-delta speedup |
| `eval:L` | 2.5 | |
| `eval:M` | 1.5 | |
| `eval:S` | 1.0 | |
| `eval:XS` | 0.5 | smallest verified speedup |
| `eval:BASELINE` | 1.0 | first verified entry (establishes a new frontier) |
| `eval:none` | 0.0 | correct, but no verified improvement |
| `eval:REJECT` | 0.0 | failed the correctness gate |

**2. `maintainer_cut`: `0.0 → 0.30`.**

## Scope

Only `label_multipliers` and `maintainer_cut` change. `emission_share` (0.1) and all other fields are untouched; total `emission_share` across the registry stays at 1.0.
