### PR TITLE
fix(validator): OSS mirror scoring rejects merged PRs with null base_ref

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -207,14 +207,17 @@ def check_merged_branch_eligibility(
     issue discovery so both reject the same non-acceptable-branch merges.
 
     Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
-    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
-    check rather than false-positive-blocking on older data.
+    ``main``; missing ``base_ref``/``head_ref``/``head_repo_full_name`` skips
+    the respective check rather than false-positive-blocking on older
+    (pre-backfill) mirror data.
     """
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
-    # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    # base_ref check. A null base_ref means pre-backfill mirror data — fall
+    # through rather than block, matching the head_ref/head_repo_full_name
+    # handling below (see #1599).
+    if base_ref is not None and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -198,6 +198,15 @@ class TestEligibilityGate:
         assert skip is True
         assert "merged to 'whatever'" in reason
 
+    def test_null_base_ref_falls_through_rather_than_blocks(self):
+        # Parity with issue discovery's handling of pre-backfill mirror rows
+        # (test_missing_base_ref_falls_through_to_solved): a null base_ref
+        # must not be coerced to '' and false-positive-blocked (#1599).
+        scored = ScoredPR(pr=_pr(base_ref=None, default_branch='main'))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
+        assert skip is False
+        assert reason is None
+
     def test_no_default_branch_no_additional_blocks_non_main_base_ref(self):
         # Legacy parity: if default_branch is missing, fallback to 'main' so
         # non-main base refs are still rejected.


### PR DESCRIPTION
check_merged_branch_eligibility() coerced a null base_ref to '' via `base_ref or ''`, which never matches the acceptable-branch set, so merged PRs missing base_ref (pre-backfill mirror rows) were rejected at load time and never entered merged_prs.

Issue discovery already treats a missing base_ref as pre-backfill data and falls through rather than blocking (see the base_ref is not None guard around its check_merged_branch_eligibility call in scan.py). OSS mirror scoring should behave the same way: skip the base_ref check entirely when base_ref is None, consistent with how head_ref and head_repo_full_name are already handled when missing.

Fixes #1599