### PR TITLE
Replace e35dev/podcast-design-canvas-2 with e35dev/podcast-design-canvas-3

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -343,15 +343,14 @@
     },
     "maintainer_cut": 0.3
   },
-  "e35dev/podcast-design-canvas-2": {
+  "e35dev/podcast-design-canvas-3": {
     "emission_share": 0.351,
     "issue_discovery_share": 0,
     "maintainer_cut": 0,
     "default_label_multiplier": 1,
     "eligibility": {
-      "min_valid_merged_prs": 1,
       "min_credibility": 0.6,
-      "max_open_pr_threshold": 1
+      "max_open_pr_threshold": 4
     },
     "scoring": {
       "pr_lookback_days": 7,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -349,6 +349,7 @@
     "maintainer_cut": 0,
     "default_label_multiplier": 1,
     "eligibility": {
+      "min_valid_merged_prs": 1,
       "min_credibility": 0.6,
       "max_open_pr_threshold": 1
     },

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -350,7 +350,7 @@
     "default_label_multiplier": 1,
     "eligibility": {
       "min_credibility": 0.6,
-      "max_open_pr_threshold": 4
+      "max_open_pr_threshold": 1
     },
     "scoring": {
       "pr_lookback_days": 7,


### PR DESCRIPTION
Adds `e35dev/podcast-design-canvas-3` to the Gittensor master repository registry.
Removes `e35dev/podcast-design-canvas-2` in the same PR so Builder Loops keeps only one active Gittensor loop.
Carries over the previous `emission_share` value to the new repository entry.