### PR TITLE
gittensor-ai-lab/sparkinfer: raise maintainer_cut to 0.5

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -173,7 +173,7 @@
       "eval:none": 0.0,
       "eval:REJECT": 0.0
     },
-    "maintainer_cut": 0.3,
+    "maintainer_cut": 0.5,
     "trusted_label_pipeline": true
   },
   "JSONbored/awesome-claude": {


### PR DESCRIPTION
Raises `maintainer_cut` for **gittensor-ai-lab/sparkinfer** from **0.3 → 0.5** in `gittensor/validator/weights/master_repositories.json`.

### Why
We are putting more of our subnet emission behind **productionizing the engine**. sparkinfer just landed the first **kernel-level decode win over llama.cpp** (v0.3.0 — 388 tok/s on RTX 5090, +4.5%), and we are onboarding a **new AI research engineer** to carry that momentum into a production runtime: native weight format, thermal-safe inference, and agent-first serving.

A larger maintainer cut funds that core R&D + productionization push, while **contributors still receive the majority (0.5)** of each PR allocation. The eval gate, label multipliers, and contributor rewards are otherwise unchanged — this only adjusts the maintainer/contributor split of **our own** repo allocation (`trusted_label_pipeline: true`).

Single-line change to our entry only; no other repositories affected.