### PR TITLE
Replace e35dev/podcast-design-canvas with podcast-design-canvas-2

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -385,5 +385,37 @@
         "min_multiplier": 0.02
       }
     }
+  },
+  "e35dev/podcast-design-canvas-2": {
+    "emission_share": 0.05,
+    "issue_discovery_share": 0,
+    "maintainer_cut": 0,
+    "trusted_label_pipeline": true,
+    "default_label_multiplier": 0,
+    "label_multipliers": {
+      "episode-ingest": 3,
+      "preset-styles": 2.5,
+      "canvas-editor": 2.5,
+      "audio-captions": 2,
+      "contextual-visuals": 2,
+      "template-system": 1.75,
+      "export-publish": 1.75,
+      "product-polish": 1.5,
+      "bugfix": 1,
+      "infrastructure": 0.5
+    },
+    "eligibility": {
+      "min_credibility": 0.6,
+      "max_open_pr_threshold": 4
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "grace_period_hours": 6,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1,
+        "min_multiplier": 0.02
+      }
+    }
   }
 }

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -354,40 +354,8 @@
     },
     "maintainer_cut": 0.3
   },
-  "e35dev/podcast-design-canvas": {
-    "emission_share": 0.301,
-    "issue_discovery_share": 0,
-    "maintainer_cut": 0,
-    "trusted_label_pipeline": true,
-    "default_label_multiplier": 0,
-    "label_multipliers": {
-      "episode-ingest": 3,
-      "preset-styles": 2.5,
-      "canvas-editor": 2.5,
-      "audio-captions": 2,
-      "contextual-visuals": 2,
-      "template-system": 1.75,
-      "export-publish": 1.75,
-      "product-polish": 1.5,
-      "bugfix": 1,
-      "infrastructure": 0.5
-    },
-    "eligibility": {
-      "min_credibility": 0.6,
-      "max_open_pr_threshold": 4
-    },
-    "scoring": {
-      "pr_lookback_days": 7,
-      "time_decay": {
-        "grace_period_hours": 6,
-        "sigmoid_midpoint_days": 2,
-        "sigmoid_steepness": 1,
-        "min_multiplier": 0.02
-      }
-    }
-  },
   "e35dev/podcast-design-canvas-2": {
-    "emission_share": 0.05,
+    "emission_share": 0.301,
     "issue_discovery_share": 0,
     "maintainer_cut": 0,
     "trusted_label_pipeline": true,


### PR DESCRIPTION
Registers e35dev/podcast-design-canvas-2 and deregisters e35dev/podcast-design-canvas in the same registry update.

The replacement carries over the previous loop emission share: 0.301.

This keeps Builder Loops to one active Gittensor registration at a time while moving the project to the fresh repo.