### PR TITLE
chore(weights): raise loopover maintainer cut to 0.66

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -227,8 +227,7 @@
     "label_multipliers": {
       "gittensor:bug": 0.05,
       "gittensor:feature": 0.25,
-      "gittensor:priority": 1.5,
-      "slop": 0.0
+      "gittensor:priority": 1.5
     },
     "eligibility": {
       "min_credibility": 0.5
@@ -256,13 +255,12 @@
     "label_multipliers": {
       "gittensor:bug": 0.05,
       "gittensor:feature": 0.25,
-      "gittensor:priority": 1.5,
-      "slop": 0.0
+      "gittensor:priority": 1.5
     },
     "eligibility": {
       "min_credibility": 0.5
     },
-    "maintainer_cut": 0.5,
+    "maintainer_cut": 0.66,
     "scoring": {
       "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,
@@ -285,8 +283,7 @@
     "label_multipliers": {
       "gittensor:bug": 0.05,
       "gittensor:feature": 0.25,
-      "gittensor:priority": 1.5,
-      "slop": 0.0
+      "gittensor:priority": 1.5
     },
     "eligibility": {
       "min_credibility": 0.5


### PR DESCRIPTION
## Weight Adjustment PR

### Changes Summary

| Metric               | Total |
| --------------------- | ----- |
| Repositories Added   | 0     |
| Repositories Removed | 0     |
| Weights Modified     | 1     |
| Net Weight Change    | 0     |

### Justification

Raising `JSONbored/loopover`'s `maintainer_cut` from `0.5` to `0.66` to fund purchasing and operating dedicated bare-metal infrastructure for TEE/SNP (confidential compute) and other cloud/hosted operations, plus increased AI token usage for maintaining the project. `0.66` is already a proven, in-range value used by `JSONbored/metagraphed`. This is a per-repo carve-out with no cross-repo sum constraint, so no other repository's weights are affected.

Also removed the now-unused `"slop": 0.0` label_multipliers entry from `JSONbored/loopover`, `JSONbored/awesome-claude`, and `JSONbored/metagraphed`. This label is no longer used to tag contributions, and since `default_label_multiplier` is already `0.0` for all three repos, removing the explicit entry is a no-op cleanup with no scoring behavior change.

### Additional Acceptable Branches

- [x] No additional_acceptable_branches changes in this PR

### Checklist

- [x] Changes summary table is filled in accurately
- [x] Net weight changes are justified in the Justification section
- [x] Added repositories have correct branch and initial weight