### PR TITLE
Stop dropping merged PRs with a missing base_ref on the OSS scoring path

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -207,14 +207,17 @@ def check_merged_branch_eligibility(
     issue discovery so both reject the same non-acceptable-branch merges.
 
     Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
-    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
-    check rather than false-positive-blocking on older data.
+    ``main``; a missing ``base_ref``, or missing ``head_ref``/``head_repo_full_name``,
+    skips that check rather than false-positive-blocking on older data.
     """
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
-    # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    # base_ref check. A null base_ref is pre-backfill mirror data (the field was
+    # added later), so fall through rather than coercing to '' and
+    # false-positive-blocking, matching the head_ref/default_branch fall-through
+    # behavior and the issue-discovery path.
+    if base_ref is not None and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable
@@ -251,8 +254,9 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
 
     When the mirror response is missing a field (older data predating the
     schema additions), some checks fall through rather than false-positive-
-    blocking. Concretely: missing ``head_ref`` or ``head_repo_full_name`` skips
-    the head_ref check. Missing ``default_branch`` falls back to ``main``.
+    blocking. Concretely: missing ``base_ref`` skips the base_ref check; missing
+    ``head_ref`` or ``head_repo_full_name`` skips the head_ref check; missing
+    ``default_branch`` falls back to ``main``.
     """
     pr = scored.pr
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -54,7 +54,7 @@ def _pr(
     author_login: str = 'bittoby',
     merged_by_login: str | None = 'anderdc',
     author_association: str = 'CONTRIBUTOR',
-    base_ref: str = 'main',
+    base_ref: str | None = 'main',
     head_ref: str | None = 'feature/foo',
     head_repo_full_name: str | None = 'entrius/gittensor-ui',
     default_branch: str | None = 'main',
@@ -210,6 +210,13 @@ class TestEligibilityGate:
         # Fallback default branch is 'main' when mirror omits default_branch.
         scored = ScoredPR(pr=_pr(base_ref='main', default_branch=None))
         skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
+        assert skip is False
+
+    def test_null_base_ref_falls_through_not_blocked(self):
+        # A null base_ref is pre-backfill mirror data; it must fall through rather
+        # than be coerced to '' and false-positive-blocked, dropping a merged PR (#1525).
+        scored = ScoredPR(pr=_pr(base_ref=None))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config())
         assert skip is False
 
     def test_head_ref_in_additional_blocks_same_repo(self):


### PR DESCRIPTION
Closes #1525

_(Reopening #1537, which the 3-open-PR-cap bot auto-closed before triage. GitHub would not let me reopen that PR, so this is a fresh PR with the same commit, opened now that I am within the 3-PR cap.)_

`check_merged_branch_eligibility` coerced a null `base_ref` to `''` before the branch-match check, so a merged PR whose mirror bundle omits `base_ref` (pre-backfill data) never matched any acceptable branch and was skipped at load time, silently costing the miner the earned score for that PR.

A null `base_ref` now falls through the base_ref check rather than blocking, matching the gate's existing fall-through for missing `default_branch` / `head_ref`, and the issue-discovery path (`scan.py`) which already guards on `base_ref is not None`. Present base_refs are validated exactly as before, so non-acceptable branch merges remain rejected.

Tests: added `test_null_base_ref_falls_through_not_blocked` in the mirror scoring suite; the existing base_ref / branch-eligibility tests still pass.
