### PR TITLE
fix(cli): non-interactive stdin auto-confirms irreversible admin and vote commands

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -239,11 +239,20 @@ def confirm_or_abort(prompt: str, yes: bool, default: bool = False) -> bool:
     """Prompt for confirmation before a destructive operation.
 
     Returns True if the caller should proceed. Returns False (and prints a
-    cancellation message) if the user declines. `yes` and non-TTY input both
-    skip the prompt and proceed.
+    cancellation message) if the user declines.
+
+    ``yes`` is the only way to skip the prompt. A non-interactive stdin exits
+    non-zero instead of self-confirming: these operations transfer ownership,
+    move bounty funds, and edit the validator whitelist irreversibly, so an
+    unattended run must fail closed. Scripts and CI opt in explicitly with
+    ``--yes``.
     """
-    if yes or not _is_interactive():
+    if yes:
         return True
+    if not _is_interactive():
+        print_error(f'Confirmation required: {prompt}')
+        err_console.print('[yellow]stdin is not interactive — re-run with --yes to confirm.[/yellow]')
+        raise SystemExit(1)
     if click.confirm(f'\n{prompt}', default=default):
         return True
     err_console.print('[yellow]Cancelled.[/yellow]')

--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -15,8 +15,8 @@ from rich.panel import Panel
 from .help import StyledCommand
 from .helpers import (
     NETWORK_CHOICE,
-    _is_interactive,
     _resolve_contract_and_network,
+    confirm_or_abort,
     console,
     err_console,
     format_alpha,
@@ -169,9 +169,7 @@ def issue_register(
         )
     )
 
-    skip_confirm = yes or not _is_interactive()
-    if not skip_confirm and not click.confirm('\nProceed with registration?', default=True):
-        err_console.print('[yellow]Registration cancelled.[/yellow]')
+    if not confirm_or_abort('Proceed with registration?', yes, default=True):
         return
 
     try:

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -877,6 +877,10 @@ class TestCliRuntimeExceptions:
                     '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
                     '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
                     '1',
+                    # CliRunner stdin is not a TTY, so the confirmation gate would
+                    # abort before the client is built. --yes is the supported
+                    # non-interactive opt-in and keeps this test on the import path.
+                    '--yes',
                 ],
                 catch_exceptions=False,
             )

--- a/tests/cli/test_confirm_or_abort.py
+++ b/tests/cli/test_confirm_or_abort.py
@@ -1,0 +1,98 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for the destructive-operation confirmation gate.
+
+``confirm_or_abort`` guards ownership transfer, bounty payouts, and validator
+whitelist edits. A non-interactive stdin must fail closed rather than
+self-confirm, so an unattended run can never perform an irreversible action
+that the operator never approved.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gittensor.cli.issue_commands.helpers import confirm_or_abort
+
+
+class TestConfirmOrAbortInteractive:
+    """With a TTY the prompt decides."""
+
+    def test_accepts_when_user_confirms(self):
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=True),
+            patch('gittensor.cli.issue_commands.helpers.click.confirm', return_value=True),
+        ):
+            assert confirm_or_abort('Transfer ownership?', yes=False) is True
+
+    def test_returns_false_when_user_declines(self):
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=True),
+            patch('gittensor.cli.issue_commands.helpers.click.confirm', return_value=False),
+        ):
+            assert confirm_or_abort('Transfer ownership?', yes=False) is False
+
+    def test_default_is_forwarded_to_prompt(self):
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=True),
+            patch('gittensor.cli.issue_commands.helpers.click.confirm', return_value=True) as confirm,
+        ):
+            confirm_or_abort('Proceed with registration?', yes=False, default=True)
+        assert confirm.call_args.kwargs['default'] is True
+
+
+class TestConfirmOrAbortYesFlag:
+    """--yes is the only supported way to skip the prompt."""
+
+    def test_yes_skips_prompt_on_a_tty(self):
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=True),
+            patch('gittensor.cli.issue_commands.helpers.click.confirm') as confirm,
+        ):
+            assert confirm_or_abort('Pay out issue 1?', yes=True) is True
+        confirm.assert_not_called()
+
+    def test_yes_skips_prompt_without_a_tty(self):
+        """Scripts and CI opt in explicitly and keep working."""
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=False),
+            patch('gittensor.cli.issue_commands.helpers.click.confirm') as confirm,
+        ):
+            assert confirm_or_abort('Pay out issue 1?', yes=True) is True
+        confirm.assert_not_called()
+
+
+class TestConfirmOrAbortNonInteractiveFailsClosed:
+    """Without --yes, a non-TTY stdin aborts instead of silently proceeding."""
+
+    def test_exits_non_zero_instead_of_proceeding(self):
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=False),
+            patch('gittensor.cli.issue_commands.helpers.click.confirm') as confirm,
+            pytest.raises(SystemExit) as exc,
+        ):
+            confirm_or_abort('Transfer ownership to 5Hxxx?', yes=False)
+
+        assert exc.value.code == 1
+        # Never fell through to a prompt that cannot be answered.
+        confirm.assert_not_called()
+
+    def test_error_names_the_action_and_the_opt_in_flag(self, capsys):
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=False),
+            pytest.raises(SystemExit),
+        ):
+            confirm_or_abort('Transfer ownership to 5Hxxx?', yes=False)
+
+        output = capsys.readouterr().err
+        assert 'Transfer ownership to 5Hxxx?' in output
+        assert '--yes' in output
+
+    def test_default_true_does_not_auto_confirm_without_a_tty(self):
+        """A permissive prompt default must not become an implicit approval."""
+        with (
+            patch('gittensor.cli.issue_commands.helpers._is_interactive', return_value=False),
+            pytest.raises(SystemExit),
+        ):
+            confirm_or_abort('Proceed with registration?', yes=False, default=True)


