### PR TITLE
fix(cli): treat a zero bounty payout as success, not failure

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -153,7 +153,9 @@ def admin_payout(
         with err_console.status('[bold cyan]Submitting payout...', spinner='dots'):
             result = client.payout_bounty(issue_id, wallet)
 
-        if result:
+        # payout_bounty returns a non-None amount on success (0 is valid when the
+        # pre-read bounty is unavailable) and None only on failure.
+        if result is not None:
             print_success(f'Payout successful! Amount: {format_alpha(result, 4)} ALPHA')
         else:
             print_error('Payout failed.')

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -11,8 +11,9 @@ validation (no live network).
 
 import json
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any, Dict, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import click
 import pytest
@@ -741,6 +742,58 @@ class TestCliAdminValidation:
             )
         assert result.exit_code != 0
         assert 'between' in result.output or '1' in result.output
+
+
+class TestCliAdminPayoutResultHandling:
+    """Ensure admin payout-issue interprets the payout return value correctly.
+
+    ``payout_bounty`` returns a non-None amount on success (0 is a valid amount
+    when the pre-read bounty is unavailable) and None only on failure, so the
+    success check must be ``is not None`` rather than truthiness.
+    """
+
+    def _invoke_payout(self, cli_root, runner, payout_return):
+        issue = SimpleNamespace(
+            id=1,
+            repository_full_name='entrius/gittensor',
+            issue_number=223,
+            bounty_amount=0,
+            target_bounty=2000,
+            status=SimpleNamespace(name='COMPLETED'),
+        )
+        client = MagicMock()
+        client.get_issue.return_value = issue
+        client.payout_bounty.return_value = payout_return
+        with (
+            patch(
+                'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.admin._make_contract_client',
+                return_value=(MagicMock(), client),
+            ),
+        ):
+            return runner.invoke(
+                cli_root,
+                ['admin', 'payout-issue', '1', '--yes'],
+                catch_exceptions=False,
+            )
+
+    def test_zero_payout_reported_as_success(self, cli_root, runner):
+        result = self._invoke_payout(cli_root, runner, 0)
+        assert result.exit_code == 0
+        assert 'Payout successful' in result.output
+        assert 'Payout failed' not in result.output
+
+    def test_none_payout_reported_as_failure(self, cli_root, runner):
+        result = self._invoke_payout(cli_root, runner, None)
+        assert result.exit_code != 0
+        assert 'Payout failed' in result.output
 
 
 class TestCliVoteCancelValidation:


### PR DESCRIPTION
## Summary

`gitt admin payout-issue` reports a successful payout as a failure whenever `payout_bounty` returns `0`. `payout_bounty` returns a non-None int on success (`0` when the pre-read bounty amount is unavailable) and `None` only on failure, but the caller in `gittensor/cli/issue_commands/admin.py` used a truthiness check (`if result:`), so a successful zero-amount payout printed "Payout failed." and exited 1 even though the transaction went through.

This implements the caller-side fix @anderdc described when closing #1577: change the guard to `if result is not None:` — one line in the caller, no change to `contract_client.py`, no extra re-read on the success path.

The sibling admin commands (`cancel-issue`, `set-owner`, `set-treasury`, `add-vali`, `remove-vali`) are deliberately unchanged: their client methods all return `bool` via `_exec_tx_bool`, so truthiness is correct there.

## Related Issues

None — implements the correct fix spelled out in the closure of PR #1577.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

Added `TestCliAdminPayoutResultHandling` in `tests/cli/test_cli_helpers.py`, mocking the contract client on the existing CLI-runner path: a `payout_bounty` return of `0` must report success and exit 0, and a return of `None` must still report failure and exit non-zero.

Full local run on this branch: `uv run pytest` — 962 passed; `uv run ruff check .` and `uv run ruff format --check .` — clean; `uv run pyright` — 0 errors, 0 warnings.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
