### PR TITLE
chore(minirouter): use only king label at 1.0

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -310,11 +310,9 @@
     "emission_share": 0.012892,
     "issue_discovery_share": 0.0,
     "additional_acceptable_branches": ["sn74*"],
+    "default_label_multiplier": 0.0,
     "label_multipliers": {
-      "bug": 0.1,
-      "feature": 0.15,
-      "refactor": 0.02,
-      "king": 10.0
+      "king": 1.0
     },
     "eligibility": {
       "min_valid_merged_prs": 0,


### PR DESCRIPTION
## Summary

- Update `mini-router/minirouter` score labels so all previous non-king labels are removed.
- Keep only one scoring label: `king` with multiplier `1.0`.
- This narrows MiniRouter label reward behavior to the single king label for PR weight routing.

## Scope

- [x] Focused change: only `gittensor/validator/weights/master_repositories.json` entry for `mini-router/minirouter`.
- [x] No UI or deployment scope.
- [x] No docs/tests required for this config-only update.
