### PR TITLE
fix(validator): load_state desyncs scores after metagraph resize on r…

### DIFF
--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -273,6 +273,30 @@ class BaseValidatorNeuron(BaseNeuron):
         else:
             bt.logging.error('set_weights failed', msg)
 
+    def _realign_state_to_metagraph(self):
+        """Realign ``self.scores``/``self.hotkeys`` to the live ``self.metagraph``.
+
+        Preserves overlapping UID scores, zeroes scores for UIDs whose hotkey
+        has been replaced, and pads/truncates to ``self.metagraph.n`` —
+        handling both growth and shrink (see #1606). Shared by
+        ``resync_metagraph`` and ``load_state`` so a validator restart after a
+        subnet resize can't leave ``self.scores`` out of sync with the
+        metagraph either.
+        """
+        target_n = self.metagraph.n
+        min_len = min(len(self.hotkeys), len(self.scores), target_n)
+
+        aligned_scores = np.zeros(target_n, dtype=np.float32)
+        aligned_scores[:min_len] = self.scores[:min_len]
+
+        # Zero out overlapping UIDs whose hotkey has been replaced.
+        for uid in range(min_len):
+            if self.hotkeys[uid] != self.metagraph.hotkeys[uid]:
+                aligned_scores[uid] = 0
+
+        self.scores = aligned_scores
+        self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
+
     def resync_metagraph(self):
         """Resyncs the metagraph and updates the hotkeys and moving averages based on the new metagraph."""
         bt.logging.info('resync_metagraph()')
@@ -288,22 +312,7 @@ class BaseValidatorNeuron(BaseNeuron):
             return
 
         bt.logging.info('Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages')
-        # Zero out all hotkeys that have been replaced.
-        for uid, hotkey in enumerate(self.hotkeys):
-            if hotkey != self.metagraph.hotkeys[uid]:
-                self.scores[uid] = 0  # hotkey has been replaced
-
-        # Check to see if the metagraph has changed size.
-        # If so, we need to add new hotkeys and moving averages.
-        if len(self.hotkeys) < len(self.metagraph.hotkeys):
-            # Update the size of the moving average scores.
-            new_moving_average = np.zeros((self.metagraph.n))
-            min_len = min(len(self.hotkeys), len(self.scores))
-            new_moving_average[:min_len] = self.scores[:min_len]
-            self.scores = new_moving_average
-
-        # Update the hotkeys.
-        self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
+        self._realign_state_to_metagraph()
 
     def update_scores(self, rewards: np.ndarray, uids: set[int], blacklisted_uids: List[int] = None):
         """Performs exponential moving average on the scores based on the rewards received from the miners."""
@@ -383,6 +392,10 @@ class BaseValidatorNeuron(BaseNeuron):
             self.step = int(state['step'])
             self.scores = state['scores']
             self.hotkeys = list(state['hotkeys'])
+            # Persisted state reflects the metagraph size at save time, which may
+            # no longer match the live metagraph after a subnet resize — realign
+            # before anything indexes self.scores by current UID (#1606).
+            self._realign_state_to_metagraph()
             bt.logging.success(f'Successfully loaded validator state from {state_path}')
         except FileNotFoundError:
             bt.logging.warning(f'No state file found at {state_path}, starting with fresh state')

