### PR TITLE
chore(label): retune Geniepod/genie-claw label multipliers

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -56,9 +56,9 @@
     "emission_share": 0.025,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
-      "enhancement": 1.25,
-      "optimization": 2.5,
-      "performance": 1.5
+      "maintainer-issue": 3.0,
+      "optimization": 5.0,
+      "verify-jetson": 4.0
     },
     "maintainer_cut": 0.3,
     "trusted_label_pipeline": true


### PR DESCRIPTION
## Summary

Retune the `label_multipliers` for `Geniepod/genie-claw`:

| label | multiplier |
|---|---|
| `optimization` | 5.0 |
| `verify-jetson` | 4.0 |
| `maintainer-issue` | 3.0 |

This replaces the previous `enhancement 1.25 / optimization 2.5 / performance 1.5`, focusing incentives on the maintainer's priorities — optimization work, on-device Jetson verification, and PRs that resolve maintainer-filed issues.

Only `Geniepod/genie-claw`'s `label_multipliers` field changes; no other repo, weight, or field is touched.
