### PR TITLE
fix(mirror): coerce null author_login so ghost-authored merged PRs aren't dropped

### DIFF
--- a/gittensor/utils/mirror/models.py
+++ b/gittensor/utils/mirror/models.py
@@ -163,7 +163,12 @@ class MirrorPullRequest:
             body=data.get('body'),
             state=data['state'],
             author_github_id=str(data['author_github_id']),
-            author_login=data.get('author_login', ''),
+            # Coerce an explicit null (ghost/deleted author) to '' like the
+            # sibling `or {}`/`or []` fields below — `.get(key, '')` only
+            # defaults on an absent key, so a JSON null would otherwise slip a
+            # None into this `str` field and crash `author_login.lower()` in the
+            # merged self-merge gate.
+            author_login=data.get('author_login') or '',
             author_association=data.get('author_association'),
             created_at=parse_github_iso_to_utc(data['created_at']),
             closed_at=parse_optional_github_iso_to_utc(data.get('closed_at')),

--- a/tests/utils/test_mirror_models.py
+++ b/tests/utils/test_mirror_models.py
@@ -320,6 +320,21 @@ class TestMirrorPullRequest:
         pr = MirrorPullRequest.from_dict(pull_request_dict)
         assert pr.author_github_id == '218712309'
 
+    def test_null_author_login_coerced_to_empty_string(self, pull_request_dict):
+        # A ghost/deleted GitHub author serializes as an explicit ``null``.
+        # ``author_login`` is typed ``str``; a null must not slip through as
+        # ``None`` (which would later crash ``author_login.lower()`` in the
+        # merged self-merge eligibility gate).
+        pull_request_dict['author_login'] = None
+        pr = MirrorPullRequest.from_dict(pull_request_dict)
+        assert pr.author_login == ''
+
+    def test_missing_author_login_coerced_to_empty_string(self, pull_request_dict):
+        # Absent key (older pre-schema responses) must also yield '' not raise.
+        pull_request_dict.pop('author_login', None)
+        pr = MirrorPullRequest.from_dict(pull_request_dict)
+        assert pr.author_login == ''
+
     def test_parity_fields_parsed(self, pull_request_dict):
         pr = MirrorPullRequest.from_dict(pull_request_dict)
         assert pr.head_ref == 'feature-branch'

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -51,7 +51,7 @@ RepositoryConfig = load_weights.RepositoryConfig
 def _pr(
     state: str = 'MERGED',
     edited_after_merge: bool = False,
-    author_login: str = 'bittoby',
+    author_login: str | None = 'bittoby',
     merged_by_login: str | None = 'anderdc',
     author_association: str = 'CONTRIBUTOR',
     base_ref: str = 'main',
@@ -171,6 +171,15 @@ class TestEligibilityGate:
         scored = ScoredPR(pr=_pr(author_login='alice', merged_by_login='alice', approved_count=1))
         skip, reason = _should_skip_merged_mirror_pr(scored, _config())
         assert skip is False
+
+    def test_null_author_login_does_not_crash_self_merge_check(self):
+        # A ghost/deleted author arrives as ``author_login=None`` from the mirror.
+        # The self-merge gate must not raise on ``author_login.lower()`` — before
+        # the coercion this dropped a legitimately merged PR from scoring.
+        scored = ScoredPR(pr=_pr(author_login=None, merged_by_login='anderdc', approved_count=0))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config())
+        assert skip is False
+        assert reason is None
 
     def test_base_ref_in_additional_passes(self):
         scored = ScoredPR(pr=_pr(base_ref='test'))


### PR DESCRIPTION
### Bug

`MirrorPullRequest.author_login` is typed `str`, but `from_dict` parses it with `data.get('author_login', '')`. That default is only used when the **key is absent** — an explicit JSON `null` returns `None`, not `''`. The mirror serializes `author_login: null` for a ghost/deleted GitHub author, so `None` slips into a field the rest of the code treats as a `str`.

That `None` then reaches the merged-PR eligibility gate in `_should_skip_merged_mirror_pr`:

```python
if pr.merged_by_login and pr.merged_by_login.lower() == pr.author_login.lower():
```

`None.lower()` raises `AttributeError`. The crash is swallowed by the load-time `except Exception` in `_maybe_add_pr`, so the PR is never appended to `merged_prs` — a legitimately merged contribution is **silently dropped**, lowering that miner's `merged_count` / credibility.

### Fix

Coerce the null to `''` exactly the way the sibling `review_summary or {}` and `labels or []` fields in the *same constructor* already handle an explicit null, honouring the declared `str` type. A null author can't be a self-merge, so `''` correctly fails the self-merge comparison instead of crashing.

The other login-bearing model, `MirrorIssue`, is intentionally typed `Optional[str]` and is left untouched.

### Tests

- `test_mirror_models.py`: `author_login` null / absent both parse to `''`.
- `test_scoring.py`: the self-merge gate no longer raises on a null-author merged PR (reproduces the swallowed `AttributeError` before the fix).

Full suite green (967 passed); `ruff check`, `ruff format --check`, and `pyright` clean.