### PR TITLE
Feat: add gitt miner advisor and scan (#1460)

### DIFF
--- a/gittensor/cli/miner_commands/__init__.py
+++ b/gittensor/cli/miner_commands/__init__.py
@@ -12,6 +12,7 @@ Command structure:
 
 import click
 
+from .advisor import advisor_command
 from .check import miner_check
 from .post import miner_post
 from .score import score_command
@@ -26,6 +27,7 @@ def miner_group():
         post     Broadcast your GitHub PAT to validators
         check    Check how many validators have your PAT stored
         score    Run the validator scoring pipeline end-to-end for a single miner
+        advisor  Turn a local pipeline run into prioritized recommendations
     """
     pass
 
@@ -33,6 +35,7 @@ def miner_group():
 miner_group.add_command(miner_post, name='post')
 miner_group.add_command(miner_check, name='check')
 miner_group.add_command(score_command, name='score')
+miner_group.add_command(advisor_command, name='advisor')
 
 
 def register_miner_commands(cli):

--- a/gittensor/cli/miner_commands/__init__.py
+++ b/gittensor/cli/miner_commands/__init__.py
@@ -8,6 +8,8 @@ Command structure:
         post                     Broadcast GitHub PAT to validators
         check                    Check how many validators have your PAT
         score                    Score GitHub entities through the production pipeline
+        advisor                  Recommend score improvements from a local pipeline run
+        scan                     Rank open issues across whitelisted repos by opportunity
 """
 
 import click
@@ -15,6 +17,7 @@ import click
 from .advisor import advisor_command
 from .check import miner_check
 from .post import miner_post
+from .scan import scan_command
 from .score import score_command
 
 
@@ -28,6 +31,7 @@ def miner_group():
         check    Check how many validators have your PAT stored
         score    Run the validator scoring pipeline end-to-end for a single miner
         advisor  Turn a local pipeline run into prioritized recommendations
+        scan     Rank open issues across whitelisted repos by opportunity
     """
     pass
 
@@ -36,6 +40,7 @@ miner_group.add_command(miner_post, name='post')
 miner_group.add_command(miner_check, name='check')
 miner_group.add_command(score_command, name='score')
 miner_group.add_command(advisor_command, name='advisor')
+miner_group.add_command(scan_command, name='scan')
 
 
 def register_miner_commands(cli):

--- a/gittensor/cli/miner_commands/advisor.py
+++ b/gittensor/cli/miner_commands/advisor.py
@@ -1,0 +1,285 @@
+# Entrius 2025
+
+"""gitt miner advisor - Run the validator scoring pipeline locally and turn the
+result into prioritized, implementable recommendations.
+
+Reuses the local-pipeline stubs from ``gitt miner score`` (no subtensor, wallet,
+DB, axon, or wandb is touched) and analyzes the resulting evaluation against the
+live eligibility/scoring gates, surfacing advice by impact level:
+
+    CRITICAL  blockers that prevent the miner from being eligible to earn
+    WARNING   active reductions shrinking an otherwise-earned score
+    TIP       unused multipliers that would raise the score
+    INFO      planning context (totals, distance to thresholds, reward)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from gittensor.cli.json_output import emit_json
+from gittensor.cli.miner_commands.score import (
+    _DEV_HOTKEY,
+    _DEV_UID,
+    _StubValidator,
+    _apply_log_level,
+    _drain_logs,
+    _override_pats_file,
+    _resolve_pat,
+    _serialize_evaluation,
+)
+
+console = Console()
+
+
+class Impact(str, Enum):
+    CRITICAL = 'CRITICAL'
+    WARNING = 'WARNING'
+    TIP = 'TIP'
+    INFO = 'INFO'
+
+
+_IMPACT_ORDER = {Impact.CRITICAL: 0, Impact.WARNING: 1, Impact.TIP: 2, Impact.INFO: 3}
+_IMPACT_STYLE = {
+    Impact.CRITICAL: 'bold red',
+    Impact.WARNING: 'yellow',
+    Impact.TIP: 'cyan',
+    Impact.INFO: 'dim',
+}
+
+
+@dataclass
+class Recommendation:
+    impact: Impact
+    title: str
+    detail: str
+    repo: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {'impact': self.impact.value, 'title': self.title, 'detail': self.detail, 'repo': self.repo}
+
+
+def _analyze_eligibility(miner: Dict[str, Any], thresholds: Dict[str, Dict[str, float]]) -> List[Recommendation]:
+    """CRITICAL: per-repo eligibility blockers (too few merged PRs, low credibility)."""
+    recs: List[Recommendation] = []
+    repo_evals = miner.get('repo_evaluations') or {}
+    for repo, re in sorted(repo_evals.items()):
+        if re.get('is_eligible'):
+            continue
+        limits = thresholds.get(repo, {})
+        merged = int(re.get('total_merged_prs', 0))
+        need_merged = int(limits.get('min_valid_merged_prs', 0))
+        cred = float(re.get('credibility', 0.0))
+        need_cred = float(limits.get('min_credibility', 0.0))
+        reasons = []
+        if merged < need_merged:
+            reasons.append(f'{merged}/{need_merged} valid merged PRs')
+        if cred < need_cred:
+            reasons.append(f'credibility {cred:.2f} < {need_cred:.2f} (raise your merged:closed ratio)')
+        recs.append(
+            Recommendation(
+                Impact.CRITICAL,
+                f'Not eligible in {repo}',
+                '; '.join(reasons) or 'eligibility gate not met',
+                repo=repo,
+            )
+        )
+    return recs
+
+
+def _analyze_reductions(miner: Dict[str, Any]) -> List[Recommendation]:
+    """WARNING: multipliers below 1.0 that are actively shrinking earned score."""
+    recs: List[Recommendation] = []
+    for pr in miner.get('merged_pull_requests', []):
+        tag = f'{pr["repository_full_name"]}#{pr["number"]}'
+        if float(pr.get('review_quality_multiplier', 1.0)) < 1.0:
+            recs.append(
+                Recommendation(
+                    Impact.WARNING,
+                    f'Review penalty on {tag}',
+                    f'maintainer change-requests cut this PR to '
+                    f'×{pr["review_quality_multiplier"]:.2f}; address review feedback before merge',
+                    repo=pr['repository_full_name'],
+                )
+            )
+        if float(pr.get('open_pr_spam_multiplier', 1.0)) == 0.0:
+            recs.append(
+                Recommendation(
+                    Impact.WARNING,
+                    f'Open-PR spam penalty zeroed {tag}',
+                    'too many open PRs in this repo zeroed its merged scores; close or land open PRs',
+                    repo=pr['repository_full_name'],
+                )
+            )
+        if float(pr.get('time_decay_multiplier', 1.0)) < 0.5:
+            recs.append(
+                Recommendation(
+                    Impact.WARNING,
+                    f'Time decay on {tag}',
+                    f'this merge has decayed to ×{pr["time_decay_multiplier"]:.2f}; recent merges score higher',
+                    repo=pr['repository_full_name'],
+                )
+            )
+    collateral = float(miner.get('total_collateral_score', 0.0))
+    if collateral > 0:
+        recs.append(
+            Recommendation(
+                Impact.WARNING,
+                'Open PRs are reserving score as collateral',
+                f'{collateral:.2f} pts held against open PRs; merging or closing them releases it',
+            )
+        )
+    return recs
+
+
+def _analyze_tips(miner: Dict[str, Any]) -> List[Recommendation]:
+    """TIP: unused multipliers (issue links, labels) that would raise score."""
+    recs: List[Recommendation] = []
+    no_issue = [
+        f'{pr["repository_full_name"]}#{pr["number"]}'
+        for pr in miner.get('merged_pull_requests', [])
+        if float(pr.get('issue_multiplier', 1.0)) <= 1.0
+    ]
+    if no_issue:
+        recs.append(
+            Recommendation(
+                Impact.TIP,
+                'Link a valid issue for the issue multiplier',
+                f'{len(no_issue)} merged PR(s) earned no issue multiplier '
+                f'({", ".join(no_issue[:5])}{"..." if len(no_issue) > 5 else ""}). '
+                'Solve a maintainer-filed issue and link it with "Fixes #N".',
+            )
+        )
+    weak_label = [
+        f'{pr["repository_full_name"]}#{pr["number"]}'
+        for pr in miner.get('merged_pull_requests', [])
+        if float(pr.get('label_multiplier', 1.0)) < 1.0
+    ]
+    if weak_label:
+        recs.append(
+            Recommendation(
+                Impact.TIP,
+                'Low-value labels are capping score',
+                f'{len(weak_label)} PR(s) carry a sub-1.0 label multiplier '
+                f'({", ".join(weak_label[:5])}{"..." if len(weak_label) > 5 else ""}); '
+                'target higher-weighted labels for this repo.',
+            )
+        )
+    return recs
+
+
+def _analyze_info(miner: Dict[str, Any], rewards: Dict[str, Any]) -> List[Recommendation]:
+    recs: List[Recommendation] = [
+        Recommendation(
+            Impact.INFO,
+            'Current standing',
+            f'earned score {float(miner.get("total_score", 0.0)):.2f} across '
+            f'{int(miner.get("unique_repos_count", 0))} repo(s); '
+            f'blended reward {float(rewards.get("blended_final", 0.0)):.6f}',
+        )
+    ]
+    return recs
+
+
+def build_recommendations(payload: Dict[str, Any], thresholds: Dict[str, Dict[str, float]]) -> List[Recommendation]:
+    miner = payload['miner_evaluation']
+    if miner.get('failed_reason'):
+        return [Recommendation(Impact.CRITICAL, 'Evaluation failed', str(miner['failed_reason']))]
+    recs: List[Recommendation] = []
+    recs += _analyze_eligibility(miner, thresholds)
+    recs += _analyze_reductions(miner)
+    recs += _analyze_tips(miner)
+    recs += _analyze_info(miner, payload.get('rewards', {}))
+    recs.sort(key=lambda r: _IMPACT_ORDER[r.impact])
+    return recs
+
+
+def _render(recs: List[Recommendation]) -> None:
+    table = Table(title='Miner advisor — prioritized recommendations')
+    table.add_column('Impact', style='bold')
+    table.add_column('Recommendation')
+    table.add_column('Detail', overflow='fold')
+    for r in recs:
+        table.add_row(f'[{_IMPACT_STYLE[r.impact]}]{r.impact.value}[/]', r.title, r.detail)
+    console.print(table)
+
+
+def _resolve_thresholds() -> Dict[str, Dict[str, float]]:
+    """Resolve each whitelisted repo's eligibility gate to concrete numbers."""
+    from gittensor.validator.utils.load_weights import load_master_repo_weights, resolve_eligibility
+
+    out: Dict[str, Dict[str, float]] = {}
+    for repo, cfg in load_master_repo_weights().items():
+        elig = resolve_eligibility(cfg.eligibility)
+        out[repo] = {
+            'min_valid_merged_prs': elig.min_valid_merged_prs,
+            'min_credibility': elig.min_credibility,
+        }
+    return out
+
+
+@click.command(name='advisor')
+@click.option('--pat', default=None, envvar='GITTENSOR_MINER_PAT', help='GitHub PAT. Uses GITTENSOR_MINER_PAT if unset.')
+@click.option(
+    '--log-level',
+    type=click.Choice(['warning', 'info', 'debug', 'trace']),
+    default='warning',
+    show_default=True,
+    help='Bittensor log verbosity for the underlying pipeline run.',
+)
+@click.option('--json', 'json_mode', is_flag=True, default=False, help='Emit recommendations as JSON on stdout.')
+def advisor_command(pat: Optional[str], log_level: str, json_mode: bool) -> None:
+    """Run the scoring pipeline locally and report prioritized recommendations.
+
+    Example:
+        gitt miner advisor --pat ghp_xxxxx
+    """
+    resolved_pat = _resolve_pat(pat, json_mode)
+
+    from gittensor.validator.emission_allocation import blend_emission_pools
+    from gittensor.validator.forward import build_maintainer_uids_by_repo, issue_discovery, oss_contributions
+    from gittensor.validator.utils.load_weights import (
+        load_master_repo_weights,
+        load_programming_language_weights,
+        load_token_config,
+    )
+
+    _apply_log_level(log_level)
+    stub = _StubValidator(_DEV_UID, _DEV_HOTKEY)
+    miner_uids = {_DEV_UID}
+    master_repositories = load_master_repo_weights()
+    programming_languages = load_programming_language_weights()
+    token_config = load_token_config()
+    pat_snapshot = [{'uid': _DEV_UID, 'hotkey': _DEV_HOTKEY, 'pat': resolved_pat}]
+
+    async def _run() -> Dict[str, Any]:
+        with _override_pats_file(pat_snapshot):
+            miner_evaluations, _, _ = await oss_contributions(
+                stub, miner_uids, master_repositories, programming_languages, token_config
+            )
+            await issue_discovery(miner_evaluations, master_repositories, programming_languages, token_config)
+        maintainer_uids_by_repo = build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
+        rewards = blend_emission_pools(miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo)
+        return {
+            'miner_evaluation': _serialize_evaluation(miner_evaluations[_DEV_UID]),
+            'rewards': {'blended_final': float(rewards[0])},
+        }
+
+    if not json_mode:
+        console.print('[bold cyan]Running validator pipeline...[/bold cyan]')
+    payload = asyncio.run(_run())
+    _drain_logs()
+
+    recommendations = build_recommendations(payload, _resolve_thresholds())
+
+    if json_mode:
+        emit_json({'success': True, 'recommendations': [r.to_dict() for r in recommendations]})
+    else:
+        _render(recommendations)

--- a/gittensor/cli/miner_commands/advisor.py
+++ b/gittensor/cli/miner_commands/advisor.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 import click
 from rich.console import Console
@@ -35,6 +35,9 @@ from gittensor.cli.miner_commands.score import (
     _resolve_pat,
     _serialize_evaluation,
 )
+
+if TYPE_CHECKING:
+    from neurons.validator import Validator
 
 console = Console()
 
@@ -252,7 +255,7 @@ def advisor_command(pat: Optional[str], log_level: str, json_mode: bool) -> None
     )
 
     _apply_log_level(log_level)
