### PR TITLE
fix(cli): honor an explicit --wallet-name default in gitt issues register

### DIFF
--- a/gittensor/cli/issue_commands/mutations.py
+++ b/gittensor/cli/issue_commands/mutations.py
@@ -20,7 +20,6 @@ from .helpers import (
     console,
     err_console,
     format_alpha,
-    load_config,
     print_error,
     print_network_header,
     print_success,
@@ -140,7 +139,6 @@ def issue_register(
         rpc_url,
         missing_contract_message='Contract address not configured. Run ./up.sh --issues to deploy the contract first.',
     )
-    config = load_config()
 
     # Validate inputs before showing summary. The register path is owner-only
     # and spends real ALPHA, so both GitHub probes run in strict mode: any
@@ -185,9 +183,17 @@ def issue_register(
         with err_console.status('[bold cyan]Connecting to network...', spinner='dots'):
             subtensor = bt.Subtensor(network=ws_endpoint)
 
-        # CLI flags override config; fall back to config if not explicitly supplied
-        effective_wallet = wallet_name if wallet_name != 'default' else config.get('wallet', wallet_name)
-        effective_hotkey = wallet_hotkey if wallet_hotkey != 'default' else config.get('hotkey', wallet_hotkey)
+        # CLI flags override config; fall back to config if not explicitly
+        # supplied. resolve_wallet_config is ParameterSource-aware, so an
+        # explicit `--wallet-name default` selects the wallet actually named
+        # "default" instead of being silently replaced by the config file's
+        # wallet — the same resolution `gitt harvest` already uses.
+        effective_wallet, effective_hotkey = resolve_wallet_config(
+            wallet_name,
+            wallet_hotkey,
+            wallet_default='default',
+            hotkey_default='default',
+        )
 
         # For local development, check config first, then fall back to //Alice
         if network_name.lower() == 'local' and effective_wallet == 'default' and effective_hotkey == 'default':

--- a/tests/cli/test_register_wallet_resolution.py
+++ b/tests/cli/test_register_wallet_resolution.py
@@ -1,0 +1,127 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Tests for wallet resolution in `gitt issues register`.
+
+The register path signs an owner-only on-chain transaction with the resolved
+wallet's coldkey, so the wallet actually loaded must follow the documented
+priority: explicit CLI flags first, then the config file, then the defaults.
+The command previously used a bare `!= 'default'` comparison, which made an
+explicit `--wallet-name default` indistinguishable from "no flag given" — the
+config file's wallet silently replaced the wallet the user asked for by name.
+`resolve_wallet_config` (already used by `gitt harvest`) is ParameterSource-
+aware and resolves all three cases correctly.
+"""
+
+import json
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gittensor.cli.issue_commands.mutations import issue_register
+
+_CONTRACT = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _invoke_register(runner, tmp_path, config, extra_args=()):
+    """Run `issues register` with all network/GitHub/contract I/O stubbed out.
+
+    ``config`` is written to a real temp config file and CONFIG_FILE is
+    redirected at it, so resolution exercises the genuine load path. Returns
+    (result, captured) where captured holds the (name, hotkey) pair passed to
+    bt.Wallet — i.e. the wallet the command would actually sign with.
+    """
+    config_file = tmp_path / 'config.json'
+    config_file.write_text(json.dumps(config))
+    captured = {}
+
+    class FakeWallet:
+        def __init__(self, name=None, hotkey=None):
+            captured['name'] = name
+            captured['hotkey'] = hotkey
+            self.coldkey = MagicMock()
+
+    fake_bt = types.SimpleNamespace(Wallet=FakeWallet, Subtensor=MagicMock())
+    fake_client = MagicMock()
+    fake_client.register_issue.return_value = ('0xabc', None)
+
+    with (
+        patch.dict('sys.modules', {'bittensor': fake_bt}),
+        patch('gittensor.cli.issue_commands.helpers.CONFIG_FILE', config_file),
+        patch('gittensor.cli.issue_commands.mutations.validate_repository', return_value=('owner', 'repo')),
+        patch('gittensor.cli.issue_commands.mutations.validate_github_issue', return_value={}),
+        patch(
+            'gittensor.validator.issue_competitions.contract_client.IssueCompetitionContractClient',
+            return_value=fake_client,
+        ),
+    ):
+        result = runner.invoke(
+            issue_register,
+            [
+                '--repo',
+                'owner/repo',
+                '--issue',
+                '1',
+                '--bounty',
+                '10',
+                '--rpc-url',
+                'wss://stub-endpoint:9944',
+                '--contract',
+                _CONTRACT,
+                '--yes',
+                *extra_args,
+            ],
+            catch_exceptions=False,
+        )
+    return result, captured
+
+
+class TestRegisterWalletResolution:
+    """CLI flags > config file > defaults — including flags spelled 'default'."""
+
+    def test_explicit_default_flags_beat_config(self, runner, tmp_path):
+        """A wallet literally named "default" must be selectable even when the
+        config file names a different wallet."""
+        result, captured = _invoke_register(
+            runner,
+            tmp_path,
+            config={'wallet': 'treasury-cold', 'hotkey': 'tk'},
+            extra_args=['--wallet-name', 'default', '--wallet-hotkey', 'default'],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured == {'name': 'default', 'hotkey': 'default'}
+
+    def test_config_fills_in_when_no_flags_given(self, runner, tmp_path):
+        result, captured = _invoke_register(
+            runner,
+            tmp_path,
+            config={'wallet': 'treasury-cold', 'hotkey': 'tk'},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured == {'name': 'treasury-cold', 'hotkey': 'tk'}
+
+    def test_explicit_named_wallet_beats_config(self, runner, tmp_path):
+        result, captured = _invoke_register(
+            runner,
+            tmp_path,
+            config={'wallet': 'treasury-cold', 'hotkey': 'tk'},
+            extra_args=['--wallet-name', 'owner', '--wallet-hotkey', 'ok'],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured == {'name': 'owner', 'hotkey': 'ok'}
+
+    def test_defaults_used_when_no_flags_and_no_config(self, runner, tmp_path):
+        result, captured = _invoke_register(runner, tmp_path, config={})
+
+        assert result.exit_code == 0, result.output
+        assert captured == {'name': 'default', 'hotkey': 'default'}


### PR DESCRIPTION
# PR body — tryeverything24 → entrius/gittensor
# Branch: fix/register-wallet-flag-resolution (commit c8a8257, in WSL /root/gtn-pr)
# Base: test
# Title: fix(cli): honor an explicit `--wallet-name default` in `gitt issues register`

## Summary

`gitt issues register` resolves its wallet with a bare string comparison:

```python
effective_wallet = wallet_name if wallet_name != 'default' else config.get('wallet', wallet_name)
effective_hotkey = wallet_hotkey if wallet_hotkey != 'default' else config.get('hotkey', wallet_hotkey)
```

An explicitly passed `--wallet-name default` (or `--wallet-hotkey default`) is
indistinguishable from "no flag given", so when `~/.gittensor/config.json` names a different
wallet, the config value silently replaces the wallet the user asked for by name. Register is
the one command in this group that signs an owner-only on-chain transaction with the resolved
wallet's **coldkey**, so "loaded a different wallet than the one I typed" is the worst place
for this to happen.

The repo already has the correct resolver: `resolve_wallet_config` in
`issue_commands/helpers.py` is `ParameterSource`-aware (an explicit flag wins regardless of
its spelling) and `gitt harvest` — in this same file — already uses it. Register kept the
pre-helper heuristic.

## Reproduction

Against `origin/test` @ 28c1d4c, with `~/.gittensor/config.json` containing
`{"wallet": "treasury-cold", "hotkey": "tk"}` and all network/GitHub/contract I/O stubbed:

```console
$ gitt issues register --repo o/r --issue 1 --bounty 10 --wallet-name default --hotkey default --yes ...
Loading wallet treasury-cold/tk...        # not the wallet named "default" that was requested
```

After the fix the same invocation loads `default/default`; omitting the flags still falls
back to `treasury-cold/tk` as documented.

## Fix

Switch `issue_register` to the shared `resolve_wallet_config` (same call shape as `harvest`)
and drop the now-unused `load_config()` snapshot. Resolution priority is now genuinely
"explicit CLI flags > config file > defaults" for every spelling of the flags. The
local-network `//Alice` fallback still triggers on the same effective values as before —
no dev-workflow change.

## Tests

New `tests/cli/test_register_wallet_resolution.py` (config written to a real temp file via a
redirected `CONFIG_FILE`, wallet construction captured through a stubbed `bittensor.Wallet`):

- `test_explicit_default_flags_beat_config` — `--wallet-name default` with a config wallet
  present loads `default/default` (fails on current `test`: loads the config wallet)
- `test_config_fills_in_when_no_flags_given` — config wallet/hotkey used when flags omitted
- `test_explicit_named_wallet_beats_config` — non-default explicit flags win
- `test_defaults_used_when_no_flags_and_no_config` — bare invocation resolves `default/default`

```
uv run pre-commit run --files gittensor/cli/issue_commands/mutations.py tests/cli/test_register_wallet_resolution.py   # all hooks Passed
uv run pyright                                                                                                         # 0 errors, 0 warnings
uv run vulture                                                                                                         # clean (exit 0)
uv run pytest tests/ -q                                                                                                # 964 passed
```

Note: open PR #1650 also touches `issue_register`, but only the confirmation-gate lines
(`confirm_or_abort`); this change is a different hunk (wallet resolution, ~15 lines below)
and merges cleanly in either order.
