### PR TITLE
SparkDistill: 50% maintainer cut + eval:BASELINE scoring

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -137,16 +137,7 @@
       "dataset:REJECT": 0.0
     },
     "maintainer_cut": 0.5,
-    "trusted_label_pipeline": true,
-    "scoring": {
-      "pr_lookback_days": 14,
-      "time_decay": {
-        "grace_period_hours": 4,
-        "sigmoid_midpoint_days": 2,
-        "sigmoid_steepness": 1.2,
-        "min_multiplier": 0.02
-      }
-    }
+    "trusted_label_pipeline": true
   },
   "gittensor-vanguard/vanguarstew": {
     "emission_share": 0.099211,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -135,8 +135,17 @@
       "dataset:none": 0.0,
       "dataset:REJECT": 0.0
     },
-    "maintainer_cut": 0.3,
-    "trusted_label_pipeline": true
+    "maintainer_cut": 0.5,
+    "trusted_label_pipeline": true,
+    "scoring": {
+      "pr_lookback_days": 14,
+      "time_decay": {
+        "grace_period_hours": 4,
+        "sigmoid_midpoint_days": 2,
+        "sigmoid_steepness": 1.2,
+        "min_multiplier": 0.02
+      }
+    }
   },
   "gittensor-vanguard/vanguarstew": {
     "emission_share": 0.099211,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -125,6 +125,7 @@
       "eval:M": 1.5,
       "eval:S": 1.0,
       "eval:XS": 0.5,
+      "eval:BASELINE": 1.0,
       "eval:none": 0.0,
       "eval:REJECT": 0.0,
       "dataset:xl": 4.0,


### PR DESCRIPTION
## Summary

Builds on [#1631](https://github.com/entrius/gittensor/pull/1631). Raises maintainer cut and adds `eval:BASELINE` scoring for SparkDistill.

**Scope:** `maintainer_cut: 0.5` + `eval:BASELINE: 1.0`. Other `eval:*` / `dataset:*` multipliers unchanged from #1631. No repo-specific time-decay override (uses global default curve).

### Changes to `gittensor-model-hub/SparkDistill`

| Field | Before (#1631) | After |
|-------|----------------|-------|
| `maintainer_cut` | 0.3 | **0.5** |
| `eval:BASELINE` | missing | **1.0** |
| `scoring.time_decay` | global default | **global default** (unchanged) |
| other `eval:*` / `dataset:*` | unchanged | **unchanged** |

`emission_share` stays **0.1**.

## Validation

- `master_repositories.json` parses (`json.load`)
- `label_multipliers` still ≤ 20 entries

Supersedes #1635 (closed — 2× eval tier multipliers split out).