### PR TITLE
fix(scoring): unique_repos_contributed_to undercounts when mirror fil…

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -130,6 +130,13 @@ async def score_pr(
     # load_miner_prs → _should_skip_merged_mirror_pr). By this point
     # eval_.merged_prs contains only eligibility-passed PRs.
 
+    # Attribute repo contribution as soon as we know the PR is a scorable MERGED
+    # PR for a recognized repo — independent of file-fetch outcome below, so a
+    # pending/failed mirror file fetch doesn't silently drop this PR's repo from
+    # unique_repos_contributed_to (see #1616).
+    if pr.state == 'MERGED':
+        eval_.unique_repos_contributed_to.add(pr.repo_full_name)
+
     has_fixed_base = repo_config.fixed_base_score is not None
     scoring_cfg = resolve_scoring(repo_config.scoring)
 
@@ -182,10 +189,8 @@ async def score_pr(
 
     _calculate_pr_multipliers(scored, repo_config, scoring_cfg)
 
-    if pr.state == 'MERGED':
-        eval_.unique_repos_contributed_to.add(pr.repo_full_name)
-        # Token totals are aggregated later in finalize_miner_scores; this
-        # function only sets per-PR state.
+    # Token totals are aggregated later in finalize_miner_scores; this
+    # function only sets per-PR state.
 
 
 # ============================================================================

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -21,6 +21,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from gittensor.classes import MinerEvaluation
+
 scoring_module = pytest.importorskip(
     'gittensor.validator.oss_contributions.mirror.scoring',
     reason='Requires gittensor mirror subpackage',
@@ -381,6 +383,103 @@ class TestScoringDataStoredGate:
 
         client.get_pr_files.assert_not_called()
         assert scored.base_score == pytest.approx(7.5)
+
+
+class TestUniqueReposContributedTo:
+    """A MERGED PR for a recognized repo must count toward
+    unique_repos_contributed_to regardless of this round's file-fetch outcome
+    (#1616) — mirroring the pre-mirror scoring path's #65/#71 fix."""
+
+    def test_counted_when_scoring_data_not_yet_stored(self):
+        scored = ScoredPR(pr=_pr(state='MERGED'))
+        scored.pr.scoring_data_stored = False
+        eval_ = MinerEvaluation(uid=1, hotkey='hk')
+
+        asyncio.run(
+            score_pr(
+                scored,
+                eval_=eval_,
+                master_repositories={scored.pr.repo_full_name: _config()},
+                programming_languages={},
+                token_config=Mock(),
+                client=Mock(),
+            )
+        )
+
+        assert eval_.unique_repos_contributed_to == {scored.pr.repo_full_name}
+
+    def test_counted_when_mirror_file_fetch_errors(self):
+        scored = ScoredPR(pr=_pr(state='MERGED'))
+        eval_ = MinerEvaluation(uid=1, hotkey='hk')
+        client = Mock()
+        client.get_pr_files.side_effect = scoring_module.MirrorRequestError('boom')
+
+        asyncio.run(
+            score_pr(
+                scored,
+                eval_=eval_,
+                master_repositories={scored.pr.repo_full_name: _config()},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert eval_.unique_repos_contributed_to == {scored.pr.repo_full_name}
+
+    def test_counted_when_mirror_returns_no_files(self):
+        scored = ScoredPR(pr=_pr(state='MERGED'))
+        eval_ = MinerEvaluation(uid=1, hotkey='hk')
+        client = Mock()
+        client.get_pr_files.return_value.files = []
+
+        asyncio.run(
+            score_pr(
+                scored,
+                eval_=eval_,
+                master_repositories={scored.pr.repo_full_name: _config()},
+                programming_languages={},
+                token_config=Mock(),
+                client=client,
+            )
+        )
+
+        assert eval_.unique_repos_contributed_to == {scored.pr.repo_full_name}
+
+    def test_not_counted_for_unrecognized_repo(self):
+        scored = ScoredPR(pr=_pr(state='MERGED'))
+        eval_ = MinerEvaluation(uid=1, hotkey='hk')
+
+        asyncio.run(
+            score_pr(
+                scored,
+                eval_=eval_,
+                master_repositories={},
+                programming_languages={},
+                token_config=Mock(),
+                client=Mock(),
+            )
+        )
+
+        assert eval_.unique_repos_contributed_to == set()
+
+    def test_not_counted_for_non_merged_pr(self):
+        scored = ScoredPR(pr=_pr(state='CLOSED'))
+        scored.pr.scoring_data_stored = False
+        eval_ = MinerEvaluation(uid=1, hotkey='hk')
+
+        asyncio.run(
+            score_pr(
+                scored,
+                eval_=eval_,
+                master_repositories={scored.pr.repo_full_name: _config()},
+                programming_languages={},
+                token_config=Mock(),
+                client=Mock(),
+            )
+        )
+
+        assert eval_.unique_repos_contributed_to == set()
 
 
 class TestFixedBaseScore:


### PR DESCRIPTION
…e-fetch is pending/fails

score_pr() only added a MERGED PR's repo to unique_repos_contributed_to at the very end of the function, after three earlier return paths that fire whenever the mirror's file-diff data isn't available yet (scoring_data_stored=False, a MirrorRequestError, or an empty files result). Since a merged PR is already counted toward total_merged_prs independent of file-fetch status, this let repo attribution silently depend on this round's file-fetch timing instead of the PR itself.

Move the attribution earlier, right after the repo_config lookup, so a pending/failed mirror fetch no longer drops the PR's repo from unique_repos_contributed_to.

Fixes #1616