### PR TITLE
fix(github): harden cross-reference PR parser against null GraphQL fields

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -283,16 +283,18 @@ def _search_issue_referencing_prs_graphql(
         bt.logging.warning(f'GraphQL cross-reference response missing issue data for {repo}#{issue_number}')
         return None
 
-    timeline_nodes = issue_data.get('timelineItems', {}).get('nodes', [])
+    timeline_nodes = (issue_data.get('timelineItems') or {}).get('nodes') or []
 
     out: List[PRInfo] = []
     for node in timeline_nodes:
+        if not node:
+            continue
         pr = node.get('source') or {}
         if not pr:
             continue
 
-        base_repo = pr.get('baseRepository', {}).get('nameWithOwner', '')
-        if base_repo.lower() != target_repo:
+        base_repo = ((pr.get('baseRepository') or {}).get('nameWithOwner') or '').lower()
+        if base_repo != target_repo:
             continue
 
         pr_number = pr.get('number')

--- a/tests/utils/test_github_api_tools.py
+++ b/tests/utils/test_github_api_tools.py
@@ -637,4 +637,61 @@ class TestCheckGithubIssueClosed:
             'pr_number': None,
             'solver_lookup_failed': False,
         }
+
+
+class TestSearchIssueReferencingPRsGraphQL:
+    """Null-field hardening for the cross-reference timeline parser.
+
+    GitHub's GraphQL API returns keys present with an explicit ``null`` value
+    (e.g. ``baseRepository`` when a referencing PR's base repo was deleted or is
+    inaccessible). Those nulls must be skipped per-node, not raise an
+    ``AttributeError`` that the ``find_prs_for_issue`` handler would turn into a
+    whole-issue lookup-failure sentinel.
+    """
+
+    _search = staticmethod(github_api_tools._search_issue_referencing_prs_graphql)
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_base_repository_pr_is_skipped_not_fatal(self, mock_logging, mock_graphql):
+        """A PR node with ``baseRepository: null`` is skipped; valid PRs still return."""
+        null_base = _pr_node(number=14)
+        null_base['source']['baseRepository'] = None
+        mock_graphql.return_value = _graphql_response(
+            [
+                null_base,
+                _pr_node(number=15, base_repo='owner/repo'),
+            ]
+        )
+
+        result = self._search('owner/repo', 12, 'fake_token')
+
+        assert result is not None
+        assert [pr['number'] for pr in result] == [15]
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_timeline_node_is_skipped(self, mock_logging, mock_graphql):
+        """A ``null`` timeline node is skipped rather than raising."""
+        mock_graphql.return_value = _graphql_response(
+            [
+                None,
+                _pr_node(number=15, base_repo='owner/repo'),
+            ]
+        )
+
+        result = self._search('owner/repo', 12, 'fake_token')
+
+        assert result is not None
+        assert [pr['number'] for pr in result] == [15]
+
+    @patch('gittensor.utils.github_api_tools.execute_graphql_query')
+    @patch('gittensor.utils.github_api_tools.bt.logging')
+    def test_null_timeline_items_returns_empty(self, mock_logging, mock_graphql):
+        """A ``timelineItems: null`` payload yields an empty list, not a crash."""
+        mock_graphql.return_value = {'data': {'repository': {'issue': {'timelineItems': None}}}}
+
+        result = self._search('owner/repo', 12, 'fake_token')
+
+        assert result == []
         mock_graphql.assert_not_called()


### PR DESCRIPTION
## Summary

`_search_issue_referencing_prs_graphql` read the PR base repo with
`pr.get('baseRepository', {}).get('nameWithOwner', '')`. The `{}` default only
applies when the key is **absent** — GitHub's GraphQL API returns the key
*present* with an explicit `null` (e.g. when a referencing PR's base repository
was deleted or is inaccessible). In that case the chained `.get` runs on `None`
and raises `AttributeError`.

`find_prs_for_issue` wraps this call in `except Exception -> return None`
(the lookup-failure sentinel). So a single unresolvable timeline node made the
**entire** issue's submission lookup report as "GitHub lookup failed" instead of
skipping that one node and returning the valid PRs — the exact failure mode the
recent read-failed/empty-submissions work (#1492/#1554) was tightening.

The sibling closure-event helpers in the same file already guard these nulls
correctly (`_select_current_close_event` uses `if node and ...` and
`.get('nodes', []) or []`; `_solver_from_closed_event` uses
`((closer.get('baseRepository') or {}).get('nameWithOwner') or '')`). This PR
brings the cross-reference parser in line with that convention:

- null `timelineItems` → treated as no nodes
- null timeline node → skipped
- null `baseRepository` → skipped (not fatal)

## Related Issues

None — surfaced while reading the issue-submission lookup path.

## Type of Change

- [x] Bug fix

## Testing

Adds `TestSearchIssueReferencingPRsGraphQL` covering each null path directly:
a `baseRepository: null` PR node is skipped while valid PRs still return, a
`null` timeline node is skipped, and a `null` timelineItems payload yields `[]`
instead of raising. Existing tests unchanged. `ruff check` / `ruff format`
clean.

## Checklist

- [x] Follows repository conventions (mirrors the null-guarding already used by the sibling closure-event helpers)
- [x] Self-reviewed
- [x] No unrelated files touched (1 source file + its test)