### PR TITLE
fix: coerce MirrorReviewSummary review counts to int

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -64,10 +64,10 @@ class MirrorReviewSummary:
                 'defaulting to 0 (review penalty/clean-bonus may be miscalculated)'
             )
         return cls(
-            maintainer_changes_requested_count=data.get('maintainer_changes_requested_count', 0),
-            changes_requested_count=data.get('changes_requested_count', 0),
-            approved_count=data.get('approved_count', 0),
-            commented_count=data.get('commented_count', 0),
+            maintainer_changes_requested_count=int(data.get('maintainer_changes_requested_count', 0)),
+            changes_requested_count=int(data.get('changes_requested_count', 0)),
+            approved_count=int(data.get('approved_count', 0)),
+            commented_count=int(data.get('commented_count', 0)),
         )
 
 

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -238,6 +238,24 @@ class TestMirrorReviewSummary:
         MirrorReviewSummary.from_dict({'maintainer_changes_requested_count': 0})
         mock_logging.warning.assert_not_called()
 
+    def test_counts_coerced_to_int(self):
+        """Counts are returned as ints even if the mirror serializes them as
+        strings, matching the int() coercion every other numeric model field uses.
+        """
+        rs = MirrorReviewSummary.from_dict(
+            {
+                'maintainer_changes_requested_count': '2',
+                'changes_requested_count': '3',
+                'approved_count': '1',
+                'commented_count': '4',
+            }
+        )
+        assert rs.maintainer_changes_requested_count == 2
+        assert isinstance(rs.maintainer_changes_requested_count, int)
+        assert rs.changes_requested_count == 3
+        assert rs.approved_count == 1
+        assert rs.commented_count == 4
+
 
 # ============================================================================
 # MirrorLinkedIssue


### PR DESCRIPTION
## Summary
`MirrorReviewSummary.from_dict` is the only model parser that doesn't coerce its
numeric fields with `int()` — every other field does (`additions`, `deletions`,
`commits_count`, `pr_number`, …). `maintainer_changes_requested_count` feeds the
review-quality multiplier and is written to the analytics DB, so a string-typed
count from the mirror would silently break comparisons/arithmetic.

This wraps the four counts in `int()` to match the established convention.
Behaviour-preserving for well-formed payloads — a robustness/parity fix, **not**
a scoring-policy change (no weights/multipliers/thresholds touched).

## Type of Change
- [x] Bug fix

## Testing
Added `test_counts_coerced_to_int`; `uv run pytest tests/utils/test_mirror_models.py` passes.

cc @anderdc @landyndev