### PR TITLE
gittensor-ai-lab/sparkinfer: raise credibility threshold to 40% (min_credibility 0.4)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -153,7 +153,7 @@
   "gittensor-ai-lab/sparkinfer": {
     "default_label_multiplier": 0.0,
     "eligibility": {
-      "min_credibility": 0.0,
+      "min_credibility": 0.4,
       "min_issue_credibility": 0.0,
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0


### PR DESCRIPTION
Sets the sparkinfer eligibility **`min_credibility` to `0.4`** (40%) in `master_repositories.json` — a contributor must reach ≥40% credibility before earning emissions on this repo.

**Why:** sparkinfer has seen repeated low-credibility farming — sybil pairs and coordinated copycat rings (documented in the repo's `.github/FLAGGED.md`). A 40% credibility floor makes fresh throwaway/sybil accounts ineligible until they've built a real track record, without affecting established contributors. Speedup-only scoring (`fixed_base_score`, `eval:*` label multipliers) is unchanged; this only gates *who is eligible*.

Only the sparkinfer entry's `min_credibility` changes (0.0 → 0.4); everything else (maintainer_cut, emission_share, label_multipliers) is untouched.