### PR TITLE
refactor: dedupe RepoEvaluation get-or-create with a MinerEvaluation helper

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -291,6 +291,21 @@ class MinerEvaluation:
     # The top-level scalars above are round-level rollups of this map.
     repo_evaluations: Dict[str, RepoEvaluation] = field(default_factory=dict)
 
+    def get_or_create_repo_evaluation(
+        self, repo_name: str, repository_full_name: Optional[str] = None
+    ) -> RepoEvaluation:
+        """Return the repo evaluation stored under ``repo_name``, creating one if absent.
+
+        ``repo_name`` is the map key (a lowercased repository_full_name). When a
+        new entry is created, ``repository_full_name`` seeds it, defaulting to
+        ``repo_name`` when not supplied.
+        """
+        repo_eval = self.repo_evaluations.get(repo_name)
+        if repo_eval is None:
+            repo_eval = RepoEvaluation(repository_full_name=repository_full_name or repo_name)
+            self.repo_evaluations[repo_name] = repo_eval
+        return repo_eval
+
     @property
     def total_prs(self) -> int:
         return self.total_merged_prs + self.total_closed_prs + self.total_open_prs
@@ -578,10 +593,7 @@ class MinerEvaluationCache:
                 value = getattr(existing.evaluation, name)
                 setattr(cached_eval, name, _copy_issue_discovery_value(name, value))
             for repo_name, prior_repo in existing.evaluation.repo_evaluations.items():
-                target = cached_eval.repo_evaluations.get(repo_name)
-                if target is None:
-                    target = RepoEvaluation(repository_full_name=prior_repo.repository_full_name)
-                    cached_eval.repo_evaluations[repo_name] = target
+                target = cached_eval.get_or_create_repo_evaluation(repo_name, prior_repo.repository_full_name)
                 target.copy_issue_discovery_from(prior_repo)
 
         self._cache[evaluation.uid] = CachedEvaluation(
@@ -621,10 +633,7 @@ class MinerEvaluationCache:
             setattr(existing.evaluation, name, _copy_issue_discovery_value(name, value))
 
         for repo_name, repo_eval in evaluation.repo_evaluations.items():
-            target = existing.evaluation.repo_evaluations.get(repo_name)
-            if target is None:
-                target = RepoEvaluation(repository_full_name=repo_eval.repository_full_name)
-                existing.evaluation.repo_evaluations[repo_name] = target
+            target = existing.evaluation.get_or_create_repo_evaluation(repo_name, repo_eval.repository_full_name)
             target.copy_issue_discovery_from(repo_eval)
 
         bt.logging.debug(f'Refreshed cached issue discovery for UID {evaluation.uid}')

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -40,7 +40,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
-from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache, RepoEvaluation
+from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache
 from gittensor.constants import (
     MAINTAINER_ASSOCIATIONS,
 )
@@ -278,10 +278,7 @@ def _apply_open_issue_counts(evaluation: MinerEvaluation, open_counts: Dict[str,
     """Record per-repo open-issue counts (and the round-level total) for a miner
     with no in-window issues to score."""
     for repo_name, count in open_counts.items():
-        repo_eval = evaluation.repo_evaluations.get(repo_name)
-        if repo_eval is None:
-            repo_eval = RepoEvaluation(repository_full_name=repo_name)
-            evaluation.repo_evaluations[repo_name] = repo_eval
+        repo_eval = evaluation.get_or_create_repo_evaluation(repo_name)
         repo_eval.total_open_issues = count
     evaluation.total_open_issues = sum(open_counts.values())
 
@@ -297,10 +294,7 @@ def _copy_issue_discovery_fields(target: MinerEvaluation, source: MinerEvaluatio
     target.total_open_issues = source.total_open_issues
     target.issue_discovery_issues = list(source.issue_discovery_issues)
     for repo_name, source_repo in source.repo_evaluations.items():
-        target_repo = target.repo_evaluations.get(repo_name)
-        if target_repo is None:
-            target_repo = RepoEvaluation(repository_full_name=source_repo.repository_full_name)
-            target.repo_evaluations[repo_name] = target_repo
+        target_repo = target.get_or_create_repo_evaluation(repo_name, source_repo.repository_full_name)
         target_repo.copy_issue_discovery_from(source_repo)
 
 
@@ -560,10 +554,7 @@ def _finalize_repo_issue_scores(
         acc = repo_acc.get(repo_name) or _RepoIssueAcc()
         open_count = open_counts.get(repo_name, 0)
 
-        repo_eval = evaluation.repo_evaluations.get(repo_name)
-        if repo_eval is None:
-            repo_eval = RepoEvaluation(repository_full_name=repo_name)
-            evaluation.repo_evaluations[repo_name] = repo_eval
+        repo_eval = evaluation.get_or_create_repo_evaluation(repo_name)
 
         repo_eval.total_solved_issues = acc.solved
         repo_eval.total_valid_solved_issues = acc.valid_solved


### PR DESCRIPTION
## Summary

The "look up a per-repo `RepoEvaluation` by key, build one seeded with the repository full name if it's missing, and store it back into `repo_evaluations`" pattern was duplicated verbatim at **five sites across two modules**:

- `gittensor/validator/issue_discovery/scan.py` — `_apply_open_issue_counts`, `_copy_issue_discovery_fields`, `_finalize_repo_issue_scores`
- `gittensor/classes.py` — `MinerEvaluationCache.store` and `MinerEvaluationCache.update_issue_discovery`

This PR centralizes it as a single `MinerEvaluation.get_or_create_repo_evaluation()` method on the dataclass that owns the `repo_evaluations` map. Each call site collapses from a 4-line block to one line, and the now-unused `RepoEvaluation` import is dropped from `scan.py`.

```python
def get_or_create_repo_evaluation(
    self, repo_name: str, repository_full_name: Optional[str] = None
) -> RepoEvaluation:
    repo_eval = self.repo_evaluations.get(repo_name)
    if repo_eval is None:
        repo_eval = RepoEvaluation(repository_full_name=repository_full_name or repo_name)
        self.repo_evaluations[repo_name] = repo_eval
    return repo_eval
```

**Behavior is unchanged.** The optional `repository_full_name` argument preserves the original casing that the copy paths used when seeding new entries; it defaults to the map key for the plain create sites, matching the prior `RepoEvaluation(repository_full_name=repo_name)` calls exactly.

The two structurally-different sites are intentionally left untouched, since folding them into this helper *would* change behavior:
- `validator/storage/repository.py` builds a transient `... or RepoEvaluation(...)` that is **never stored** back into the map (read-only serialization).
- `validator/emission_allocation.py` does get-or-**skip** (`continue`), not get-or-create.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

No new tests: this is a pure, behavior-preserving consolidation already covered by existing tests. The full suite passes (`uv run pytest` → 937 passed), including `tests/validator/test_store_or_use_cached_evaluation.py` and `tests/validator/issue_discovery/test_scan.py` which exercise all five call sites. `ruff check`, `ruff format --check`, and `pyright` are all clean.

This is an internal validator refactor with no CLI/output changes, so the CLI before/after evidence requirement does not apply.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)