### PR TITLE
fix(validator): fall through OSS scoring when mirror omits base_ref

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -207,14 +207,14 @@ def check_merged_branch_eligibility(
     issue discovery so both reject the same non-acceptable-branch merges.
 
     Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
-    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
-    check rather than false-positive-blocking on older data.
+    ``main``; missing ``base_ref``/``head_ref``/``head_repo_full_name`` skip
+    their respective checks rather than false-positive-blocking on older data.
     """
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
-    # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    # base_ref check — skip when absent (pre-backfill mirror data).
+    if base_ref is not None and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable
@@ -251,8 +251,9 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
 
     When the mirror response is missing a field (older data predating the
     schema additions), some checks fall through rather than false-positive-
-    blocking. Concretely: missing ``head_ref`` or ``head_repo_full_name`` skips
-    the head_ref check. Missing ``default_branch`` falls back to ``main``.
+    blocking. Concretely: missing ``base_ref`` skips the base_ref check;
+    missing ``head_ref`` or ``head_repo_full_name`` skips the head_ref check.
+    Missing ``default_branch`` falls back to ``main``.
     """
     pr = scored.pr
 

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -54,7 +54,7 @@ def _pr(
     author_login: str = 'bittoby',
     merged_by_login: str | None = 'anderdc',
     author_association: str = 'CONTRIBUTOR',
-    base_ref: str = 'main',
+    base_ref: str | None = 'main',
     head_ref: str | None = 'feature/foo',
     head_repo_full_name: str | None = 'entrius/gittensor-ui',
     default_branch: str | None = 'main',
@@ -275,6 +275,23 @@ class TestEligibilityGate:
             _config(additional_branches=['main']),
         )
         assert skip is False
+
+    def test_null_base_ref_skips_check(self):
+        # Pre-backfill mirror rows omit base_ref; parity with issue discovery.
+        scored = ScoredPR(
+            pr=_pr(
+                base_ref=None,
+                default_branch='main',
+                head_ref='feature/foo',
+                head_repo_full_name='entrius/gittensor-ui',
+            )
+        )
+        skip, reason = _should_skip_merged_mirror_pr(
+            scored,
+            _config(additional_branches=['test', 'staging']),
+        )
+        assert skip is False
+        assert reason is None
 
     def test_null_head_repo_full_name_skips_check(self):
         # Pre-schema mirror rows may have NULL head_repo_full_name — we can't


### PR DESCRIPTION
Fixes #1636

## Summary

Pre-backfill mirror rows can omit `base_ref`. OSS scoring treated `null` as `''` and rejected those merged PRs at load time, while issue discovery already fall-throughs missing branch metadata.

Skip the base-ref gate when `base_ref is None`, matching the existing null `head_ref` / `head_repo_full_name` behavior and issue-discovery parity.

## Root cause

`check_merged_branch_eligibility` used `base_ref or ''`, so a missing `base_ref` became an empty string that never matched the acceptable branch set. Valid merged PRs were dropped before scoring.

## Fix approach

Gate on `base_ref` only when it is present (`base_ref is not None`), consistent with issue discovery (`scan.py`) and existing null `head_ref` fall-through.

## Impact

Pre-backfill mirror rows and any merged PR missing branch metadata can score OSS contributions instead of being silently dropped.

## Risk / tradeoffs

- Intentionally permissive for absent metadata only; explicit non-matching `base_ref` values are still rejected.
- No producer-side mirror change required.

## Test plan

- [x] Added `test_null_base_ref_skips_check` in `tests/validator/oss_contributions/mirror/test_scoring.py`
- [x] CI validated on fork (Tests + Lint passing):
  - https://github.com/RealDiligent/gittensor/actions/runs/29393812928
  - https://github.com/RealDiligent/gittensor/actions/runs/29393813897