### PR TITLE
fix(issue-competitions): SCALE-encode str args in _encode_args (#1375)

### DIFF
--- a/gittensor/validator/issue_competitions/contract_client.py
+++ b/gittensor/validator/issue_competitions/contract_client.py
@@ -551,6 +551,19 @@ class IssueCompetitionContractClient:
             bt.logging.error(err)
             return None, err
 
+    @staticmethod
+    def _encode_compact_len(length: int) -> bytes:
+        """SCALE compact-encode a non-negative length (used as the Vec<u8>/str prefix)."""
+        if length < 0:
+            raise ValueError(f'Length must be non-negative, got {length}')
+        if length <= 0b0011_1111:  # single-byte mode
+            return bytes([length << 2])
+        if length <= 0b0011_1111_1111_1111:  # two-byte mode
+            return struct.pack('<H', (length << 2) | 0b01)
+        if length <= 0x3FFF_FFFF:  # four-byte mode
+            return struct.pack('<I', (length << 2) | 0b10)
+        raise ValueError(f'Length too large to SCALE compact-encode: {length}')
+
     def _encode_args(self, method_name: str, args: dict) -> bytes:
         """SCALE-encode method arguments using hardcoded type definitions."""
         arg_types = CONTRACT_ARG_TYPES.get(method_name, [])
@@ -568,6 +581,12 @@ class IssueCompetitionContractClient:
                 encoded += struct.pack('<Q', value)
             elif type_def == 'u128':
                 encoded += struct.pack('<QQ', value & 0xFFFFFFFFFFFFFFFF, value >> 64)
+            elif type_def == 'str':
+                # SCALE encodes str as a Vec<u8>: compact length prefix + UTF-8 bytes.
+                if not isinstance(value, str):
+                    raise ValueError(f'Expected str for arg {arg_name}, got {type(value)}')
+                utf8 = value.encode('utf-8')
+                encoded += self._encode_compact_len(len(utf8)) + utf8
             elif type_def == 'AccountId':
                 if isinstance(value, str):
                     encoded += bytes.fromhex(self.subtensor.substrate.ss58_decode(value))

--- a/tests/validator/test_contract_client_transactions.py
+++ b/tests/validator/test_contract_client_transactions.py
@@ -3,6 +3,7 @@
 """Tests for IssueCompetitionContractClient transaction methods."""
 
 import hashlib
+import struct
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -102,6 +103,53 @@ def test_revert_returns_false(client, wallet, method, kwargs_fn, _cm, _ea, _hk, 
 def test_exception_returns_false(client, wallet, method, kwargs_fn, _cm, _ea, _hk, _gas):
     with patch.object(client, '_exec_contract_raw', side_effect=RuntimeError('node down')):
         assert getattr(client, method)(**kwargs_fn(wallet)) is False
+
+
+def test_register_issue_encodes_str_args(client):
+    """register_issue declares github_url/repository_full_name as `str`; encoding
+    must SCALE-encode them (compact length prefix + UTF-8) rather than raising.
+
+    Regression test for the `Unsupported type: str` bug (#1375).
+    """
+    github_url = 'https://github.com/owner/repo/issues/1'
+    repo = 'owner/repo'
+
+    encoded = client._encode_args(
+        'register_issue',
+        {
+            'github_url': github_url,
+            'repository_full_name': repo,
+            'issue_number': 1,
+            'target_bounty': 10_000_000_000,
+        },
+    )
+
+    url_bytes = github_url.encode('utf-8')
+    repo_bytes = repo.encode('utf-8')
+    expected = (
+        IssueCompetitionContractClient._encode_compact_len(len(url_bytes))
+        + url_bytes
+        + IssueCompetitionContractClient._encode_compact_len(len(repo_bytes))
+        + repo_bytes
+        + struct.pack('<I', 1)  # issue_number: u32
+        + struct.pack('<QQ', 10_000_000_000, 0)  # target_bounty: u128
+    )
+    assert encoded == expected
+
+
+@pytest.mark.parametrize(
+    'length, expected',
+    [
+        (0, b'\x00'),
+        (1, b'\x04'),
+        (63, b'\xfc'),  # single-byte mode upper bound
+        (64, b'\x01\x01'),  # two-byte mode lower bound
+        (16383, b'\xfd\xff'),  # two-byte mode upper bound
+        (16384, b'\x02\x00\x01\x00'),  # four-byte mode lower bound
+    ],
+)
+def test_encode_compact_len_modes(length, expected):
+    assert IssueCompetitionContractClient._encode_compact_len(length) == expected
 
 
 def _packed_treasury_storage():


### PR DESCRIPTION
## Summary
`_encode_args` had no `str` branch, so every `register_issue` call raised
`ValueError: Unsupported type: str` while encoding `github_url` — before
`compose_call` was reached. This adds SCALE `str` encoding (Vec<u8>: compact
length prefix + UTF-8) via a new `_encode_compact_len` helper.

## Testing
- Added regression tests for register_issue encoding + compact-length boundaries
- `pytest tests/validator/test_contract_client_transactions.py` → 38 passed
- `ruff check` / `ruff format --check` clean
- Verified the issue's exact reproduction now encodes correctly

Fixes #1375