### PR TITLE
style: apply pending ruff-format to submissions.py

### DIFF
--- a/gittensor/cli/issue_commands/submissions.py
+++ b/gittensor/cli/issue_commands/submissions.py
@@ -87,8 +87,7 @@ def issues_submissions(
     if pull_requests is None:
         handle_exception(
             as_json,
-            f'GitHub lookup failed for {repo_name}#{issue_number}; '
-            'submissions could not be determined. Please retry.',
+            f'GitHub lookup failed for {repo_name}#{issue_number}; submissions could not be determined. Please retry.',
             'github_lookup_failed',
         )
 


### PR DESCRIPTION
Applies the ruff-format that pre-commit wants on `gittensor/cli/issue_commands/submissions.py` (collapses a two-line f-string).

Pre-existing on `test` from #1554, which was a fork PR merged without the Lint workflow ever running (fork workflows need manual approval; `test` has no required status checks). Because `pre-commit run --all-files` checks every file, this unformatted line makes the lint job red on unrelated PRs (e.g. #1578). Merging this clears the baseline.

Format-only; no logic change.