### PR TITLE
fix(utils): retry GraphQL 200 responses with malformed bodies instead of raising

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -374,7 +374,25 @@ def execute_graphql_query(
             )
 
             if response.status_code == 200:
-                return response.json()
+                try:
+                    return response.json()
+                except ValueError as e:
+                    # A 200 with a malformed body (truncated response, proxy/HTML
+                    # interstitial, empty body) is a transient failure. json.JSONDecodeError
+                    # subclasses ValueError and is NOT a RequestException, so without this
+                    # guard it would escape the retry loop and the documented None contract.
+                    # Mirrors the response.json() guards in get_github_identity and
+                    # MirrorClient._request.
+                    if attempt < (max_attempts - 1):
+                        backoff_delay = backoff_seconds(attempt)
+                        bt.logging.warning(
+                            f'GraphQL request returned invalid JSON '
+                            f'(attempt {attempt + 1}/{max_attempts}), retrying in {backoff_delay}s: {e}'
+                        )
+                        time.sleep(backoff_delay)
+                        continue
+                    bt.logging.error(f'GraphQL request returned invalid JSON after {max_attempts} attempts: {e}')
+                    return None
 
             # Retry on failure
             if attempt < (max_attempts - 1):

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -144,6 +144,26 @@ class TestExecuteGraphQLQueryRetryLogic:
         mock_sleep.assert_has_calls(expected_delays)
         assert mock_sleep.call_count == 7
 
+    @patch('gittensor.utils.github_api_tools.get_session')
+    @patch('gittensor.utils.github_api_tools.time.sleep')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_invalid_json_on_200_is_retried_then_returns_none(self, mock_logging, mock_sleep, mock_get_session):
+        """A 200 response with a malformed body must be treated as a transient
+        failure: retried with backoff and ultimately returning None (not raising
+        JSONDecodeError out of the retry loop)."""
+        response = Mock(status_code=200)
+        response.json.side_effect = ValueError('Expecting value: line 1 column 1 (char 0)')
+        mock_session = Mock()
+        mock_session.post.return_value = response
+        mock_get_session.return_value = mock_session
+
+        result = execute_graphql_query('query {}', {}, 'fake_token', max_attempts=3)
+
+        assert result is None
+        assert mock_session.post.call_count == 3
+        # One backoff sleep per retry (no sleep after the final attempt).
+        assert mock_sleep.call_count == 2
+
 
 # ============================================================================
 # PR Discovery Fallback Tests


### PR DESCRIPTION
## Problem
`execute_graphql_query` parses 200 responses with an unguarded `response.json()`:

```python
if response.status_code == 200:
    return response.json()
```

A 200 OK with a malformed body (truncated response, proxy/HTML interstitial,
empty body) makes response.json() raise json.JSONDecodeError — a ValueError,
not a requests.exceptions.RequestException. The retry loop only catches
RequestException, so the error escapes the loop entirely: no retry, no backoff,
and the function never returns its documented None. It instead propagates an
unhandled error into callers (find_solver_from_closure_event,
_search_issue_referencing_prs_graphql), which expect "None if all attempts failed".

This is the lone unguarded parse: get_github_identity and MirrorClient._request
both wrap response.json() and treat a bad body as a retryable transient failure.

## Fix
Guard the parse and treat a malformed 200 body as transient — log, back off, retry
on the same backoff_seconds/max_attempts schedule, and return None after
exhausting attempts. Both callers already handle None, so blast radius is minimal.

## Tests
Adds a regression test: a 200 whose .json() raises is retried (max_attempts
POSTs, backoff between) and returns None rather than raising. No prior coverage
existed for this path.
pytest tests/utils/ (118 passed), ruff, and pyright all clean.

That's the medium, focused version — problem → fix → tests, with just enough evidence (the sibling-precedent line and the caller impact) to make it compelling without bloat. Want any trims, or shall I leave the commit message as-is?
