### PR TITLE
chore(weights): retune label + issue multipliers for JSONbored repos

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -97,13 +97,13 @@
     "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:bug": 1.1,
-      "gittensor:feature": 1.5,
-      "gittensor:priority": 2.5,
+      "gittensor:bug": 0.05,
+      "gittensor:feature": 0.25,
+      "gittensor:priority": 1.5,
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.5
+      "min_credibility": 0.7
     },
     "maintainer_cut": 0.55,
     "scoring": {
@@ -126,13 +126,13 @@
     "emission_share": 0.1,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:bug": 0.1,
-      "gittensor:feature": 1.5,
-      "gittensor:priority": 2.5,
+      "gittensor:bug": 0.05,
+      "gittensor:feature": 0.25,
+      "gittensor:priority": 1.5,
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.65
+      "min_credibility": 0.7
     },
     "maintainer_cut": 0.55,
     "scoring": {
@@ -155,13 +155,13 @@
     "emission_share": 0.23,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:bug": 0.1,
-      "gittensor:feature": 1.5,
-      "gittensor:priority": 2.5,
+      "gittensor:bug": 0.05,
+      "gittensor:feature": 0.25,
+      "gittensor:priority": 1.5,
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.65
+      "min_credibility": 0.7
     },
     "maintainer_cut": 0.55,
     "scoring": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -97,9 +97,9 @@
     "emission_share": 0.005,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:bug": 0.5,
-      "gittensor:feature": 1.25,
-      "gittensor:priority": 1.75,
+      "gittensor:bug": 1.1,
+      "gittensor:feature": 1.5,
+      "gittensor:priority": 2.5,
       "slop": 0.0
     },
     "eligibility": {
@@ -110,8 +110,8 @@
       "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
-      "standard_issue_multiplier": 1.1,
-      "maintainer_issue_multiplier": 1.5,
+      "standard_issue_multiplier": 1.0,
+      "maintainer_issue_multiplier": 1.25,
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 3,
@@ -126,9 +126,9 @@
     "emission_share": 0.1,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:bug": 0.5,
-      "gittensor:feature": 1.25,
-      "gittensor:priority": 1.75,
+      "gittensor:bug": 0.1,
+      "gittensor:feature": 1.5,
+      "gittensor:priority": 2.5,
       "slop": 0.0
     },
     "eligibility": {
@@ -139,8 +139,8 @@
       "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
-      "standard_issue_multiplier": 1.1,
-      "maintainer_issue_multiplier": 1.5,
+      "standard_issue_multiplier": 1.0,
+      "maintainer_issue_multiplier": 1.25,
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 3,
@@ -155,7 +155,7 @@
     "emission_share": 0.23,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "gittensor:bug": 0.5,
+      "gittensor:bug": 0.1,
       "gittensor:feature": 1.5,
       "gittensor:priority": 2.5,
       "slop": 0.0
@@ -168,8 +168,8 @@
       "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
-      "standard_issue_multiplier": 1.1,
-      "maintainer_issue_multiplier": 1.5,
+      "standard_issue_multiplier": 1.0,
+      "maintainer_issue_multiplier": 1.25,
       "time_decay": {
         "grace_period_hours": 24,
         "sigmoid_midpoint_days": 3,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -132,7 +132,7 @@
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.6
+      "min_credibility": 0.65
     },
     "maintainer_cut": 0.55,
     "scoring": {
@@ -161,7 +161,7 @@
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.6
+      "min_credibility": 0.65
     },
     "maintainer_cut": 0.55,
     "scoring": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -105,7 +105,7 @@
     "eligibility": {
       "min_credibility": 0.5
     },
-    "maintainer_cut": 0.5,
+    "maintainer_cut": 0.55,
     "scoring": {
       "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
@@ -134,7 +134,7 @@
     "eligibility": {
       "min_credibility": 0.6
     },
-    "maintainer_cut": 0.5,
+    "maintainer_cut": 0.55,
     "scoring": {
       "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,
@@ -163,7 +163,7 @@
     "eligibility": {
       "min_credibility": 0.6
     },
-    "maintainer_cut": 0.5,
+    "maintainer_cut": 0.55,
     "scoring": {
       "pr_lookback_days": 7,
       "open_pr_collateral_percent": 0.2,


### PR DESCRIPTION
Retunes reward/eligibility config for the three JSONbored-owned repos (`JSONbored/awesome-claude`, `JSONbored/gittensory`, `JSONbored/metagraphed`) in `gittensor/validator/weights/master_repositories.json`, own-repo config only.

## Motivation

Unsolicited bug-fix PRs against these repos are mostly low-effort "easy win" farming rather than work on the issues that are actually planned. This shifts reward heavily toward priority-labeled work, keeps feature work meaningfully ahead of bug fixes (5x), and raises the credibility bar and maintainer cut.

## Changes (identical across all 3 repos)

| Field | Before | After |
|---|---|---|
| `label_multipliers["gittensor:bug"]` | 0.5 | **0.05** |
| `label_multipliers["gittensor:feature"]` | 1.25 / 1.25 / 1.5 | **0.25** |
| `label_multipliers["gittensor:priority"]` | 1.75 / 1.75 / 2.5 | **1.5** |
| `scoring.standard_issue_multiplier` | 1.1 | **1.0** |
| `scoring.maintainer_issue_multiplier` | 1.5 | **1.25** |
| `maintainer_cut` | 0.5 | **0.55** |
| `eligibility.min_credibility` | 0.5 / 0.6 / 0.6 | **0.7** |

All values stay within the existing config bounds (label multipliers >= 0, `maintainer_issue_multiplier`/`standard_issue_multiplier` in [1, 5], `maintainer_cut`/`min_credibility` in [0, 1]). No code changes, own-repo entries only.
