### PR TITLE
feat: reward Kata promotions by tier and recency

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -5,9 +5,13 @@
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
     "default_label_multiplier": 0.0,
-    "maintainer_cut": 0.4,
+    "maintainer_cut": 0.5,
     "label_multipliers": {
       "kata:winner:*": 1.0,
+      "kata:reward:xl": 10.0,
+      "kata:reward:l": 5.0,
+      "kata:reward:m": 3.0,
+      "kata:reward:s": 1.5,
       "kata:invalid": 0.0,
       "kata:losing": 0.0,
       "kata:stale": 0.0,
@@ -17,10 +21,16 @@
     "eligibility": {
       "min_valid_merged_prs": 1,
       "min_credibility": 0.0,
-      "max_open_pr_threshold": 2
+      "max_open_pr_threshold": 1
     },
     "scoring": {
-      "pr_lookback_days": 14
+      "pr_lookback_days": 14,
+      "time_decay": {
+        "grace_period_hours": 0,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1.0,
+        "min_multiplier": 0.05
+      }
     }
   },
   "DPBG/Engram.AI": {


### PR DESCRIPTION
## Summary

Updates the `Autovara/kata` reward configuration so Kata promotion PRs can be rewarded by both quality tier and recency.

## Changes

- Adds tiered Kata reward labels:
  - `kata:reward:s` = `1.5x`
  - `kata:reward:m` = `3.0x`
  - `kata:reward:l` = `5.0x`
  - `kata:reward:xl` = `10.0x`
- Adds Kata-specific time decay:
  - `0h` grace period
  - `2d` sigmoid midpoint
  - `1.0` sigmoid steepness
  - `0.05` minimum multiplier
- Updates `maintainer_cut` from `0.4` to `0.5`.
- Updates `max_open_pr_threshold` from `2` to `1`.

## Rationale

Previously, every Kata winner PR matched only `kata:winner:*` with a fixed `1.0x` multiplier. This made weak and strong promotions indistinguishable for reward allocation.

The new tier labels allow Kata to publish a deterministic promotion-strength signal, while the time-decay config gives newer kings stronger reward weight than older winners inside the lookback window.

## Validation

- Confirmed `master_repositories.json` remains valid JSON.