-    stub = _StubValidator(_DEV_UID, _DEV_HOTKEY)
+    stub = cast('Validator', _StubValidator(_DEV_UID, _DEV_HOTKEY))
     miner_uids = {_DEV_UID}
     master_repositories = load_master_repo_weights()
     programming_languages = load_programming_language_weights()

--- a/gittensor/cli/miner_commands/scan.py
+++ b/gittensor/cli/miner_commands/scan.py
@@ -1,0 +1,224 @@
+# Entrius 2025
+
+"""gitt miner scan - Rank open GitHub issues across whitelisted repos by TAO
+opportunity.
+
+For every repo in ``master_repositories.json`` with a positive emission share,
+fetch its open issues (REST) and order them by an opportunity score combining:
+
+    - emission_share   how much of the subnet pool the repo carries
+    - multiplier        the best issue/label multiplier you could realistically earn
+    - freshness         newer issues are less likely already solved
+    - competition       (optional) fewer existing referencing PRs is better
+
+The scoring helpers are pure and injectable so the ranking is unit-testable
+without network access.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from gittensor.cli.json_output import emit_json
+from gittensor.cli.miner_commands.helpers import _error
+
+console = Console()
+
+# Half the opportunity weight is gone once an issue is this many days old.
+FRESHNESS_HALF_LIFE_DAYS = 30.0
+DEFAULT_ISSUES_PER_REPO = 10
+DEFAULT_TOP = 20
+
+
+@dataclass
+class Opportunity:
+    repo: str
+    issue_number: int
+    title: str
+    url: str
+    emission_share: float
+    multiplier: float
+    age_days: float
+    competition: int
+    score: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'repo': self.repo,
+            'issue_number': self.issue_number,
+            'title': self.title,
+            'url': self.url,
+            'emission_share': round(self.emission_share, 6),
+            'multiplier': round(self.multiplier, 3),
+            'age_days': round(self.age_days, 1),
+            'competition': self.competition,
+            'score': round(self.score, 6),
+        }
+
+
+def freshness_factor(age_days: float, half_life: float = FRESHNESS_HALF_LIFE_DAYS) -> float:
+    """Exponential decay in [0, 1]: 1.0 at age 0, 0.5 at one half-life."""
+    if age_days <= 0:
+        return 1.0
+    return math.pow(0.5, age_days / max(half_life, 1e-9))
+
+
+def best_repo_multiplier(repo_config: Any) -> float:
+    """The best multiplier a contributor could realistically earn in a repo:
+    the issue-link multiplier times the strongest configured label multiplier.
+    """
+    from gittensor.validator.utils.load_weights import resolve_scoring
+
+    scoring = resolve_scoring(getattr(repo_config, 'scoring', None))
+    issue_mult = max(scoring.standard_issue_multiplier, scoring.maintainer_issue_multiplier)
+    labels = getattr(repo_config, 'label_multipliers', None) or {}
+    best_label = max([float(v) for v in labels.values()], default=1.0)
+    # A zero default label means unlabeled PRs score nothing; only a positive
+    # configured label earns, so fall back to the best label, not 1.0.
+    return issue_mult * max(best_label, 0.0 if best_label else 1.0)
+
+
+def opportunity_score(emission_share: float, multiplier: float, age_days: float, competition: int) -> float:
+    """Higher is better. Linear in share/multiplier/freshness, divided by crowding."""
+    return (emission_share * multiplier * freshness_factor(age_days)) / (1 + max(0, competition))
+
+
+def _age_days(created_at: str, now: Optional[datetime] = None) -> float:
+    now = now or datetime.now(timezone.utc)
+    try:
+        created = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return 0.0
+    return max(0.0, (now - created).total_seconds() / 86400.0)
+
+
+def fetch_open_issues(repo: str, token: str, limit: int) -> List[Dict[str, Any]]:
+    """Fetch up to ``limit`` open issues for a repo via REST, excluding PRs.
+
+    GitHub's issues endpoint returns pull requests too; items carrying a
+    ``pull_request`` key are filtered out.
+    """
+    from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS
+    from gittensor.utils.github_api_tools import get_session
+
+    session = get_session(token)
+    resp = session.get(
+        f'{BASE_GITHUB_API_URL}/repos/{repo}/issues',
+        params={'state': 'open', 'sort': 'created', 'direction': 'desc', 'per_page': limit},
+        timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
+    )
+    if resp.status_code != 200:
+        return []
+    return [item for item in resp.json() if 'pull_request' not in item]
+
+
+def _competition_count(repo: str, issue_number: int, token: str) -> int:
+    from gittensor.utils.github_api_tools import find_prs_for_issue
+
+    return len(find_prs_for_issue(repo, issue_number, open_only=True, token=token) or [])
+
+
+def gather_opportunities(
+    repositories: Dict[str, Any],
+    token: str,
+    *,
+    issues_per_repo: int = DEFAULT_ISSUES_PER_REPO,
+    check_competition: bool = False,
+    issue_fetcher: Callable[[str, str, int], List[Dict[str, Any]]] = fetch_open_issues,
+    competition_fn: Callable[[str, int, str], int] = _competition_count,
+    now: Optional[datetime] = None,
+) -> List[Opportunity]:
+    """Rank open issues across repos with a positive emission share."""
+    opportunities: List[Opportunity] = []
+    for repo, cfg in repositories.items():
+        share = float(getattr(cfg, 'emission_share', 0.0))
+        if share <= 0:
+            continue
+        multiplier = best_repo_multiplier(cfg)
+        for issue in issue_fetcher(repo, token, issues_per_repo):
+            number = int(issue.get('number', 0))
+            age = _age_days(str(issue.get('created_at', '')), now=now)
+            competition = competition_fn(repo, number, token) if check_competition else 0
+            opportunities.append(
+                Opportunity(
+                    repo=repo,
+                    issue_number=number,
+                    title=str(issue.get('title', '')),
+                    url=str(issue.get('html_url', '')),
+                    emission_share=share,
+                    multiplier=multiplier,
+                    age_days=age,
+                    competition=competition,
+                    score=opportunity_score(share, multiplier, age, competition),
+                )
+            )
+    opportunities.sort(key=lambda o: o.score, reverse=True)
+    return opportunities
+
+
+def _render(opportunities: List[Opportunity]) -> None:
+    table = Table(title='Issue opportunities by TAO potential')
+    table.add_column('Score', justify='right', style='bold green')
+    table.add_column('Repo', style='cyan')
+    table.add_column('Issue', justify='right')
+    table.add_column('Share', justify='right')
+    table.add_column('Mult', justify='right')
+    table.add_column('Age (d)', justify='right')
+    table.add_column('Comp', justify='right')
+    table.add_column('Title', overflow='fold')
+    for o in opportunities:
+        table.add_row(
+            f'{o.score:.5f}',
+            o.repo,
+            f'#{o.issue_number}',
+            f'{o.emission_share:.3f}',
+            f'×{o.multiplier:.2f}',
+            f'{o.age_days:.0f}',
+            str(o.competition),
+            o.title,
+        )
+    console.print(table)
+
+
+@click.command(name='scan')
+@click.option('--pat', default=None, envvar='GITTENSOR_MINER_PAT', help='GitHub PAT. Uses GITTENSOR_MINER_PAT if unset.')
+@click.option('--limit', default=DEFAULT_ISSUES_PER_REPO, show_default=True, help='Open issues to pull per repo.')
+@click.option('--top', default=DEFAULT_TOP, show_default=True, help='Number of top opportunities to display.')
+@click.option(
+    '--check-competition',
+    is_flag=True,
+    default=False,
+    help='Count existing referencing PRs per issue (slower; extra API calls).',
+)
+@click.option('--json', 'json_mode', is_flag=True, default=False, help='Emit ranked opportunities as JSON on stdout.')
+def scan_command(pat: Optional[str], limit: int, top: int, check_competition: bool, json_mode: bool) -> None:
+    """Rank open issues across whitelisted repos by earning opportunity.
+
+    Example:
+        gitt miner scan --pat ghp_xxxxx --check-competition
+    """
+    if not pat:
+        _error('--pat flag or GITTENSOR_MINER_PAT environment variable is required.', json_mode)
+        raise SystemExit(1)
+
+    from gittensor.validator.utils.load_weights import load_master_repo_weights
+
+    repositories = load_master_repo_weights()
+    if not json_mode:
+        console.print('[bold cyan]Scanning whitelisted repos for issue opportunities...[/bold cyan]')
+
+    opportunities = gather_opportunities(
+        repositories, pat, issues_per_repo=limit, check_competition=check_competition
+    )[:top]
+
+    if json_mode:
+        emit_json({'success': True, 'opportunities': [o.to_dict() for o in opportunities]})
+    else:
+        _render(opportunities)

--- a/gittensor/cli/miner_commands/scan.py
+++ b/gittensor/cli/miner_commands/scan.py
@@ -35,6 +35,7 @@ console = Console()
 FRESHNESS_HALF_LIFE_DAYS = 30.0
 DEFAULT_ISSUES_PER_REPO = 10
 DEFAULT_TOP = 20
+GITHUB_MAX_PER_PAGE = 100  # GitHub REST caps per_page at 100
 
 
 @dataclass
@@ -96,27 +97,49 @@ def _age_days(created_at: str, now: Optional[datetime] = None) -> float:
         created = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
     except (ValueError, AttributeError):
         return 0.0
+    # A parseable but timezone-naive value (no 'Z'/offset) would raise TypeError
+    # when subtracted from the aware `now`; treat such timestamps as UTC.
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
     return max(0.0, (now - created).total_seconds() / 86400.0)
 
 
 def fetch_open_issues(repo: str, token: str, limit: int) -> List[Dict[str, Any]]:
     """Fetch up to ``limit`` open issues for a repo via REST, excluding PRs.
 
