### PR TITLE
DPBG/Engram.AI: add label_multipliers

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -5,7 +5,14 @@
   },
   "DPBG/Engram.AI": {
     "emission_share": 0.0025,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "feature": 1,
+      "bug": 0.5,
+      "refactor": 0.2,
+      "chore": 0.1,
+      "enhancement": 0.7
+    }
   },
   "entrius/das-github-mirror": {
     "emission_share": 0.005,


### PR DESCRIPTION
## Weight Adjustment PR

### Changes Summary

| Metric               | Total |
| -------------------- | ----- |
| Repositories Added   | 0     |
| Repositories Removed | 0     |
| Weights Modified     | 0     |
| Net Weight Change    | 0     |

### Justification

Adds per-label PR scoring multipliers to `DPBG/Engram.AI`. This does **not** touch `emission_share` (stays `0.0025`) or any other repository — the total registry `emission_share` remains `1.0`. It only changes how individual merged PRs in this repo are weighted by label.

New `label_multipliers`:

| Label       | Multiplier |
| ----------- | ---------- |
| feature     | 1.0        |
| enhancement | 0.7        |
| bug         | 0.5        |
| refactor    | 0.2        |
| chore       | 0.1        |

Unlabelled PRs keep the neutral `default_label_multiplier` (1.0). Verified the registry still loads and passes emission/eligibility/scoring validation.

### Additional Acceptable Branches

- [x] No additional_acceptable_branches changes in this PR
- [ ] Proof of merged PR(s) provided above for all additional_acceptable_branches entries

### Checklist

- [x] Changes summary table is filled in accurately
- [x] Net weight changes are justified in the Justification section
- [x] Added repositories have correct branch and initial weight
