### PR TITLE
fix(validator): guard null author_login in mirror self-merge check

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -263,7 +263,7 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
     if not os.environ.get('DEV_MODE') and pr.author_association in MAINTAINER_ASSOCIATIONS:
         return True, f'PR #{pr.pr_number} author is {pr.author_association}'
 
-    if pr.merged_by_login and pr.merged_by_login.lower() == pr.author_login.lower():
+    if pr.merged_by_login and pr.merged_by_login.lower() == (pr.author_login or '').lower():
         if pr.review_summary.approved_count == 0:
             return True, f'PR #{pr.pr_number} self-merged without external approval'
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -172,6 +172,15 @@ class TestEligibilityGate:
         skip, reason = _should_skip_merged_mirror_pr(scored, _config())
         assert skip is False
 
+    def test_null_author_login_does_not_crash_self_merge_check(self):
+        # author_login can be null in cached mirror data (e.g. a deleted/ghost
+        # account); the self-merge comparison must not raise on it and drop an
+        # otherwise-eligible merged PR (the REST path coerces logins the same way).
+        scored = ScoredPR(pr=_pr(author_login=None, merged_by_login='anderdc'))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config())
+        assert skip is False
+        assert reason is None
+
     def test_base_ref_in_additional_passes(self):
         scored = ScoredPR(pr=_pr(base_ref='test'))
         skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=['test', 'staging']))


### PR DESCRIPTION
`_should_skip_merged_mirror_pr` compares `pr.merged_by_login.lower() == pr.author_login.lower()` to detect self-merges. `merged_by_login` is null-guarded, but `author_login` is dereferenced unguarded in the same expression. `MirrorPullRequest.author_login` is populated via `data.get('author_login', '')`, whose default only applies to an absent key — a present-but-null value (deleted/ghost account in cached mirror data) makes it `None`, so `None.lower()` raises `AttributeError`.

That exception is swallowed by the try/except in `load_miner_prs`, silently dropping a legitimate merged PR from `merged_prs` and understating the miner's merged_count in `check_eligibility`. The legacy REST path already coerces a possibly-null login (`author.get('login') or 'ghost'`); this brings the mirror path in line.

Adds a regression test for a null-author_login merged PR.