### PR TITLE
chore(weights): rename imagent repo key to gittensor-agent-forge/gt-imagent

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -138,7 +138,7 @@
       }
     }
   },
-  "imagent-ai/imagent": {
+  "gittensor-agent-forge/gt-imagent": {
     "emission_share": 0.008891,
     "issue_discovery_share": 0.0,
     "trusted_label_pipeline": true,


### PR DESCRIPTION
Renames the tracked repository key `imagent-ai/imagent` to `gittensor-agent-forge/gt-imagent` in the validator weights registry to reflect the repository's new org/name. The scoring/emission value block is unchanged.