### PR TITLE
fix: update vanguard credibility

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -124,6 +124,7 @@
       "mult:docs": 0.8
     },
     "eligibility": {
+      "min_credibility": 0.7,
       "max_open_pr_threshold": 2
     },
     "scoring": {


### PR DESCRIPTION
## Summary

[Vanguarstew](https://github.com/gittensor-vanguard/vanguarstew/) repo min credibility update:
80 -> 70%
