### PR TITLE
fix: score Dockerfile variants

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -74,9 +74,11 @@ class FileChange:
 
     def _calculate_file_extension(self) -> str:
         basename = self.filename.split('/')[-1]
+        basename_lower = basename.lower()
+        if basename_lower.startswith('dockerfile.'):
+            return 'dockerfile'
         if '.' in basename:
             return basename.split('.')[-1].lower()
-        basename_lower = basename.lower()
         return basename_lower if basename_lower in EXTENSIONLESS_FILE_EXTENSIONS else ''
 
     def is_test_file(self) -> bool:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -78,6 +78,8 @@ def test_is_test_file_preserves_existing_test_conventions():
         ('Dockerfile', 'dockerfile'),
         ('dockerfile', 'dockerfile'),
         ('ops/Dockerfile', 'dockerfile'),
+        ('Dockerfile.dev', 'dockerfile'),
+        ('ops/Dockerfile.prod', 'dockerfile'),
         ('Makefile', 'makefile'),
         ('makefile', 'makefile'),
         ('build.mk', 'mk'),


### PR DESCRIPTION
## Summary

- Normalize suffixed Dockerfile names like `Dockerfile.dev` and `Dockerfile.prod` to the configured `dockerfile` scoring key.
- Preserve existing extension behavior for bare `Dockerfile`, `Makefile`, dotted files such as `build.mk`, and unrelated extensionless files.
- Add regression coverage for Dockerfile variant filenames.

## Related Issues

- Follow-up to #985 / #986

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Commands:
- `git diff --check`
- `./.venv/bin/pytest tests/test_classes.py -q` (blocked locally by existing `bittensor` import conflict between `scalecodec` and `cyscale`)
- Stubbed local import proof that `Dockerfile.dev` maps to `dockerfile` and reaches the `tree-diff` scoring path

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
