### PR TITLE
refactor(validator): reuse uid_index map for treasury/recycle lookups in blend_emission_pools

### DIFF
--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -58,7 +58,7 @@ def blend_emission_pools(
 
     # Issue treasury (10% flat to UID 111)
     if ISSUES_TREASURY_UID > 0 and ISSUES_TREASURY_UID in miner_uids:
-        treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
+        treasury_idx = uid_index[ISSUES_TREASURY_UID]
         rewards[treasury_idx] += ISSUES_TREASURY_EMISSION_SHARE
         bt.logging.info(
             f'Treasury allocation: UID {ISSUES_TREASURY_UID} receives '
@@ -67,7 +67,7 @@ def blend_emission_pools(
 
     # Recycle receives registry slack and empty repo slices.
     if RECYCLE_UID in miner_uids:
-        recycle_idx = sorted_uids.index(RECYCLE_UID)
+        recycle_idx = uid_index[RECYCLE_UID]
         rewards[recycle_idx] += recycle_share
         if recycle_share > EMISSION_SHARE_TOLERANCE:
             bt.logging.info(f'Recycling {recycle_share * 100:.0f}% unclaimed emissions from repo allocation')


### PR DESCRIPTION
## Summary

`blend_emission_pools()` (in `gittensor/validator/emission_allocation.py`) builds a `uid_index` map for O(1) UID → reward-row lookups and already uses it for every maintainer / PR / issue-discovery reward write (lines 53, 55, 57).

The two flat allocations — the issue treasury and the recycle slice — instead fell back to `sorted_uids.index(...)`, an O(n) linear scan, to resolve the *same* row index. This change makes them reuse the existing `uid_index` map.

```diff
-        treasury_idx = sorted_uids.index(ISSUES_TREASURY_UID)
+        treasury_idx = uid_index[ISSUES_TREASURY_UID]
...
-        recycle_idx = sorted_uids.index(RECYCLE_UID)
+        recycle_idx = uid_index[RECYCLE_UID]
```

**Why this is behavior-preserving:** both branches are already guarded by membership checks (`ISSUES_TREASURY_UID in miner_uids` and `RECYCLE_UID in miner_uids`), and `sorted_uids == sorted(miner_uids)` holds unique values. So the looked-up UID is always a key in `uid_index`, and `uid_index[uid]` returns the identical integer index that `sorted_uids.index(uid)` would. No output, ordering, or value changes — it only removes the last two O(n) scans on the allocation path and makes the lookup strategy consistent throughout the function.

## Related Issues

<!-- none -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

No new tests needed — the change is behavior-identical and fully covered by the existing `tests/validator/test_blend_emission_pools.py` suite (treasury, recycle, registry-slack, and compatibility paths).

- `uv run pytest tests/validator/test_blend_emission_pools.py` → 35 passed
- `uv run pytest` (full suite) → 937 passed
- `uv run pyright` → 0 errors
- `uv run ruff check` / `ruff format --check` → clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

---

cc @anderdc @landyndev for review — small, self-contained, behavior-preserving refactor with no CLI/output impact. Happy to adjust scope or wording.
