### PR TITLE
chore(weights): update vanguarstew and genie-claw weight settings

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -83,7 +83,7 @@
       "optimization": 5.0,
       "verify-jetson": 4.0
     },
-    "maintainer_cut": 0.3,
+    "maintainer_cut": 0.5,
     "trusted_label_pipeline": true
   },
   "gittensor-ai-lab/sparkinfer": {
@@ -145,12 +145,11 @@
     "emission_share": 0.099211,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.5,
+    "maintainer_cut": 0.6,
     "additional_acceptable_branches": ["test"],
     "trusted_label_pipeline": true,
-    "default_label_multiplier": 0.0,
+    "default_label_multiplier": 0.02,
     "label_multipliers": {
-      "mult:contribution": 0.05,
       "perf:xl": 4.0,
       "perf:l": 2.5,
       "perf:m": 1.5,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -145,7 +145,7 @@
     "emission_share": 0.099211,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
-    "maintainer_cut": 0.6,
+    "maintainer_cut": 0.5,
     "additional_acceptable_branches": ["test"],
     "trusted_label_pipeline": true,
     "default_label_multiplier": 0.02,


### PR DESCRIPTION
## Weight Adjustment PR

### Changes Summary

| Metric | Total |
| --- | --- |
| Repositories Added | 0 |
| Repositories Removed | 0 |
| Weights Modified | 2 |
| Net Weight Change | 0 |

### Justification

Raise `Geniepod/genie-claw`'s `maintainer_cut` from `0.3` to `0.5` to increase maintainer support for another repository operated by the same maintainer.

For `gittensor-vanguard/vanguarstew`, leave `maintainer_cut` at its original `0.5`, retain `fixed_base_score: 1.0`, set `default_label_multiplier` from `0.0` to `0.02`, and remove the `mult:contribution` label multiplier. This establishes the small default multiplier directly while retiring the flat contribution label; the measured `perf:*` tiers remain available for higher-value contributions.

Emission shares are unchanged, so the registry's total emission allocation is unaffected.

### Validation

- Parsed the registry as JSON.
- Checked live registry numeric ranges and total emission invariants.
- Asserted the requested values and removal exactly.
- Confirmed the diff contains only `gittensor/validator/weights/master_repositories.json`.
- Ran `git diff --check`.

### Additional Acceptable Branches

- [x] No `additional_acceptable_branches` changes in this PR

### Checklist

- [x] Changes summary table is filled in accurately
- [x] Net weight changes are justified in the Justification section
- [x] Added repositories have correct branch and initial weight
