### PR TITLE
fix(cli): don't round issues-list bounty fill % up to (100%)

### DIFF
--- a/gittensor/cli/issue_commands/view.py
+++ b/gittensor/cli/issue_commands/view.py
@@ -189,7 +189,7 @@ def issues_list(
                 if fill_pct >= 100:
                     bounty_display = f'{bounty_str} (100%)'
                 elif bounty_val > 0:
-                    bounty_display = f'{bounty_str}/{target_str} ({fill_pct:.0f}%)'
+                    bounty_display = f'{bounty_str}/{target_str} ({fill_pct:.1f}%)'
                 else:
                     bounty_display = f'0/{target_str} (0%)'
             else:


### PR DESCRIPTION
## Summary

The all-issues table in `gitt issues list` formatted the bounty fill percentage with `{fill_pct:.0f}%`, which **rounds**. A bounty funded to 99.5–99.99% therefore rendered as `(100%)` right next to a `Registered` status — a self-contradiction, since an issue only flips to `Active` at a true 100% (`fill_pct >= 100` is a separate branch). A tiny nonzero fill likewise rendered as `(0%)`.

The fix uses `.1f`, matching the single-issue Panel view (`view.py:141`) which already formats the same value with one decimal.

### Before / after — `gitt issues list`

**Before** (two partially-funded bounties):
```
┃ ID ┃ Repository ┃ Issue # ┃       Bounty Pool ┃   Status   ┃
│  1 │ owner/repo │     #42 │ 99.6/100.0 (100%) │ Registered │
│  2 │ owner/repo │     #43 │    0.3/100.0 (0%) │ Registered │
```

**After**:
```
┃ ID ┃ Repository ┃ Issue # ┃        Bounty Pool ┃   Status   ┃
│  1 │ owner/repo │     #42 │ 99.6/100.0 (99.6%) │ Registered │
│  2 │ owner/repo │     #43 │   0.3/100.0 (0.3%) │ Registered │
```

## Related Issues

_None._

## Type of Change

- [x] Bug fix

## Testing

- [x] Tests added — `test_issues_list_table_fill_percent_is_not_rounded` renders the real command via `CliRunner` and asserts the table shows the fractional percentage (`99.6%` / `0.3%`) and never `(100%)` for a partially-funded bounty. Fails on `test` before the fix, passes after.
- [x] Full suite green (961 passed), `ruff` + `pyright` clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
