### PR TITLE
chore(weights): configure gt-imagent winner-only rewards

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -173,10 +173,9 @@
     "default_label_multiplier": 0.0,
     "label_multipliers": {
       "round-winner": 10.0,
-      "leaderboard-ui-pass": 1.0,
+      "past-round-winner": 0.0,
       "invalid-pr": 0.0,
-      "duplicate-pr": 0.0,
-      "needs-evidence": 0.0
+      "duplicate-pr": 0.0
     },
     "eligibility": {
       "min_valid_merged_prs": 1,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -173,12 +173,9 @@
     "default_label_multiplier": 0.0,
     "label_multipliers": {
       "round-winner": 10.0,
-      "generation-ui-pass": 1.0,
-      "benchmark-fail": 0.0,
-      "below-threshold": 0.0,
+      "leaderboard-ui-pass": 1.0,
       "invalid-pr": 0.0,
       "duplicate-pr": 0.0,
-      "needs-rebase": 0.0,
       "needs-evidence": 0.0
     },
     "eligibility": {
@@ -187,7 +184,7 @@
       "max_open_pr_threshold": 2
     },
     "scoring": {
-      "pr_lookback_days": 7,
+      "pr_lookback_days": 90,
       "open_pr_collateral_percent": 0.1,
       "standard_issue_multiplier": 1.0,
       "maintainer_issue_multiplier": 1.0,
@@ -195,7 +192,7 @@
         "grace_period_hours": 0,
         "sigmoid_midpoint_days": 3,
         "sigmoid_steepness": 1.0,
-        "min_multiplier": 0.05
+        "min_multiplier": 1.0
       }
     }
   },


### PR DESCRIPTION
## Summary
- retain `round-winner` as the only positive Gittensor reward label
- add explicit zero-score `past-round-winner` history
- keep `leaderboard-ui-pass` and `needs-evidence` as Imagent workflow labels without a reward multiplier
- retain qualifying merged PRs for the maximum 90-day window with no time-decay reduction

## Validation
- `uv run pytest tests/validator/test_load_weights.py tests/validator/test_scoring_resolver.py -q`
- confirmed valid UI and evidence labels resolve to `0.0`, past winners resolve to `0.0`, and the active `round-winner` resolves to `10.0`