### PR TITLE
Add Gittensor TinyRouter to master repositories

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,6 @@
 {
   "Autovara/kata": {
-    "emission_share": 0.08,
+    "emission_share": 0.077769,
     "issue_discovery_share": 0.0,
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
@@ -24,7 +24,7 @@
     }
   },
   "DPBG/Engram.AI": {
-    "emission_share": 0.0025,
+    "emission_share": 0.00243,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1,
@@ -35,7 +35,7 @@
     }
   },
   "entrius/das-github-mirror": {
-    "emission_share": 0.005,
+    "emission_share": 0.004861,
     "issue_discovery_share": 0.5,
     "label_multipliers": {
       "bug": 1.25,
@@ -46,7 +46,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.05,
+    "emission_share": 0.048606,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,
@@ -63,7 +63,7 @@
     "eligibility": {
       "max_open_pr_threshold": 2
     },
-    "emission_share": 0.02,
+    "emission_share": 0.019442,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "enhancement": 1.25,
@@ -81,7 +81,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.3425,
+    "emission_share": 0.35,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -98,7 +98,7 @@
     "trusted_label_pipeline": true
   },
   "gittensor-vanguard/vanguarstew": {
-    "emission_share": 0.1,
+    "emission_share": 0.097211,
     "issue_discovery_share": 0.0,
     "maintainer_cut": 0.5,
     "additional_acceptable_branches": ["test"],
@@ -123,10 +123,14 @@
     "emission_share": 0.01,
     "issue_discovery_share": 0.0
   },
+  "James-CUDA/Gittensor-TinyRouter": {
+    "emission_share": 0.01,
+    "issue_discovery_share": 0.0
+  },
   "JSONbored/awesome-claude": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.005,
+    "emission_share": 0.004861,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -155,7 +159,7 @@
   "JSONbored/gittensory": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.1,
+    "emission_share": 0.097211,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -184,7 +188,7 @@
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.23,
+    "emission_share": 0.223585,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -215,7 +219,7 @@
     "issue_discovery_share": 0.0
   },
   "vouchdev/vouch": {
-    "emission_share": 0.02,
+    "emission_share": 0.019442,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -240,7 +244,7 @@
     "maintainer_cut": 0.5
   },
   "phase-rs/phase": {
-    "emission_share": 0.015,
+    "emission_share": 0.014582,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,


### PR DESCRIPTION
## Summary
- add James-CUDA/Gittensor-TinyRouter to master_repositories.json at 1% emission share
- keep the existing 1% tier repos at 1% each
- rebalance active emission shares with sparkinfer at 35%, touchpilot and sure remaining at 0%

## Emission share changes

| Repository | Before | After | Change |
| --- | ---: | ---: | ---: |
| `gittensor-ai-lab/sparkinfer` | `0.342500` | `0.350000` | `+0.007500` |
| `JSONbored/metagraphed` | `0.230000` | `0.223585` | `-0.006415` |
| `gittensor-vanguard/vanguarstew` | `0.100000` | `0.097211` | `-0.002789` |
| `JSONbored/gittensory` | `0.100000` | `0.097211` | `-0.002789` |
| `Autovara/kata` | `0.080000` | `0.077769` | `-0.002231` |
| `entrius/gittensor` | `0.050000` | `0.048606` | `-0.001394` |
| `Geniepod/genie-claw` | `0.020000` | `0.019442` | `-0.000558` |
| `vouchdev/vouch` | `0.020000` | `0.019442` | `-0.000558` |
| `phase-rs/phase` | `0.015000` | `0.014582` | `-0.000418` |
| `imagent-ai/imagent` | `0.010000` | `0.010000` | `0.000000` |
| `mini-router/minirouter` | `0.010000` | `0.010000` | `0.000000` |
| `zeokin/Cuda-Compute-OSS` | `0.010000` | `0.010000` | `0.000000` |
| `James-CUDA/Gittensor-TinyRouter` | `0.000000` | `0.010000` | `+0.010000` |
| `entrius/das-github-mirror` | `0.005000` | `0.004861` | `-0.000139` |
| `JSONbored/awesome-claude` | `0.005000` | `0.004861` | `-0.000139` |
| `DPBG/Engram.AI` | `0.002500` | `0.002430` | `-0.000070` |
| `touchpilot/touchpilot` | `0.000000` | `0.000000` | `0.000000` |
| `we-promise/sure` | `0.000000` | `0.000000` | `0.000000` |

## Validation
- emission_share total: 1.0
- issue_discovery_share total: 0.5
- uv run pytest tests/validator/test_load_weights.py
