### PR TITLE
Adjust repository emission shares

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -25,7 +25,7 @@
     "maintainer_cut": 0.4
   },
   "DPBG/Engram.AI": {
-    "emission_share": 0.0,
+    "emission_share": 0.0025,
     "issue_discovery_share": 0.0
   },
   "e35ventura/taopedia": {
@@ -160,7 +160,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.1,
+    "emission_share": 0.3,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -286,7 +286,7 @@
     "maintainer_cut": 0.3
   },
   "vouchdev/vouch": {
-    "emission_share": 0.0,
+    "emission_share": 0.01,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -311,7 +311,7 @@
     "maintainer_cut": 0.5
   },
   "phase-rs/phase": {
-    "emission_share": 0.02,
+    "emission_share": 0.04,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,
@@ -332,7 +332,7 @@
     }
   },
   "touchpilot/touchpilot": {
-    "emission_share": 0.0,
+    "emission_share": 0.0035,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "type: bug": 1.1,
@@ -343,8 +343,17 @@
     },
     "maintainer_cut": 0.3
   },
+  "we-promise/sure": {
+    "emission_share": 0.01,
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "performance": 1.5,
+      "mobile/Flutter": 1.2
+    },
+    "maintainer_cut": 0.3
+  },
   "e35dev/podcast-design-canvas-2": {
-    "emission_share": 0.351,
+    "emission_share": 0.105,
     "issue_discovery_share": 0,
     "maintainer_cut": 0,
     "default_label_multiplier": 1,


### PR DESCRIPTION
## Weight Adjustment PR

### Changes Summary

| Metric | Total |
| --- | ---: |
| Repositories Added | 1 |
| Repositories Removed | 0 |
| Weights Modified | 7 |
| Net Weight Change | 0.000 |

### Added Repositories

| Repository | Branch | Weight |
| --- | --- | ---: |
| `we-promise/sure` | `main` | 1.00% |

`we-promise/sure` keeps its prior repo-specific config: `maintainer_cut = 0.3`, `performance = 1.5`, and `mobile/Flutter = 1.2`.

### Removed Repositories

None.

### Justification

This reallocates raw emission share toward a concentrated set of high-conviction repos while preserving a long tail for emerging opportunities. The total configured `emission_share` remains 1.0.

Changes:

| Repository | Before | After | Change |
| --- | ---: | ---: | ---: |
| `gittensor-ai-lab/sparkinfer` | 10.00% | 30.00% | +20.00% |
| `phase-rs/phase` | 2.00% | 4.00% | +2.00% |
| `vouchdev/vouch` | 0.00% | 1.00% | +1.00% |
| `we-promise/sure` | 0.00% | 1.00% | +1.00% |
| `touchpilot/touchpilot` | 0.00% | 0.35% | +0.35% |
| `DPBG/Engram.AI` | 0.00% | 0.25% | +0.25% |
| `e35dev/podcast-design-canvas-2` | 35.10% | 10.50% | -24.60% |

`sparkinfer` has a high-signal, benchmark-driven contribution surface where PRs are built from source, checked for correctness, benchmarked on the target hardware, and labeled by verified speedup tiers. This update moves it to the top allocation at 30.00% after recent performance progress.

`phase-rs/phase` receives a larger allocation due to strong recent maintainer and contributor activity. `vouchdev/vouch`, `we-promise/sure`, `touchpilot/touchpilot`, and `DPBG/Engram.AI` receive smaller long-tail allocations to broaden the opportunity surface for new development. The offset comes entirely from `e35dev/podcast-design-canvas-2`, which remains a meaningful allocation after this change at 10.50%.

### Additional Acceptable Branches

- [x] No additional_acceptable_branches changes in this PR
- [ ] Proof of merged PR(s) provided above for all additional_acceptable_branches entries

### Checklist

- [x] Changes summary table is filled in accurately
- [x] Net weight changes are justified in the Justification section
- [x] Added repositories have correct branch and initial weight

### Validation

- `python3 -m json.tool gittensor/validator/weights/master_repositories.json`
- Confirmed raw `emission_share` sum remains `1.0`
- `uv run --extra dev pytest tests/validator/test_load_weights.py`