### PR TITLE
fix(cli): harden gitt issues against crashes on malformed storage/config inputs

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -625,13 +625,13 @@ def resolve_network(network: Optional[str] = None, rpc_url: Optional[str] = None
     # override a user who set `network: finney` to point at mainnet.
     config = load_config()
 
-    config_network = config.get('network', '').lower()
+    config_network = (config.get('network') or '').lower()
     if config_network and config_network in NETWORK_MAP:
         return NETWORK_MAP[config_network], config_network
 
     if config.get('ws_endpoint'):
         endpoint = config['ws_endpoint']
-        name = _URL_TO_NETWORK.get(endpoint, config.get('network', 'custom'))
+        name = _URL_TO_NETWORK.get(endpoint, config.get('network') or 'custom')
         return endpoint, name
 
     # Default: finney (mainnet)
@@ -735,8 +735,8 @@ def _read_one_issue_from_child_storage(
             err_console.print(f'[dim]Debug: No storage found for issue_id={issue_id} (key={lazy_key[:20]}...)[/dim]')
         return None
 
-    data = bytes.fromhex(val_result['result'].replace('0x', ''))
     try:
+        data = bytes.fromhex(val_result['result'].replace('0x', ''))
         decoded = decode_issue_from_storage(data)
         if decoded is None:
             raise ValueError('Issue decode returned no data')

--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -87,8 +87,7 @@ def issues_submissions(
     if pull_requests is None:
         handle_exception(
             as_json,
-            f'GitHub lookup failed for {repo_name}#{issue_number}; '
-            'submissions could not be determined. Please retry.',
+            f'GitHub lookup failed for {repo_name}#{issue_number}; submissions could not be determined. Please retry.',
             'github_lookup_failed',
         )
 

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -24,9 +24,11 @@ from gittensor.cli.issue_commands.helpers import (
     MAX_BOUNTY_ALPHA,
     MAX_ISSUE_ID,
     MAX_ISSUE_NUMBER,
+    NETWORK_MAP,
     STATUS_COLORS,
     colorize_status,
     format_alpha,
+    resolve_network,
     validate_bounty_amount,
     validate_github_issue,
     validate_repository,
@@ -919,3 +921,18 @@ class TestEmitJson:
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
         assert parsed['field'] == str(value)
+
+
+class TestResolveNetworkNullConfig:
+    """resolve_network must tolerate a null ``network`` in the config file the
+    same way the miner-command resolver already does, instead of crashing on
+    ``None.lower()`` and taking down every ``gitt issues`` command."""
+
+    def test_null_network_falls_back_to_default(self):
+        with patch('gittensor.cli.issue_commands.helpers.load_config', return_value={'network': None}):
+            assert resolve_network() == (NETWORK_MAP['finney'], 'finney')
+
+    def test_null_network_with_ws_endpoint_uses_endpoint(self):
+        cfg = {'network': None, 'ws_endpoint': 'ws://mynode:9944'}
+        with patch('gittensor.cli.issue_commands.helpers.load_config', return_value=cfg):
+            assert resolve_network() == ('ws://mynode:9944', 'custom')

--- a/tests/cli/test_issue_single_read.py
+++ b/tests/cli/test_issue_single_read.py
@@ -46,6 +46,15 @@ def test_read_one_issue_returns_none_when_absent():
     assert helpers._read_one_issue_from_child_storage(substrate, '0xchild', 7) is None
 
 
+def test_read_one_issue_returns_none_on_malformed_hex():
+    """A malformed (odd-length / non-hex) storage payload is a decode failure and
+    must return ``None`` per the docstring, not raise ``ValueError`` out of the
+    scan loop and abort ``gitt issues list`` for every remaining issue."""
+    substrate = MagicMock()
+    substrate.rpc_request.return_value = {'result': '0xabc'}  # odd-length -> not decodable
+    assert helpers._read_one_issue_from_child_storage(substrate, '0xchild', 9) is None
+
+
 def test_fetch_issue_uses_single_read_not_full_scan():
     sample = {
         'id': 42,


### PR DESCRIPTION
## Summary

Two `gitt issues` code paths in `gittensor/cli/issue_commands/helpers.py` raise an unhandled exception on malformed-but-realistic input, aborting the whole command instead of degrading gracefully. Both are fixed to match the surrounding code's own documented/established behavior:

1. **`_read_one_issue_from_child_storage`** ran `bytes.fromhex(...)` *outside* the decode `try/except`. A malformed / odd-length hex payload raises `ValueError`, which escapes the per-issue guard and aborts the entire `gitt issues list` scan — even though the docstring states "Decode failures ... return `None`". Moving the decode inside the existing `try` honors that contract, so one bad entry is skipped and the rest still list.

2. **`resolve_network`** did `config.get('network', '').lower()`; the `''` default only applies when the key is *absent*, so a `{"network": null}` config makes `.get` return `None` and `None.lower()` raises `AttributeError`, taking down every `gitt issues` command. Guarded with `(config.get('network') or '')`, mirroring the existing guard in the sibling `miner_commands` resolver.

Before → after (both previously crashed):

```
resolve_network({network: null})   AttributeError: 'NoneType' has no attribute 'lower'  →  ('wss://…finney', 'finney')
_read_one_issue(malformed hex)     ValueError: non-hexadecimal number found in fromhex()  →  None
```

The second commit is an unrelated one-line `ruff format` fix to `submissions.py` (pre-existing `--all-files` drift on `test` from the ruff 0.15.12 bump) so this PR's fork CI is green; no behavior change, happy to split it out if preferred.

## Related Issues

_None — small internal bug fix._

## Type of Change

- [x] Bug fix

## Testing

- Full suite green (956 passed); `ruff` + `pyright` clean; `pre-commit run --all-files` passes.
- Added `test_read_one_issue_returns_none_on_malformed_hex` and `TestResolveNetworkNullConfig` (2 cases) reproducing both crashes and asserting graceful behavior.

## Checklist

- [x] Code follows style guidelines (ruff/pyright clean)
- [x] Self-review performed
- [x] Tests added/updated
