### PR TITLE
chore(weights): configure Gittensor-TinyRouter maintainer cut, eligib…

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -167,7 +167,24 @@
   },
   "James-CUDA/Gittensor-TinyRouter": {
     "emission_share": 0.01,
-    "issue_discovery_share": 0.0
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "bug": 0.1,
+      "feature": 0.15,
+      "refactor": 0.02,
+      "king": 10.0
+    },
+    "eligibility": {
+      "min_valid_merged_prs": 0,
+      "min_credibility": 0.0
+    },
+    "scoring": {
+      "pr_lookback_days": 7,
+      "time_decay": {
+        "sigmoid_midpoint_days": 3
+      }
+    },
+    "maintainer_cut": 0.3
   },
   "JSONbored/awesome-claude": {
     "default_label_multiplier": 0.0,


### PR DESCRIPTION
### Summary
Activates a full reward configuration for `James-CUDA/Gittensor-TinyRouter`. Previously the entry carried only `emission_share` / `issue_discovery_share` and inherited all global defaults. This sets an explicit per-repo policy that opens up eligibility, shortens the reward window/decay, introduces label multipliers (including a `king` reward), and carves out a 30% maintainer cut.

### Changes
The config mirrors the established `mini-router/minirouter` policy.

| Field | Before (global default) | After |
|---|---|---|
| `maintainer_cut` | `0.0` | `0.3` |
| `eligibility.min_valid_merged_prs` | `3` | `0` |
| `eligibility.min_credibility` | `0.80` | `0.0` |
| `scoring.pr_lookback_days` | `30` | `7` |
| `scoring.time_decay.sigmoid_midpoint_days` | `10` | `3` |
| `label_multipliers` | _(none)_ | `bug` 0.1, `feature` 0.15, `refactor` 0.02, `king` 10.0 |

### Rationale
- **Eligibility relaxed** (`min_valid_merged_prs` 3→0, `min_credibility` 0.80→0.0): new contributors can earn rewards immediately rather than clearing the global 3-PR / 0.80 credibility gate.
- **Shorter reward window** (`pr_lookback_days` 30→7) and **faster decay** (`sigmoid_midpoint_days` 10→3): rewards concentrate on recent, relevant work and stale PRs depreciate quickly.
- **Label multipliers**: scale PR value by type — `bug`/`feature`/`refactor` are de-emphasized, while a `king` label grants a 10× reward for high-impact contributions.
- **Maintainer cut 30%**: routes a share of the repo's emission to registered maintainer miners via the existing `maintainer_cut` carve-out.

### Validation
- All values within the loader's enforced bounds (`maintainer_cut` ∈ [0,1], `min_credibility` ∈ [0,1], `min_valid_merged_prs` ≥ 0, `pr_lookback_days` ∈ [1,90], `sigmoid_midpoint_days` ∈ [1,90], `label_multipliers` ≤ 10 entries / values ∈ [0,20]).
- Total `emission_share` across the registry remains `1.0` (this PR does not alter `emission_share`).
- `load_master_repo_weights()` parsing and all three validators (`_validate_emission_shares`, `_validate_eligibility_configs`, `_validate_scoring_configs`) pass for this entry.

### Verification
- `py -m pytest tests/validator/test_load_weights.py `