### PR TITLE
chore(weights): zero metagraphed and loopover emission shares

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -251,7 +251,7 @@
   "JSONbored/loopover": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.106932,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -280,7 +280,7 @@
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.198785,
+    "emission_share": 0.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,


### PR DESCRIPTION
## Summary
- set `JSONbored/metagraphed` emission share to `0.0`
- set `JSONbored/loopover` emission share to `0.0`

## Test Plan
- verified the JSON diff only changes those two `emission_share` values
- ran `python3 -m json.tool gittensor/validator/weights/master_repositories.json`
