### PR TITLE
taopedia: reward only ui-ux/feature, fold the rest into other (0.01)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -38,9 +38,7 @@
     "label_multipliers": {
       "ui-ux": 5.0,
       "feature": 2.0,
-      "bug": 0.35,
-      "security": 0.35,
-      "other": 0.05
+      "other": 0.01
     },
     "eligibility": {
       "min_credibility": 0.6,


### PR DESCRIPTION
## What

Narrows the `e35ventura/taopedia` reward taxonomy to three labels and pushes everything off the UI/UX + feature path to near-zero.

```diff
 "label_multipliers": {
   "ui-ux": 5.0,
   "feature": 2.0,
-  "bug": 0.35,
-  "security": 0.35,
-  "other": 0.05
+  "other": 0.01
 }
```

## Why

Taopedia contribution should concentrate on **new features and UI/UX** — specifically UI/UX features and making the existing UI/UX better. Recent contributor volume has been dominated by low-value maintenance churn (speculative content-sanitizer blocklist expansion labeled `security`, one-per-endpoint refactor splits) that earned meaningful emissions while moving the product very little.

Removing `bug` and `security` as rewarded labels (they fall to `default_label_multiplier: 0.0`) and dropping `other` from 0.05 to 0.01 removes the economic incentive to farm maintenance work, while `ui-ux` (5.0) and `feature` (2.0) keep real product progress well rewarded. The `taopedia-site-maintainer` label pipeline is being collapsed to emit only `ui-ux`/`feature`/`other` to match (share-preview/OG work counts as `ui-ux`; bug/security fold into `other`).

Only the `e35ventura/taopedia` entry changes; `taopedia-articles` and all other repos are untouched.
