### PR TITLE
fix(validator): don't reject merged PRs with a missing base_ref

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -213,8 +213,11 @@ def check_merged_branch_eligibility(
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
-    # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    # base_ref check — gate only when base_ref is present. A missing base_ref
+    # means pre-backfill mirror data; fall through rather than false-positive-
+    # blocking, matching the head_ref check below and issue discovery
+    # (issue_discovery/scan.py only gates when ``base_ref is not None``).
+    if base_ref and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -212,6 +212,17 @@ class TestEligibilityGate:
         skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
         assert skip is False
 
+    def test_missing_base_ref_falls_through_not_blocked(self):
+        # Pre-backfill mirror rows can omit base_ref (Optional[str] -> None). A
+        # missing base_ref must fall through rather than false-positive-block the
+        # merged PR — matching the head_ref check in the same gate and issue
+        # discovery, which gates only when ``base_ref is not None``
+        # (issue_discovery/scan.py). See #1599.
+        scored = ScoredPR(pr=_pr(base_ref=None, default_branch='main'))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
+        assert skip is False
+        assert reason is None
+
     def test_head_ref_in_additional_blocks_same_repo(self):
         scored = ScoredPR(
             pr=_pr(


### PR DESCRIPTION
## Summary

`check_merged_branch_eligibility` gated the base_ref check with `not branch_matches_pattern(base_ref or '', acceptable)`. When the mirror omits `base_ref` on pre-backfill rows (`base_ref` is `Optional[str]` → `None`), `base_ref or ''` becomes `''`, which never matches the acceptable branch set — so a valid **MERGED** PR is dropped at load time and never enters `merged_prs`, earning no OSS contribution score even though it still counts toward eligibility.

The fix gates only when `base_ref` is present, so a missing `base_ref` falls through rather than false-positive-blocking. This matches three existing precedents:

- the **head_ref check in the same function** (`if acceptable and head_ref and ...`), which already skips on a falsy `head_ref`;
- the function's **own docstring**: *"missing head_ref/head_repo_full_name skips the head_ref check rather than false-positive-blocking on older data"*;
- **issue discovery**, which calls this same shared gate only when `base_ref is not None` (`issue_discovery/scan.py`), covered by `test_missing_base_ref_falls_through_to_solved`.

## Related Issues

Fixes #1599

## Type of Change

- [x] Bug fix

## Testing

- [x] Tests added — `TestEligibilityGate::test_missing_base_ref_falls_through_not_blocked` asserts a merged PR with `base_ref=None` falls through the gate. Fails on `test` before the fix (blocked), passes after. A real non-matching `base_ref` is still blocked (existing eligibility tests unchanged, all 21 green).
- [x] Full suite green (961 passed), `ruff` + `pyright` clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
