### PR TITLE
refactor(validator): dedupe metagraph guards in PAT axon handlers

### DIFF
--- a/gittensor/validator/pat_handler.py
+++ b/gittensor/validator/pat_handler.py
@@ -44,6 +44,23 @@ def _github_identity_pin_error(uid: int, hotkey: str, github_id: Optional[str]) 
     return None
 
 
+def _blacklist_if_unregistered(validator: 'Validator', synapse: bt.Synapse) -> Tuple[bool, str]:
+    """Blacklist a synapse whose sender hotkey isn't registered in the metagraph."""
+    hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        return True, f'Hotkey {hotkey[:16]}... not registered'
+    return False, 'Hotkey recognized'
+
+
+def _stake_priority(validator: 'Validator', synapse: bt.Synapse) -> float:
+    """Priority a synapse by its sender hotkey's stake, or 0.0 if it isn't registered."""
+    hotkey = _get_hotkey(synapse)
+    if hotkey not in validator.metagraph.hotkeys:
+        return 0.0
+    uid = validator.metagraph.hotkeys.index(hotkey)
+    return float(validator.metagraph.S[uid])
+
+
 # ---------------------------------------------------------------------------
 # PatBroadcastSynapse handlers
 # ---------------------------------------------------------------------------
@@ -103,19 +120,12 @@ async def handle_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSyna
 
 async def blacklist_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSynapse) -> Tuple[bool, str]:
     """Reject PAT broadcasts from unregistered hotkeys."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return True, f'Hotkey {hotkey[:16]}... not registered'
-    return False, 'Hotkey recognized'
+    return _blacklist_if_unregistered(validator, synapse)
 
 
 async def priority_pat_broadcast(validator: 'Validator', synapse: PatBroadcastSynapse) -> float:
     """Prioritize PAT broadcasts by stake."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return 0.0
-    uid = validator.metagraph.hotkeys.index(hotkey)
-    return float(validator.metagraph.S[uid])
+    return _stake_priority(validator, synapse)
 
 
 # ---------------------------------------------------------------------------
@@ -185,19 +195,12 @@ async def handle_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> 
 
 async def blacklist_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> Tuple[bool, str]:
     """Reject PAT checks from unregistered hotkeys."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return True, f'Hotkey {hotkey[:16]}... not registered'
-    return False, 'Hotkey recognized'
+    return _blacklist_if_unregistered(validator, synapse)
 
 
 async def priority_pat_check(validator: 'Validator', synapse: PatCheckSynapse) -> float:
     """Prioritize PAT checks by stake."""
-    hotkey = _get_hotkey(synapse)
-    if hotkey not in validator.metagraph.hotkeys:
-        return 0.0
-    uid = validator.metagraph.hotkeys.index(hotkey)
-    return float(validator.metagraph.S[uid])
+    return _stake_priority(validator, synapse)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The four PAT axon handlers in `gittensor/validator/pat_handler.py` come in two broadcast/check pairs that carried **byte-for-byte identical** bodies:

- `blacklist_pat_broadcast` / `blacklist_pat_check` — same unregistered-hotkey rejection (`Hotkey {…}… not registered` / `Hotkey recognized`)
- `priority_pat_broadcast` / `priority_pat_check` — same `hotkey → uid → S[uid]` stake lookup, `0.0` when unregistered

This extracts two small module-level helpers so each rule lives in one place:

- `_blacklist_if_unregistered(validator, synapse) -> Tuple[bool, str]`
- `_stake_priority(validator, synapse) -> float`

Each helper is now the single source of truth for its rule, so the broadcast and check handlers can't drift out of sync (same rejection string, same stake formula).

## Why

The two blacklist handlers must return the identical rejection message/shape, and the two priority handlers must apply the identical stake formula — today that invariant is only held by copy-paste. Consolidating enforces it structurally.

## Scope / safety

- **No public API change** — the four `async` handler signatures are untouched; they're still what `neurons/validator.py` binds via `partial(fn, self)` and what the axon awaits.
- No new base-class methods, no import reordering, no threaded params.
- Behavior is identical; both helpers are plain sync functions the async handlers delegate to.
- Full suite green (`969 passed`), including `tests/validator/test_pat_handler.py` (27 passed) which covers both blacklist branches. `ruff check` / `ruff format --check` clean.

Happy to adjust naming or scope. Thanks!