### PR TITLE
fix(validator): fall through OSS scoring when mirror omits base_ref

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -207,14 +207,14 @@ def check_merged_branch_eligibility(
     issue discovery so both reject the same non-acceptable-branch merges.
 
     Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
-    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
-    check rather than false-positive-blocking on older data.
+    ``main``; missing ``base_ref``/``head_ref``/``head_repo_full_name`` skip
+    their checks rather than false-positive-blocking on older mirror data.
     """
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
-    # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    # base_ref check — only when present; pre-backfill mirror rows omit it.
+    if base_ref is not None and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable
@@ -251,8 +251,9 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
 
     When the mirror response is missing a field (older data predating the
     schema additions), some checks fall through rather than false-positive-
-    blocking. Concretely: missing ``head_ref`` or ``head_repo_full_name`` skips
-    the head_ref check. Missing ``default_branch`` falls back to ``main``.
+    blocking. Concretely: missing ``base_ref`` skips the base_ref check;
+    missing ``head_ref`` or ``head_repo_full_name`` skips the head_ref check.
+    Missing ``default_branch`` falls back to ``main``.
     """
     pr = scored.pr
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -212,6 +212,12 @@ class TestEligibilityGate:
         skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
         assert skip is False
 
+    def test_null_base_ref_skips_check(self):
+        # Pre-backfill mirror rows omit base_ref; must not false-positive-block.
+        scored = ScoredPR(pr=_pr(base_ref=None, default_branch='main'))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
+        assert skip is False
+
     def test_head_ref_in_additional_blocks_same_repo(self):
         scored = ScoredPR(
             pr=_pr(


### PR DESCRIPTION
## Summary

Pre-backfill mirror rows can omit `base_ref`. OSS scoring treated `null` as `''` and rejected those merged PRs at load time, while issue discovery already fall-throughs missing branch metadata.

Skip the base-ref gate when `base_ref is None`, matching the existing null `head_ref` / `head_repo_full_name` behavior and issue-discovery parity.

Fixes #1599

## Related Issues

Fixes #1599

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `test_null_base_ref_skips_check` in `tests/validator/oss_contributions/mirror/test_scoring.py`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
