### PR TITLE
refactor(validator): share one MirrorClient across the OSS scoring round

### DIFF
--- a/gittensor/validator/oss_contributions/reward.py
+++ b/gittensor/validator/oss_contributions/reward.py
@@ -31,6 +31,7 @@ async def evaluate_miners_pull_requests(
     master_repositories: Dict[str, RepositoryConfig],
     programming_languages: Dict[str, LanguageConfig],
     token_config: TokenConfig,
+    mirror_client: Optional[MirrorClient] = None,
     stale_hotkey: Optional[str] = None,
     stored_github_id: Optional[str] = None,
 ) -> MinerEvaluation:
@@ -44,6 +45,9 @@ async def evaluate_miners_pull_requests(
         master_repositories: The incentivized repositories and their RepositoryConfig objects
         programming_languages: The programming languages and their weights
         token_config: Token-based scoring weights configuration
+        mirror_client: A shared MirrorClient to reuse across the scoring round. When
+            omitted (e.g. standalone/test calls), a short-lived client is created and
+            closed for this single evaluation.
         stale_hotkey: If set, the UID has a stored PAT from this old hotkey (re-registration detected)
         stored_github_id: GitHub id recorded when the stored PAT was accepted
 
@@ -68,11 +72,17 @@ async def evaluate_miners_pull_requests(
         bt.logging.warning(f'UID {uid}: GitHub identity lookup failed transiently; deferring to cache fallback')
         return miner_eval
 
-    with MirrorClient() as mirror_client:
-        await asyncio.to_thread(load_miner_prs, miner_eval, master_repositories, client=mirror_client)
-        await score_miner_prs(
-            miner_eval, master_repositories, programming_languages, token_config, client=mirror_client
-        )
+    # Reuse the caller's client so the mirror connection pool is shared across the
+    # whole scoring round instead of reopened per miner. Only close a client we
+    # created ourselves; a caller-supplied one stays open for the next miner.
+    owns_client = mirror_client is None
+    client = mirror_client or MirrorClient()
+    try:
+        await asyncio.to_thread(load_miner_prs, miner_eval, master_repositories, client=client)
+        await score_miner_prs(miner_eval, master_repositories, programming_languages, token_config, client=client)
+    finally:
+        if owns_client:
+            client.close()
 
     bt.logging.info('*' * 50 + '\n')
     return miner_eval
@@ -104,32 +114,37 @@ async def get_rewards(
 
     miner_evaluations: Dict[int, MinerEvaluation] = {}
 
-    # Look up PATs and calculate score.
-    for uid in uids:
-        hotkey = self.metagraph.hotkeys[uid]
-        pat_entry = pat_by_uid.get(uid)
-        pat = None
-        stale_hotkey = None
-        stored_github_id = None
-        if pat_entry:
-            if pat_entry.get('hotkey') == hotkey:
-                pat = pat_entry['pat']
-                stored_github_id = pat_entry.get('github_id')
-            else:
-                stale_hotkey = pat_entry.get('hotkey')
+    # One mirror client for the whole round so the per-miner loop reuses a single
+    # pooled connection instead of opening a fresh session per UID. Mirrors how
+    # issue discovery threads one client through every miner.
+    with MirrorClient() as mirror_client:
+        # Look up PATs and calculate score.
+        for uid in uids:
+            hotkey = self.metagraph.hotkeys[uid]
+            pat_entry = pat_by_uid.get(uid)
+            pat = None
+            stale_hotkey = None
+            stored_github_id = None
+            if pat_entry:
+                if pat_entry.get('hotkey') == hotkey:
+                    pat = pat_entry['pat']
+                    stored_github_id = pat_entry.get('github_id')
+                else:
+                    stale_hotkey = pat_entry.get('hotkey')
 
-        # Calculate score
-        miner_evaluation = await evaluate_miners_pull_requests(
-            uid,
-            hotkey,
-            pat,
-            master_repositories,
-            programming_languages,
-            token_config,
-            stale_hotkey=stale_hotkey,
-            stored_github_id=stored_github_id,
-        )
-        miner_evaluations[uid] = miner_evaluation
+            # Calculate score
+            miner_evaluation = await evaluate_miners_pull_requests(
+                uid,
+                hotkey,
+                pat,
+                master_repositories,
+                programming_languages,
+                token_config,
+                mirror_client=mirror_client,
+                stale_hotkey=stale_hotkey,
+                stored_github_id=stored_github_id,
+            )
+            miner_evaluations[uid] = miner_evaluation
 
     # If evaluation of miner was successful, store to cache, if api failure, fallback to previous successful evaluation if any
     cached_uids = self.store_or_use_cached_evaluation(miner_evaluations)

--- a/tests/validator/oss_contributions/mirror/test_routing.py
+++ b/tests/validator/oss_contributions/mirror/test_routing.py
@@ -7,7 +7,7 @@ Verifies that:
 """
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -62,6 +62,64 @@ def test_load_and_score_run_with_all_repos():
         passed = mock_load.call_args.args[1]
         assert set(passed.keys()) == {'entrius/gittensor-ui', 'entrius/allways'}
         mock_score.assert_called_once()
+
+
+def test_injected_client_is_reused_not_reconstructed():
+    """A caller-supplied mirror client is threaded into load/score and no new
+    MirrorClient is constructed (the per-round connection pool is reused)."""
+    shared_client = MagicMock(name='shared_mirror_client')
+
+    with (
+        patch.object(reward_module, 'validate_response_and_initialize_miner_evaluation') as mock_init,
+        patch.object(reward_module, 'load_miner_prs') as mock_load,
+        patch.object(reward_module, 'score_miner_prs') as mock_score,
+        patch.object(reward_module, 'MirrorClient') as mock_client_cls,
+    ):
+        mock_init.return_value = _make_miner_eval()
+
+        _run(
+            evaluate_miners_pull_requests(
+                uid=1,
+                hotkey='hk',
+                pat='fake-pat',
+                master_repositories=_configs(),
+                programming_languages={},
+                token_config=TokenConfig(),
+                mirror_client=shared_client,
+            )
+        )
+
+        mock_client_cls.assert_not_called()
+        assert mock_load.call_args.kwargs['client'] is shared_client
+        assert mock_score.call_args.kwargs['client'] is shared_client
+        shared_client.close.assert_not_called()
+
+
+def test_standalone_call_owns_and_closes_its_client():
+    """Without an injected client, a short-lived one is created and closed so
+    the standalone/test path does not leak a session."""
+    with (
+        patch.object(reward_module, 'validate_response_and_initialize_miner_evaluation') as mock_init,
+        patch.object(reward_module, 'load_miner_prs'),
+        patch.object(reward_module, 'score_miner_prs'),
+        patch.object(reward_module, 'MirrorClient') as mock_client_cls,
+    ):
+        mock_init.return_value = _make_miner_eval()
+        owned_client = mock_client_cls.return_value
+
+        _run(
+            evaluate_miners_pull_requests(
+                uid=1,
+                hotkey='hk',
+                pat='fake-pat',
+                master_repositories=_configs(),
+                programming_languages={},
+                token_config=TokenConfig(),
+            )
+        )
+
+        mock_client_cls.assert_called_once_with()
+        owned_client.close.assert_called_once_with()
 
 
 def test_failed_init_short_circuits():


### PR DESCRIPTION
## Summary

`get_rewards` opened a fresh `MirrorClient` — and therefore a brand-new `requests.Session` — for **every UID** inside the per-miner loop:

```python
# evaluate_miners_pull_requests, called once per uid in get_rewards
with MirrorClient() as mirror_client:
    await asyncio.to_thread(load_miner_prs, ..., client=mirror_client)
    await score_miner_prs(..., client=mirror_client)
```

So a full scoring round builds and tears down one HTTPS session per miner against `mirror.gittensor.io`, discarding the connection pool between miners and re-doing the TLS handshake on every iteration. Connection reuse also matters under the mirror's Cloudflare rate limit (50 req / 10s / IP).

This PR hoists a **single** `MirrorClient` to the round level in `get_rewards` and threads it through `evaluate_miners_pull_requests`. This mirrors the pattern the issue-discovery path already uses — it builds one client and passes it through every miner (`issue_discovery/scan.py:156`). The OSS-scoring path is now consistent with it.

`evaluate_miners_pull_requests` gains an optional `mirror_client` parameter and only **owns/closes** a client when it created one itself; a caller-supplied client stays open for the next miner. Standalone and test calls (which pass no client) keep their previous create-and-close behavior, so there is no new session leak on that path.

### Why it's behavior-preserving

`MirrorClient` holds no per-miner or per-instance request state — only the pooled `requests.Session` (`utils/mirror/client.py`). Sharing one instance across miners changes nothing about request content, retries, rate-limit handling, or scoring; it only reuses the connection pool instead of recreating it ~N times per round.

## Related Issues

None — this is a latent inefficiency found by inspection, not a tracked issue.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added two tests in `tests/validator/oss_contributions/mirror/test_routing.py` pinning the client-ownership contract:
- `test_injected_client_is_reused_not_reconstructed` — an injected client is threaded into `load_miner_prs`/`score_miner_prs`, no new `MirrorClient` is constructed, and it is **not** closed by the callee.
- `test_standalone_call_owns_and_closes_its_client` — with no injected client, exactly one is constructed and closed (no leak).

Full suite: `958 passed`. `ruff check`, `ruff format --check`, and `pyright` all clean.

No CLI output is affected by this change.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)