### PR TITLE
Update repository emission weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,71 +1,11 @@
 {
   "Autovara/kata": {
-    "emission_share": 0.01,
+    "emission_share": 0.08,
     "issue_discovery_share": 0.0
-  },
-  "cogniax/tao-pulse-app": {
-    "emission_share": 0.0,
-    "issue_discovery_share": 0.5,
-    "maintainer_cut": 0.4
   },
   "DPBG/Engram.AI": {
     "emission_share": 0.0025,
     "issue_discovery_share": 0.0
-  },
-  "e35ventura/taopedia": {
-    "emission_share": 0.039,
-    "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.0,
-    "additional_acceptable_branches": ["test"],
-    "trusted_label_pipeline": true,
-    "default_label_multiplier": 0.0,
-    "label_multipliers": {
-      "ui-ux": 5.0,
-      "feature": 2.0,
-      "other": 0.01
-    },
-    "eligibility": {
-      "min_credibility": 0.6,
-      "max_open_pr_threshold": 4
-    },
-    "scoring": {
-      "pr_lookback_days": 7,
-      "maintainer_issue_multiplier": 5.0,
-      "time_decay": {
-        "grace_period_hours": 6,
-        "sigmoid_midpoint_days": 2,
-        "sigmoid_steepness": 1.0,
-        "min_multiplier": 0.02
-      }
-    }
-  },
-  "e35ventura/taopedia-articles": {
-    "emission_share": 0.025,
-    "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.0,
-    "additional_acceptable_branches": ["test"],
-    "trusted_label_pipeline": true,
-    "default_label_multiplier": 0.0,
-    "label_multipliers": {
-      "article": 1.0,
-      "correction": 1.25,
-      "image": 0.75,
-      "category": 0.5,
-      "other": 0.1
-    },
-    "eligibility": {
-      "min_credibility": 0.7,
-      "min_token_score_for_valid_issue": 0.0
-    },
-    "scoring": {
-      "pr_lookback_days": 7,
-      "time_decay": {
-        "grace_period_hours": 3,
-        "sigmoid_midpoint_days": 1,
-        "sigmoid_steepness": 1.25,
-        "min_multiplier": 0.01
-      }
-    }
   },
   "entrius/das-github-mirror": {
     "emission_share": 0.005,
@@ -131,7 +71,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.3,
+    "emission_share": 0.3425,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -148,7 +88,7 @@
     "trusted_label_pipeline": true
   },
   "gittensor-vanguard/vanguarstew": {
-    "emission_share": 0.01,
+    "emission_share": 0.1,
     "issue_discovery_share": 0.0
   },
   "JSONbored/awesome-claude": {
@@ -212,7 +152,7 @@
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.24,
+    "emission_share": 0.23,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.5,
@@ -239,7 +179,7 @@
     }
   },
   "MkDev11/gittensor-hub": {
-    "emission_share": 0.005,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 2,
@@ -261,7 +201,7 @@
     "maintainer_cut": 0.3
   },
   "vouchdev/vouch": {
-    "emission_share": 0.01,
+    "emission_share": 0.02,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -286,7 +226,7 @@
     "maintainer_cut": 0.5
   },
   "phase-rs/phase": {
-    "emission_share": 0.04,
+    "emission_share": 0.015,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,
@@ -307,7 +247,7 @@
     }
   },
   "touchpilot/touchpilot": {
-    "emission_share": 0.003,
+    "emission_share": 0.0025,
     "issue_discovery_share": 0.0,
     "eligibility": {
       "min_valid_merged_prs": 1,
@@ -323,33 +263,13 @@
     "maintainer_cut": 0.3
   },
   "we-promise/sure": {
-    "emission_share": 0.005,
+    "emission_share": 0.0025,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "performance": 1.5,
       "mobile/Flutter": 1.2
     },
     "maintainer_cut": 0.3
-  },
-  "e35dev/podcast-design-canvas-3": {
-    "emission_share": 0.1055,
-    "issue_discovery_share": 0,
-    "maintainer_cut": 0,
-    "default_label_multiplier": 1,
-    "eligibility": {
-      "min_valid_merged_prs": 1,
-      "min_credibility": 0.6,
-      "max_open_pr_threshold": 1
-    },
-    "scoring": {
-      "pr_lookback_days": 7,
-      "time_decay": {
-        "grace_period_hours": 6,
-        "sigmoid_midpoint_days": 2,
-        "sigmoid_steepness": 1,
-        "min_multiplier": 0.02
-      }
-    }
   },
   "zeokin/Cuda-Compute-OSS": {
     "emission_share": 0.01,


### PR DESCRIPTION
## Summary

Updates the repository emission distribution to concentrate weight on repos showing strong progress, maintainer execution, and public value communication, while removing stale/internal entries from the active list.

Only `gittensor/validator/weights/master_repositories.json` is changed.

## Weight changes

| Repo | Before | After | Diff |
|---|---:|---:|---:|
| `gittensor-ai-lab/sparkinfer` | 30.00% | 34.25% | +4.25% |
| `JSONbored/metagraphed` | 24.00% | 23.00% | -1.00% |
| `JSONbored/gittensory` | 10.00% | 10.00% | 0.00% |
| `gittensor-vanguard/vanguarstew` | 1.00% | 10.00% | +9.00% |
| `Autovara/kata` | 1.00% | 8.00% | +7.00% |
| `entrius/gittensor` | 6.00% | 6.00% | 0.00% |
| `Geniepod/genie-claw` | 2.50% | 2.50% | 0.00% |
| `vouchdev/vouch` | 1.00% | 2.00% | +1.00% |
| `phase-rs/phase` | 4.00% | 1.50% | -2.50% |
| `zeokin/Cuda-Compute-OSS` | 1.00% | 1.00% | 0.00% |
| `JSONbored/awesome-claude` | 0.50% | 0.50% | 0.00% |
| `entrius/das-github-mirror` | 0.50% | 0.50% | 0.00% |
| `we-promise/sure` | 0.50% | 0.25% | -0.25% |
| `touchpilot/touchpilot` | 0.30% | 0.25% | -0.05% |
| `DPBG/Engram.AI` | 0.25% | 0.25% | 0.00% |
| `MkDev11/gittensor-hub` | 0.50% | 0.00% | -0.50% |
| `entrius/oc-1` | 0.00% | 0.00% | 0.00% |

Removed from the repository list:

- `e35dev/podcast-design-canvas-3`
- `e35ventura/taopedia`
- `e35ventura/taopedia-articles`
- `cogniax/tao-pulse-app`

## Validation

- Parsed `master_repositories.json` as JSON successfully
- Verified emission shares sum to exactly `1.0`
- Verified removed repos are no longer present
- Verified `MkDev11/gittensor-hub` remains present with `emission_share: 0.0`