-    GitHub's issues endpoint returns pull requests too; items carrying a
-    ``pull_request`` key are filtered out.
+    GitHub caps ``per_page`` at 100, so a ``limit`` above that is paginated
+    rather than silently truncated. GitHub's issues endpoint also returns pull
+    requests; items carrying a ``pull_request`` key are filtered out.
     """
     from gittensor.constants import BASE_GITHUB_API_URL, GITHUB_HTTP_TIMEOUT_SECONDS
     from gittensor.utils.github_api_tools import get_session
 
     session = get_session(token)
-    resp = session.get(
-        f'{BASE_GITHUB_API_URL}/repos/{repo}/issues',
-        params={'state': 'open', 'sort': 'created', 'direction': 'desc', 'per_page': limit},
-        timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
-    )
-    if resp.status_code != 200:
-        return []
-    return [item for item in resp.json() if 'pull_request' not in item]
+    per_page = min(limit, GITHUB_MAX_PER_PAGE)
+    issues: List[Dict[str, Any]] = []
+    page = 1
+    while len(issues) < limit:
+        resp = session.get(
+            f'{BASE_GITHUB_API_URL}/repos/{repo}/issues',
+            params={
+                'state': 'open',
+                'sort': 'created',
+                'direction': 'desc',
+                'per_page': per_page,
+                'page': page,
+            },
+            timeout=GITHUB_HTTP_TIMEOUT_SECONDS,
+        )
+        if resp.status_code != 200:
+            break
+        batch = resp.json()
+        if not batch:
+            break
+        issues.extend(item for item in batch if 'pull_request' not in item)
+        if len(batch) < per_page:  # final page reached
+            break
+        page += 1
+    return issues[:limit]
 
 
 def _competition_count(repo: str, issue_number: int, token: str) -> int:

--- a/tests/cli/test_miner_advisor.py
+++ b/tests/cli/test_miner_advisor.py
@@ -1,0 +1,91 @@
+# Entrius 2025
+
+"""Unit tests for `gitt miner advisor` recommendation analysis.
+
+The analyzer is pure (operates on the serialized pipeline payload), so these
+tests run without network, chain, or DB access.
+"""
+
+from gittensor.cli.miner_commands.advisor import Impact, build_recommendations
+
+
+def _impacts(recs):
+    return {r.impact for r in recs}
+
+
+def test_failed_evaluation_yields_single_critical():
+    payload = {'miner_evaluation': {'failed_reason': 'no PAT'}, 'rewards': {}}
+    recs = build_recommendations(payload, thresholds={})
+    assert len(recs) == 1
+    assert recs[0].impact is Impact.CRITICAL
+    assert 'no PAT' in recs[0].detail
+
+
+def test_ineligible_repo_is_critical_with_numbers():
+    payload = {
+        'miner_evaluation': {
+            'failed_reason': None,
+            'total_score': 0.0,
+            'unique_repos_count': 1,
+            'total_collateral_score': 0.0,
+            'repo_evaluations': {
+                'owner/repo': {'is_eligible': False, 'credibility': 0.4, 'total_merged_prs': 1},
+            },
+            'merged_pull_requests': [],
+        },
+        'rewards': {'blended_final': 0.0},
+    }
+    thresholds = {'owner/repo': {'min_valid_merged_prs': 3, 'min_credibility': 0.6}}
+    recs = build_recommendations(payload, thresholds)
+    critical = [r for r in recs if r.impact is Impact.CRITICAL]
+    assert critical and critical[0].repo == 'owner/repo'
+    assert '1/3' in critical[0].detail  # merged-PR gap surfaced
+    assert '0.6' in critical[0].detail  # credibility threshold surfaced
+
+
+def test_reductions_and_tips_detected():
+    payload = {
+        'miner_evaluation': {
+            'failed_reason': None,
+            'total_score': 12.0,
+            'unique_repos_count': 1,
+            'total_collateral_score': 2.5,
+            'repo_evaluations': {'owner/repo': {'is_eligible': True, 'credibility': 0.9, 'total_merged_prs': 5}},
+            'merged_pull_requests': [
+                {
+                    'repository_full_name': 'owner/repo',
+                    'number': 7,
+                    'review_quality_multiplier': 0.5,  # WARNING: review penalty
+                    'open_pr_spam_multiplier': 1.0,
+                    'time_decay_multiplier': 1.0,
+                    'issue_multiplier': 1.0,  # TIP: no linked issue
+                    'label_multiplier': 1.0,
+                },
+            ],
+        },
+        'rewards': {'blended_final': 0.01},
+    }
+    recs = build_recommendations(payload, thresholds={})
+    impacts = _impacts(recs)
+    assert Impact.WARNING in impacts  # review penalty + collateral
+    assert Impact.TIP in impacts  # missing issue link
+    assert Impact.INFO in impacts  # standing summary
+
+
+def test_recommendations_sorted_by_impact():
+    payload = {
+        'miner_evaluation': {
+            'failed_reason': None,
+            'total_score': 1.0,
+            'unique_repos_count': 1,
+            'total_collateral_score': 1.0,
+            'repo_evaluations': {'a/b': {'is_eligible': False, 'credibility': 0.0, 'total_merged_prs': 0}},
+            'merged_pull_requests': [],
+        },
+        'rewards': {'blended_final': 0.0},
+    }
+    thresholds = {'a/b': {'min_valid_merged_prs': 1, 'min_credibility': 0.5}}
+    recs = build_recommendations(payload, thresholds)
+    order = [r.impact for r in recs]
+    # CRITICAL must come before INFO in the rendered order.
+    assert order.index(Impact.CRITICAL) < order.index(Impact.INFO)

--- a/tests/cli/test_miner_scan.py
+++ b/tests/cli/test_miner_scan.py
@@ -1,0 +1,92 @@
+# Entrius 2025
+
+"""Unit tests for `gitt miner scan` opportunity ranking.
+
+The scoring + ranking helpers are pure and accept injectable fetchers, so these
+tests run without any network access.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from gittensor.cli.miner_commands.scan import (
+    Opportunity,
+    freshness_factor,
+    gather_opportunities,
+    opportunity_score,
+)
+
+_NOW = datetime(2026, 6, 29, tzinfo=timezone.utc)
+
+
+def test_freshness_decays_with_age():
+    assert freshness_factor(0) == 1.0
+    assert abs(freshness_factor(30, half_life=30) - 0.5) < 1e-9
+    assert freshness_factor(60, half_life=30) < freshness_factor(30, half_life=30)
+
+
+def test_opportunity_score_monotonicity():
+    base = opportunity_score(emission_share=0.1, multiplier=2.0, age_days=0, competition=0)
+    # More emission share -> higher score.
+    assert opportunity_score(0.2, 2.0, 0, 0) > base
+    # More competition -> lower score.
+    assert opportunity_score(0.1, 2.0, 0, 3) < base
+    # Older issue -> lower score.
+    assert opportunity_score(0.1, 2.0, 90, 0) < base
+
+
+def test_gather_skips_zero_share_and_ranks_desc():
+    repos = {
+        'big/repo': SimpleNamespace(emission_share=0.35, scoring=None, label_multipliers={'feature': 3.0}),
+        'small/repo': SimpleNamespace(emission_share=0.02, scoring=None, label_multipliers=None),
+        'dead/repo': SimpleNamespace(emission_share=0.0, scoring=None, label_multipliers=None),  # skipped
+    }
+
+    def fake_fetch(repo, token, limit):
+        return [{'number': 1, 'title': f'issue in {repo}', 'html_url': f'https://x/{repo}/1', 'created_at': '2026-06-20T00:00:00Z'}]
+
+    def no_competition(repo, number, token):
+        return 0
+
+    opps = gather_opportunities(
+        repos,
+        'tok',
+        issue_fetcher=fake_fetch,
+        competition_fn=no_competition,
+        now=_NOW,
+    )
+
+    repos_seen = [o.repo for o in opps]
+    assert 'dead/repo' not in repos_seen  # zero emission share dropped
+    assert len(opps) == 2
+    assert opps[0].repo == 'big/repo'  # highest share+multiplier ranks first
+    assert all(isinstance(o, Opportunity) for o in opps)
+    assert opps[0].score >= opps[1].score
+
+
+def test_competition_only_queried_when_enabled():
+    repos = {'a/b': SimpleNamespace(emission_share=0.1, scoring=None, label_multipliers={'feature': 2.0})}
+    calls = {'n': 0}
+
+    def fake_fetch(repo, token, limit):
+        return [{'number': 9, 'title': 't', 'html_url': 'u', 'created_at': '2026-06-25T00:00:00Z'}]
+
+    def counting_competition(repo, number, token):
+        calls['n'] += 1
+        return 2
+
+    # Disabled: competition_fn must not be called.
+    gather_opportunities(repos, 'tok', issue_fetcher=fake_fetch, competition_fn=counting_competition, now=_NOW)
+    assert calls['n'] == 0
+
+    # Enabled: competition_fn is consulted and reflected in the result.
+    opps = gather_opportunities(
+        repos,
+        'tok',
+        check_competition=True,
+        issue_fetcher=fake_fetch,
+        competition_fn=counting_competition,
+        now=_NOW,
+    )
+    assert calls['n'] == 1
+    assert opps[0].competition == 2

