### PR TITLE
Update master repository emission weights

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -46,7 +46,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.06,
+    "emission_share": 0.05,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,
@@ -58,29 +58,12 @@
     "maintainer_cut": 0.0,
     "trusted_label_pipeline": true
   },
-  "entrius/oc-1": {
-    "default_label_multiplier": 0.0,
-    "eligibility": {
-      "min_credibility": 0.0,
-      "min_issue_credibility": 0.0,
-      "min_valid_merged_prs": 0,
-      "min_valid_solved_issues": 0
-    },
-    "emission_share": 0.0,
-    "fixed_base_score": 1.0,
-    "issue_discovery_share": 0.0,
-    "label_multipliers": {
-      "benchmark-improvement": 1.0
-    },
-    "maintainer_cut": 0.0,
-    "trusted_label_pipeline": true
-  },
   "Geniepod/genie-claw": {
     "default_label_multiplier": 1.0,
     "eligibility": {
       "max_open_pr_threshold": 2
     },
-    "emission_share": 0.025,
+    "emission_share": 0.02,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "enhancement": 1.25,
@@ -135,6 +118,10 @@
     "scoring": {
       "pr_lookback_days": 30
     }
+  },
+  "imagent-ai/imagent": {
+    "emission_share": 0.01,
+    "issue_discovery_share": 0.0
   },
   "JSONbored/awesome-claude": {
     "default_label_multiplier": 0.0,
@@ -223,27 +210,9 @@
       }
     }
   },
-  "MkDev11/gittensor-hub": {
-    "emission_share": 0.0,
-    "issue_discovery_share": 0.0,
-    "label_multipliers": {
-      "feature": 2,
-      "whale": 20,
-      "shark": 5,
-      "bug": 0.3,
-      "refactor": 0.3
-    },
-    "scoring": {
-      "open_pr_collateral_percent": 0.2,
-      "review_penalty_rate": 0.2,
-      "maintainer_issue_multiplier": 2,
-      "time_decay": {
-        "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 14,
-        "min_multiplier": 0.1
-      }
-    },
-    "maintainer_cut": 0.3
+  "mini-router/minirouter": {
+    "emission_share": 0.01,
+    "issue_discovery_share": 0.0
   },
   "vouchdev/vouch": {
     "emission_share": 0.02,
@@ -292,7 +261,7 @@
     }
   },
   "touchpilot/touchpilot": {
-    "emission_share": 0.0025,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "eligibility": {
       "min_valid_merged_prs": 1,
@@ -308,7 +277,7 @@
     "maintainer_cut": 0.3
   },
   "we-promise/sure": {
-    "emission_share": 0.0025,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "performance": 1.5,

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -364,14 +364,6 @@ class TestRepositoryConfigMirrorScoringFields:
                 f'{repo_name} time_decay.min_multiplier out of range'
             )
 
-    def test_oc_1_runs_ungated(self):
-        """The oc-1 benchmark repo opts out of the gate via zeroed thresholds."""
-        repos = load_master_repo_weights()
-        resolved = resolve_eligibility(repos['entrius/oc-1'].eligibility)
-        assert resolved.min_valid_merged_prs == 0
-        assert resolved.min_credibility == 0.0
-        assert resolved.min_valid_solved_issues == 0
-
 
 class TestRepositoryConfigScoringBlock:
     """Dataclass + JSON-parsing tests for the per-repo scoring block."""


### PR DESCRIPTION
## Summary
- add mini-router/minirouter and imagent-ai/imagent at 0.01 emission share each
- reduce entrius/gittensor by 0.01 and Geniepod/genie-claw by 0.005
- set touchpilot/touchpilot and we-promise/sure to 0.0
- remove zero-weight entrius/oc-1 and MkDev11/gittensor-hub entries

## Validation
- uv run pytest tests/validator/test_load_weights.py::TestRepositoryEmissionShare::test_live_master_repo_emission_shares_are_valid -q