### PR TITLE
fix(cli): don't crash issue commands on a null network in config.json

### DIFF
--- a/gittensor/cli/issue_commands/helpers.py
+++ b/gittensor/cli/issue_commands/helpers.py
@@ -625,13 +625,17 @@ def resolve_network(network: Optional[str] = None, rpc_url: Optional[str] = None
     # override a user who set `network: finney` to point at mainnet.
     config = load_config()
 
-    config_network = config.get('network', '').lower()
+    # `or ''` guards a null/absent `network` value (e.g. `"network": null` in a
+    # hand-edited config) — `config.get('network', '')` returns None when the
+    # key is present but null, and None.lower() would crash every issue
+    # command. Mirrors the guard in miner_commands.helpers._resolve_endpoint.
+    config_network = (config.get('network') or '').lower()
     if config_network and config_network in NETWORK_MAP:
         return NETWORK_MAP[config_network], config_network
 
     if config.get('ws_endpoint'):
         endpoint = config['ws_endpoint']
-        name = _URL_TO_NETWORK.get(endpoint, config.get('network', 'custom'))
+        name = _URL_TO_NETWORK.get(endpoint, config.get('network') or 'custom')
         return endpoint, name
 
     # Default: finney (mainnet)

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -27,6 +27,7 @@ from gittensor.cli.issue_commands.helpers import (
     STATUS_COLORS,
     colorize_status,
     format_alpha,
+    resolve_network,
     validate_bounty_amount,
     validate_github_issue,
     validate_repository,
@@ -34,6 +35,7 @@ from gittensor.cli.issue_commands.helpers import (
 )
 from gittensor.cli.issue_commands.vote import parse_pr_number
 from gittensor.cli.json_output import emit_json
+from gittensor.constants import NETWORK_MAP
 
 # =============================================================================
 # format_alpha
@@ -919,3 +921,37 @@ class TestEmitJson:
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
         assert parsed['field'] == str(value)
+
+
+class TestResolveNetwork:
+    """resolve_network config-file fallback, including a null `network` value.
+
+    A hand-edited or externally-written ~/.gittensor/config.json can carry
+    `"network": null`; `config.get('network', '')` returns None for that (the
+    key exists, so the default is unused) and must not crash every issue
+    command with `AttributeError: 'NoneType' object has no attribute 'lower'`.
+    """
+
+    def _resolve_with_config(self, config):
+        with patch('gittensor.cli.issue_commands.helpers.load_config', return_value=config):
+            return resolve_network()
+
+    def test_null_network_falls_back_to_default(self):
+        endpoint, name = self._resolve_with_config({'network': None})
+        assert endpoint == NETWORK_MAP['finney']
+        assert name == 'finney'
+
+    def test_null_network_with_ws_endpoint_uses_endpoint(self):
+        endpoint, name = self._resolve_with_config({'network': None, 'ws_endpoint': 'ws://localhost:9944'})
+        assert endpoint == 'ws://localhost:9944'
+        assert name == 'custom'
+
+    def test_recognized_config_network(self):
+        endpoint, name = self._resolve_with_config({'network': 'test'})
+        assert endpoint == NETWORK_MAP['test']
+        assert name == 'test'
+
+    def test_empty_config_falls_back_to_default(self):
+        endpoint, name = self._resolve_with_config({})
+        assert endpoint == NETWORK_MAP['finney']
+        assert name == 'finney'


### PR DESCRIPTION
# PR body — rsnetworkinginc → entrius/gittensor
# Branch: fix/issues-cli-null-network (commit d9e0491, in WSL /root/gtn-pr)
# Base: test
# Title: fix(cli): don't crash issue commands on a null `network` in config.json

## Summary

`resolve_network()` reads the config-file fallback with

```python
config_network = config.get('network', '').lower()
```

When `~/.gittensor/config.json` contains `"network": null` (hand-edited, or written by an
external tool), the key **exists**, so the `.get()` default is never used — `None` comes back
and `None.lower()` raises `AttributeError`. `_resolve_contract_and_network()` calls this on the
startup path of every issue command, so `gitt issues list`, `gitt submissions`, `gitt vote`,
`gitt admin …` all die with a raw traceback instead of falling back to the default network.

The miner-side resolver already guards this exact access — `miner_commands/helpers.py`
`_resolve_endpoint` checks `if config_network and config_network.lower() in NETWORK_MAP:` — so
today the two CLIs disagree on the same config file: `gitt miner post` works, `gitt issues list`
crashes.

## Reproduction

```console
$ cat ~/.gittensor/config.json
{"network": null}

$ gitt issues list
Traceback (most recent call last):
  ...
  File "gittensor/cli/issue_commands/helpers.py", line 628, in resolve_network
    config_network = config.get('network', '').lower()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
```

After the fix, the same config resolves to the documented default:

```console
$ gitt issues list        # resolves to finney default, command proceeds
```

(Repro verified against `origin/test` @ f70007c with `HOME` pointed at a scratch dir.)

## Fix

Guard the access with `(config.get('network') or '')`, and apply the same guard to the
`ws_endpoint` fallback label on the line below (`config.get('network', 'custom')` has the same
None hole — the network name attached to a custom endpoint would silently become `None`).
This matches the miner helper's existing behavior, so both resolvers now treat a
null/absent `network` identically.

## Tests

New `TestResolveNetwork` class in `tests/cli/test_cli_helpers.py`:

- `test_null_network_falls_back_to_default` — `{"network": null}` → finney default (crashed before)
- `test_null_network_with_ws_endpoint_uses_endpoint` — null network + `ws_endpoint` → endpoint with `custom` label (crashed before)
- `test_recognized_config_network` — `{"network": "test"}` still resolves via `NETWORK_MAP`
- `test_empty_config_falls_back_to_default` — no keys → finney default

```
uv run pre-commit run --all-files                          # all hooks Passed
SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push   # pyright Passed, vulture Passed
uv run pytest tests/ -q                                    # 964 passed
```
