### PR TITLE
fix(cli): honor an explicit --wallet/--hotkey in `issues register`

### DIFF
--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -20,7 +20,6 @@ from .helpers import (
     console,
     err_console,
     format_alpha,
-    load_config,
     print_error,
     print_network_header,
     print_success,
@@ -140,7 +139,6 @@ def issue_register(
         rpc_url,
         missing_contract_message='Contract address not configured. Run ./up.sh --issues to deploy the contract first.',
     )
-    config = load_config()
 
     # Validate inputs before showing summary. The register path is owner-only
     # and spends real ALPHA, so both GitHub probes run in strict mode: any
@@ -185,9 +183,16 @@ def issue_register(
         with err_console.status('[bold cyan]Connecting to network...', spinner='dots'):
             subtensor = bt.Subtensor(network=ws_endpoint)
 
-        # CLI flags override config; fall back to config if not explicitly supplied
-        effective_wallet = wallet_name if wallet_name != 'default' else config.get('wallet', wallet_name)
-        effective_hotkey = wallet_hotkey if wallet_hotkey != 'default' else config.get('hotkey', wallet_hotkey)
+        # Explicit --wallet/--hotkey override config; an explicitly-passed value
+        # that happens to equal the default still wins (detected via Click's
+        # ParameterSource). Shared with `harvest` through resolve_wallet_config so
+        # both commands resolve the wallet identically.
+        effective_wallet, effective_hotkey = resolve_wallet_config(
+            wallet_name,
+            wallet_hotkey,
+            wallet_default='default',
+            hotkey_default='default',
+        )
 
         # For local development, check config first, then fall back to //Alice
         if network_name.lower() == 'local' and effective_wallet == 'default' and effective_hotkey == 'default':

--- a/tests/cli/test_issue_register.py
+++ b/tests/cli/test_issue_register.py
@@ -1,0 +1,118 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""CLI tests for `issues register` wallet resolution."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _register_mocks(load_config_return):
+    """Patch everything the register command touches up to the wallet load."""
+    return (
+        patch(
+            'gittensor.cli.issue_commands.mutations._resolve_contract_and_network',
+            return_value=('5Fakeaddr', 'ws://x', 'finney'),
+        ),
+        patch('gittensor.cli.issue_commands.helpers.load_config', return_value=load_config_return),
+        patch('gittensor.cli.issue_commands.mutations.validate_repository', return_value=('owner', 'repo')),
+        patch('gittensor.cli.issue_commands.mutations.validate_github_issue', return_value={}),
+        patch('bittensor.Subtensor', return_value=MagicMock()),
+    )
+
+
+def test_register_honors_explicit_wallet_default_over_config(cli_root, runner):
+    """`gitt issues register --wallet default` must sign with the wallet the user
+    named on the command line, even though it equals the option default and a
+    different wallet is set in config.
+
+    Regression: register resolved the wallet with a value comparison
+    (`wallet_name != 'default'`) instead of Click's ParameterSource, so an
+    explicit `--wallet default` was silently overridden by the config wallet —
+    unlike `harvest`, which resolves via `resolve_wallet_config`. Since register
+    spends real ALPHA and is owner-only, signing with the wrong wallet matters.
+    """
+    captured = {}
+
+    class FakeWallet:
+        def __init__(self, name=None, hotkey=None):
+            captured['name'] = name
+            captured['hotkey'] = hotkey
+            self.coldkey = object()
+
+    fake_client = MagicMock()
+    fake_client.register_issue.return_value = ('0xhash', None)
+
+    a, b, c, d, e = _register_mocks({'wallet': 'alice', 'hotkey': 'bob'})
+    with (
+        a,
+        b,
+        c,
+        d,
+        e,
+        patch('bittensor.Wallet', FakeWallet),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+    ):
+        result = runner.invoke(
+            cli_root,
+            [
+                'issues',
+                'register',
+                '--repo',
+                'owner/repo',
+                '--issue',
+                '1',
+                '--bounty',
+                '10',
+                '--wallet',
+                'default',
+                '-y',
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    # Explicit --wallet default wins over the config wallet 'alice'.
+    assert captured['name'] == 'default'
+    # --hotkey was not passed, so the config hotkey is still used.
+    assert captured['hotkey'] == 'bob'
+
+
+def test_register_falls_back_to_config_wallet_when_flag_omitted(cli_root, runner):
+    """When neither --wallet nor --hotkey is passed, register uses the config
+    wallet/hotkey (unchanged behavior, guards against over-correcting)."""
+    captured = {}
+
+    class FakeWallet:
+        def __init__(self, name=None, hotkey=None):
+            captured['name'] = name
+            captured['hotkey'] = hotkey
+            self.coldkey = object()
+
+    fake_client = MagicMock()
+    fake_client.register_issue.return_value = ('0xhash', None)
+
+    a, b, c, d, e = _register_mocks({'wallet': 'alice', 'hotkey': 'bob'})
+    with (
+        a,
+        b,
+        c,
+        d,
+        e,
+        patch('bittensor.Wallet', FakeWallet),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'register', '--repo', 'owner/repo', '--issue', '1', '--bounty', '10', '-y'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured['name'] == 'alice'
+    assert captured['hotkey'] == 'bob'


### PR DESCRIPTION
## Summary

`gitt issues register` silently ignores an explicitly-passed `--wallet` / `--hotkey` when the value equals the option default, substituting the config wallet instead.

`register` resolved the wallet with a value comparison:

```python
effective_wallet = wallet_name if wallet_name != 'default' else config.get('wallet', wallet_name)
```

So `--wallet default` (the wallet literally named `default`) is treated as "not supplied" and the config wallet wins. Every other wallet-taking command — including `harvest`, in the same file — resolves via `resolve_wallet_config`, which uses Click's `ParameterSource` to distinguish an explicitly-passed flag from a defaulted one. `register` is the only command that doesn't, so it resolves the wallet inconsistently with the rest of the CLI.

This is not merely cosmetic: `register` is owner-only and **spends real ALPHA on-chain**. A user who explicitly selects `--wallet default` to sign the registration gets signed with a *different* (config) wallet — a silent, surprising override of an explicit flag on a money-moving command.

Fix: resolve the wallet through the shared `resolve_wallet_config` helper (already imported and already used by `harvest`), so `register` honors an explicit flag exactly like its sibling commands. The now-unused `config = load_config()` line and its import are removed — `resolve_wallet_config` loads the config internally.

### Behavior

`~/.gittensor/config.json` = `{"wallet": "alice"}`, running:

```
gitt issues register --repo owner/repo --issue 1 --bounty 10 --wallet default -y
```

- **Before:** signs with `alice` — the explicit `--wallet default` is ignored.
- **After:** signs with `default` — the explicit flag is honored. Omitting `--wallet` still falls back to `alice`.

(No user-facing output shape changes; the only observable difference is that the `Loading wallet …` status line now names the wallet the user actually asked for.)

## Related Issues

<!-- none -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `tests/cli/test_issue_register.py` (the command had no prior test coverage):

- `test_register_honors_explicit_wallet_default_over_config` — explicit `--wallet default` beats config `alice`.
- `test_register_falls_back_to_config_wallet_when_flag_omitted` — omitting the flag still uses the config wallet, guarding against over-correction.

Both drive the real `issues register` command and assert on the wallet passed to `bittensor.Wallet`. Both fail on the pre-fix code and pass with the fix. `ruff check`, `ruff format --check`, and `vulture` are clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