--- a/tests/cli/test_miner_scan.py
+++ b/tests/cli/test_miner_scan.py
@@ -8,9 +8,12 @@ tests run without any network access.
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from gittensor.cli.miner_commands.scan import (
     Opportunity,
+    _age_days,
+    fetch_open_issues,
     freshness_factor,
     gather_opportunities,
     opportunity_score,
@@ -90,3 +93,37 @@ def test_competition_only_queried_when_enabled():
     )
     assert calls['n'] == 1
     assert opps[0].competition == 2
+
+
+def test_age_days_handles_naive_timestamp_without_crashing():
+    # A parseable but timezone-naive timestamp must not raise (was a TypeError).
+    assert _age_days('2026-06-01T00:00:00', now=_NOW) == 28.0  # treated as UTC
+    assert _age_days('not-a-date', now=_NOW) == 0.0  # malformed -> 0.0
+
+
+@patch('gittensor.utils.github_api_tools.get_session')
+def test_fetch_open_issues_paginates_and_excludes_prs(mock_get_session):
+    def resp(items):
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = items
+        return r
+
+    page1 = [
+        {'number': n, 'title': 't', 'html_url': 'u', 'created_at': '2026-06-01T00:00:00Z'}
+        for n in range(100)
+    ]
+    page1[0]['pull_request'] = {'url': 'x'}  # one PR that must be filtered out
+    page2 = [
+        {'number': n, 'title': 't', 'html_url': 'u', 'created_at': '2026-06-01T00:00:00Z'}
+        for n in range(100, 130)
+    ]
+    session = MagicMock()
+    session.get.side_effect = [resp(page1), resp(page2)]
+    mock_get_session.return_value = session
+
+    out = fetch_open_issues('owner/repo', 'tok', 150)
+
+    assert session.get.call_count == 2  # paginated past the 100-per-page cap
+    assert all('pull_request' not in i for i in out)  # PRs excluded
+    assert len(out) == 129  # 99 issues (page1) + 30 (page2)


### PR DESCRIPTION
Fixes #1460

Type: Feature

Draft — `gitt miner advisor` landed (reuses the score.py local pipeline,
emits CRITICAL/WARNING/TIP/INFO recommendations). `scan` + tests +
before/after screenshots to follow before marking ready.

cc @anderdc @landyndev