### PR TITLE
gittensor-vanguard/vanguarstew: add label multipliers and scoring config

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -149,7 +149,20 @@
   },
   "gittensor-vanguard/vanguarstew": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "trusted_label_pipeline": false,
+    "default_label_multiplier": 1.0,
+    "label_multipliers": {
+      "mult:core-correctness": 2.0,
+      "mult:leakage-integrity": 1.8,
+      "mult:capability": 1.5,
+      "mult:enhancement": 1.2,
+      "mult:maintenance": 1.0,
+      "mult:docs": 0.8
+    },
+    "scoring": {
+      "pr_lookback_days": 30
+    }
   },
   "JSONbored/awesome-claude": {
     "default_label_multiplier": 0.0,


### PR DESCRIPTION
Adds per-repo configuration for `gittensor-vanguard/vanguarstew` in `master_repositories.json`.

- **label_multipliers**: a maintainer-applied value ladder — `mult:core-correctness` (2.0), `mult:leakage-integrity` (1.8), `mult:capability` (1.5), `mult:enhancement` (1.2), `mult:maintenance` (1.0), `mult:docs` (0.8).
- **default_label_multiplier**: 1.0 (neutral for untriaged PRs).
- **trusted_label_pipeline**: false — only maintainer-associated labels count toward the multiplier.
- **scoring.pr_lookback_days**: 30.

`emission_share` (0.01) and `issue_discovery_share` (0.0) are unchanged; no other repo entries are touched. Total emission_share still sums to 1.0. Values are within the documented ranges (pr_lookback_days ∈ [1, 90]).