### PR TITLE
refactor(storage): dedupe repeated u128 little-endian decode into a helper

### DIFF
--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -87,8 +87,7 @@ def issues_submissions(
     if pull_requests is None:
         handle_exception(
             as_json,
-            f'GitHub lookup failed for {repo_name}#{issue_number}; '
-            'submissions could not be determined. Please retry.',
+            f'GitHub lookup failed for {repo_name}#{issue_number}; submissions could not be determined. Please retry.',
             'github_lookup_failed',
         )
 

--- a/gittensor/validator/issue_competitions/storage_utils.py
+++ b/gittensor/validator/issue_competitions/storage_utils.py
@@ -12,6 +12,12 @@ logger = logging.getLogger(__name__)
 ISSUES_MAPPING_ROOT_KEY = '52789899'
 
 
+def _decode_u128le(data: bytes, offset: int) -> int:
+    """Decode a little-endian u128 (two u64 limbs) from ``data`` at ``offset``."""
+    lo, hi = struct.unpack_from('<QQ', data, offset)
+    return lo + (hi << 64)
+
+
 @dataclass
 class PackedContractStorage:
     """Decoded root packed storage layout for the issue competition contract."""
@@ -107,8 +113,7 @@ def decode_packed_contract_storage(data: bytes) -> Optional[PackedContractStorag
         offset += 2
         next_issue_id = struct.unpack_from('<Q', data, offset)[0]
         offset += 8
-        alpha_pool_lo, alpha_pool_hi = struct.unpack_from('<QQ', data, offset)
-        alpha_pool = alpha_pool_lo + (alpha_pool_hi << 64)
+        alpha_pool = _decode_u128le(data, offset)
     except (struct.error, IndexError) as e:
         logger.debug('Failed to decode packed contract storage: %s', e)
         return None
@@ -162,12 +167,10 @@ def decode_issue_from_storage(data: bytes) -> Optional[DecodedIssueStorage]:
         issue_number = struct.unpack_from('<I', data, offset)[0]
         offset += 4
 
-        bounty_lo, bounty_hi = struct.unpack_from('<QQ', data, offset)
-        bounty_amount = bounty_lo + (bounty_hi << 64)
+        bounty_amount = _decode_u128le(data, offset)
         offset += 16
 
-        target_lo, target_hi = struct.unpack_from('<QQ', data, offset)
-        target_bounty = target_lo + (target_hi << 64)
+        target_bounty = _decode_u128le(data, offset)
         offset += 16
 
         status_byte = data[offset]


### PR DESCRIPTION
## Summary

The little-endian u128 reconstruction — `lo, hi = struct.unpack_from('<QQ', data, offset)` then `lo + (hi << 64)` — was repeated verbatim three times in `storage_utils.py` when decoding `alpha_pool`, `bounty_amount`, and `target_bounty`. This folds it into a single named `_decode_u128le(data, offset)` helper so the intent is explicit and the `'<QQ'` limb layout lives in one place.

**Pure structural change** — identical decoded values, and the `struct.error`/`IndexError` raised by `struct.unpack_from` still propagates to the same enclosing `try/except` as before.

The second commit is a one-line `ruff format` fix to `submissions.py` (pre-existing `--all-files` drift on `test` from the ruff 0.15.12 bump) so this PR's fork CI is green; no behavior change, happy to split it out if preferred.

## Related Issues

_None — small internal refactor._

## Type of Change

- [x] Refactor (no functional change)

## Testing

- Full suite green (953 passed); `ruff` + `pyright` clean; `pre-commit run --all-files` passes.
- No new tests needed: the existing round-trip tests in `tests/utils/test_issue_competitions_storage_utils.py` already exercise all three decode paths, including the nonzero-high-limb / max-u64 cases (`test_decode_packed_contract_storage_handles_maximum_field_values`).

## Checklist

- [x] Code follows style guidelines (ruff/pyright clean)
- [x] Self-review performed
- [x] Tests added/updated (existing coverage confirmed)
