### PR TITLE
weights: rebalance allways/gittensor into podcast-design-canvas-2

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -86,7 +86,7 @@
     }
   },
   "entrius/allways": {
-    "emission_share": 0.04,
+    "emission_share": 0.0,
     "issue_discovery_share": 1.0,
     "label_multipliers": {
       "bug": 1.25,
@@ -108,25 +108,14 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.07,
+    "emission_share": 0.06,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "bug": 1.1,
-      "enhancement": 1.25,
-      "feature": 1.5,
-      "refactor": 0.25
-    },
-    "maintainer_cut": 0.0,
-    "trusted_label_pipeline": true
-  },
-  "entrius/gittensor-ui": {
-    "emission_share": 0.0,
-    "issue_discovery_share": 0.0,
-    "label_multipliers": {
-      "bug": 1.1,
-      "enhancement": 1.0,
-      "feature": 1.25,
-      "refactor": 0.5
+      "bug": 1.2,
+      "enhancement": 1.3,
+      "feature": 1.0,
+      "cli": 0.2,
+      "refactor": 0.1
     },
     "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
@@ -355,7 +344,7 @@
     "maintainer_cut": 0.3
   },
   "e35dev/podcast-design-canvas-2": {
-    "emission_share": 0.301,
+    "emission_share": 0.351,
     "issue_discovery_share": 0,
     "maintainer_cut": 0,
     "trusted_label_pipeline": true,


### PR DESCRIPTION
## Summary
Rebalances emission shares in `master_repositories.json` so the total stays at exactly **1.0**.

| Repo | Old | New |
|------|-----|-----|
| `entrius/allways` | 0.04 | 0.0 |
| `entrius/gittensor` | 0.07 | 0.06 |
| `e35dev/podcast-design-canvas-2` | 0.301 | 0.351 |

The 0.05 freed from allways (−0.04) and gittensor (−0.01) is applied to the podcast design repo.

Also folds in related edits made alongside the rebalance:
- `entrius/gittensor`: retuned `label_multipliers` (add `cli`, adjust bug/enhancement/feature/refactor)
- Removed the `entrius/gittensor-ui` entry (was at 0.0)

## Testing
- `pytest tests/` — 933 passed (incl. `test_live_master_repo_emission_shares_are_valid`)
- JSON valid; emission shares sum to 1.0
- pre-commit JSON hooks verified (check-json, trailing-whitespace, EOF newline, LF)