### PR TITLE
chore(weights): tune imagent reward parameters

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -133,7 +133,37 @@
   },
   "imagent-ai/imagent": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "trusted_label_pipeline": true,
+    "fixed_base_score": 1.0,
+    "default_label_multiplier": 0.0,
+    "label_multipliers": {
+      "round-winner": 10.0,
+      "generation-ui-pass": 1.0,
+      "benchmark-fail": 0.0,
+      "below-threshold": 0.0,
+      "invalid-pr": 0.0,
+      "duplicate-pr": 0.0,
+      "needs-rebase": 0.0,
+      "needs-evidence": 0.0
+    },
+    "eligibility": {
+      "min_valid_merged_prs": 1,
+      "min_credibility": 0.0,
+      "max_open_pr_threshold": 2
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "open_pr_collateral_percent": 0.1,
+      "standard_issue_multiplier": 1.0,
+      "maintainer_issue_multiplier": 1.0,
+      "time_decay": {
+        "grace_period_hours": 0,
+        "sigmoid_midpoint_days": 3,
+        "sigmoid_steepness": 1.0,
+        "min_multiplier": 0.05
+      }
+    }
   },
   "James-CUDA/Gittensor-TinyRouter": {
     "emission_share": 0.01,


### PR DESCRIPTION
## Weight Adjustment PR

### Changes Summary

| Metric               | Total |
| -------------------- | ----- |
| Repositories Added   | 0     |
| Repositories Removed | 0     |
| Weights Modified     | 1     |
| Net Weight Change    | 0     |

### Added Repositories

None.

### Removed Repositories

None.

### Justification

This tunes the existing `imagent-ai/imagent` registry entry for Imagent's round-based contribution workflow.

- Keeps `emission_share` at `0.01`, so the total registry emission remains unchanged.
- Keeps `issue_discovery_share` at `0.0`, because Imagent rewards should currently come from merged PR contributions.
- Enables `trusted_label_pipeline` so repository-owned automation labels can drive scoring.
- Uses `fixed_base_score` with `default_label_multiplier: 0.0`, so reward comes from approved workflow labels instead of diff size.
- Rewards benchmark winners through `round-winner` and manually reviewable Generation UI work through `generation-ui-pass`.
- Sets invalid, failed, stale, duplicate, and evidence-missing workflow states to `0.0` multipliers.
- Uses a 7-day lookback and fast decay to align rewards with frequent Imagent rounds.

### Additional Acceptable Branches

- [x] No additional_acceptable_branches changes in this PR
- [ ] Proof of merged PR(s) provided above for all additional_acceptable_branches entries

### Validation

- [x] `uv run pytest tests/validator/test_load_weights.py -q` passed with 132 tests.

### Checklist

- [x] Changes summary table is filled in accurately
- [x] Net weight changes are justified in the Justification section
- [x] Added repositories have correct branch and initial weight
