### PR TITLE
fix(validator): clamp scoring rounds to single-flight

### DIFF
--- a/gittensor/utils/config.py
+++ b/gittensor/utils/config.py
@@ -98,7 +98,7 @@ def add_validator_args(cls, parser):
     parser.add_argument(
         '--neuron.num_concurrent_forwards',
         type=int,
-        help='The number of concurrent forwards running at any time.',
+        help='The number of concurrent forwards running at any time. Validator scoring rounds are single-flight.',
         default=1,
     )
 

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -103,6 +103,15 @@ class BaseValidatorNeuron(BaseNeuron):
             pass
 
     async def concurrent_forward(self):
+        # Validator forward() runs a whole scoring round with DB + chain side effects.
+        # Keep it single-flight even if an operator passes a higher template value.
+        if self.config.neuron.num_concurrent_forwards != 1:
+            bt.logging.warning(
+                'Validator forward concurrency is unsupported for scoring rounds; '
+                f'clamping neuron.num_concurrent_forwards={self.config.neuron.num_concurrent_forwards} to 1'
+            )
+            self.config.neuron.num_concurrent_forwards = 1
+
         coroutines = [self.forward() for _ in range(self.config.neuron.num_concurrent_forwards)]
         await asyncio.gather(*coroutines)
 

--- a/tests/validator/test_validator_single_flight_forward.py
+++ b/tests/validator/test_validator_single_flight_forward.py
@@ -1,0 +1,32 @@
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+
+from neurons.base.validator import BaseValidatorNeuron
+
+
+class _StubValidator:
+    def __init__(self, configured_forwards: int):
+        self.calls = 0
+        self.config = SimpleNamespace(neuron=SimpleNamespace(num_concurrent_forwards=configured_forwards))
+
+    async def forward(self):
+        self.calls += 1
+
+
+def test_concurrent_forward_clamps_validator_rounds_to_single_flight():
+    validator = _StubValidator(configured_forwards=3)
+
+    asyncio.run(BaseValidatorNeuron.concurrent_forward(cast(BaseValidatorNeuron, validator)))
+
+    assert validator.calls == 1
+    assert validator.config.neuron.num_concurrent_forwards == 1
+
+
+def test_concurrent_forward_preserves_default_single_round():
+    validator = _StubValidator(configured_forwards=1)
+
+    asyncio.run(BaseValidatorNeuron.concurrent_forward(cast(BaseValidatorNeuron, validator)))
+
+    assert validator.calls == 1
+    assert validator.config.neuron.num_concurrent_forwards == 1


### PR DESCRIPTION
## Summary

- clamp validator scoring rounds to a single in-flight forward even if `--neuron.num_concurrent_forwards` is set above `1`
- emit a warning when a validator is started with an unsupported forward concurrency value
- add regression coverage for the single-flight behavior and clarify the validator config help text

## Related Issues

- Related to #1433
- Prior maintainer disposition on this bug was `not planned`; this PR supplies a concrete fix with regression coverage

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)