### PR TITLE
chore(labels): configure subnet-specific Kata winner labels

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -8,15 +8,16 @@
     "maintainer_cut": 0.5,
     "label_multipliers": {
       "kata:winner:*": 1.0,
-      "kata:reward:xl": 10.0,
-      "kata:reward:l": 5.0,
-      "kata:reward:m": 3.0,
-      "kata:reward:s": 1.5,
-      "kata:defeat": 0.25,
+      "kata:winner:sn60__bitsec": 2.0,
+      "kata:winner:sn22__desearch": 3.0,
+      "kata:defeat:*": 0.2,
+      "kata:pending": 0.0,
+      "kata:review": 0.0,
+      "kata:executing": 0.0,
       "kata:invalid": 0.0,
       "kata:losing": 0.0,
-      "kata:stale": 0.0,
-      "kata:hold": 0.0
+      "kata:hold": 0.0,
+      "kata:stale": 0.0
     },
     "eligibility": {
       "min_valid_merged_prs": 1,


### PR DESCRIPTION
## Summary

Configure subnet-specific Gittensor rewards for Kata winners.

- SN60 winner: `2.0`
- SN22 winner: `3.0`
- Other subnet winners: `1.0`
- Defeated former king: `0.2`
- Non-winning Kata labels: `0.0`

Removes legacy reward, generic defeat, miner-mode, and evaluating label rules.