### PR TITLE
Honor GitHub rate limit reset headers when backing off API retries

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -22,6 +22,9 @@ NETWORK_MAP = {
 # =============================================================================
 BASE_GITHUB_API_URL = 'https://api.github.com'
 GITHUB_HTTP_TIMEOUT_SECONDS = 15
+
+# Longest we will sleep to wait out a GitHub rate limit before deferring to a later cycle.
+GITHUB_RATE_LIMIT_MAX_WAIT_SECONDS = 300
 GRAPHQL_VIEWER_QUERY = '{ viewer { login } }'
 # 1MB max file size for github api file fetches. Files exceeding this get no score.
 MAX_FILE_SIZE_BYTES = 1_000_000

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -11,6 +11,7 @@ import requests
 from gittensor.constants import (
     BASE_GITHUB_API_URL,
     GITHUB_HTTP_TIMEOUT_SECONDS,
+    GITHUB_RATE_LIMIT_MAX_WAIT_SECONDS,
 )
 from gittensor.utils.models import PRInfo
 from gittensor.utils.utils import backoff_seconds
@@ -93,6 +94,64 @@ def _is_rate_limited_response(response: requests.Response) -> bool:
     return 'rate limit' in message
 
 
+def _rate_limit_retry_after_seconds(response: requests.Response, now: Optional[float] = None) -> Optional[int]:
+    """Seconds GitHub asks us to wait before retrying a rate-limited response.
+
+    Reads ``Retry-After`` (seconds, sent on secondary rate limits) first, then
+    falls back to ``x-ratelimit-reset`` (epoch seconds, sent once the primary
+    quota is exhausted). Returns None when neither header yields a usable value
+    so callers can fall back to their default backoff.
+
+    Args:
+        response (requests.Response): The rate-limited GitHub response.
+        now (Optional[float]): Current epoch seconds; defaults to ``time.time()``.
+            Injectable for tests.
+
+    Returns:
+        Optional[int]: Non-negative seconds to wait, or None when unavailable.
+    """
+    retry_after = response.headers.get('Retry-After')
+    if retry_after is not None:
+        try:
+            return max(0, int(float(retry_after)))
+        except (TypeError, ValueError):
+            pass
+
+    reset = response.headers.get('x-ratelimit-reset')
+    if reset is not None:
+        try:
+            current = time.time() if now is None else now
+            return max(0, int(float(reset) - current))
+        except (TypeError, ValueError):
+            pass
+
+    return None
+
+
+def _rate_limit_delay(response: requests.Response, fallback_delay: float) -> Optional[float]:
+    """Seconds to sleep for a rate-limited response, or None to stop retrying.
+
+    Honors GitHub's advertised wait when present: a window within
+    ``GITHUB_RATE_LIMIT_MAX_WAIT_SECONDS`` returns that many seconds, while a
+    longer window returns None so the caller defers the work to a later cycle
+    instead of sleeping through a window it cannot wait out. Falls back to
+    ``fallback_delay`` when GitHub advertises no wait hint.
+
+    Args:
+        response (requests.Response): The rate-limited GitHub response.
+        fallback_delay (float): Delay to use when no rate-limit header is present.
+
+    Returns:
+        Optional[float]: Seconds to sleep, or None to abort retrying.
+    """
+    advertised = _rate_limit_retry_after_seconds(response)
+    if advertised is None:
+        return fallback_delay
+    if advertised > GITHUB_RATE_LIMIT_MAX_WAIT_SECONDS:
+        return None
+    return advertised
+
+
 def get_github_identity(token: str) -> GitHubIdentityResult:
     """Get GitHub numeric user id and whether lookup failure is cacheable.
 
@@ -133,10 +192,19 @@ def get_github_identity(token: str) -> GitHubIdentityResult:
                     continue
                 return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
 
-            if response.status_code == 408 or _is_rate_limited_response(response):
-                bt.logging.warning(
-                    f'GitHub /user request failed with status {response.status_code} (attempt {attempt + 1}/6)'
-                )
+            if _is_rate_limited_response(response):
+                delay = _rate_limit_delay(response, 2)
+                if delay is None:
+                    bt.logging.warning('GitHub /user rate limit window exceeds cap; deferring lookup to a later cycle')
+                    return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+                bt.logging.warning(f'GitHub /user rate limited (attempt {attempt + 1}/6), waiting {delay:.0f}s')
+                if attempt < 5:
+                    time.sleep(delay)
+                    continue
+                return GitHubIdentityResult(None, GitHubIdentityStatus.TRANSIENT_FAILURE)
+
+            if response.status_code == 408:
+                bt.logging.warning(f'GitHub /user request timed out (attempt {attempt + 1}/6)')
                 if attempt < 5:
                     time.sleep(2)
                     continue
@@ -375,6 +443,21 @@ def execute_graphql_query(
 
             if response.status_code == 200:
                 return response.json()
+
+            if _is_rate_limited_response(response):
+                delay = _rate_limit_delay(response, backoff_seconds(attempt))
+                if delay is None:
+                    bt.logging.warning('GitHub GraphQL rate limit window exceeds cap; deferring retry to a later cycle')
+                    return None
+                if attempt < (max_attempts - 1):
+                    bt.logging.warning(
+                        f'GraphQL rate limited (attempt {attempt + 1}/{max_attempts}), '
+                        f'waiting {delay:.0f}s before retry...'
+                    )
+                    time.sleep(delay)
+                    continue
+                bt.logging.error(f'GraphQL rate limited after {max_attempts} attempts')
+                return None
 
             # Retry on failure
             if attempt < (max_attempts - 1):

--- a/tests/utils/test_github_api_rate_limit.py
+++ b/tests/utils/test_github_api_rate_limit.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""
+Unit tests for GitHub rate-limit aware retry backoff in github_api_tools.
+
+Covers the header parsing helpers and the retry loops in get_github_identity and
+execute_graphql_query honoring Retry-After / x-ratelimit-reset, capping the wait,
+and deferring to a later cycle when the advertised window exceeds the cap.
+
+Note: These tests require the full gittensor package to be importable.
+Run with: python run_tests.py tests/utils/
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+github_api_tools = pytest.importorskip(
+    'gittensor.utils.github_api_tools', reason='Requires gittensor package with all dependencies'
+)
+
+_rate_limit_retry_after_seconds = github_api_tools._rate_limit_retry_after_seconds
+_rate_limit_delay = github_api_tools._rate_limit_delay
+get_github_identity = github_api_tools.get_github_identity
+execute_graphql_query = github_api_tools.execute_graphql_query
+GitHubIdentityStatus = github_api_tools.GitHubIdentityStatus
+CAP = github_api_tools.GITHUB_RATE_LIMIT_MAX_WAIT_SECONDS
+
+
+def _response(status_code, headers=None, json_data=None):
+    """Build a mock requests.Response with the given status, headers, and JSON body."""
+    response = Mock(status_code=status_code)
+    response.headers = headers or {}
+    if json_data is not None:
+        response.json.return_value = json_data
+    return response
+
+
+class TestRateLimitRetryAfterSeconds:
+    """Header parsing for the advertised rate-limit wait."""
+
+    def test_reads_retry_after_seconds(self):
+        response = _response(429, {'Retry-After': '42'})
+        assert _rate_limit_retry_after_seconds(response) == 42
+
+    def test_reads_ratelimit_reset_with_injected_now(self):
+        response = _response(403, {'x-ratelimit-reset': '1030'})
+        assert _rate_limit_retry_after_seconds(response, now=1000) == 30
+
+    def test_reset_in_the_past_clamps_to_zero(self):
+        response = _response(403, {'x-ratelimit-reset': '990'})
+        assert _rate_limit_retry_after_seconds(response, now=1000) == 0
+
+    def test_retry_after_takes_precedence_over_reset(self):
+        response = _response(429, {'Retry-After': '5', 'x-ratelimit-reset': '9999'})
+        assert _rate_limit_retry_after_seconds(response, now=0) == 5
+
+    def test_no_headers_returns_none(self):
+        assert _rate_limit_retry_after_seconds(_response(429, {})) is None
+
+    def test_malformed_headers_return_none(self):
+        response = _response(429, {'Retry-After': 'soon'})
+        assert _rate_limit_retry_after_seconds(response) is None
+
+
+class TestRateLimitDelay:
+    """Wait selection, cap enforcement, and fallback."""
+
+    def test_within_cap_returns_advertised(self):
+        response = _response(429, {'Retry-After': str(CAP - 1)})
+        assert _rate_limit_delay(response, fallback_delay=2) == CAP - 1
+
+    def test_over_cap_returns_none_to_abort(self):
+        response = _response(429, {'Retry-After': str(CAP + 1)})
+        assert _rate_limit_delay(response, fallback_delay=2) is None
+
+    def test_falls_back_when_no_header(self):
+        assert _rate_limit_delay(_response(429, {}), fallback_delay=7) == 7
+
+
+class TestGetGithubIdentityRateLimit:
+    """get_github_identity honors the advertised wait and defers long windows."""
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_waits_retry_after_then_succeeds(self, mock_logging, mock_sleep, mock_get):
+        mock_get.side_effect = [
+            _response(429, {'Retry-After': '5'}),
+            _response(200, json_data={'id': 12345}),
+        ]
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id == '12345'
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once_with(5)
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_defers_when_window_exceeds_cap(self, mock_logging, mock_sleep, mock_get):
+        mock_get.return_value = _response(429, {'Retry-After': str(CAP + 9999)})
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id is None
+        assert result.status is GitHubIdentityStatus.TRANSIENT_FAILURE
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch('gittensor.utils.github_api_tools.requests.get')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_falls_back_to_flat_delay_without_header(self, mock_logging, mock_sleep, mock_get):
+        mock_get.side_effect = [
+            _response(429, {}),
+            _response(200, json_data={'id': 777}),
+        ]
+
+        result = get_github_identity('fake_token')
+
+        assert result.github_id == '777'
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once_with(2)
+
+
+class TestExecuteGraphqlQueryRateLimit:
+    """execute_graphql_query honors the advertised wait and defers long windows."""
+
+    @patch('gittensor.utils.github_api_tools.requests.post')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_waits_retry_after_then_succeeds(self, mock_logging, mock_sleep, mock_post):
+        mock_post.side_effect = [
+            _response(429, {'Retry-After': '5'}),
+            _response(200, json_data={'data': {'ok': True}}),
+        ]
+
+        result = execute_graphql_query('query {}', {}, 'fake_token')
+
+        assert result == {'data': {'ok': True}}
+        assert mock_post.call_count == 2
+        mock_sleep.assert_called_once_with(5)
+
+    @patch('gittensor.utils.github_api_tools.requests.post')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_defers_when_window_exceeds_cap(self, mock_logging, mock_sleep, mock_post):
+        mock_post.return_value = _response(429, {'Retry-After': str(CAP + 9999)})
+
+        result = execute_graphql_query('query {}', {}, 'fake_token')
+
+        assert result is None
+        assert mock_post.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
Closes #1531

GitHub publishes the exact wait on a rate-limited response (`Retry-After` on secondary limits, `x-ratelimit-reset` once the primary quota is exhausted). The retry paths in `github_api_tools.py` ignored these: `get_github_identity` slept a flat 2s and `execute_graphql_query` used a generic 30s-capped backoff, so a lookup could burn its whole attempt budget during a window a single correctly sized wait would have cleared.

This reads those headers and waits the advertised window, bounded by `GITHUB_RATE_LIMIT_MAX_WAIT_SECONDS` (300s). When the window exceeds the cap it stops retrying and lets a later cycle pick up the work instead of sleeping through a window it cannot wait out. Falls back to the existing backoff when neither header is present.

- `get_github_identity`: split rate-limit handling out of the 408 branch
- `execute_graphql_query`: honor rate-limit headers before the generic backoff
- new helpers `_rate_limit_retry_after_seconds` / `_rate_limit_delay`

Tests: `tests/utils/test_github_api_rate_limit.py` covers header parsing, the cap and fallback, and the retry-loop behavior for both functions. Existing `github_api_tools` tests still pass.
