### PR TITLE
DPBG/Engram.AI: set maintainer_cut to 0.20

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -32,7 +32,8 @@
       "refactor": 0.2,
       "chore": 0.1,
       "enhancement": 0.7
-    }
+    },
+    "maintainer_cut": 0.2
   },
   "entrius/das-github-mirror": {
     "emission_share": 0.005,


### PR DESCRIPTION
## Weight Adjustment PR

### Changes Summary

| Metric               | Total |
| -------------------- | ----- |
| Repositories Added   | 0     |
| Repositories Removed | 0     |
| Weights Modified     | 0     |
| Net Weight Change    | 0     |

### Justification

Sets `maintainer_cut` to `0.20` for `DPBG/Engram.AI` — routing 20% of the repo's emission slice directly to the repo's registered maintainer miner(s), split evenly, before normal scoring. This does **not** change `emission_share` (stays `0.0025`) or any other repository; total registry `emission_share` remains `1.0`.

`maintainer_cut` was previously unset (defaulted to `0.0`).

### Additional Acceptable Branches

- [x] No additional_acceptable_branches changes in this PR
- [ ] Proof of merged PR(s) provided above for all additional_acceptable_branches entries

### Checklist

- [x] Changes summary table is filled in accurately
- [x] Net weight changes are justified in the Justification section
- [x] Added repositories have correct branch and initial weight
