### PR TITLE
chore: set touchpilot min_valid_merged_prs and min_credibility to zero

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -332,6 +332,10 @@
   "touchpilot/touchpilot": {
     "emission_share": 0.0035,
     "issue_discovery_share": 0.0,
+    "eligibility": {
+      "min_valid_merged_prs": 1,
+      "min_credibility": 0.5
+    },
     "label_multipliers": {
       "type: bug": 1.1,
       "type: enhancement": 1.25,


### PR DESCRIPTION
## Summary

Update the `touchpilot/touchpilot` repository config in `gittensor/validator/weights/master_repositories.json` to relax the PR-side eligibility gate.

## Changes

- Set `eligibility.min_valid_merged_prs` to `1`
- Set `eligibility.min_credibility` to `0.5`

## Why

The `touchpilot/touchpilot` maintainer requested these hyperparameter changes so the repository uses less restrictive PR-side eligibility thresholds than the current defaults.

## Validation

- Verified the JSON remains valid after the update
- Confirmed the diff is scoped to the `touchpilot/touchpilot` config block
