### PR TITLE
fix(issue-discovery): zero stale per-repo issue fields on scoring path

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -40,7 +40,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
-from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache
+from gittensor.classes import Issue, MinerEvaluation, MinerEvaluationCache, RepoEvaluation
 from gittensor.constants import (
     MAINTAINER_ASSOCIATIONS,
 )
@@ -264,14 +264,19 @@ def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
     evaluation.total_open_issues = 0
     evaluation.issue_discovery_issues = []
     for repo_eval in evaluation.repo_evaluations.values():
-        repo_eval.is_issue_eligible = False
-        repo_eval.issue_credibility = 0.0
-        repo_eval.issue_discovery_score = 0.0
-        repo_eval.issue_token_score = 0.0
-        repo_eval.total_solved_issues = 0
-        repo_eval.total_valid_solved_issues = 0
-        repo_eval.total_closed_issues = 0
-        repo_eval.total_open_issues = 0
+        _clear_repo_issue_discovery_fields(repo_eval)
+
+
+def _clear_repo_issue_discovery_fields(repo_eval: RepoEvaluation) -> None:
+    """Zero a single repo's issue-discovery fields for a round it was not scored in."""
+    repo_eval.is_issue_eligible = False
+    repo_eval.issue_credibility = 0.0
+    repo_eval.issue_discovery_score = 0.0
+    repo_eval.issue_token_score = 0.0
+    repo_eval.total_solved_issues = 0
+    repo_eval.total_valid_solved_issues = 0
+    repo_eval.total_closed_issues = 0
+    repo_eval.total_open_issues = 0
 
 
 def _apply_open_issue_counts(evaluation: MinerEvaluation, open_counts: Dict[str, int]) -> None:
@@ -546,7 +551,12 @@ def _finalize_repo_issue_scores(
     """Gate + score issue discovery per repository, then roll up the totals."""
     evaluation.issue_discovery_issues = []
 
-    for repo_name in sorted(set(repo_acc) | set(open_counts)):
+    seen_repos = set(repo_acc) | set(open_counts)
+    for repo_name, repo_eval in evaluation.repo_evaluations.items():
+        if repo_name not in seen_repos:
+            _clear_repo_issue_discovery_fields(repo_eval)
+
+    for repo_name in sorted(seen_repos):
         repo_config = mirror_repos.get(repo_name)
         if repo_config is None:
             continue

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -921,6 +921,45 @@ class TestRunMirrorIssueDiscovery:
         assert cached.issue_discovery_score == 8.12
         assert cached.total_solved_issues == 7
 
+    def test_scoring_path_zeroes_stale_repo_not_seen_this_round(self):
+        """A repo issue-scored in a prior round (restored from cache) but absent
+        this round must have its per-repo issue fields zeroed by the scoring
+        path, so the round-level roll-up reflects only this round's issues."""
+        stale_repo = 'entrius/gittensor'
+        fresh_repo = 'entrius/gittensor-ui'
+
+        eval_ = _eval(uid=1, github_id='999')
+        stale = eval_.get_or_create_repo_evaluation(stale_repo)
+        stale.total_solved_issues = 7
+        stale.total_valid_solved_issues = 7
+        stale.issue_discovery_score = 8.12
+        stale.issue_credibility = 1.0
+        stale.is_issue_eligible = True
+
+        client = Mock()
+        client.get_miner_issues.return_value = _response([_issue_dict(repo=fresh_repo)])
+        client.get_pr_files.return_value = _empty_files_response(fresh_repo, 100)
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos(stale_repo, fresh_repo),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        stale_after = eval_.repo_evaluations[stale_repo]
+        assert stale_after.total_solved_issues == 0
+        assert stale_after.total_valid_solved_issues == 0
+        assert stale_after.issue_discovery_score == 0.0
+        assert stale_after.issue_credibility == 0.0
+        assert stale_after.is_issue_eligible is False
+
+        assert eval_.total_solved_issues == 1
+        assert eval_.total_valid_solved_issues == 0
+
 
 # ============================================================================
 # Cache behavior


### PR DESCRIPTION
The scoring path (_finalize_repo_issue_scores) only rewrote repos seen
this round, so a repo issue-scored in a prior round but absent this round
kept stale per-repo values that _roll_up_issue_totals summed back into the
round-level totals. This is reachable when an OSS-fetch-failed miner is
restored from the evaluation cache. Extract the per-repo reset into a
shared helper and apply it on both the no-issues and scoring paths so the
roll-up reflects only this round's issues.

Closes #1610

