### PR TITLE
fix(validator): count the valid-solved issue gate per distinct solving PR

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -106,7 +106,7 @@ class _RepoIssueAcc:
     """Per-repository issue-discovery accumulator for one miner."""
 
     solved: int = 0
-    valid_solved: int = 0
+    valid_solving_prs: Set[int] = field(default_factory=set)
     closed: int = 0
     issue_token_score: float = 0.0
     fetch_failed: bool = False
@@ -494,8 +494,11 @@ async def _score_miner_issues(
             continue
 
         # Valid-solved gate: solving PR must meet the repo's token threshold.
+        # Counted per distinct solving PR (matching the one-issue-per-PR
+        # doctrine used for scoring) so a single PR that closes many issues
+        # can't inflate the miner past the min_valid_solved_issues gate.
         if cached.token_score >= cfg.min_token_score_for_valid_issue:
-            acc.valid_solved += 1
+            acc.valid_solving_prs.add(solving_pr.pr_number)
 
         # Same-account: discoverer == solver gets credibility only, no score
         if issue.author_github_id == solving_pr.author_github_id:
@@ -556,13 +559,14 @@ def _finalize_repo_issue_scores(
 
         repo_eval = evaluation.get_or_create_repo_evaluation(repo_name)
 
+        valid_solved = len(acc.valid_solving_prs)
         repo_eval.total_solved_issues = acc.solved
-        repo_eval.total_valid_solved_issues = acc.valid_solved
+        repo_eval.total_valid_solved_issues = valid_solved
         repo_eval.total_closed_issues = acc.closed
         repo_eval.total_open_issues = open_count
         repo_eval.issue_token_score = round(acc.issue_token_score, 2)
 
-        is_eligible, credibility, reason = check_issue_eligibility(cfg, acc.solved, acc.valid_solved, acc.closed)
+        is_eligible, credibility, reason = check_issue_eligibility(cfg, acc.solved, valid_solved, acc.closed)
         repo_eval.is_issue_eligible = is_eligible
         repo_eval.issue_credibility = credibility
 
@@ -571,7 +575,7 @@ def _finalize_repo_issue_scores(
             if acc.solved or acc.closed:
                 bt.logging.info(
                     f'├─ {repo_name}: issue-ineligible ({reason}) | {acc.solved} solved '
-                    f'({acc.valid_solved} valid) | {acc.closed} closed | {open_count} open'
+                    f'({valid_solved} valid) | {acc.closed} closed | {open_count} open'
                 )
             continue
 
@@ -594,7 +598,7 @@ def _finalize_repo_issue_scores(
         repo_eval.issue_discovery_score = round(repo_score, 2)
         evaluation.issue_discovery_issues.extend(acc.scored_issues)
         bt.logging.info(
-            f'├─ {repo_name}: {acc.solved} solved ({acc.valid_solved} valid) | {acc.closed} closed | '
+            f'├─ {repo_name}: {acc.solved} solved ({valid_solved} valid) | {acc.closed} closed | '
             f'{open_count} open | {len(acc.scored_issues)} scored | credibility={credibility:.2f} | '
             f'spam_mult={spam_mult:.1f} | discovery_score={repo_eval.issue_discovery_score:.2f}'
         )

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -1075,6 +1075,38 @@ class TestSolvingPrCache:
         assert eval_.total_valid_solved_issues == 0  # below gate
         assert eval_.issue_discovery_score == 0
 
+    def test_one_pr_closing_many_issues_counts_as_one_valid_solved(self):
+        """Anti-gaming: a single solving PR that closes several of a miner's
+        issues must count once toward the min_valid_solved_issues gate, not once
+        per issue. Otherwise a colluding discoverer/solver pair clears the gate
+        with a single multi-close PR. All issues still count toward
+        solved/credibility."""
+        client = Mock()
+        client.get_miner_issues.return_value = _response(
+            [_issue_dict(issue_number=10 + i, author_github_id='B', solved_by_pr=100) for i in range(3)]
+        )
+        eval_ = _eval()
+        # Seed the shared solving PR (#100) so no file fetch is needed and its
+        # token_score (100) clears the valid-issue threshold.
+        eval_.merged_prs = [_scored_mirror_pr('entrius/gittensor-ui', 100)]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        assert eval_.total_solved_issues == 3  # all three still count for credibility
+        assert eval_.total_valid_solved_issues == 1  # one distinct solving PR, not three
+        # Gate (min_valid_solved_issues=3) is not cleared by the single PR.
+        assert eval_.is_issue_eligible is False
+        assert eval_.issue_discovery_score == 0
+        client.get_pr_files.assert_not_called()
+
 
 class TestCacheStats:
     """Verify the _CacheStats counter accurately tracks hits / misses /


### PR DESCRIPTION
## Summary

`_score_miner_issues` incremented `valid_solved` once per solved issue whose solving PR met the token threshold. Because a single PR can close many issues (`Fixes #1, #2, #3`), one solving PR could add multiple counts toward the per-repo `min_valid_solved_issues` eligibility gate.

That lets a colluding discoverer/solver pair clear the gate cheaply: the miner opens N issues, one cross-account PR closes them all, and the miner is unlocked for issue-discovery scoring on the repo having demonstrated a single solving event — defeating the purpose of the "N valid solved issues" barrier.

The module already enforces a one-issue-per-PR rule for the discovery *score* (canonical PR owner). This extends the same doctrine to the eligibility gate: count distinct solving PRs (`valid_solving_prs` set) instead of issues. Issues still each count toward solved/credibility, unchanged.

## Type of Change

- [x] Bug fix

## Testing

Adds a regression test: one PR closing three of a miner's issues yields `total_valid_solved_issues == 1` (not 3), leaving the miner below the gate. All existing `total_valid_solved_issues` assertions use distinct solving PRs and stay green. `ruff` clean.

## Checklist

- [x] Follows repository conventions (extends the existing one-issue-per-PR doctrine to the gate)
- [x] Self-reviewed
- [x] No unrelated files touched (1 source file + its test)