### PR TITLE
feat(validator): configurable miner_pats.json path via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,9 @@ WANDB_API_KEY=
 GITTENSOR_VALIDATOR_PAT=
 # Optional custom name for wandb logging
 WANDB_VALIDATOR_NAME=vali
-# Optional: store the miner PATs file outside the repo (default: data/miner_pats.json)
+# Optional: store the miner PATs file at an exact, absolute path (default: data/miner_pats.json).
+# Docker users: this path must live inside a mounted volume or it will be wiped on image
+# update. Simpler in Docker is to change the host side of the `./data:/app/data` mount instead.
 # GITTENSOR_MINER_PATS_FILE=/path/to/miner_pats.json
 
 # validator database settings (for gittensor validator/dashboard)

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ WANDB_API_KEY=
 GITTENSOR_VALIDATOR_PAT=
 # Optional custom name for wandb logging
 WANDB_VALIDATOR_NAME=vali
+# Optional: store the miner PATs file outside the repo (default: data/miner_pats.json)
+# GITTENSOR_MINER_PATS_FILE=/path/to/miner_pats.json
 
 # validator database settings (for gittensor validator/dashboard)
 STORE_DB_RESULTS=false

--- a/gittensor/validator/pat_storage.py
+++ b/gittensor/validator/pat_storage.py
@@ -5,6 +5,9 @@
 Validators store PATs received via PatBroadcastSynapse in miner_pats.json at the project root.
 The scoring loop snapshots the full file once per round via load_all_pats(); mid-round
 broadcasts update the file but do not affect the current scoring round.
+
+The store location defaults to data/miner_pats.json at the project root and can be
+relocated by setting the GITTENSOR_MINER_PATS_FILE env var to an exact file path.
 """
 
 import json
@@ -17,7 +20,11 @@ from typing import Optional
 
 import bittensor as bt
 
-PATS_FILE = Path(__file__).resolve().parents[2] / 'data' / 'miner_pats.json'
+# Where the PAT store lives. Defaults to data/miner_pats.json at the project root;
+# validators who keep subnet data elsewhere can override the exact file path via
+# the GITTENSOR_MINER_PATS_FILE env var.
+_DEFAULT_PATS_FILE = Path(__file__).resolve().parents[2] / 'data' / 'miner_pats.json'
+PATS_FILE = Path(os.environ['GITTENSOR_MINER_PATS_FILE']) if os.environ.get('GITTENSOR_MINER_PATS_FILE') else _DEFAULT_PATS_FILE
 
 _lock = threading.Lock()
 

--- a/gittensor/validator/pat_storage.py
+++ b/gittensor/validator/pat_storage.py
@@ -24,7 +24,9 @@ import bittensor as bt
 # validators who keep subnet data elsewhere can override the exact file path via
 # the GITTENSOR_MINER_PATS_FILE env var.
 _DEFAULT_PATS_FILE = Path(__file__).resolve().parents[2] / 'data' / 'miner_pats.json'
-PATS_FILE = Path(os.environ['GITTENSOR_MINER_PATS_FILE']) if os.environ.get('GITTENSOR_MINER_PATS_FILE') else _DEFAULT_PATS_FILE
+PATS_FILE = (
+    Path(os.environ['GITTENSOR_MINER_PATS_FILE']) if os.environ.get('GITTENSOR_MINER_PATS_FILE') else _DEFAULT_PATS_FILE
+)
 
 _lock = threading.Lock()
 

--- a/tests/validator/test_pat_storage.py
+++ b/tests/validator/test_pat_storage.py
@@ -2,6 +2,7 @@
 
 """Tests for validator PAT storage."""
 
+import importlib
 import json
 import threading
 from pathlib import Path
@@ -145,6 +146,36 @@ class TestGetPatByUid:
     def test_get_missing(self):
         entry = pat_storage.get_pat_by_uid(999)
         assert entry is None
+
+
+class TestPatsFileLocation:
+    """The store path defaults to data/miner_pats.json but honors GITTENSOR_MINER_PATS_FILE."""
+
+    def test_defaults_to_project_data_dir(self, monkeypatch):
+        monkeypatch.delenv('GITTENSOR_MINER_PATS_FILE', raising=False)
+        reloaded = importlib.reload(pat_storage)
+        try:
+            assert reloaded.PATS_FILE == reloaded._DEFAULT_PATS_FILE
+            assert reloaded.PATS_FILE.name == 'miner_pats.json'
+        finally:
+            importlib.reload(pat_storage)
+
+    def test_env_var_overrides_with_exact_path(self, monkeypatch, tmp_path):
+        custom = tmp_path / 'subnet-data' / 'pats.json'
+        monkeypatch.setenv('GITTENSOR_MINER_PATS_FILE', str(custom))
+        reloaded = importlib.reload(pat_storage)
+        try:
+            assert reloaded.PATS_FILE == custom
+        finally:
+            importlib.reload(pat_storage)
+
+    def test_empty_env_var_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv('GITTENSOR_MINER_PATS_FILE', '')
+        reloaded = importlib.reload(pat_storage)
+        try:
+            assert reloaded.PATS_FILE == reloaded._DEFAULT_PATS_FILE
+        finally:
+            importlib.reload(pat_storage)
 
 
 class TestConcurrency:


### PR DESCRIPTION
## What

Adds an optional `GITTENSOR_MINER_PATS_FILE` env var that lets validators store the miner PAT file outside the repo.

- **Unset / empty** → defaults to `data/miner_pats.json` at the project root (current behavior, no change for existing deployments).
- **Set** → uses the exact file path provided.

## Why

Validators (e.g. Yuma) keep subnet data in a separate folder to keep the subnet repo clean. There was no way to relocate `miner_pats.json`, so they were resorting to symlinks. This also reduces the risk of the PAT store being disturbed on validator updates — a suspected cause of PATs getting wiped and miners having to re-broadcast (low vtrust symptom reported in Discord).

## Changes

- `gittensor/validator/pat_storage.py` — resolve `PATS_FILE` from `GITTENSOR_MINER_PATS_FILE`, falling back to the existing default.
- `.env.example` — document the new optional var.
- `tests/validator/test_pat_storage.py` — cover default, exact-path override, and empty-string fallback.

## Test

`pytest tests/validator/test_pat_storage.py` → 17 passed.