### PR TITLE
fix(validator): stale per-repo issue-discovery fields survive a succe…

### DIFF
--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -242,6 +242,17 @@ class RepoEvaluation:
         for name in _ISSUE_DISCOVERY_REPO_FIELDS:
             setattr(self, name, getattr(other, name))
 
+    def clear_issue_discovery(self) -> None:
+        """Reset the issue-discovery-owned fields to their round-start defaults."""
+        self.is_issue_eligible = False
+        self.issue_credibility = 0.0
+        self.issue_discovery_score = 0.0
+        self.issue_token_score = 0.0
+        self.total_solved_issues = 0
+        self.total_valid_solved_issues = 0
+        self.total_closed_issues = 0
+        self.total_open_issues = 0
+
 
 @dataclass
 class MinerEvaluation:

--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -264,14 +264,7 @@ def _clear_issue_discovery_fields(evaluation: MinerEvaluation) -> None:
     evaluation.total_open_issues = 0
     evaluation.issue_discovery_issues = []
     for repo_eval in evaluation.repo_evaluations.values():
-        repo_eval.is_issue_eligible = False
-        repo_eval.issue_credibility = 0.0
-        repo_eval.issue_discovery_score = 0.0
-        repo_eval.issue_token_score = 0.0
-        repo_eval.total_solved_issues = 0
-        repo_eval.total_valid_solved_issues = 0
-        repo_eval.total_closed_issues = 0
-        repo_eval.total_open_issues = 0
+        repo_eval.clear_issue_discovery()
 
 
 def _apply_open_issue_counts(evaluation: MinerEvaluation, open_counts: Dict[str, int]) -> None:
@@ -545,8 +538,18 @@ def _finalize_repo_issue_scores(
 ) -> None:
     """Gate + score issue discovery per repository, then roll up the totals."""
     evaluation.issue_discovery_issues = []
+    seen_repos = set(repo_acc) | set(open_counts)
 
-    for repo_name in sorted(set(repo_acc) | set(open_counts)):
+    # A repo issue-scored in a prior round but absent this round (e.g. the
+    # miner's evaluation was restored from cache after a transient DAS fetch
+    # failure, then this round's mirror fetch succeeded with issues only in
+    # other repos) must not keep contributing its stale per-repo values to
+    # the round-level roll-up below (#1610).
+    for repo_name, repo_eval in evaluation.repo_evaluations.items():
+        if repo_name not in seen_repos:
+            repo_eval.clear_issue_discovery()
+
+    for repo_name in sorted(seen_repos):
         repo_config = mirror_repos.get(repo_name)
         if repo_config is None:
             continue

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -26,6 +26,8 @@ run_issue_discovery = scan_module.run_issue_discovery
 _classify_issue = scan_module._classify_issue
 _build_solving_pr_cache = scan_module._build_solving_pr_cache
 _mirror_issue_for_scoring = scan_module._mirror_issue_for_scoring
+_finalize_repo_issue_scores = scan_module._finalize_repo_issue_scores
+_RepoIssueAcc = scan_module._RepoIssueAcc
 CachedSolvingPR = scan_module.CachedSolvingPR
 MirrorIssue = mirror_models.MirrorIssue
 MirrorIssuesResponse = mirror_models.MirrorIssuesResponse
