### PR TITLE
fix(cli): admin payout-issue reports a successful zero-return payout as failure

### DIFF
--- a/gittensor/cli/issue_commands/admin.py
+++ b/gittensor/cli/issue_commands/admin.py
@@ -153,7 +153,7 @@ def admin_payout(
         with err_console.status('[bold cyan]Submitting payout...', spinner='dots'):
             result = client.payout_bounty(issue_id, wallet)
 
-        if result:
+        if result is not None:
             print_success(f'Payout successful! Amount: {format_alpha(result, 4)} ALPHA')
         else:
             print_error('Payout failed.')

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -12,7 +12,7 @@ validation (no live network).
 import json
 from decimal import Decimal
 from typing import Any, Dict, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import click
 import pytest
@@ -741,6 +741,69 @@ class TestCliAdminValidation:
             )
         assert result.exit_code != 0
         assert 'between' in result.output or '1' in result.output
+
+
+class TestCliAdminPayoutResult:
+    """Ensure admin payout-issue maps payout_bounty's return to the right outcome.
+
+    payout_bounty returns Optional[int]: a non-None int on success (0 when the
+    pre-submit get_issue read was unavailable, so the amount is unknown) and
+    None only on failure. Only None may take the failure branch.
+    """
+
+    @staticmethod
+    def _invoke_payout(cli_root, runner, payout_return):
+        from gittensor.validator.issue_competitions.contract_client import ContractIssue, IssueStatus
+
+        issue = ContractIssue(
+            id=3,
+            github_url_hash=b'\x00' * 32,
+            repository_full_name='entrius/gittensor',
+            issue_number=42,
+            bounty_amount=0,
+            target_bounty=100 * ALPHA_RAW_UNIT,
+            status=IssueStatus.COMPLETED,
+            registered_at_block=1,
+            is_fully_funded=True,
+        )
+        client = MagicMock()
+        client.get_issue.return_value = issue
+        client.payout_bounty.return_value = payout_return
+        with (
+            patch(
+                'gittensor.cli.issue_commands.admin._resolve_contract_and_network',
+                return_value=(
+                    '0x1234567890123456789012345678901234567890',
+                    'wss://entrypoint-finney.opentensor.ai:443',
+                    'finney',
+                ),
+            ),
+            patch(
+                'gittensor.cli.issue_commands.admin._make_contract_client',
+                return_value=(MagicMock(), client),
+            ),
+        ):
+            return runner.invoke(
+                cli_root,
+                ['admin', 'payout-issue', '3', '--yes'],
+                catch_exceptions=False,
+            )
+
+    def test_positive_amount_reports_success(self, cli_root, runner):
+        result = self._invoke_payout(cli_root, runner, 5 * ALPHA_RAW_UNIT)
+        assert result.exit_code == 0
+        assert 'Payout successful' in result.output
+
+    def test_zero_amount_is_success_not_failure(self, cli_root, runner):
+        result = self._invoke_payout(cli_root, runner, 0)
+        assert result.exit_code == 0
+        assert 'Payout successful' in result.output
+        assert 'Payout failed' not in result.output
+
+    def test_none_reports_failure(self, cli_root, runner):
+        result = self._invoke_payout(cli_root, runner, None)
+        assert result.exit_code != 0
+        assert 'Payout failed' in result.output
 
 
 class TestCliVoteCancelValidation:


### PR DESCRIPTION
## Summary

`gitt admin payout-issue` reports **"Payout failed."** and exits 1 for a payout that actually succeeded on-chain, whenever `payout_bounty` returns `0`.

`IssueCompetitionContractClient.payout_bounty` (`gittensor/validator/issue_competitions/contract_client.py:700`) returns `Optional[int]` with three shapes:

| Return | Meaning |
| --- | --- |
| positive `int` | success — amount from the pre-submit `get_issue` read |
| `0` | success — extrinsic submitted and confirmed (`tx_hash and not error`), but the pre-submit `get_issue` read returned `None`, so `expected_payout` is unknown: `return int(expected_payout) if expected_payout else 0` |
| `None` | failure — tx error or exception |

The caller at `gittensor/cli/issue_commands/admin.py:156` used a truthiness check (`if result:`), which collapses the success-with-unknown-amount `0` into the failure branch.

**Reachability:** `get_issue` swallows all exceptions to `None` (`contract_client.py:229`). `payout_bounty` performs its *own* `get_issue` read after the CLI has already read and displayed the issue, so a transient RPC failure on that second read — with the extrinsic itself succeeding — yields exactly `0`. The operator is told the payout failed (exit 1), while the transfer went through; a retry then runs into the contract's already-finalized state (`BountyNotCompleted`).

**Fix:** the caller-side one-liner — `if result is not None:` — as prescribed in the #1577 review. Only `None` (the genuine failure sentinel) takes the failure branch. No change to `contract_client.py`; the sibling admin commands (`cancel-issue`, `set-owner`, `add-vali`, `remove-vali`, `set-treasury`) wrap `bool`-returning client methods, where truthiness is correct — they are untouched.

## Related Issues

Implements the caller-side fix described by @anderdc in the close comment of #1577.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Before / After

Reproduced by running the real CLI with only the contract client stubbed (`payout_bounty` → `0`, i.e. successful tx with the pre-submit read unavailable):

**Before** — on-chain success reported as failure, exit 1:

```
$ gitt admin payout-issue 3 --yes
Network: finney • Contract: 0x1234567890...567890
╭────────────────────────────── Payout Issue #3 ───────────────────────────────╮
│ Issue: entrius/gittensor#42                                                  │
│ Status: COMPLETED                                                            │
│ Bounty: 0.0000 ALPHA                                                         │
╰──────────────────────────────────────────────────────────────────────────────╯

✗ Payout failed.

(exit code: 1)
```

**After** — success reported, exit 0:

```
$ gitt admin payout-issue 3 --yes
Network: finney • Contract: 0x1234567890...567890
╭────────────────────────────── Payout Issue #3 ───────────────────────────────╮
│ Issue: entrius/gittensor#42                                                  │
│ Status: COMPLETED                                                            │
│ Bounty: 0.0000 ALPHA                                                         │
╰──────────────────────────────────────────────────────────────────────────────╯

✓ Payout successful! Amount: 0.0000 ALPHA

(exit code: 0)
```

Failure path (`payout_bounty` → `None`) is unchanged: `✗ Payout failed.`, exit 1.

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `TestCliAdminPayoutResult` (3 cases: positive int → success, `0` → success, `None` → failure) exercising the command through `CliRunner` with the contract client mocked. Full suite: `uv run pytest` — **963 passed**; `uv run pre-commit run --all-files --hook-stage pre-push` (ruff, pyright, vulture, pytest) — all green.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
