### PR TITLE
refactor(mirror): dedupe malformed-item skip loop in response parsers

### DIFF
--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -87,8 +87,7 @@ def issues_submissions(
     if pull_requests is None:
         handle_exception(
             as_json,
-            f'GitHub lookup failed for {repo_name}#{issue_number}; '
-            'submissions could not be determined. Please retry.',
+            f'GitHub lookup failed for {repo_name}#{issue_number}; submissions could not be determined. Please retry.',
             'github_lookup_failed',
         )
 

--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -11,7 +11,7 @@ from https://mirror.gittensor.io/api/v1/*.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Optional
+from typing import Callable, List, Optional, TypeVar
 
 import bittensor as bt
 
@@ -19,6 +19,28 @@ from gittensor.validator.utils.datetime_utils import (
     parse_github_iso_to_utc,
     parse_optional_github_iso_to_utc,
 )
+
+_T = TypeVar('_T')
+
+
+def _parse_mirror_items(
+    raw_list: Optional[list],
+    parse: Callable[[dict], _T],
+    label: str,
+    describe: Callable[[dict], object],
+) -> List[_T]:
+    """Parse mirror-response items, skipping (and warning on) any malformed one.
+
+    ``describe`` builds the identifier shown in the skip warning.
+    """
+    items: List[_T] = []
+    for raw in raw_list or []:
+        try:
+            items.append(parse(raw))
+        except Exception as e:
+            identifier = describe(raw) if isinstance(raw, dict) else '?'
+            bt.logging.warning(f'Skipping malformed mirror {label} {identifier}: {e}')
+    return items
 
 
 @dataclass
@@ -330,15 +352,12 @@ class MirrorPullRequestsResponse:
 
     @classmethod
     def from_dict(cls, data: dict) -> 'MirrorPullRequestsResponse':
-        pull_requests: List[MirrorPullRequest] = []
-        for raw in data.get('pull_requests') or []:
-            try:
-                pull_requests.append(MirrorPullRequest.from_dict(raw))
-            except Exception as e:
-                identifier = (
-                    f'{raw.get("repo_full_name", "?")}#{raw.get("pr_number", "?")}' if isinstance(raw, dict) else '?'
-                )
-                bt.logging.warning(f'Skipping malformed mirror PR {identifier}: {e}')
+        pull_requests = _parse_mirror_items(
+            data.get('pull_requests'),
+            MirrorPullRequest.from_dict,
+            'PR',
+            lambda raw: f'{raw.get("repo_full_name", "?")}#{raw.get("pr_number", "?")}',
+        )
         return cls(
             github_id=str(data['github_id']),
             since=parse_optional_github_iso_to_utc(data.get('since')),
@@ -358,15 +377,12 @@ class MirrorIssuesResponse:
 
     @classmethod
     def from_dict(cls, data: dict) -> 'MirrorIssuesResponse':
-        issues: List[MirrorIssue] = []
-        for raw in data.get('issues') or []:
-            try:
-                issues.append(MirrorIssue.from_dict(raw))
-            except Exception as e:
-                identifier = (
-                    f'{raw.get("repo_full_name", "?")}#{raw.get("issue_number", "?")}' if isinstance(raw, dict) else '?'
-                )
-                bt.logging.warning(f'Skipping malformed mirror issue {identifier}: {e}')
+        issues = _parse_mirror_items(
+            data.get('issues'),
+            MirrorIssue.from_dict,
+            'issue',
+            lambda raw: f'{raw.get("repo_full_name", "?")}#{raw.get("issue_number", "?")}',
+        )
         return cls(
             github_id=str(data['github_id']),
             since=parse_optional_github_iso_to_utc(data.get('since')),
@@ -389,13 +405,12 @@ class MirrorPullRequestFilesResponse:
 
     @classmethod
     def from_dict(cls, data: dict) -> 'MirrorPullRequestFilesResponse':
-        files: List[MirrorFile] = []
-        for raw in data.get('files') or []:
-            try:
-                files.append(MirrorFile.from_dict(raw))
-            except Exception as e:
-                filename = raw.get('filename', '?') if isinstance(raw, dict) else '?'
-                bt.logging.warning(f'Skipping malformed mirror file {filename}: {e}')
+        files = _parse_mirror_items(
+            data.get('files'),
+            MirrorFile.from_dict,
+            'file',
+            lambda raw: raw.get('filename', '?'),
+        )
         return cls(
             repo_full_name=data['repo_full_name'].lower(),
             pr_number=int(data['pr_number']),
@@ -439,13 +454,12 @@ class MirrorRepoMaintainersResponse:
 
     @classmethod
     def from_dict(cls, data: dict) -> 'MirrorRepoMaintainersResponse':
-        maintainers: List[MirrorMaintainer] = []
-        for raw in data.get('maintainers') or []:
-            try:
-                maintainers.append(MirrorMaintainer.from_dict(raw))
-            except Exception as e:
-                identifier = raw.get('github_id', '?') if isinstance(raw, dict) else '?'
-                bt.logging.warning(f'Skipping malformed mirror maintainer {identifier}: {e}')
+        maintainers = _parse_mirror_items(
+            data.get('maintainers'),
+            MirrorMaintainer.from_dict,
+            'maintainer',
+            lambda raw: raw.get('github_id', '?'),
+        )
         return cls(
             repo_full_name=data['repo_full_name'].lower(),
             generated_at=parse_optional_github_iso_to_utc(data.get('generated_at')),

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -24,9 +24,11 @@ MirrorIssue = models.MirrorIssue
 MirrorIssuesResponse = models.MirrorIssuesResponse
 MirrorLabel = models.MirrorLabel
 MirrorLinkedIssue = models.MirrorLinkedIssue
+MirrorMaintainer = models.MirrorMaintainer
 MirrorPullRequest = models.MirrorPullRequest
 MirrorPullRequestFilesResponse = models.MirrorPullRequestFilesResponse
 MirrorPullRequestsResponse = models.MirrorPullRequestsResponse
+MirrorRepoMaintainersResponse = models.MirrorRepoMaintainersResponse
 MirrorReviewSummary = models.MirrorReviewSummary
 MirrorSolvingPR = models.MirrorSolvingPR
 
@@ -569,4 +571,34 @@ class TestMirrorPullRequestFilesResponse:
         resp = MirrorPullRequestFilesResponse.from_dict(payload)
         assert len(resp.files) == 1
         assert resp.files[0].filename == 'src/components/MinerCard.tsx'
+        mock_logging.warning.assert_called()
+
+
+class TestMirrorRepoMaintainersResponse:
+    """The maintainers response wrapper had no direct coverage; these also lock
+    the shared malformed-skip parsing for the maintainer call site."""
+
+    def test_parses_maintainers_and_lowercases_repo(self):
+        payload = {
+            'repo_full_name': 'Entrius/Gittensor',
+            'generated_at': '2026-03-20T00:00:00Z',
+            'maintainers': [{'github_id': 42, 'login': 'alice', 'association': 'MEMBER'}],
+        }
+        resp = MirrorRepoMaintainersResponse.from_dict(payload)
+        assert resp.repo_full_name == 'entrius/gittensor'
+        assert len(resp.maintainers) == 1
+        assert resp.maintainers[0].github_id == '42'  # coerced to str
+        assert resp.maintainers[0].association == 'MEMBER'
+
+    @patch('gittensor.utils.mirror.models.bt.logging')
+    def test_malformed_maintainer_skipped_others_parsed(self, mock_logging):
+        bad = {'login': 'no-id'}  # missing required github_id / association
+        payload = {
+            'repo_full_name': 'entrius/gittensor',
+            'generated_at': None,
+            'maintainers': [bad, {'github_id': 7, 'login': 'bob', 'association': 'COLLABORATOR'}],
+        }
+        resp = MirrorRepoMaintainersResponse.from_dict(payload)
+        assert len(resp.maintainers) == 1
+        assert resp.maintainers[0].github_id == '7'
         mock_logging.warning.assert_called()


### PR DESCRIPTION
## Summary

The same "parse each item, skip and warn on a malformed one" loop was duplicated across all four mirror-response `from_dict` parsers in `gittensor/utils/mirror/models.py` (`MirrorPullRequestsResponse`, `MirrorIssuesResponse`, `MirrorPullRequestFilesResponse`, `MirrorRepoMaintainersResponse`). Only the item class, the JSON key, the log noun, and the identifier expression differed — the loop/try/except/isinstance/warn skeleton was identical.

This folds the four copies into one small `_parse_mirror_items` helper so the skip-malformed behavior lives in a single place. **Pure structural change** — every parsed result and every warning string is byte-identical to before.

It also adds direct test coverage for `MirrorRepoMaintainersResponse`, which previously had none (a happy-path parse + the malformed-skip case), so all four call sites are now locked.

## Related Issues

_None — small internal refactor._

## Type of Change

- [x] Refactor (no functional change)

## Testing

- Full suite green (955 passed); `ruff` + `pyright` clean.
- The existing `test_malformed_{pr,issue,file}_skipped_others_parsed` tests — which assert the exact warning text — pass unchanged, confirming behavior is preserved.
- Added `TestMirrorRepoMaintainersResponse` (2 cases) covering the previously-untested maintainer response.

## Checklist

- [x] Code follows style guidelines (ruff/pyright clean)
- [x] Self-review performed
- [x] Tests added/updated