--- a/tests/validator/test_realign_state_to_metagraph.py
+++ b/tests/validator/test_realign_state_to_metagraph.py
@@ -1,0 +1,166 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""
+Regression test for #1606: load_state() restored self.scores/self.hotkeys
+from state.npz with no length validation against the live metagraph, so a
+validator restart after a subnet resize left self.scores out of sync with
+self.metagraph.n. resync_metagraph() had the same gap for shrinks (it only
+special-cased growth).
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from neurons.base.validator import BaseValidatorNeuron
+
+
+class _FakeMetagraph:
+    def __init__(self, hotkeys: list):
+        self.hotkeys = hotkeys
+        self.n = len(hotkeys)
+
+
+class _DummyValidator(BaseValidatorNeuron):
+    """Skips BaseValidatorNeuron.__init__ (wallet/subtensor/config setup) —
+    only the attributes _realign_state_to_metagraph/load_state touch are
+    set, but subclassing (rather than duck-typing) keeps `self.<method>()`
+    calls inside load_state resolving correctly."""
+
+    def __init__(self, scores: np.ndarray, hotkeys: list, metagraph_hotkeys: list):
+        self.scores = scores
+        self.hotkeys = hotkeys
+        self.metagraph = _FakeMetagraph(metagraph_hotkeys)
+        self.config = MagicMock()
+
+    async def forward(self):
+        """Unused abstract method stub — required to instantiate BaseNeuron."""
+        raise NotImplementedError
+
+
+def _realign(validator: _DummyValidator) -> None:
+    validator._realign_state_to_metagraph()
+
+
+class TestRealignStateToMetagraph:
+    def test_growth_preserves_overlapping_scores_and_pads_with_zeros(self):
+        validator = _DummyValidator(
+            scores=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2'],
+            metagraph_hotkeys=['hk0', 'hk1', 'hk2', 'hk3', 'hk4'],
+        )
+
+        _realign(validator)
+
+        assert validator.scores.shape == (5,)
+        assert list(validator.scores) == [1.0, 2.0, 3.0, 0.0, 0.0]
+        assert validator.hotkeys == ['hk0', 'hk1', 'hk2', 'hk3', 'hk4']
+
+    def test_shrink_truncates_without_crashing(self):
+        # This is the case resync_metagraph previously dropped entirely: it
+        # only resized self.scores when the metagraph grew.
+        validator = _DummyValidator(
+            scores=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2', 'hk3', 'hk4'],
+            metagraph_hotkeys=['hk0', 'hk1', 'hk2'],
+        )
+
+        _realign(validator)
+
+        assert validator.scores.shape == (3,)
+        assert list(validator.scores) == [1.0, 2.0, 3.0]
+        assert validator.hotkeys == ['hk0', 'hk1', 'hk2']
+
+    def test_replaced_hotkey_within_overlap_is_zeroed(self):
+        validator = _DummyValidator(
+            scores=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2'],
+            metagraph_hotkeys=['hk0', 'new-hk1', 'hk2'],
+        )
+
+        _realign(validator)
+
+        assert list(validator.scores) == [1.0, 0.0, 3.0]
+
+    def test_same_size_no_replacement_is_a_no_op(self):
+        validator = _DummyValidator(
+            scores=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2'],
+            metagraph_hotkeys=['hk0', 'hk1', 'hk2'],
+        )
+
+        _realign(validator)
+
+        assert list(validator.scores) == [1.0, 2.0, 3.0]
+
+
+class TestLoadStateRealignsToMetagraph:
+    def test_restart_after_metagraph_growth_does_not_desync(self, tmp_path):
+        # Reproduces the issue's repro steps: persist state for a smaller
+        # metagraph, then "restart" against a grown live metagraph.
+        full_path = tmp_path
+        validator = _DummyValidator(
+            scores=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2'],
+            metagraph_hotkeys=['hk0', 'hk1', 'hk2', 'hk3', 'hk4'],
+        )
+        validator.config.neuron.full_path = str(full_path)
+        validator.step = 0
+
+        np.savez(
+            str(full_path / 'state.npz'),
+            step=7,
+            scores=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2'],
+        )
+
+        validator.load_state()
+
+        assert validator.step == 7
+        assert validator.scores.shape == (5,)
+        assert list(validator.scores) == [1.0, 2.0, 3.0, 0.0, 0.0]
+        assert validator.hotkeys == ['hk0', 'hk1', 'hk2', 'hk3', 'hk4']
+
+    def test_restart_after_metagraph_shrink_does_not_index_out_of_range(self, tmp_path):
+        full_path = tmp_path
+        validator = _DummyValidator(
+            scores=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2', 'hk3', 'hk4'],
+            metagraph_hotkeys=['hk0', 'hk1', 'hk2'],
+        )
+        validator.config.neuron.full_path = str(full_path)
+        validator.step = 0
+
+        np.savez(
+            str(full_path / 'state.npz'),
+            step=3,
+            scores=np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2', 'hk3', 'hk4'],
+        )
+
+        validator.load_state()
+
+        assert validator.scores.shape == (3,)
+        assert list(validator.scores) == [1.0, 2.0, 3.0]
+
+        # The bug's actual failure mode: a subsequent scoring step indexing
+        # UIDs up to the live metagraph size must not go out of bounds.
+        uids_array = np.arange(validator.metagraph.n)
+        scattered = np.zeros_like(validator.scores)
+        scattered[uids_array] = 1.0  # would raise IndexError pre-fix
+        assert scattered.shape == (3,)
+
+    def test_missing_state_file_leaves_fresh_state_untouched(self, tmp_path):
+        validator = _DummyValidator(
+            scores=np.zeros(3, dtype=np.float32),
+            hotkeys=['hk0', 'hk1', 'hk2'],
+            metagraph_hotkeys=['hk0', 'hk1', 'hk2'],
+        )
+        validator.config.neuron.full_path = str(tmp_path)
+        validator.step = 0
+
+        validator.load_state()
+
+        assert validator.scores.shape == (3,)
+        assert list(validator.scores) == [0.0, 0.0, 0.0]


### PR DESCRIPTION
…estart

load_state() restored self.scores/self.hotkeys from state.npz with no length validation against the live metagraph. After a subnet resize, a validator restart could then index self.scores out of bounds during the next scoring step, or emit misaligned on-chain weights.

resync_metagraph() had a related gap: it only resized self.scores when the metagraph grew, never when it shrank, so a live resize down could leave self.scores stale by the same failure mode.

Added a shared _realign_state_to_metagraph() that preserves overlapping UID scores, zeroes scores for replaced hotkeys, and pads/truncates to metagraph.n in both directions. Used it in both load_state() and resync_metagraph() so a validator restart and a live resize get identical, correct realignment.

Fixes #1606