### PR TITLE
fix(cli): fail `issues submissions` when no PAT is set instead of reporting zero

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -260,10 +260,18 @@ def fetch_open_issue_pull_requests(
     Returns a (possibly empty) list of PRs, or ``None`` when the GitHub lookup
     fails. Callers must treat ``None`` as a failure (not "no submissions"); see
     ``find_prs_for_issue``.
+
+    Raises ``click.ClickException`` when no ``GITTENSOR_MINER_PAT`` is set: the
+    GraphQL lookup cannot run without a token, so continuing would report an
+    empty submission list that is a false negative rather than a real result.
     """
     token = os.environ.get('GITTENSOR_MINER_PAT') or ''
-    if not token and not as_json:
-        print_warning('No GitHub token found; set GITTENSOR_MINER_PAT to fetch GitHub issue submissions')
+    if not token:
+        # Without a PAT, find_prs_for_issue returns [] for the falsy token — the
+        # caller would then report "0 submissions" indistinguishably from a
+        # genuine empty result. Fail loudly (in both human and JSON modes) so the
+        # missing precondition surfaces instead of a silent false negative.
+        raise click.ClickException('A GitHub token is required to list submissions. Set GITTENSOR_MINER_PAT and retry.')
 
     try:
         from gittensor.utils.github_api_tools import find_prs_for_issue
@@ -272,7 +280,7 @@ def fetch_open_issue_pull_requests(
             prs = find_prs_for_issue(
                 repository_full_name,
                 issue_number,
-                token=token or None,
+                token=token,
                 open_only=True,
             )
             # Intentionally return GitHub tool output as-is (no CLI schema mapping yet);

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -155,6 +155,49 @@ def test_submissions_human_lookup_failure_errors_instead_of_no_submissions(cli_r
     assert 'GitHub lookup failed' in result.output
 
 
+def test_submissions_json_missing_token_returns_structured_error(cli_root, runner, sample_issue, monkeypatch):
+    """With no GITTENSOR_MINER_PAT the GraphQL lookup cannot run, so the command
+    must surface a `success: false` error instead of a false-negative
+    `submission_count: 0`. Exercises the real `fetch_open_issue_pull_requests`."""
+    monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+    with (
+        patch('gittensor.cli.issue_commands.submissions.get_contract_address', return_value='0xabc'),
+        patch('gittensor.cli.issue_commands.submissions.resolve_network', return_value=('ws://x', 'test')),
+        patch('gittensor.cli.issue_commands.submissions.fetch_issue_from_contract', return_value=sample_issue),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'submissions', '--id', '42', '--json'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert 'GITTENSOR_MINER_PAT' in payload['error']['message']
+    assert 'submission_count' not in payload
+
+
+def test_submissions_human_missing_token_errors_instead_of_no_submissions(cli_root, runner, sample_issue, monkeypatch):
+    """In human mode a missing token must error out, not print the misleading
+    'No open submissions available' message used for a genuinely empty list."""
+    monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+    with (
+        patch('gittensor.cli.issue_commands.submissions.get_contract_address', return_value='0xabc'),
+        patch('gittensor.cli.issue_commands.submissions.resolve_network', return_value=('ws://x', 'test')),
+        patch('gittensor.cli.issue_commands.submissions.fetch_issue_from_contract', return_value=sample_issue),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'submissions', '--id', '42'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    assert 'No open submissions available' not in result.output
+    assert 'GITTENSOR_MINER_PAT' in result.output
+
+
 def test_submissions_json_contract_read_failure_returns_structured_error(cli_root, runner):
     """`fetch_issue_from_contract` now converts contract-read failures to a
     `ClickException`, which `submissions` routes through `handle_exception` —


### PR DESCRIPTION
## Summary

`gitt issues submissions` reports a **false negative** when `GITTENSOR_MINER_PAT` is not set.

The command lists open PR submissions for a bountied issue via GitHub's GraphQL API, which requires a PAT. When no token is present, `find_prs_for_issue` returns `[]` for the falsy token (it cannot query GitHub at all), and `submissions` treats that empty list as a genuine result — printing `success: true, submission_count: 0` and exiting `0`. That is indistinguishable from an issue that really has zero open submissions, and in `--json` mode there is **no diagnostic whatsoever** (the "No GitHub token found" warning was gated to human mode only).

This is exactly the false-negative the command's own code already guards against for the `None` GitHub-lookup-failure sentinel (added in #1554):

```python
# None is the GitHub lookup-failure sentinel ... Surface it as an explicit error
# instead of reporting an empty submission list, which would be a false negative
# for monitoring/automation.
```

The missing-token case is another way the lookup cannot be performed, so it should surface the same way. This change makes `fetch_open_issue_pull_requests` raise a `ClickException` when no PAT is set; `submissions` already routes `ClickException` through `handle_exception`, so the error is surfaced correctly in **both** human and JSON modes (exit 1). This also matches how `gitt miner post` / `gitt miner score` already treat a missing PAT, and keeps JSON and human modes in agreement on exit codes (per #724).

### Before / After

Command (no `GITTENSOR_MINER_PAT` in the environment):

```
$ gitt issues submissions --id 42 --json
```

**Before** — false negative, exit `0`:
```json
{"success": true, "issue_id": 42, "repository": "owner/repo", "issue_number": 123, "submission_count": 0, "submissions": []}
```

**After** — surfaced precondition, exit `1`:
```json
{"success": false, "error": {"type": "cli_error", "message": "A GitHub token is required to list submissions. Set GITTENSOR_MINER_PAT and retry."}}
```

In human mode, the misleading `No open submissions available (...)` line is likewise replaced by a clear error and a non-zero exit.

> Note: end-to-end terminal capture requires a live subtensor connection and a real on-chain bounty issue, so the before/after above is shown as the exact JSON envelopes the command emits. The two added tests assert precisely this behavior and fail on the pre-fix code.

## Related Issues

<!-- none -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added two tests to `tests/cli/test_issue_submission.py`, mirroring the existing `None` lookup-failure tests:

- `test_submissions_json_missing_token_returns_structured_error` — asserts `success: false` and no `submission_count` key.
- `test_submissions_human_missing_token_errors_instead_of_no_submissions` — asserts a non-zero exit and that the misleading "No open submissions available" line is not printed.

Both tests **fail on the pre-fix code** (the command exits `0`) and pass with the fix, so they lock the regression. `ruff check`, `ruff format --check`, and `vulture` are all clean on the changed files.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
