### PR TITLE
chore(weights): raise metagraphed to 0.24, offset from taopedia

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -13,7 +13,7 @@
     "issue_discovery_share": 0.0
   },
   "e35ventura/taopedia": {
-    "emission_share": 0.049,
+    "emission_share": 0.039,
     "issue_discovery_share": 0.0,
     "maintainer_cut": 0.0,
     "additional_acceptable_branches": ["test"],
@@ -212,7 +212,7 @@
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.23,
+    "emission_share": 0.24,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.5,


### PR DESCRIPTION
Follow-up to #1569. Raise `JSONbored/metagraphed` to 0.24 and take the offset from `e35ventura/taopedia`, keeping the pool at exactly 1.0.

## Rebalances
| repo | old | new |
|---|---:|---:|
| JSONbored/metagraphed | 0.2300 | 0.2400 |
| e35ventura/taopedia | 0.0490 | 0.0390 |

## Totals
- Previous: `1.0` (headroom 0.0)
- New: `1.0` (headroom 0.0)

## Notes
- `metagraphed` +0.01; the full offset (−0.01) comes from `taopedia`. Net change to the pool is zero.