### PR DESCRIPTION
## Summary

`confirm_or_abort` — the confirmation gate in front of every destructive issue-bounty command — returns `True` whenever stdin is not a TTY:

```python
if yes or not _is_interactive():
    return True
```

So the safeguard silently disappears in exactly the environments where a mistake is least recoverable. These commands run unattended all the time: `systemd`, `pm2`, `cron`, `docker run` without `-it`, a shell pipeline, or a non-interactive `ssh host 'gitt ...'`.

Eight destructive call sites are affected:

| Command | Effect when auto-confirmed |
|---|---|
| `admin set-owner` | Transfers contract ownership — the code itself warns *"IRREVERSIBLE. A mistyped address makes the contract unrecoverable."* |
| `admin set-treasury` | Resets every Active/Registered issue's bounty amount to 0 |
| `admin payout-issue` | Irreversible ALPHA transfer |
| `admin cancel-issue` | Returns a bounty to the alpha pool |
| `admin add-vali` / `remove-vali` | Edits the validator consensus whitelist that authorises bounty payouts |
| `vote solution` / `vote cancel` | Casts a consensus vote that moves bounty funds |

`issues register` (which spends real ALPHA) carried an inline copy of the same expression.

This also made the documented opt-in a no-op — `--yes` is advertised as *"Skip confirmation prompt (non-interactive/CI)"*, but non-interactive runs already skipped it, so passing the flag changed nothing.

### Root cause

`confirm_or_abort` collapses two distinct cases into one branch: *"the operator explicitly approved"* (`yes`) and *"nobody can be asked"* (no TTY). The second is treated as approval — a fail-**open** default on irreversible operations.

### Fix

Fail closed. `--yes` remains the only way to skip the prompt; a non-interactive stdin now exits `1`, naming both the action and the flag to pass. This is the convention used by `apt`, `docker`, `terraform`, `gh`, and `btcli`. `issues register` now routes through the shared helper instead of duplicating the fail-open expression.

Scope is 2 source files, +8/−4 lines of logic.

## CLI output evidence

Literal terminal captures of `echo | gitt admin set-owner 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY` (piped stdin ⇒ not a TTY, no `--yes`).

**Before** — the confirmation never happens. Execution runs straight past the gate into wallet/contract-client loading; in this capture environment it stops only because an optional dependency is absent. On an operator machine with dependencies installed, this call **submits the ownership transfer**:

```
Network: finney • Contract: 5FWNdk8YNtNc...ew3MrD
┌──────────────────────────────────── Transfer Ownership ─────────────────────────────────────┐
│ New Owner: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY                                 │
│ This transfer is IRREVERSIBLE. A mistyped address makes the contract unrecoverable.         │
└─────────────────────────────────────────────────────────────────────────────────────────────┘

✗ Missing dependency — No module named 'async_substrate_interface'

[process exit code: 1]
```

**After** — execution stops at the gate and names the flag required to proceed:

```
Network: finney • Contract: 5FWNdk8YNtNc...ew3MrD
┌──────────────────────────────────── Transfer Ownership ─────────────────────────────────────┐
│ New Owner: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY                                 │
│ This transfer is IRREVERSIBLE. A mistyped address makes the contract unrecoverable.         │
└─────────────────────────────────────────────────────────────────────────────────────────────┘

✗ Confirmation required: Transfer ownership to
5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY?

stdin is not interactive — re-run with --yes to confirm.

[process exit code: 1]
```

With `--yes` the behaviour is unchanged from before this PR (prompt skipped, command proceeds).

## Related Issues

None open — this behaviour has not been reported previously.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

New `tests/cli/test_confirm_or_abort.py` (8 cases) covers the interactive accept/decline paths, both `--yes` paths, and the three fail-closed cases. The fail-closed tests were verified to fail against the unpatched helper and pass with it.

Full CI on this branch: **968 tests passed**; `ruff lint`, `ruff format`, `pyright`, and `vulture` all pass with no auto-format changes.

One existing test (`test_vote_solution_import_error_exits_non_zero`) reached its import-error path only because non-TTY stdin self-confirmed — `CliRunner` stdin is never a TTY. It now passes `--yes`, preserving the test's original intent.

## Risk / tradeoffs

Deliberately a behaviour change: a script that today relies on the implicit non-TTY skip will now exit `1` instead of proceeding. That is the point of the fix, and the error message states the one-flag remedy. Anyone already following the documented `--yes` pattern sees no change.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
