### PR TITLE
Fix Podcast Design Canvas label scoring

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -347,20 +347,7 @@
     "emission_share": 0.351,
     "issue_discovery_share": 0,
     "maintainer_cut": 0,
-    "trusted_label_pipeline": true,
-    "default_label_multiplier": 0,
-    "label_multipliers": {
-      "episode-ingest": 3,
-      "preset-styles": 2.5,
-      "canvas-editor": 2.5,
-      "audio-captions": 2,
-      "contextual-visuals": 2,
-      "template-system": 1.75,
-      "export-publish": 1.75,
-      "product-polish": 1.5,
-      "bugfix": 1,
-      "infrastructure": 0.5
-    },
+    "default_label_multiplier": 1,
     "eligibility": {
       "min_valid_merged_prs": 1,
       "min_credibility": 0.6,


### PR DESCRIPTION
Updates `e35dev/podcast-design-canvas-2` so merged PRs can score without requiring repo-specific Gittensor labels.

Changes:
- Set `default_label_multiplier` to `1`
- Remove the custom `label_multipliers` map
- Remove `trusted_label_pipeline` because scoring no longer depends on maintainer-applied labels

This aligns the registry with the repo behavior: accepted merged PRs should not need `gittensor:*` labels to receive nonzero score.