### PR TITLE
fix(issue-discovery): clear stale per-repo issue fields on the scoring path

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -40,7 +40,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
-from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache
+from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache, RepoEvaluation
 from gittensor.constants import (
     MAINTAINER_ASSOCIATIONS,
 )
@@ -252,6 +252,25 @@ async def run_issue_discovery(
     )
 
 
+def _reset_repo_issue_fields(repo_eval: RepoEvaluation) -> None:
+    """Zero every per-repo issue-discovery field.
+
+    Both issue-discovery reset paths — the no-issues path
+    (``_clear_issue_discovery_fields``) and the scoring path
+    (``_finalize_repo_issue_scores``) — must clear these identically. Otherwise a
+    repo scored in a prior round but absent this round keeps stale values that
+    ``_roll_up_issue_totals`` then sums into the round-level totals.
+    """
+    repo_eval.is_issue_eligible = False
+    repo_eval.issue_credibility = 0.0
+    repo_eval.issue_discovery_score = 0.0
+    repo_eval.issue_token_score = 0.0
+    repo_eval.total_solved_issues = 0
+    repo_eval.total_valid_solved_issues = 0
+    repo_eval.total_closed_issues = 0
+    repo_eval.total_open_issues = 0
+
+
 def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
     """Reset issue-discovery aggregates after a successful fetch with no mirror issues."""
     evaluation.issue_discovery_score = 0.0
@@ -264,14 +283,7 @@ def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
     evaluation.total_open_issues = 0
     evaluation.issue_discovery_issues = []
     for repo_eval in evaluation.repo_evaluations.values():
-        repo_eval.is_issue_eligible = False
-        repo_eval.issue_credibility = 0.0
-        repo_eval.issue_discovery_score = 0.0
-        repo_eval.issue_token_score = 0.0
-        repo_eval.total_solved_issues = 0
-        repo_eval.total_valid_solved_issues = 0
-        repo_eval.total_closed_issues = 0
-        repo_eval.total_open_issues = 0
+        _reset_repo_issue_fields(repo_eval)
 
 
 def _apply_open_issue_counts(evaluation: MinerEvaluation, open_counts: Dict[str, int]) -> None:
@@ -545,6 +557,13 @@ def _finalize_repo_issue_scores(
 ) -> None:
     """Gate + score issue discovery per repository, then roll up the totals."""
     evaluation.issue_discovery_issues = []
+
+    # Clear stale per-repo issue fields carried over from a prior round (e.g. an
+    # OSS cache-restored evaluation) before rewriting only the repos seen this
+    # round. Without this, a repo scored previously but absent now keeps its old
+    # values and _roll_up_issue_totals sums them into the round-level totals.
+    for repo_eval in evaluation.repo_evaluations.values():
+        _reset_repo_issue_fields(repo_eval)
 
     for repo_name in sorted(set(repo_acc) | set(open_counts)):
         repo_config = mirror_repos.get(repo_name)

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -921,6 +921,51 @@ class TestRunMirrorIssueDiscovery:
         assert cached.issue_discovery_score == 8.12
         assert cached.total_solved_issues == 7
 
+    def test_successful_scoring_clears_stale_issue_fields_for_repos_absent_this_round(self):
+        # An OSS cache-restored evaluation carries a repo scored in a prior round.
+        # This round the miner only has issues in a DIFFERENT enabled repo, so the
+        # scoring path must zero the now-absent repo's issue fields (parity with the
+        # no-issues path) rather than leak them into _roll_up_issue_totals.
+        eval_ = _eval(uid=1, github_id='999')
+        stale = eval_.get_or_create_repo_evaluation('entrius/gittensor')
+        stale.total_solved_issues = 7
+        stale.total_valid_solved_issues = 7
+        stale.total_closed_issues = 2
+        stale.issue_discovery_score = 8.12
+        stale.issue_token_score = 700.0
+        stale.issue_credibility = 1.0
+        stale.is_issue_eligible = True
+
+        client = Mock()
+        # Both the scoring fetch and the open-count fetch return issues only for the
+        # other enabled repo; 'entrius/gittensor' is absent from repo_acc/open_counts.
+        client.get_miner_issues.return_value = _response(
+            [_issue_dict(repo='entrius/gittensor-ui', state='CLOSED', state_reason='NOT_PLANNED', solved_by_pr=None)]
+        )
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor', 'entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        stale_after = eval_.repo_evaluations['entrius/gittensor']
+        assert stale_after.total_solved_issues == 0
+        assert stale_after.total_valid_solved_issues == 0
+        assert stale_after.total_closed_issues == 0
+        assert stale_after.issue_discovery_score == 0.0
+        assert stale_after.issue_token_score == 0.0
+        assert stale_after.is_issue_eligible is False
+
+        # Round-level roll-up must not inherit the stale repo's solved count / score.
+        assert eval_.total_solved_issues == 0
+        assert eval_.issue_discovery_score == 0.0
+        assert eval_.is_issue_eligible is False
+
 
 # ============================================================================
 # Cache behavior


### PR DESCRIPTION
## Summary

Issue discovery has two per-round reset paths that must clear a miner's per-repo issue fields identically, but they drifted:

- `_clear_issue_discovery_fields` (no-issues path) zeroes the issue fields on **every** `repo_evaluation`.
- `_finalize_repo_issue_scores` (scoring path) only rewrites the repos seen this round (`sorted(set(repo_acc) | set(open_counts))`), while `_roll_up_issue_totals` sums over **all** `repo_evaluations`.

So a repo scored in a prior round but absent this round keeps stale per-repo values that leak into the round-level totals.

**Root cause.** The only way a `repo_evaluation` carries prior-round issue data into a new round is the OSS cache-restore path: on `github_pr_fetch_failed`, `store_or_use_cached_evaluation` replaces the eval with the cached one (which carries `repo_evaluations`). Issue discovery is expected to recompute fresh fields on top (see the `forward.py` comment: *"cached UIDs now have fresh issue-discovery fields"*), but the scoring path never clears the repos it doesn't revisit, so `_roll_up_issue_totals` sums stale + fresh.

**Impact.** Inflated per-repo issue rows (persisted via `bulk_store_evaluation`) and round-level `total_solved_issues` / `issue_discovery_score` / `is_issue_eligible`, which also get re-written to the evaluation cache (`update_issue_discovery`) and compound across rounds. Consumed by CLI `miner score` and analytics. Current-round emission allocation reads the freshly-rebuilt `issue_discovery_issues` list, so this is a stored-data/reporting correctness bug, not an emissions change.

**Fix.** Extract the per-repo reset into a shared `_reset_repo_issue_fields` helper (removing the duplication that let the two paths drift) and call it at the top of `_finalize_repo_issue_scores`, mirroring `_clear_issue_discovery_fields`.

## Related Issues

Fixes #1610

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `test_successful_scoring_clears_stale_issue_fields_for_repos_absent_this_round`: pre-populates a `repo_evaluation` with prior-round issue data (simulating the OSS cache restore), returns mirror issues only for a different enabled repo, and asserts the stale repo and the round-level roll-up are both zeroed. The test fails on `main` (`assert 7 == 0`) and passes with the fix. Full issue-discovery suite green (73 passed); `ruff`, `ruff format`, and `vulture` clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