@@ -181,6 +183,92 @@ def _mirror_repos(*names: str) -> dict:
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+# ============================================================================
+# _finalize_repo_issue_scores (stale per-repo field clearing, #1610)
+# ============================================================================
+
+
+class TestFinalizeRepoIssueScoresClearsStaleRepos:
+    """A repo issue-scored in a prior round but absent this round (repo_acc and
+    open_counts both empty for it) must have its per-repo issue-discovery
+    fields reset — otherwise _roll_up_issue_totals keeps summing its stale
+    values into the round-level totals every round after."""
+
+    def test_stale_repo_cleared_from_repo_eval_and_roll_up(self):
+        evaluation = _eval()
+
+        # Simulate a repo issue-scored in a prior round (e.g. restored from
+        # the evaluation cache after a transient DAS fetch failure).
+        stale = evaluation.get_or_create_repo_evaluation('entrius/gittensor-ui')
+        stale.is_issue_eligible = True
+        stale.issue_credibility = 0.9
+        stale.issue_discovery_score = 8.12
+        stale.issue_token_score = 40.0
+        stale.total_solved_issues = 7
+        stale.total_valid_solved_issues = 7
+        stale.total_closed_issues = 1
+        stale.total_open_issues = 2
+
+        # This round: no accumulated issues and no open-issue counts for that
+        # repo at all — it's simply absent from both.
+        _finalize_repo_issue_scores(
+            evaluation,
+            repo_acc={},
+            open_counts={},
+            mirror_repos=_mirror_repos('entrius/gittensor-ui'),
+        )
+
+        cleared = evaluation.repo_evaluations['entrius/gittensor-ui']
+        assert cleared.is_issue_eligible is False
+        assert cleared.issue_credibility == 0.0
+        assert cleared.issue_discovery_score == 0.0
+        assert cleared.issue_token_score == 0.0
+        assert cleared.total_solved_issues == 0
+        assert cleared.total_valid_solved_issues == 0
+        assert cleared.total_closed_issues == 0
+        assert cleared.total_open_issues == 0
+
+        # The round-level roll-up must reflect the cleared state, not the
+        # stale prior-round values.
+        assert evaluation.total_solved_issues == 0
+        assert evaluation.total_valid_solved_issues == 0
+        assert evaluation.total_closed_issues == 0
+        assert evaluation.total_open_issues == 0
+        assert evaluation.issue_discovery_score == 0.0
+        assert evaluation.is_issue_eligible is False
+
+    def test_repo_seen_this_round_is_not_cleared_by_the_stale_pass(self):
+        evaluation = _eval()
+        acc = _RepoIssueAcc(closed=1)  # closed-only, ineligible by default thresholds
+
+        _finalize_repo_issue_scores(
+            evaluation,
+            repo_acc={'entrius/gittensor-ui': acc},
+            open_counts={'entrius/gittensor-ui': 3},
+            mirror_repos=_mirror_repos('entrius/gittensor-ui'),
+        )
+
+        repo_eval = evaluation.repo_evaluations['entrius/gittensor-ui']
+        assert repo_eval.total_closed_issues == 1
+        assert repo_eval.total_open_issues == 3
+
+    def test_other_miners_repo_evaluations_are_independent(self):
+        """Guard against a shared-default-dict regression: clearing one
+        MinerEvaluation's stale repo must not touch another miner's."""
+        stale_eval = _eval(uid=1)
+        stale_eval.get_or_create_repo_evaluation('entrius/gittensor-ui').total_solved_issues = 5
+
+        other_eval = _eval(uid=2)
+        other_eval.get_or_create_repo_evaluation('entrius/gittensor-ui').total_solved_issues = 9
+
+        _finalize_repo_issue_scores(
+            stale_eval, repo_acc={}, open_counts={}, mirror_repos=_mirror_repos('entrius/gittensor-ui')
+        )
+
+        assert stale_eval.repo_evaluations['entrius/gittensor-ui'].total_solved_issues == 0
+        assert other_eval.repo_evaluations['entrius/gittensor-ui'].total_solved_issues == 9
 
 
 # ============================================================================


### PR DESCRIPTION
…ssful scoring round

_finalize_repo_issue_scores only rewrote repo_evaluations for repos seen this round (union of repo_acc and open_counts), then _roll_up_issue_totals summed over ALL repo_evaluations. A repo that was issue-scored in a prior round but is absent this round (e.g. the miner's evaluation was restored from cache after a transient DAS fetch failure, then this round's mirror fetch succeeded with issues only in other repos) kept its stale per-repo values, which got summed back into the round-level totals every round after.

_clear_issue_discovery_fields already zeroed these same fields for every repo when a miner had no in-window issues at all; _finalize_repo_issue_scores needs the same treatment for repos individually absent from this round.

Added RepoEvaluation.clear_issue_discovery() (symmetric to the existing copy_issue_discovery_from()) and used it both to de-duplicate _clear_issue_discovery_fields's per-repo reset and to clear repos not seen this round before the roll-up.

Fixes #1610