### PR TITLE
weights: sparkinfer — lower credibility gate to 0.2, raise maintainer_cut to 0.5

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -126,7 +126,7 @@
   "gittensor-ai-lab/sparkinfer": {
     "default_label_multiplier": 0.0,
     "eligibility": {
-      "min_credibility": 0.35,
+      "min_credibility": 0.0,
       "min_issue_credibility": 0.0,
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -66,7 +66,7 @@
   "gittensor-ai-lab/sparkinfer": {
     "default_label_multiplier": 0.0,
     "eligibility": {
-      "min_credibility": 0.1,
+      "min_credibility": 0.2,
       "min_issue_credibility": 0.0,
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -84,7 +84,7 @@
       "eval:none": 0.0,
       "eval:REJECT": 0.0
     },
-    "maintainer_cut": 0.3,
+    "maintainer_cut": 0.5,
     "trusted_label_pipeline": true
   },
   "gittensor-vanguard/vanguarstew": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -126,7 +126,7 @@
   "gittensor-ai-lab/sparkinfer": {
     "default_label_multiplier": 0.0,
     "eligibility": {
-      "min_credibility": 0.0,
+      "min_credibility": 0.1,
       "min_issue_credibility": 0.0,
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0


### PR DESCRIPTION
Two governance tweaks to the `gittensor-ai-lab/sparkinfer` entry in `master_repositories.json`:

- **min_credibility 0.35 → 0.2** — lower the eligibility gate so more contributors can earn.
- **maintainer_cut 0.3 → 0.5** — maintainer takes 50% of merged-PR emission (contributors 50%).

No other fields changed.