### PR TITLE
fix(scoring): allow merged PRs with missing base ref

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -207,14 +207,14 @@ def check_merged_branch_eligibility(
     issue discovery so both reject the same non-acceptable-branch merges.
 
     Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
-    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
-    check rather than false-positive-blocking on older data.
+    ``main``; missing ``base_ref``/``head_ref``/``head_repo_full_name`` skips
+    the corresponding check rather than false-positive-blocking on older data.
     """
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
     # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    if base_ref is not None and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable
@@ -251,8 +251,9 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
 
     When the mirror response is missing a field (older data predating the
     schema additions), some checks fall through rather than false-positive-
-    blocking. Concretely: missing ``head_ref`` or ``head_repo_full_name`` skips
-    the head_ref check. Missing ``default_branch`` falls back to ``main``.
+    blocking. Concretely: missing ``base_ref`` skips the base_ref check;
+    missing ``head_ref`` or ``head_repo_full_name`` skips the head_ref check.
+    Missing ``default_branch`` falls back to ``main``.
     """
     pr = scored.pr
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -54,7 +54,7 @@ def _pr(
     author_login: str = 'bittoby',
     merged_by_login: str | None = 'anderdc',
     author_association: str = 'CONTRIBUTOR',
-    base_ref: str = 'main',
+    base_ref: str | None = 'main',
     head_ref: str | None = 'feature/foo',
     head_repo_full_name: str | None = 'entrius/gittensor-ui',
     default_branch: str | None = 'main',
@@ -189,6 +189,12 @@ class TestEligibilityGate:
         scored = ScoredPR(pr=_pr(base_ref='main', default_branch='main'))
         skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
         assert skip is False
+
+    def test_missing_base_ref_falls_through(self):
+        scored = ScoredPR(pr=_pr(base_ref=None, default_branch='test'))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config())
+        assert skip is False
+        assert reason is None
 
     def test_base_ref_mismatches_default_branch_blocks(self):
         # Closes the prior gap: with default_branch known and no additional,


### PR DESCRIPTION
Older mirror rows may predate base-ref backfilling. Skip the branch gate when base_ref is absent, matching the existing fall-through behavior for missing head metadata.

Add a regression test for the null base_ref case.

Fixes #1599