### PR TITLE
gittensor-ai-lab/sparkinfer: raise credibility threshold to 35% (min_credibility 0.35)

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -153,7 +153,7 @@
   "gittensor-ai-lab/sparkinfer": {
     "default_label_multiplier": 0.0,
     "eligibility": {
-      "min_credibility": 0.0,
+      "min_credibility": 0.35,
       "min_issue_credibility": 0.0,
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0


### PR DESCRIPTION
Targets `test` (contributor branch; main advances via Release).

Sets the sparkinfer eligibility **`min_credibility` to `0.35`** (35%) in `master_repositories.json` — a contributor must reach ≥35% credibility before earning emissions on this repo.

**Why:** repeated low-credibility farming on sparkinfer (sybil pairs + coordinated copycat rings, see `.github/FLAGGED.md`). A 35% floor makes fresh throwaway/sybil accounts ineligible until they build a real track record, without affecting established contributors. Speedup-only scoring is unchanged — this only gates *who is eligible*.

Only `min_credibility` changes (0.0 → 0.35); maintainer_cut / emission_share / label_multipliers untouched.