### PR TITLE
chore(weights): loosen credibility gate, shorten reward decay for JSONbored repos

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -150,18 +150,18 @@
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.7
+      "min_credibility": 0.5
     },
     "maintainer_cut": 0.55,
     "scoring": {
-      "pr_lookback_days": 7,
+      "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
       "standard_issue_multiplier": 1.0,
       "maintainer_issue_multiplier": 1.25,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 3,
+        "sigmoid_midpoint_days": 2,
         "sigmoid_steepness": 1.0,
         "min_multiplier": 0.05
       }
@@ -179,18 +179,18 @@
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.7
+      "min_credibility": 0.5
     },
     "maintainer_cut": 0.55,
     "scoring": {
-      "pr_lookback_days": 7,
+      "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
       "standard_issue_multiplier": 1.0,
       "maintainer_issue_multiplier": 1.25,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 3,
+        "sigmoid_midpoint_days": 2,
         "sigmoid_steepness": 1.0,
         "min_multiplier": 0.05
       }
@@ -208,18 +208,18 @@
       "slop": 0.0
     },
     "eligibility": {
-      "min_credibility": 0.7
+      "min_credibility": 0.5
     },
     "maintainer_cut": 0.55,
     "scoring": {
-      "pr_lookback_days": 7,
+      "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,
       "review_penalty_rate": 0.2,
       "standard_issue_multiplier": 1.0,
       "maintainer_issue_multiplier": 1.25,
       "time_decay": {
         "grace_period_hours": 24,
-        "sigmoid_midpoint_days": 3,
+        "sigmoid_midpoint_days": 2,
         "sigmoid_steepness": 1.0,
         "min_multiplier": 0.05
       }


### PR DESCRIPTION
Applies to JSONbored/awesome-claude, JSONbored/gittensory, and JSONbored/metagraphed:

- `eligibility.min_credibility` 0.7 -> 0.5. The trusted label pipeline already fails closed on unlabeled/low-value merges (`default_label_multiplier: 0.0`), and the gittensory gate bot enforces strict merge/close review per PR, so the account-level credibility floor was redundant on top of that and mostly punished contributors still finding their footing.
- `scoring.pr_lookback_days` 7 -> 5 and `scoring.time_decay.sigmoid_midpoint_days` 3 -> 2. Front-loads reward value (full multiplier through the 24h grace period, ~50% by day 2) and shortens the tail (floored out and aging out of the window by day 5), so contributors have to keep submitting rather than living off older merges.

`emission_share` is unchanged for all three repos.

## Test plan
- [x] `load_master_repo_weights()` loads the updated registry and passes its own range/schema validation
- [x] `tests/validator/test_load_weights.py` — 132 passed