### PR TITLE
Raise taopedia-articles min_credibility to 0.70

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -72,7 +72,7 @@
       "other": 0.1
     },
     "eligibility": {
-      "min_credibility": 0.5,
+      "min_credibility": 0.7,
       "min_token_score_for_valid_issue": 0.0
     },
     "scoring": {


### PR DESCRIPTION
## What
Raise `eligibility.min_credibility` for `e35ventura/taopedia-articles` from **0.5 → 0.70** in `master_repositories.json`.

## Why
The taopedia-articles repo is under sustained low-credibility farm volume (~1,600 PRs/day). The maintainer bot's review gate already rejects the resulting churn at decision time, but that still burns serial review throughput on PRs that should never have been eligible. Raising the credibility floor throttles the volume at the source: accounts below 0.70 credibility are no longer eligible to earn on this repo.

## Scope
- Only `e35ventura/taopedia-articles` `eligibility.min_credibility` changes.
- `e35ventura/taopedia` (site repo) is untouched (stays 0.6).
- No other repos, multipliers, or scoring fields changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)