### PR TITLE
find_prs_for_issue: preserve lookup failure instead of reporting zero submissions

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -270,10 +270,15 @@ def fetch_open_issue_pull_requests(
                 token=token or None,
                 open_only=True,
             )
-            # Intentionally return GitHub tool output as-is (no CLI schema mapping yet).
-            return prs
     except Exception as e:
         raise click.ClickException(f'Failed to fetch PR submissions from GitHub: {e}')
+
+    if prs is None:
+        raise click.ClickException(
+            'GitHub PR submission lookup failed (rate limit or transient error). Try again shortly.'
+        )
+    # Intentionally return GitHub tool output as-is (no CLI schema mapping yet).
+    return prs
 
 
 def print_issue_submission_table(

--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -329,14 +329,19 @@ def find_prs_for_issue(
     issue_number: int,
     open_only: bool = True,
     token: Optional[str] = None,
-) -> List[PRInfo]:
-    """Find PRs that reference an issue via GraphQL cross-reference data."""
+) -> Optional[List[PRInfo]]:
+    """Find PRs that reference an issue via GraphQL cross-reference data.
+
+    Returns a (possibly empty) list of submissions, or None when the lookup
+    could not be completed (rate limit, network error, GraphQL errors) so
+    callers can distinguish a failed lookup from a genuinely empty result.
+    """
     if token:
         try:
-            prs = _search_issue_referencing_prs_graphql(repo, issue_number, token, open_only=open_only)
-            return prs or []
+            return _search_issue_referencing_prs_graphql(repo, issue_number, token, open_only=open_only)
         except Exception as exc:
             bt.logging.debug(f'GraphQL PR fetch failed for {repo}#{issue_number}: {exc}')
+            return None
 
     return []
 

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -149,3 +149,23 @@ def test_submissions_help_via_issue_alias_routes_to_command_help(cli_root, runne
     assert 'On-chain issue ID' in result.output
     assert '--id' in result.output
     assert '--logging.debug' not in result.output
+
+
+def test_submissions_json_reports_lookup_failure(cli_root, runner, sample_issue):
+    """A failed GitHub lookup is reported as an error, not a successful empty result (#1492)."""
+    with (
+        patch('gittensor.cli.issue_commands.submissions.get_contract_address', return_value='0xabc'),
+        patch('gittensor.cli.issue_commands.submissions.resolve_network', return_value=('ws://x', 'test')),
+        patch('gittensor.cli.issue_commands.submissions.fetch_issue_from_contract', return_value=sample_issue),
+        patch('gittensor.utils.github_api_tools.find_prs_for_issue', return_value=None),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'submissions', '--id', '42', '--json'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert 'error' in payload

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -172,12 +172,24 @@ def test_find_prs_returns_empty_when_graphql_empty(mock_graphql):
 
 
 @patch('gittensor.utils.github_api_tools._search_issue_referencing_prs_graphql')
-def test_find_prs_returns_empty_when_graphql_errors(mock_graphql):
+def test_find_prs_returns_none_when_graphql_raises(mock_graphql):
+    # A lookup that raises is a failure, not an empty result (#1492).
     mock_graphql.side_effect = RuntimeError('boom')
 
     result = find_prs_for_issue('owner/repo', 12, open_only=True, token='fake_token')
 
-    assert result == []
+    assert result is None
+    mock_graphql.assert_called_once_with('owner/repo', 12, 'fake_token', open_only=True)
+
+
+@patch('gittensor.utils.github_api_tools._search_issue_referencing_prs_graphql')
+def test_find_prs_returns_none_when_graphql_lookup_fails(mock_graphql):
+    # The failure sentinel (None) from the GraphQL helper must propagate, not collapse to [] (#1492).
+    mock_graphql.return_value = None
+
+    result = find_prs_for_issue('owner/repo', 12, open_only=True, token='fake_token')
+
+    assert result is None
     mock_graphql.assert_called_once_with('owner/repo', 12, 'fake_token', open_only=True)
 
 


### PR DESCRIPTION
Closes #1492

_(Reopening #1536, which the 3-open-PR-cap bot auto-closed before triage. GitHub would not let me reopen that PR, so this is a fresh PR with the same commit, opened now that I am within the 3-PR cap.)_

`_search_issue_referencing_prs_graphql` returns `None` on lookup failure (rate limit, network error, GraphQL errors, missing payload), but `find_prs_for_issue` collapsed that to `[]` via `return prs or []`. Downstream, `gitt issues submissions --json` then emitted a successful response with `"submission_count": 0`, indistinguishable from a genuinely empty list. This is inconsistent with `find_solver_from_closure_event` / `check_github_issue_closed`, which preserve a failure signal.

`find_prs_for_issue` now returns `Optional[List[PRInfo]]` and propagates `None` on failure. `fetch_open_issue_pull_requests` raises a `ClickException` on `None`, so the submissions command reports an error (`success: false`) instead of a false-empty success. A genuinely empty result still returns `[]`.

Note (intentional behavior change): the existing `test_find_prs_returns_empty_when_graphql_errors` is renamed to `test_find_prs_returns_none_when_graphql_raises` and now asserts `None`.

Tests: updated/added unit tests in `tests/utils/test_github_api_tools.py`, plus an end-to-end CLI test in `tests/cli/test_issue_submission.py` asserting a failed lookup yields `success: false`.
