### PR TITLE
Add validator weights CLI and consensus docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,38 @@ See full guide **[here](https://docs.gittensor.io/validator.html)**
 
 ### Repository Weight Consensus
 
-Repository emission shares are voted by validators, not hardcoded: each validator publishes a basket of up to 10 repos to the chain (commitments pallet), and every validator applies the stake-weighted mean of all eligible baskets (vpermit + 30k alpha), aggregated at a fixed snapshot block twice a day, so all validators derive identical weights. Validators without a basket run on the aggregate with a warning. Recommended: connect to an archive endpoint (`wss://archive.chain.opentensor.ai:443`) so snapshot state is always queryable; lite nodes gracefully fall back to the last-good aggregate.
+Repository emission shares are voted by validators, not hardcoded. Each validator publishes a basket of up to **10 repos** to the chain; the **stake-weighted mean** of all eligible baskets becomes the emission shares every validator scores with — computed at a fixed snapshot block so all validators derive byte-identical weights and vtrust is unaffected.
+
+```
+1. VOTE      gitt validator weights set            (any GitHub repo, ≤10, weights relative)
+                │ set_commitment — hotkey-signed, free, fully on-chain (≤512 B)
+                ▼
+2. CHAIN     Commitments pallet: netuid → hotkey → basket payload
+                │ read at snapshot B = block − (block % 3600)   ~2×/day
+                ▼
+3. AGGREGATE every validator, deterministically:
+             filter vpermit ∧ stake ≥ 30k α → normalize each basket → stake-weighted mean
+             gates: <50% eligible stake voted → baked JSON; errors → last-good → baked JSON
+                │ same block ⇒ same bytes ⇒ same aggregate
+                ▼
+4. SCORING   emission_share ⟵ aggregate (known repo → tuned params, novel → defaults)
+             → identical weight vectors across validators → full vtrust
+```
+
+Rules and mechanics:
+- Any GitHub repository is votable — no whitelist. A repo only *scores* once the GT mirror tracks it (owner installs the Gittensor GitHub App + registration); until then its share redistributes to active repos.
+- Weights are relative within your basket; the aggregator normalizes every basket to 1.0, so influence is exactly proportional to stake.
+- Votes take effect at the next snapshot (~12h cadence). No basket published → loud warning, the validator still scores using the aggregate.
+- Per-repo scoring hyperparameters (label multipliers, maintainer cut, eligibility) come from `master_repositories.json` when present, code defaults otherwise.
+- Recommended: connect to an archive endpoint (`wss://archive.chain.opentensor.ai:443`) so snapshot state is always queryable; lite nodes gracefully fall back to the last-good aggregate.
+
+CLI:
+
+```bash
+gitt validator weights show               # aggregated shares, voter turnout, gate status
+gitt validator weights set                # interactively build + publish your basket
+gitt validator weights basket <hotkey>    # inspect any validator's basket
+```
 
 ## Reward Algorithm
 

--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -221,6 +221,11 @@ register_miner_commands(cli)
 # Register issue commands with new flat structure
 register_commands(cli)
 
+# Register validator commands
+from gittensor.cli.validator_commands import register_validator_commands  # noqa: E402
+
+register_validator_commands(cli)
+
 
 def main():
     """Main entry point for the CLI"""

--- a/gittensor/cli/validator_commands/__init__.py
+++ b/gittensor/cli/validator_commands/__init__.py
@@ -1,0 +1,20 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+import click
+
+from gittensor.cli.issue_commands.help import StyledGroup
+from gittensor.cli.validator_commands.weights import weights_group
+
+
+@click.group(name='validator', cls=StyledGroup)
+def validator_group():
+    """Validator operations."""
+
+
+validator_group.add_command(weights_group)
+
+
+def register_validator_commands(cli):
+    cli.add_command(validator_group)
+    cli.add_alias('validator', 'vali')

--- a/gittensor/cli/validator_commands/weights.py
+++ b/gittensor/cli/validator_commands/weights.py
@@ -1,0 +1,269 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Repo weight basket commands for validators.
+
+Commands:
+    gitt validator weights show
+    gitt validator weights set
+    gitt validator weights basket <hotkey>
+"""
+
+import json
+from typing import Dict, Optional, Tuple
+
+import click
+import requests
+from rich.table import Table
+
+from gittensor.cli.issue_commands.help import StyledGroup
+from gittensor.cli.issue_commands.helpers import (
+    confirm_or_abort,
+    console,
+    err_console,
+    resolve_network,
+    resolve_wallet_config,
+    with_wallet_options,
+)
+from gittensor.cli.issue_commands.types import SS58
+from gittensor.cli.miner_commands.helpers import NETUID_DEFAULT
+from gittensor.constants import GITTENSOR_MIRROR_DEFAULT_URL
+from gittensor.validator.utils.config import CONSENSUS_MAX_REPOS
+from gittensor.validator.weight_consensus.chain import fetch_all_commitments, fetch_own_prefs, publish_payload
+from gittensor.validator.weight_consensus.codec import CodecError, canonicalize_prefs, decode_prefs, encode_prefs
+from gittensor.validator.weight_consensus.consensus import aggregate_preferences, compute_snapshot_block
+
+
+def _with_chain_options(command):
+    for option in (
+        click.option('--netuid', type=int, default=NETUID_DEFAULT, help='Subnet UID.', show_default=True),
+        click.option('--network', '-n', default=None, help='Network (finney/test/local)'),
+        click.option('--rpc-url', default=None, help='Subtensor RPC endpoint (overrides --network)'),
+    ):
+        command = option(command)
+    return command
+
+
+def _connect(network: Optional[str], rpc_url: Optional[str]):
+    import bittensor as bt
+
+    ws_endpoint, network_name = resolve_network(network, rpc_url)
+    err_console.print(f'[dim]Network: {network_name} ({ws_endpoint})[/dim]')
+    return bt.Subtensor(network=ws_endpoint)
+
+
+def _check_repo(repo_full_name: str) -> Tuple[Optional[bool], str, Optional[bool]]:
+    """Best-effort guardrail checks: (exists_on_github, description, mirror_tracked).
+
+    None means the check could not run (rate limit / network) — warn, don't block.
+    """
+    exists, description, tracked = None, '', None
+    try:
+        response = requests.get(f'https://api.github.com/repos/{repo_full_name}', timeout=10)
+        if response.status_code == 200:
+            exists, description = True, response.json().get('description') or ''
+        elif response.status_code == 404:
+            exists = False
+    except requests.RequestException:
+        pass
+    try:
+        response = requests.get(f'{GITTENSOR_MIRROR_DEFAULT_URL}/api/v1/repos/{repo_full_name}/maintainers', timeout=10)
+        tracked = response.status_code == 200
+    except requests.RequestException:
+        pass
+    return exists, description, tracked
+
+
+def _basket_table(title: str, prefs: Dict[str, int]) -> Table:
+    table = Table(title=title)
+    table.add_column('Repository', style='cyan')
+    table.add_column('Weight', justify='right')
+    table.add_column('Share', justify='right')
+    total = sum(prefs.values())
+    for repo in sorted(prefs, key=lambda r: prefs[r], reverse=True):
+        table.add_row(repo, str(prefs[repo]), f'{prefs[repo] / total:.1%}')
+    return table
+
+
+@click.group(name='weights', cls=StyledGroup)
+def weights_group():
+    """Repository weight basket voting.
+
+    Validators publish a basket of up to 10 repos with relative weights to the
+    chain. The stake-weighted mean of all baskets becomes the repository
+    emission shares, recomputed at fixed snapshot blocks (~2x/day).
+    """
+
+
+@weights_group.command('show')
+@_with_chain_options
+def show_weights(netuid: int, network: Optional[str], rpc_url: Optional[str]):
+    """Show the current aggregated repository weights and voter turnout."""
+    subtensor = _connect(network, rpc_url)
+    block = subtensor.get_current_block()
+    snapshot = compute_snapshot_block(block)
+
+    try:
+        commitments, stakes_rao, permits = _voter_state(subtensor, netuid, snapshot)
+        at_block = snapshot
+    except Exception as e:
+        err_console.print(f'[yellow]Snapshot {snapshot} state unavailable ({e}); showing live chain state.[/yellow]')
+        commitments, stakes_rao, permits = _voter_state(subtensor, netuid, block)
+        at_block = block
+
+    result = aggregate_preferences(commitments, stakes_rao, permits)
+    voters_by_repo: Dict[str, int] = {}
+    for hotkey, payload in commitments.items():
+        prefs = decode_prefs(payload)
+        if prefs and permits.get(hotkey):
+            for repo in prefs:
+                voters_by_repo[repo] = voters_by_repo.get(repo, 0) + 1
+
+    gate = (
+        '[green]ACTIVE[/green]' if result.shares is not None else '[yellow]INACTIVE — baked-in weights apply[/yellow]'
+    )
+    console.print(f'Snapshot block: {at_block}   Voters: {result.voter_count}   Aggregate: {gate}')
+    if result.eligible_stake_rao:
+        console.print(
+            f'Voting stake: {result.valid_stake_rao / result.eligible_stake_rao:.1%} of eligible (gate needs ≥50%)'
+        )
+
+    shares = result.shares or {}
+    if not shares:
+        return
+    table = Table(title='Aggregated repository weights')
+    table.add_column('Repository', style='cyan')
+    table.add_column('Share', justify='right')
+    table.add_column('Voters', justify='right')
+    for repo in sorted(shares, key=lambda r: shares[r], reverse=True):
+        table.add_row(repo, f'{shares[repo]:.2%}', str(voters_by_repo.get(repo, 0)))
+    console.print(table)
+
+
+@weights_group.command('basket')
+@click.argument('hotkey', type=SS58)
+@_with_chain_options
+def show_basket(hotkey: str, netuid: int, network: Optional[str], rpc_url: Optional[str]):
+    """Show a validator's published weight basket."""
+    subtensor = _connect(network, rpc_url)
+    prefs = fetch_own_prefs(subtensor, netuid, hotkey)
+    if prefs is None:
+        console.print(f'[yellow]No weight basket on chain for {hotkey}[/yellow]')
+        return
+    console.print(_basket_table(f'Basket of {hotkey}', prefs))
+
+
+@weights_group.command('set')
+@with_wallet_options()
+@_with_chain_options
+@click.option(
+    '--save-prefs',
+    type=click.Path(),
+    default=None,
+    help='Also write the basket to a prefs JSON (use on the validator host to pin the vote).',
+)
+@click.option('--yes', is_flag=True, help='Skip confirmation prompt.')
+def set_weights(
+    wallet_name: str,
+    wallet_hotkey: str,
+    netuid: int,
+    network: Optional[str],
+    rpc_url: Optional[str],
+    save_prefs: Optional[str],
+    yes: bool,
+):
+    """Interactively build and publish your repo weight basket.
+
+    Any GitHub repository can be voted, max 10 per basket. Weights are
+    relative — they are normalized against the rest of your basket. The vote
+    takes effect at the next consensus snapshot (~12h cadence).
+    """
+    import bittensor as bt
+
+    effective_wallet, effective_hotkey = resolve_wallet_config(wallet_name, wallet_hotkey)
+    wallet = bt.Wallet(name=effective_wallet, hotkey=effective_hotkey)
+    subtensor = _connect(network, rpc_url)
+
+    basket: Dict[str, float] = {}
+    current = fetch_own_prefs(subtensor, netuid, wallet.hotkey.ss58_address)
+    if current:
+        basket = dict(current)
+        console.print(_basket_table('Current on-chain basket', current))
+    else:
+        console.print('[yellow]No basket on chain yet — starting empty.[/yellow]')
+
+    console.print(
+        f'\nEnter [cyan]owner/repo weight[/cyan] to add or update (e.g. [dim]entrius/gittensor 40[/dim]), '
+        f'[cyan]-owner/repo[/cyan] to remove, blank line to finish. Max {CONSENSUS_MAX_REPOS} repos.\n'
+    )
+    while True:
+        entry = click.prompt('>', default='', show_default=False).strip()
+        if not entry:
+            break
+        if entry.startswith('-'):
+            removed = basket.pop(entry[1:].lower(), None)
+            console.print('[dim]removed[/dim]' if removed is not None else '[yellow]not in basket[/yellow]')
+            continue
+        try:
+            name, weight_str = entry.rsplit(None, 1)
+            name, weight = name.lower(), float(weight_str)
+            if weight <= 0:
+                raise ValueError('weight must be positive')
+        except ValueError as e:
+            console.print(f'[red]Invalid entry ({e})[/red]')
+            continue
+        if name not in basket and len(basket) >= CONSENSUS_MAX_REPOS:
+            console.print(f'[red]Basket is capped at {CONSENSUS_MAX_REPOS} repos — remove one first.[/red]')
+            continue
+
+        exists, description, tracked = _check_repo(name)
+        if exists is False:
+            console.print(f'[red]{name} does not exist on GitHub — not added.[/red]')
+            continue
+        if description:
+            console.print(f'[dim]{description}[/dim]')
+        if tracked is False:
+            console.print(
+                f'[yellow]Warning: {name} is not tracked by the GT mirror — it cannot be scored '
+                f'until its owner installs the Gittensor GitHub App and it is registered. '
+                f'Until then its emission share redistributes to active repos.[/yellow]'
+            )
+        basket[name] = weight
+        console.print(_basket_table('Draft basket', canonicalize_prefs(basket)))
+
+    if not basket:
+        console.print('[yellow]Empty basket — nothing to publish.[/yellow]')
+        return
+
+    try:
+        prefs = canonicalize_prefs(basket)
+        payload = encode_prefs(prefs)
+    except CodecError as e:
+        console.print(f'[red]Cannot encode basket: {e}[/red]')
+        raise SystemExit(1)
+
+    console.print(_basket_table('Final basket', prefs))
+    if prefs == current:
+        console.print('[green]Identical basket already on chain — nothing to do.[/green]')
+        return
+    if not confirm_or_abort('Publish this basket to the chain?', yes):
+        return
+
+    if publish_payload(subtensor, wallet, netuid, payload):
+        console.print('[green]Basket published. It takes effect at the next consensus snapshot (~12h cadence).[/green]')
+    else:
+        console.print('[red]Publish was rejected by the chain — check hotkey registration and try again.[/red]')
+        raise SystemExit(1)
+
+    if save_prefs:
+        with open(save_prefs, 'w') as f:
+            json.dump({'version': 1, 'repos': basket}, f, indent=2)
+        console.print(f'[dim]Prefs written to {save_prefs}[/dim]')
+
+
+def _voter_state(subtensor, netuid: int, block: int):
+    commitments = fetch_all_commitments(subtensor, netuid, block)
+    metagraph = subtensor.metagraph(netuid, block=block, lite=True)
+    stakes_rao = {hk: int(round(float(metagraph.S[uid]) * 1e9)) for uid, hk in enumerate(metagraph.hotkeys)}
+    permits = {hk: bool(metagraph.validator_permit[uid]) for uid, hk in enumerate(metagraph.hotkeys)}
+    return commitments, stakes_rao, permits

--- a/gittensor/validator/weight_consensus/chain.py
+++ b/gittensor/validator/weight_consensus/chain.py
@@ -12,7 +12,6 @@ extracted here. Writes use the low-level pallet builder because the high-level
 from typing import Any, Dict, List, Optional, cast
 
 import bittensor as bt
-from bittensor.core.extrinsics.pallets.commitments import Commitments
 
 from gittensor.validator.weight_consensus.codec import decode_prefs
 
@@ -79,6 +78,10 @@ def fetch_own_prefs(subtensor: 'bt.Subtensor', netuid: int, hotkey_ss58: str) ->
 
 def publish_payload(subtensor: 'bt.Subtensor', wallet: 'bt.Wallet', netuid: int, payload: bytes) -> bool:
     """Publish one BigRaw commitment field signed by the validator hotkey."""
+    # Imported lazily so the CLI's --help/completion stub of `bittensor` never
+    # has to resolve SDK submodules.
+    from bittensor.core.extrinsics.pallets.commitments import Commitments
+
     # The pallet builder is typed for sync and async subtensors; sync returns the call directly.
     call = cast(Any, Commitments(subtensor).set_commitment(netuid=netuid, info={'fields': [[{'BigRaw': payload}]]}))
     response = subtensor.sign_and_send_extrinsic(

--- a/gittensor/validator/weight_consensus/manager.py
+++ b/gittensor/validator/weight_consensus/manager.py
@@ -28,7 +28,7 @@ from gittensor.validator.weight_consensus.consensus import (
     compute_snapshot_block,
     shares_from_numerators,
 )
-from gittensor.validator.weight_consensus.publisher import maybe_publish_prefs, resolve_local_prefs
+from gittensor.validator.weight_consensus.publisher import ensure_vote
 
 StoreHook = Callable[[int, Dict[str, bytes], Dict[str, int], Dict[str, bool], AggregateResult], None]
 
@@ -141,8 +141,7 @@ def run_weight_consensus(validator, master: Dict[str, RepositoryConfig]) -> Dict
             validator.config.neuron.consensus_prefs_path
             or Path(validator.config.neuron.full_path) / 'repo_weight_prefs.json'
         )
-        prefs = resolve_local_prefs(prefs_path, master)
-        if not maybe_publish_prefs(validator.subtensor, validator.wallet, validator.config.netuid, prefs):
+        if not ensure_vote(validator.subtensor, validator.wallet, validator.config.netuid, prefs_path, master):
             bt.logging.warning(
                 'weight_consensus: no preference vector on chain — running as bystander on the '
                 'aggregate. Future releases may require participation.'

--- a/gittensor/validator/weight_consensus/publisher.py
+++ b/gittensor/validator/weight_consensus/publisher.py
@@ -29,6 +29,32 @@ def resolve_local_prefs(prefs_path: Optional[Path], master: Dict[str, Repository
     return canonicalize_prefs({name: cfg.emission_share for name, cfg in master.items() if cfg.emission_share > 0})
 
 
+def ensure_vote(
+    subtensor: 'bt.Subtensor',
+    wallet: 'bt.Wallet',
+    netuid: int,
+    prefs_path: Optional[Path],
+    master: Dict[str, RepositoryConfig],
+) -> bool:
+    """Make sure the validator has a vote on chain.
+
+    Precedence: a local prefs file always wins; otherwise an existing on-chain
+    vote is kept untouched (e.g. set via the CLI from another machine); only a
+    validator with neither votes the baked-in registry shares.
+    """
+    if prefs_path is not None and prefs_path.exists():
+        return maybe_publish_prefs(subtensor, wallet, netuid, resolve_local_prefs(prefs_path, master))
+
+    try:
+        if fetch_own_prefs(subtensor, netuid, wallet.hotkey.ss58_address) is not None:
+            return True
+    except Exception as e:
+        bt.logging.warning(f'weight_consensus: could not read own commitment ({e}); will retry next round')
+        return False
+
+    return maybe_publish_prefs(subtensor, wallet, netuid, resolve_local_prefs(None, master))
+
+
 def maybe_publish_prefs(subtensor: 'bt.Subtensor', wallet: 'bt.Wallet', netuid: int, prefs: Dict[str, int]) -> bool:
     """Publish prefs unless the identical vector is already on chain.
 

--- a/tests/validator/test_consensus_publisher.py
+++ b/tests/validator/test_consensus_publisher.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 from gittensor.validator.utils.load_weights import RepositoryConfig
 from gittensor.validator.weight_consensus.chain import extract_payload_candidates, extract_prefs
 from gittensor.validator.weight_consensus.codec import encode_prefs
-from gittensor.validator.weight_consensus.publisher import maybe_publish_prefs, resolve_local_prefs
+from gittensor.validator.weight_consensus.publisher import ensure_vote, maybe_publish_prefs, resolve_local_prefs
 
 MASTER = {
     'a/big': RepositoryConfig(emission_share=0.6),
@@ -66,6 +66,31 @@ class TestExtractPayload:
     def test_no_fields_returns_none(self):
         assert extract_prefs({'info': {'fields': []}}) is None
         assert extract_prefs(None) is None
+
+
+class TestEnsureVote:
+    def test_prefs_file_overrides_chain(self, tmp_path):
+        path = tmp_path / 'prefs.json'
+        path.write_text(json.dumps({'version': 1, 'repos': {'x/y': 1}}))
+        subtensor = _subtensor_with_own_commitment(encode_prefs({'a/b': 65535}))
+        assert ensure_vote(subtensor, _wallet(), 74, path, MASTER) is True
+        subtensor.sign_and_send_extrinsic.assert_called_once()
+
+    def test_existing_onchain_vote_kept_without_prefs_file(self, tmp_path):
+        subtensor = _subtensor_with_own_commitment(encode_prefs({'a/b': 65535}))
+        assert ensure_vote(subtensor, _wallet(), 74, tmp_path / 'missing.json', MASTER) is True
+        subtensor.sign_and_send_extrinsic.assert_not_called()
+
+    def test_no_file_no_vote_publishes_baked_default(self, tmp_path):
+        subtensor = _subtensor_with_own_commitment(None)
+        assert ensure_vote(subtensor, _wallet(), 74, tmp_path / 'missing.json', MASTER) is True
+        subtensor.sign_and_send_extrinsic.assert_called_once()
+
+    def test_chain_read_failure_returns_false(self, tmp_path):
+        subtensor = _subtensor_with_own_commitment(None)
+        subtensor.substrate.query.side_effect = RuntimeError('chain down')
+        assert ensure_vote(subtensor, _wallet(), 74, tmp_path / 'missing.json', MASTER) is False
+        subtensor.sign_and_send_extrinsic.assert_not_called()
 
 
 class TestMaybePublish:


### PR DESCRIPTION
## Summary
CLI for validators to publish, inspect, and audit repo weight baskets, plus the consensus section in the README. Also fixes vote precedence so a basket set via CLI from another machine is not clobbered by the validator's default vote.

## Changes
- `gitt validator weights show` — aggregated shares, per-repo voter counts, gate status; falls back to live state when snapshot state is pruned
- `gitt validator weights set` — interactive basket builder: GitHub existence check with repo description, GT-mirror trackability warning (the publish-time guardrail), 10-repo cap, canonicalization preview, BigRaw publish signed by hotkey, optional `--save-prefs` to pin the vote on the validator host
- `gitt validator weights basket <hotkey>` — decode any validator's on-chain basket
- `publisher.ensure_vote`: prefs file > existing on-chain vote > baked default. Previously a CLI-set vote would be overwritten by the validator's default vote next round
- Lazy pallet-builder import so the CLI's `--help`/completion bittensor stub keeps working
- README: consensus flow diagram, rules, CLI usage

Stacked on #1651.
