### PR TITLE
chore(weights): rebalance JSONbored repo maintainer_cut for infra costs

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -207,7 +207,7 @@
     "eligibility": {
       "min_credibility": 0.5
     },
-    "maintainer_cut": 0.55,
+    "maintainer_cut": 0.5,
     "scoring": {
       "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,
@@ -236,7 +236,7 @@
     "eligibility": {
       "min_credibility": 0.5
     },
-    "maintainer_cut": 0.55,
+    "maintainer_cut": 0.5,
     "scoring": {
       "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,
@@ -265,7 +265,7 @@
     "eligibility": {
       "min_credibility": 0.5
     },
-    "maintainer_cut": 0.55,
+    "maintainer_cut": 0.66,
     "scoring": {
       "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,


### PR DESCRIPTION
## Summary
- `JSONbored/awesome-claude`: `maintainer_cut` 0.55 -> 0.5
- `JSONbored/gittensory`: `maintainer_cut` 0.55 -> 0.5
- `JSONbored/metagraphed`: `maintainer_cut` 0.55 -> 0.66

Rebalances the maintainer carve-out across my three registered repos to better reflect real infrastructure costs. `metagraphed` runs the most infrastructure-heavy setup of the three and needs a larger share to stay sustainable. `gittensory` carries some hosting overhead as well. `awesome-claude` has minimal infrastructure costs by comparison, so its share moves down.

`emission_share` values are untouched — out of scope for this PR.

## Test plan
- [x] `python3 -m json.tool` validates the file
- [x] All three `maintainer_cut` values remain in `[0, 1]`
- [x] No other fields touched