### PR TITLE
fix(cli): issues submissions --json reports empty success when GITTENSOR_MINER_PAT is unset

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -260,9 +260,16 @@ def fetch_open_issue_pull_requests(
     Returns a (possibly empty) list of PRs, or ``None`` when the GitHub lookup
     fails. Callers must treat ``None`` as a failure (not "no submissions"); see
     ``find_prs_for_issue``.
+
+    A missing ``GITTENSOR_MINER_PAT`` skips the lookup entirely
+    (``find_prs_for_issue`` returns ``[]`` for a falsy token), so in JSON mode
+    it raises ``click.UsageError`` instead of letting the caller report success
+    with zero submissions. Human mode keeps the warn-and-continue behavior.
     """
     token = os.environ.get('GITTENSOR_MINER_PAT') or ''
-    if not token and not as_json:
+    if not token:
+        if as_json:
+            raise click.UsageError('No GitHub token found; set GITTENSOR_MINER_PAT to fetch GitHub issue submissions')
         print_warning('No GitHub token found; set GITTENSOR_MINER_PAT to fetch GitHub issue submissions')
 
     try:

--- a/tests/cli/test_issue_submission.py
+++ b/tests/cli/test_issue_submission.py
@@ -192,3 +192,41 @@ def test_submissions_help_via_issue_alias_routes_to_command_help(cli_root, runne
     assert 'On-chain issue ID' in result.output
     assert '--id' in result.output
     assert '--logging.debug' not in result.output
+
+
+def test_submissions_json_missing_token_is_an_error_not_empty_success(cli_root, runner, sample_issue, monkeypatch):
+    monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+    with (
+        patch('gittensor.cli.issue_commands.submissions.get_contract_address', return_value='0xabc'),
+        patch('gittensor.cli.issue_commands.submissions.resolve_network', return_value=('ws://x', 'test')),
+        patch('gittensor.cli.issue_commands.submissions.fetch_issue_from_contract', return_value=sample_issue),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'submissions', '--id', '42', '--json'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.stdout)
+    assert payload['success'] is False
+    assert payload['error']['type'] == 'usage_error'
+    assert 'GITTENSOR_MINER_PAT' in payload['error']['message']
+
+
+def test_submissions_human_missing_token_keeps_warning_and_continues(cli_root, runner, sample_issue, monkeypatch):
+    monkeypatch.delenv('GITTENSOR_MINER_PAT', raising=False)
+    with (
+        patch('gittensor.cli.issue_commands.submissions.get_contract_address', return_value='0xabc'),
+        patch('gittensor.cli.issue_commands.submissions.resolve_network', return_value=('ws://x', 'test')),
+        patch('gittensor.cli.issue_commands.submissions.fetch_issue_from_contract', return_value=sample_issue),
+    ):
+        result = runner.invoke(
+            cli_root,
+            ['issues', 'submissions', '--id', '42'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert 'No GitHub token found' in result.output
+    assert 'No open submissions available' in result.output


### PR DESCRIPTION
## Summary

`gitt issues submissions --id N --json` reports `success: true, submission_count: 0` when `GITTENSOR_MINER_PAT` is not set — even though the GitHub lookup never ran.

#1554 (for #1492) made the GraphQL **lookup-failure** path an explicit error instead of a silent empty success. The **missing-token** path still falls through to the same false negative, and only in the mode aimed at automation:

- `fetch_open_issue_pull_requests` (`gittensor/cli/issue_commands/helpers.py:264`) prints the "No GitHub token found" warning **only when `not as_json`** — JSON mode gets no signal
- it then calls `find_prs_for_issue(..., token=None)`, which returns `[]` **by design** for a falsy token (documented as the precondition-not-met case, distinct from the `None` failure sentinel — that contract is unchanged here)
- back in `submissions.py`, only `None` is special-cased, so the `[]` flows into `success: true, submission_count: 0`

**Production scenario:** monitoring/automation runs `gitt issues submissions --id N --json` in an environment without `GITTENSOR_MINER_PAT` (read-only setups that never posted a PAT). It concludes the bounty issue has no open submissions when in reality nothing was looked up. Human mode at least prints a warning; `--json` mode is completely silent.

**Fix:** in JSON mode, a missing token now raises `click.UsageError`, which the existing handler maps to the canonical error envelope (`error.type: "usage_error"`) with exit 1. This mirrors `gitt miner post --json`, which already refuses to run without a PAT ("required for JSON mode", `miner_commands/post.py:93`). Human mode is untouched (warn and continue). `find_prs_for_issue`'s documented falsy-token → `[]` contract is untouched.

## Related Issues

Completes the false-negative elimination started in #1554 (#1492) for the remaining silent path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Before / After

Reproduced with the contract reads stubbed and `GITTENSOR_MINER_PAT` unset; the GitHub-lookup CLI path is real.

**Before** — lookup never ran, reported as a successful empty result:

```
$ gitt issues submissions --id 42 --json   # GITTENSOR_MINER_PAT unset
{
  "success": true,
  "issue_id": 42,
  "repository": "entrius/gittensor",
  "issue_number": 223,
  "submission_count": 0,
  "submissions": []
}

(exit code: 0)
```

**After** — explicit error envelope, non-zero exit:

```
$ gitt issues submissions --id 42 --json   # GITTENSOR_MINER_PAT unset
{"success": false, "error": {"type": "usage_error", "message": "No GitHub token found; set GITTENSOR_MINER_PAT to fetch GitHub issue submissions"}}

(exit code: 1)
```

Human mode (no `--json`) is unchanged: prints the existing "No GitHub token found; set GITTENSOR_MINER_PAT..." warning and continues to "No open submissions available", exit 0. With a token set, both modes behave exactly as before.

## Testing

- [x] Tests added/updated
- [x] Manually tested

Two tests added in `tests/cli/test_issue_submission.py`: JSON mode with the env var unset → `success: false`, `error.type == "usage_error"`, non-zero exit; human mode with the env var unset → warning preserved, exit 0. Full suite: `uv run pytest` — **962 passed**; `uv run pre-commit run --all-files --hook-stage pre-push` (ruff, pyright, vulture, pytest) — all green.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
