### PR TITLE
fix(validator): DEV_MODE=false enables the maintainer-filter bypass it should disable

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -33,7 +33,6 @@ to the cache so sibling discoveries benefit.
 """
 
 import asyncio
-import os
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Set, Tuple
@@ -57,6 +56,7 @@ from gittensor.validator.oss_contributions.mirror.scoring import (
     calculate_base_score_for_pr_files,
     check_merged_branch_eligibility,
 )
+from gittensor.validator.utils.config import dev_mode_enabled
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.load_weights import (
     LanguageConfig,
@@ -121,7 +121,7 @@ def _should_include_issue(issue: MirrorIssue) -> bool:
     discovery rewards in repos they maintain — mirrors the PR-side maintainer
     skip in ``oss_contributions/mirror/load.py``. Bypassed under DEV_MODE.
     """
-    if not os.environ.get('DEV_MODE') and issue.author_association in MAINTAINER_ASSOCIATIONS:
+    if not dev_mode_enabled() and issue.author_association in MAINTAINER_ASSOCIATIONS:
         return False
     return True
 

--- a/gittensor/validator/oss_contributions/mirror/load.py
+++ b/gittensor/validator/oss_contributions/mirror/load.py
@@ -14,7 +14,6 @@ Filtering applied at load time:
   merged_count used by ``check_eligibility`` isn't inflated by ineligible PRs.
 """
 
-import os
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
@@ -26,6 +25,7 @@ from gittensor.utils.mirror.client import MirrorClient, MirrorRequestError
 from gittensor.utils.mirror.models import MirrorPullRequest
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
 from gittensor.validator.oss_contributions.mirror.scoring import _should_skip_merged_mirror_pr
+from gittensor.validator.utils.config import dev_mode_enabled
 from gittensor.validator.utils.load_weights import RepositoryConfig, resolve_scoring
 
 
@@ -103,7 +103,7 @@ def _maybe_add_pr(
 
     # Silent maintainer skip — logging every maintainer-merged PR would dominate
     # the skip-reason log.
-    if not os.environ.get('DEV_MODE') and pr.author_association in MAINTAINER_ASSOCIATIONS:
+    if not dev_mode_enabled() and pr.author_association in MAINTAINER_ASSOCIATIONS:
         return
 
     if pr.state == 'OPEN':

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -23,7 +23,6 @@ Anti-gaming notes:
 
 import asyncio
 import math
-import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
@@ -48,6 +47,7 @@ from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
 from gittensor.validator.oss_contributions.scoring import (
     calculate_review_quality_multiplier,
 )
+from gittensor.validator.utils.config import dev_mode_enabled
 from gittensor.validator.utils.datetime_utils import calculate_time_decay
 from gittensor.validator.utils.isolated_scoring import isolated_calculate_token_score
 from gittensor.validator.utils.load_weights import (
@@ -260,7 +260,7 @@ def _should_skip_merged_mirror_pr(scored: ScoredPR, repo_config: RepositoryConfi
         return True, f'PR #{pr.pr_number} is MERGED but missing merged_at'
 
     # Defensive recheck — load already drops these (with DEV_MODE bypass)
-    if not os.environ.get('DEV_MODE') and pr.author_association in MAINTAINER_ASSOCIATIONS:
+    if not dev_mode_enabled() and pr.author_association in MAINTAINER_ASSOCIATIONS:
         return True, f'PR #{pr.pr_number} author is {pr.author_association}'
 
     if pr.merged_by_login and pr.merged_by_login.lower() == pr.author_login.lower():

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -14,6 +14,19 @@ WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 # optional env vars
 STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'
 
+_TRUTHY_ENV_VALUES = frozenset({'1', 'true', 'yes', 'on'})
+
+
+def dev_mode_enabled() -> bool:
+    """Whether DEV_MODE bypasses the maintainer filters.
+
+    Read at call time rather than import time so tests and operators can toggle it
+    per process. Matched by value, not presence: DEV_MODE=false must disable the
+    bypass on a production validator.
+    """
+    return os.getenv('DEV_MODE', '').strip().lower() in _TRUTHY_ENV_VALUES
+
+
 # log values
 bt.logging.info(f'VALIDATOR_WAIT: {VALIDATOR_WAIT}')
 bt.logging.info(f'VALIDATOR_STEPS_INTERVAL: {VALIDATOR_STEPS_INTERVAL}')

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -16,7 +16,6 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-import os
 import time
 from functools import partial
 from typing import Dict, List, Set
@@ -36,7 +35,12 @@ from gittensor.validator.pat_handler import (
     priority_pat_broadcast,
     priority_pat_check,
 )
-from gittensor.validator.utils.config import STORE_DB_RESULTS, WANDB_PROJECT, WANDB_VALIDATOR_NAME
+from gittensor.validator.utils.config import (
+    STORE_DB_RESULTS,
+    WANDB_PROJECT,
+    WANDB_VALIDATOR_NAME,
+    dev_mode_enabled,
+)
 from gittensor.validator.utils.load_weights import RepositoryConfig
 from gittensor.validator.utils.storage import DatabaseStorage
 from neurons.base.validator import BaseValidatorNeuron
@@ -55,7 +59,7 @@ class Validator(BaseValidatorNeuron):
     def __init__(self, config=None):
         super(Validator, self).__init__(config=config)
 
-        if os.environ.get('DEV_MODE'):
+        if dev_mode_enabled():
             bt.logging.warning('⚠ DEV_MODE is active — maintainer PR filtering is bypassed')
 
         # Ensure PAT storage file exists on boot

--- a/tests/validator/oss_contributions/mirror/test_load.py
+++ b/tests/validator/oss_contributions/mirror/test_load.py
@@ -202,6 +202,24 @@ class TestMaintainerSkip:
 
         assert len(eval_.merged_prs) == 1
 
+    @pytest.mark.parametrize('dev_mode', ['0', 'false', 'off', 'no', '', ' '])
+    def test_dev_mode_disabled_values_keep_maintainer_skip(self, dev_mode, monkeypatch):
+        # An explicitly-disabled DEV_MODE must not bypass the filter on a
+        # production validator.
+        monkeypatch.setenv('DEV_MODE', dev_mode)
+        client = Mock()
+        client.get_miner_pulls.return_value = _build_response(
+            [
+                _pr_dict(1, author_association='OWNER'),
+                _pr_dict(2, author_association='CONTRIBUTOR'),
+            ]
+        )
+        eval_ = _eval()
+        load_miner_prs(eval_, _mirror_repos('entrius/gittensor-ui'), client=client)
+
+        assert len(eval_.merged_prs) == 1
+        assert eval_.merged_prs[0].pr.pr_number == 2
+
 
 # ============================================================================
 # Lookback window (sent to the mirror; windowing happens server-side)


### PR DESCRIPTION
## Summary

`DEV_MODE` gates the maintainer filters via `not os.environ.get('DEV_MODE')`, which tests for **presence** rather than **value**. Every non-empty string is truthy in Python, so:

| `.env` line | operator intent | actual behaviour |
| --- | --- | --- |
| `DEV_MODE=1` / `DEV_MODE=true` | bypass on | bypass on (correct) |
| `DEV_MODE=false` | bypass **off** | **bypass ON** |
| `DEV_MODE=0` / `off` / `no` | bypass **off** | **bypass ON** |
| _(unset)_ | bypass off | bypass off (correct) |

An operator who writes `DEV_MODE=false` to turn the flag off gets the exact opposite: `_maybe_add_pr` stops dropping `OWNER`/`MEMBER`/`COLLABORATOR` PRs, `_should_skip_merged_mirror_pr`'s defensive recheck stops firing, and `_should_include_issue` stops dropping maintainer-discovered issues. That validator then scores maintainer contributions the rest of the network rejects, and diverges from consensus on every miner it evaluates.

`.env.example` makes this a realistic keystroke rather than a hypothetical: it already ships `STORE_DB_RESULTS=false`, so `KEY=false` is the idiom this project teaches its own operators. Today `DEV_MODE` has no working "off" value — the only way to disable it is to remove the line entirely.

### Root cause

`os.environ.get('DEV_MODE')` returns the string `'false'`, and `bool('false') is True`. The check never looks at the value.

### Fix

Parse by value in `dev_mode_enabled()`, placed next to `STORE_DB_RESULTS` in the validator config module and following the convention already established there:

```python
STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'   # existing
```

It is read at call time rather than at import so per-process toggling (and the existing `monkeypatch.setenv` tests) keep working. `1`/`true`/`yes`/`on` remain truthy, so **existing `DEV_MODE=1` setups are unaffected**; only the falsy spellings change, and they change to what they say.

### Why this is not the `#1067`/`#1069` pattern

Those were closed — correctly — as hardening parsers against input the team itself controls (`master_repositories.json` is maintainer-curated; the mirror API is gittensor-owned and emits real JSON booleans). This is a different source: `DEV_MODE` is **operator-supplied**, set by independent validator operators in their own `.env`, and the value that misfires is the one `.env.example` trains them to write. It is an operator-facing footgun in a flag that disables an anti-gaming filter, not defence against schema drift the team owns.

## Related Issues

None. Self-contained, self-evident fix; no linked issue filed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `test_dev_mode_disabled_values_keep_maintainer_skip`, parametrized over `0`, `false`, `off`, `no`, `''` and `' '`, asserting the `OWNER` PR is still dropped and only the `CONTRIBUTOR` PR loads. It fails on `test` and passes here.

The existing `test_dev_mode_bypasses_maintainer_skip` (`DEV_MODE=1`) still passes on both the PR and issue-discovery surfaces, pinning backward compatibility.

Full suite: **970 passed, 0 failed, 0 skipped**; `ruff check`, `ruff format --check`, `pyright` and `vulture` all clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

No CLI surface is touched, so the before/after evidence rule does not apply.