### PR TITLE
chore(weights): retune mini-router/minirouter scoring

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -227,7 +227,26 @@
   },
   "mini-router/minirouter": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "additional_acceptable_branches": ["sn74*"],
+    "label_multipliers": {
+      "maintainer": 0.5,
+      "bug": 0.1,
+      "feature": 0.15,
+      "refactor": 0.02,
+      "king": 10.0
+    },
+    "eligibility": {
+      "min_valid_merged_prs": 0,
+      "min_credibility": 0.0
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "sigmoid_midpoint_days": 3
+      }
+    },
+    "maintainer_cut": 0.3
   },
   "vouchdev/vouch": {
     "emission_share": 0.019442,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -230,7 +230,6 @@
     "issue_discovery_share": 0.0,
     "additional_acceptable_branches": ["sn74*"],
     "label_multipliers": {
-      "maintainer": 0.5,
       "bug": 0.1,
       "feature": 0.15,
       "refactor": 0.02,


### PR DESCRIPTION
## Changes Summary

| Metric | Total |
| -------------------- | ----- |
| Repositories Added   | 0 |
| Repositories Removed | 0 |
| Weights Modified     | 1 |
| Net Weight Change    | 0.00 |

## Summary

Retunes `mini-router/minirouter` to favor recent high-signal submissions while reserving a maintainer slice for repository upkeep and evaluator costs.

- `maintainer_cut`: `0.0` -> `0.3`
- `eligibility.min_valid_merged_prs`: `3` -> `0`
- `eligibility.min_credibility`: `0.80` -> `0.0`
- `scoring.pr_lookback_days`: `30` -> `7`
- `scoring.time_decay.sigmoid_midpoint_days`: `10` -> `3`
- `additional_acceptable_branches`: `[]` -> `["sn74*"]`
- `label_multipliers`: `bug 0.1`, `feature 0.15`, `refactor 0.02`, `king 10.0`

## Rationale

The maintainer cut is meant to fund maintenance work and the operational cost of running evaluator infrastructure, including GPU and LLM API usage.
Zeroing the merged-PR and credibility gates removes a redundant barrier for a repo that already has a controlled scoring path.
The `sn74*` branch pattern matches the current submission workflow in `mini-router/minirouter`; the repo has merged PRs from `sn74-tmimmanuel` already, including https://github.com/mini-router/minirouter/pull/1.
The `king` label is intentionally the highest multiplier for submissions that exceed the current benchmark. Bug fixes, features, and refactors still receive differentiated rewards.

## Testing

- `uv run --with pytest pytest tests/validator/test_load_weights.py -q`
- Result: `132 passed`
