### PR TITLE
fix(cli): validate gitt config set network against known networks

### DIFF
--- a/gittensor/cli/main.py
+++ b/gittensor/cli/main.py
@@ -41,6 +41,7 @@ from gittensor.cli.issue_commands import register_commands
 from gittensor.cli.issue_commands.help import StyledAliasGroup, StyledGroup
 from gittensor.cli.issue_commands.helpers import CONFIG_FILE, GITTENSOR_DIR, console, err_console
 from gittensor.cli.json_output import click_error_type, emit_error_json, wants_json_output
+from gittensor.constants import NETWORK_MAP
 
 
 class JsonAwareAliasGroup(StyledAliasGroup):
@@ -153,6 +154,24 @@ def config_set(key: str, value: str):
     [/dim]
     """
     key = key.lower()
+
+    # `network` is resolver-sensitive: the resolvers only honor the known
+    # names, so an unvalidated typo like `tesnet` silently falls back to
+    # finney (mainnet) in the issue commands, while the miner commands treat
+    # the same stored value as a raw endpoint URL. Mirror the `--network`
+    # flag's choice validation at write time so the file can never hold a
+    # value the resolvers disagree on.
+    if key == 'network':
+        normalized = value.strip().lower()
+        if normalized not in NETWORK_MAP:
+            known = ', '.join(NETWORK_MAP)
+            raise click.BadParameter(
+                f"'{value}' is not a known network (choose from: {known}). "
+                'To point at a custom endpoint, set ws_endpoint instead.',
+                param_hint='VALUE',
+            )
+        value = normalized
+
     # Ensure config directory exists
     GITTENSOR_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/tests/cli/test_config_set.py
+++ b/tests/cli/test_config_set.py
@@ -72,11 +72,14 @@ class TestConfigSetWhitelist:
     @pytest.mark.parametrize('key', list(CONFIG_KEYS))
     def test_every_recognised_key_round_trips(self, temp_config_dir, key):
         _, config_file = temp_config_dir
+        # `network` values are themselves validated, so use a real network name
+        # for that key and a free-form value for the rest.
+        value = 'test' if key == 'network' else 'value-for-' + key
         runner = CliRunner()
-        result = runner.invoke(config_group, ['set', key, 'value-for-' + key])
+        result = runner.invoke(config_group, ['set', key, value])
 
         assert result.exit_code == 0, result.output
-        assert _read(config_file)[key] == 'value-for-' + key
+        assert _read(config_file)[key] == value
 
     def test_uppercase_key_normalised_to_lowercase(self, temp_config_dir):
         """`click.Choice(case_sensitive=False)` matches mixed case; we persist the canonical lowercase form."""
@@ -99,3 +102,61 @@ class TestConfigSetWhitelist:
         assert result.exit_code == 0, result.output
         assert 'alice' in result.output and 'bob' in result.output
         assert _read(config_file) == {'wallet': 'bob'}
+
+
+class TestConfigSetNetworkValue:
+    """Reject unresolvable `network` values so they can't silently flip the
+    issue commands back to finney (mainnet) while the miner commands treat the
+    same stored string as a raw endpoint URL."""
+
+    def test_typo_network_value_is_rejected(self, temp_config_dir):
+        """`tesnet` is the hazardous case: the user meant testnet, but the
+        issue-command resolver would silently fall back to mainnet."""
+        _, config_file = temp_config_dir
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'network', 'tesnet'])
+
+        assert result.exit_code != 0
+        assert 'tesnet' in result.output
+        assert not config_file.exists()
+
+    def test_rejected_network_does_not_clobber_existing_config(self, temp_config_dir):
+        config_dir, config_file = temp_config_dir
+        config_dir.mkdir(parents=True)
+        config_file.write_text(json.dumps({'network': 'test'}, indent=2))
+
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'network', 'finy'])
+
+        assert result.exit_code != 0
+        assert _read(config_file) == {'network': 'test'}
+
+    def test_custom_url_is_rejected_with_ws_endpoint_hint(self, temp_config_dir):
+        """Custom endpoints belong in `ws_endpoint`; storing a URL under
+        `network` resolves inconsistently across the CLI."""
+        _, config_file = temp_config_dir
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'network', 'wss://my-node:9944'])
+
+        assert result.exit_code != 0
+        assert 'ws_endpoint' in result.output
+        assert not config_file.exists()
+
+    @pytest.mark.parametrize('name', ['finney', 'test', 'local'])
+    def test_known_networks_are_accepted(self, temp_config_dir, name):
+        _, config_file = temp_config_dir
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'network', name])
+
+        assert result.exit_code == 0, result.output
+        assert _read(config_file) == {'network': name}
+
+    def test_value_case_and_whitespace_are_normalised(self, temp_config_dir):
+        """` TEST ` previously round-tripped verbatim and then failed the
+        exact-match lookup in both resolvers; store the canonical form."""
+        _, config_file = temp_config_dir
+        runner = CliRunner()
+        result = runner.invoke(config_group, ['set', 'network', ' TEST '])
+
+        assert result.exit_code == 0, result.output
+        assert _read(config_file) == {'network': 'test'}


### PR DESCRIPTION
# PR body — rsnetworkinginc → entrius/gittensor
# Branch: fix/config-set-network-validation (commit 8a87847, in WSL /root/gtn-pr)
# Base: test
# Title: fix(cli): reject unresolvable `network` values in `gitt config set`

## Summary

`gitt config set network <value>` accepts any string, but the two resolvers that read the
stored value only honor the known names (`finney` / `test` / `local`) — and they disagree
about what to do with anything else:

- `issue_commands/helpers.py::resolve_network` skips an unrecognized config `network` and
  silently falls back to the **finney mainnet** endpoint.
- `miner_commands/helpers.py::_resolve_endpoint` returns the same unrecognized string as a
  **raw endpoint URL** and tries to connect to it.

So a typo'd `gitt config set network tesnet` (or a value with stray case/whitespace like
`" TEST "`) is accepted at write time, and afterwards every issue command signs against
mainnet while the user believes they switched to testnet — and `gitt miner post/check` on the
same machine fails trying to use `tesnet` as a websocket URL. Every command's `--network`
flag already validates with `click.Choice(['finney', 'test', 'local'])`; the config file was
the one unvalidated path into the same setting.

## Reproduction

Against `origin/test` @ 28c1d4c with `HOME` pointed at a scratch dir:

```console
$ gitt config set network tesnet
Set network: tesnet                       # accepted

$ python -c "from gittensor.cli.issue_commands.helpers import resolve_network; print(resolve_network())"
('wss://entrypoint-finney.opentensor.ai:443', 'finney')   # MAINNET, silently

$ python -c "from gittensor.cli.miner_commands.helpers import _resolve_endpoint; print(_resolve_endpoint(None, None))"
tesnet                                                    # used as a raw endpoint URL
```

Same class of failure for `gitt config set network " TEST "` — stored verbatim, then fails
the exact-match lookup in both resolvers (issue commands → mainnet again).

## Fix

Validate the value in `config_set` (`gittensor/cli/main.py`) when the key is `network`:
strip + lowercase, require membership in `NETWORK_MAP`, and store the canonical form.
Unknown values raise `click.BadParameter` listing the valid names and pointing at
`ws_endpoint` for custom endpoints. This mirrors the `--network` flag's existing choice
validation and extends `config set`'s documented typo-safety (unknown *keys* are already
rejected for exactly this reason) to the one *value* the resolvers are sensitive to.

Write-time validation only — no resolver behavior changes, so existing configs and every
command flag behave exactly as before.

## Tests

`tests/cli/test_config_set.py`, new `TestConfigSetNetworkValue` class:

- `test_typo_network_value_is_rejected` — `tesnet` → non-zero exit, nothing written
- `test_rejected_network_does_not_clobber_existing_config` — invalid value leaves prior config intact
- `test_custom_url_is_rejected_with_ws_endpoint_hint` — URL under `network` → error mentions `ws_endpoint`
- `test_known_networks_are_accepted` — `finney` / `test` / `local` round-trip
- `test_value_case_and_whitespace_are_normalised` — `" TEST "` → stored as `test`

Plus a one-line update to the existing round-trip test so the `network` key uses a valid value.

```
uv run pre-commit run --files gittensor/cli/main.py tests/cli/test_config_set.py   # all hooks Passed
uv run pyright                                                                     # 0 errors, 0 warnings
uv run vulture                                                                     # clean (exit 0)
uv run pytest tests/ -q                                                            # 967 passed
```
