### PR TITLE
chore(repos): rename JSONbored/gittensory -> JSONbored/loopover

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -249,7 +249,7 @@
       }
     }
   },
-  "JSONbored/gittensory": {
+  "JSONbored/loopover": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
     "emission_share": 0.106932,


### PR DESCRIPTION
## What

Renames the `master_repositories.json` key `JSONbored/gittensory` -> `JSONbored/loopover`. Weights, emission share, and label config are unchanged — key rename only.

## Why

The maintainer is rebranding the repo (Loopover) and gave us a heads-up before renaming on GitHub. Same owner, name-only rename, so the mirror GitHub App installation carries over automatically.

## Cutover ordering — do not merge early

This PR is **draft until the mirror-side cutover is done**:

1. Maintainer renames the repo on GitHub
2. Mirror DB repo-keyed rows renamed to `jsonbored/loopover` + 1-day gap backfill
3. Mirror verified (`installed:true` under new slug, PR data reachable)
4. **Then** this PR merges

Merging before step 3 would have validators querying a slug with zero mirrored PRs. Context: same failure mode as das-github-mirror#216 / #72.