### PR TITLE
Reset SparkDistill to default repository config

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -109,26 +109,7 @@
     "trusted_label_pipeline": true
   },
   "gittensor-model-hub/SparkDistill": {
-    "default_label_multiplier": 0.0,
-    "eligibility": {
-      "min_credibility": 0.2,
-      "min_issue_credibility": 0.0,
-      "min_valid_merged_prs": 0,
-      "min_valid_solved_issues": 0
-    },
-    "emission_share": 0.1,
-    "fixed_base_score": 1.0,
-    "issue_discovery_share": 0.0,
-    "label_multipliers": {
-      "*:XL": 4.0,
-      "*:L": 2.5,
-      "*:M": 1.5,
-      "*:S": 1.0,
-      "*:XS": 0.5,
-      "eval:BASELINE": 1.0
-    },
-    "maintainer_cut": 0.5,
-    "trusted_label_pipeline": true
+    "emission_share": 0.1
   },
   "gittensor-vanguard/vanguarstew": {
     "emission_share": 0.099211,


### PR DESCRIPTION
## Summary

Reduce the new SparkDistill registry entry to the neutral minimum:

```json
"gittensor-model-hub/SparkDistill": {
  "emission_share": 0.1
}
```

This removes the inherited eligibility overrides, fixed base score, issue-discovery override, label multipliers, trusted-label setting, and 50% maintainer cut.

## Why

Those settings were copied from SparkInfer when SparkDistill was added in #1623, but they were not requested or proposed by the SparkDistill maintainers. Keeping only the emission share makes the registry addition neutral and lets the maintainers submit a separate PR for the scoring, eligibility, label trust, and maintainer policy they actually want.

## Impact

- SparkDistill keeps its 10% emission allocation.
- Repository weights and the 100% allocation total do not change.
- SparkDistill uses the validator's standard repository defaults until maintainers propose explicit overrides.

## Validation

- `uv run pytest tests/validator/test_load_weights.py tests/validator/test_label_multiplier.py -q` (146 passed)
- emission shares still sum to 1.0
- `git diff --check`
