### PR TITLE
Tune Podcast Design Canvas eligibility

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -362,8 +362,9 @@
       "infrastructure": 0.5
     },
     "eligibility": {
+      "min_valid_merged_prs": 1,
       "min_credibility": 0.6,
-      "max_open_pr_threshold": 4
+      "max_open_pr_threshold": 1
     },
     "scoring": {
       "pr_lookback_days": 7,


### PR DESCRIPTION
Updates e35dev/podcast-design-canvas-2 eligibility so contributors can start earning after their first merged PR while keeping open-PR spam pressure tight.

Changes:
- Set `eligibility.min_valid_merged_prs` to `1`
- Set `eligibility.max_open_pr_threshold` to `1`

The rest of the repository config is unchanged.