### PR TITLE
feat(label): add king:defeat label

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -12,11 +12,11 @@
       "kata:reward:l": 5.0,
       "kata:reward:m": 3.0,
       "kata:reward:s": 1.5,
+      "kata:defeat": 0.25,
       "kata:invalid": 0.0,
       "kata:losing": 0.0,
       "kata:stale": 0.0,
-      "kata:hold": 0.0,
-      "kata:evaluating": 0.0
+      "kata:hold": 0.0
     },
     "eligibility": {
       "min_valid_merged_prs": 1,
@@ -24,11 +24,11 @@
       "max_open_pr_threshold": 1
     },
     "scoring": {
-      "pr_lookback_days": 14,
+      "pr_lookback_days": 7,
       "time_decay": {
         "grace_period_hours": 0,
-        "sigmoid_midpoint_days": 2,
-        "sigmoid_steepness": 1.0,
+        "sigmoid_midpoint_days": 3,
+        "sigmoid_steepness": 0.75,
         "min_multiplier": 0.05
       }
     }


### PR DESCRIPTION
### Summary

Tunes the `Autovara/kata` entry in `master_repositories.json` so a newly crowned king clearly out-earns the king it replaced, and rewards fade over a shorter window.

### Changes
- **Add `kata:defeat: 0.25`** — when a new king is promoted, the previous king's PR is relabeled `kata:defeat`. At `0.25` it sits below the smallest reward tier (`kata:reward:s` = 1.5), so a dethroned king always earns less than any current king (winner-take-all, with a small residual instead of zero).
- **Remove dead `kata:evaluating`** — Kata never emits this label, and at `0.0` it duplicated `default_label_multiplier: 0.0`. Removing it also keeps the entry within the 10-label limit enforced by the live-config test.
- **`pr_lookback_days`: 14 → 7** — shorter reward memory.
- **Time decay retuned for the 7-day window** — `sigmoid_midpoint_days` 2 → 3, `sigmoid_steepness` 1.0 → 0.75. Gentle curve that reaches the 5% floor right at the 7-day edge (no cliff): ~0.90 (day 0) → 0.50 (day 3) → 0.05 (day 7).

### Notes
- Kata's `emission_share` is unchanged; total shares still sum to 1.0.
- The `kata:defeat` multiplier only takes effect once the Kata bot strips the ex-king's `kata:winner:*` / `kata:reward:*` labels (label scoring uses the max of matching labels). That change ships separately in the Kata repo.

### Testing
- `master_repositories.json` parses and loads via `load_master_repo_weights`.
- Full validator/config suite passes (emission-share, eligibility, scoring, and the label-multiplier bound test).
