### PR TITLE
Add repo_registry python contract client

### DIFF
--- a/gittensor/validator/repo_registry/__init__.py
+++ b/gittensor/validator/repo_registry/__init__.py
@@ -1,0 +1,2 @@
+# The MIT License (MIT)
+# Copyright 2025 Entrius

--- a/gittensor/validator/repo_registry/contract_client.py
+++ b/gittensor/validator/repo_registry/contract_client.py
@@ -1,0 +1,481 @@
+# The MIT License (MIT)
+# Copyright 2025 Entrius
+
+"""Client for the repos-v0 repository registry smart contract.
+
+Reads go through childstate storage only (no chain extensions, no dry-runs)
+and accept an `at` block hash so every read pins to a snapshot. Mutations go
+through raw Contracts::call extrinsics, mirroring IssueCompetitionContractClient.
+"""
+
+import json
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import bittensor as bt
+from async_substrate_interface.errors import ExtrinsicNotFound
+
+from gittensor.validator.issue_competitions.storage_utils import (
+    compute_ink5_lazy_key,
+    get_contract_child_storage_key,
+)
+from gittensor.validator.repo_registry import price
+from gittensor.validator.repo_registry.storage_utils import (
+    BASKETS_ROOT_KEY,
+    BRANCH_PATTERNS_ROOT_KEY,
+    LABEL_MULTS_ROOT_KEY,
+    PARAM_BOUNDS_ROOT_KEY,
+    PARAMS_ROOT_KEY,
+    REPOS_ROOT_KEY,
+    WEIGHT_SUM,
+    PackedRegistryStorage,
+    ParamBounds,
+    decode_basket_entries,
+    decode_bounds,
+    decode_label_entries,
+    decode_param_entries,
+    decode_repo,
+    decode_string_vec,
+    encode_compact_length,
+    read_child_storage_bytes,
+    read_packed_registry_storage,
+)
+
+DEFAULT_GAS_LIMIT = {
+    'ref_time': 10_000_000_000,
+    'proof_size': 500_000,
+}
+
+REGISTER_GAS_LIMIT = {
+    'ref_time': 10_000_000_000,
+    'proof_size': 1_000_000,
+}
+
+# Load contract metadata from JSON (selectors and arg types)
+# Regenerate with: python gittensor/validator/repo_registry/update_metadata.py
+_METADATA_PATH = Path(__file__).parent / 'metadata.json'
+
+
+def load_contract_metadata() -> Tuple[Dict[str, bytes], Dict[str, List]]:
+    """Load selectors and arg types from metadata.json."""
+    with open(_METADATA_PATH) as f:
+        data = json.load(f)
+
+    selectors = {name: bytes.fromhex(sel) for name, sel in data['selectors'].items()}
+    arg_types = {name: [tuple(arg) for arg in args] for name, args in data['arg_types'].items()}
+
+    return selectors, arg_types
+
+
+CONTRACT_SELECTORS, CONTRACT_ARG_TYPES = load_contract_metadata()
+
+
+@dataclass
+class ContractRepo:
+    """Repository record from the registry contract."""
+
+    github_id: int
+    full_name: str
+    owner: str
+    reg_block: int
+    active: bool
+
+
+def validate_basket_entries(entries: List[Tuple[int, int]]) -> None:
+    """Validate chain-independent basket invariants; raises ValueError."""
+    if not entries:
+        raise ValueError('Basket must not be empty')
+    seen = set()
+    total = 0
+    for github_id, weight in entries:
+        if weight == 0:
+            raise ValueError(f'Zero weight for repo {github_id}')
+        if github_id in seen:
+            raise ValueError(f'Duplicate basket entry for repo {github_id}')
+        seen.add(github_id)
+        total += weight
+    if total != WEIGHT_SUM:
+        raise ValueError(f'Basket weights must sum to {WEIGHT_SUM}, got {total}')
+
+
+class RepoRegistryContractClient:
+    """Client for the repos-v0 registry contract (childstate reads + raw tx writes)."""
+
+    def __init__(
+        self,
+        contract_address: str,
+        subtensor: bt.Subtensor,
+    ):
+        """Initialize the contract client.
+
+        Args:
+            contract_address: SS58 address of the deployed contract.
+            subtensor: Connected Subtensor instance.
+
+        Raises:
+            ValueError: If contract_address is empty or contract not found on-chain.
+        """
+        if not contract_address:
+            raise ValueError('contract_address is required')
+
+        self.contract_address = contract_address
+        self.subtensor = subtensor
+
+        try:
+            contract_info = self.subtensor.substrate.query('Contracts', 'ContractInfoOf', [self.contract_address])
+            if not contract_info or (hasattr(contract_info, 'value') and not contract_info.value):
+                raise ValueError(
+                    f'No contract found at {self.contract_address}. '
+                    'Verify the address and that the contract is deployed.'
+                )
+        except ValueError:
+            raise
+        except Exception as e:
+            bt.logging.warning(f'Could not verify contract at {self.contract_address}: {e}')
+
+        bt.logging.debug(f'Repo registry client initialized: {self.contract_address}')
+
+    # =========================================================================
+    # Query Functions (childstate storage, pinnable via `at` block hash)
+    # =========================================================================
+
+    def _get_child_storage_key(self) -> Optional[str]:
+        """Get the child storage key for the contract's trie (stable for the contract's lifetime)."""
+        try:
+            return get_contract_child_storage_key(self.subtensor.substrate, self.contract_address)
+        except Exception as e:
+            bt.logging.debug(f'Error getting child storage key: {e}')
+            return None
+
+    def _read_mapping(self, root_key_hex: str, encoded_key: bytes, at: Optional[str]) -> Optional[bytes]:
+        """Read one lazy-mapping cell from contract child storage."""
+        child_key = self._get_child_storage_key()
+        if not child_key:
+            return None
+        lazy_key = compute_ink5_lazy_key(root_key_hex, encoded_key)
+        try:
+            return read_child_storage_bytes(self.subtensor.substrate, child_key, lazy_key, at)
+        except Exception as e:
+            bt.logging.debug(f'Error reading mapping cell {lazy_key}: {e}')
+            return None
+
+    def get_registry(self, at: Optional[str] = None) -> Optional[PackedRegistryStorage]:
+        """Read the packed root cell (config, repo_ids, voters, bound_keys)."""
+        try:
+            return read_packed_registry_storage(self.subtensor.substrate, self.contract_address, at)
+        except Exception as e:
+            bt.logging.debug(f'Error reading packed registry storage: {e}')
+            return None
+
+    def get_repo(self, github_id: int, at: Optional[str] = None) -> Optional[ContractRepo]:
+        """Read a single repository record."""
+        data = self._read_mapping(REPOS_ROOT_KEY, struct.pack('<Q', github_id), at)
+        if not data:
+            return None
+        decoded = decode_repo(data)
+        if decoded is None:
+            return None
+        return ContractRepo(
+            github_id=decoded.github_id,
+            full_name=decoded.full_name,
+            owner=self.subtensor.substrate.ss58_encode(decoded.owner.hex()),
+            reg_block=decoded.reg_block,
+            active=decoded.active,
+        )
+
+    def get_all_repos(self, at: Optional[str] = None) -> List[ContractRepo]:
+        """Read all active repositories (repo_ids walk; inactive entries filtered)."""
+        packed = self.get_registry(at)
+        if not packed:
+            return []
+        repos = []
+        for github_id in packed.repo_ids:
+            repo = self.get_repo(github_id, at)
+            if repo and repo.active:
+                repos.append(repo)
+        return repos
+
+    def get_params(self, github_id: int, at: Optional[str] = None) -> Dict[int, int]:
+        """Read a repo's hyperparam entries as {key: value}."""
+        data = self._read_mapping(PARAMS_ROOT_KEY, struct.pack('<Q', github_id), at)
+        if not data:
+            return {}
+        entries = decode_param_entries(data)
+        return dict(entries) if entries else {}
+
+    def get_bounds(self, key: int, at: Optional[str] = None) -> Optional[ParamBounds]:
+        """Read the bounds for one param key."""
+        data = self._read_mapping(PARAM_BOUNDS_ROOT_KEY, struct.pack('<B', key), at)
+        if not data:
+            return None
+        return decode_bounds(data)
+
+    def get_all_bounds(self, at: Optional[str] = None) -> Dict[int, ParamBounds]:
+        """Read the full bounds table as {key: ParamBounds} (bound_keys walk)."""
+        packed = self.get_registry(at)
+        if not packed:
+            return {}
+        bounds = {}
+        for key in packed.bound_keys:
+            entry = self.get_bounds(key, at)
+            if entry:
+                bounds[key] = entry
+        return bounds
+
+    def get_label_multipliers(self, github_id: int, at: Optional[str] = None) -> Dict[str, int]:
+        """Read a repo's label multipliers as {label: value}."""
+        data = self._read_mapping(LABEL_MULTS_ROOT_KEY, struct.pack('<Q', github_id), at)
+        if not data:
+            return {}
+        entries = decode_label_entries(data)
+        return dict(entries) if entries else {}
+
+    def get_branch_patterns(self, github_id: int, at: Optional[str] = None) -> List[str]:
+        """Read a repo's additional acceptable branch patterns."""
+        data = self._read_mapping(BRANCH_PATTERNS_ROOT_KEY, struct.pack('<Q', github_id), at)
+        if not data:
+            return []
+        return decode_string_vec(data) or []
+
+    def get_basket(self, hotkey: str, at: Optional[str] = None) -> Optional[List[Tuple[int, int]]]:
+        """Read one validator's basket as [(github_id, weight)]."""
+        account = bytes.fromhex(self.subtensor.substrate.ss58_decode(hotkey))
+        data = self._read_mapping(BASKETS_ROOT_KEY, account, at)
+        if not data:
+            return None
+        return decode_basket_entries(data)
+
+    def get_all_baskets(self, at: Optional[str] = None) -> Dict[str, List[Tuple[int, int]]]:
+        """Read all whitelisted voters' baskets as {hotkey_ss58: entries} (voters walk)."""
+        packed = self.get_registry(at)
+        if not packed:
+            return {}
+        baskets = {}
+        for voter in packed.voters:
+            data = self._read_mapping(BASKETS_ROOT_KEY, voter, at)
+            if not data:
+                continue
+            entries = decode_basket_entries(data)
+            if entries:
+                baskets[self.subtensor.substrate.ss58_encode(voter.hex())] = entries
+        return baskets
+
+    def get_voters(self, at: Optional[str] = None) -> List[str]:
+        """Read the whitelisted voter hotkeys as SS58 addresses."""
+        packed = self.get_registry(at)
+        if not packed:
+            return []
+        return [self.subtensor.substrate.ss58_encode(voter.hex()) for voter in packed.voters]
+
+    def quote_price(self, at: Optional[str] = None) -> Optional[int]:
+        """Registration price quote via the python price replica (no dry-run)."""
+        packed = self.get_registry(at)
+        if not packed:
+            return None
+        try:
+            now = self.subtensor.substrate.get_block_number(at) if at else self.subtensor.block
+        except Exception as e:
+            bt.logging.debug(f'Error resolving block number for price quote: {e}')
+            return None
+        constants = packed.constants
+        return price.lazy_price(
+            packed.price_last,
+            max(0, now - packed.price_last_block),
+            constants.price_half_life,
+            constants.price_floor,
+            constants.price_ceiling,
+        )
+
+    # =========================================================================
+    # Transaction Functions (Write)
+    # =========================================================================
+
+    def register(
+        self,
+        github_id: int,
+        full_name: str,
+        fee_hotkey: str,
+        wallet: bt.Wallet,
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Register a repository, paying the dynamic alpha fee from the caller's
+        stake on `fee_hotkey`. Signed by the registrant coldkey.
+
+        Returns:
+            (hash, error). Revert: both set. Pre-submission failure: hash is None.
+        """
+        return self._exec_contract_raw(
+            method_name='register',
+            args={'github_id': github_id, 'full_name': full_name, 'fee_hotkey': fee_hotkey},
+            keypair=wallet.coldkey,
+            gas_limit=REGISTER_GAS_LIMIT,
+        )
+
+    def set_basket(self, entries: List[Tuple[int, int]], wallet: bt.Wallet) -> bool:
+        """Publish a validator basket (whitelisted hotkey signs).
+
+        Raises:
+            ValueError: If entries violate chain-independent basket invariants.
+        """
+        validate_basket_entries(entries)
+        return self._exec_tx_bool(
+            method_name='set_basket',
+            args={'entries': entries},
+            keypair=wallet.hotkey,
+            label=f'Setting basket ({len(entries)} entries)',
+            gas_limit=DEFAULT_GAS_LIMIT,
+        )
+
+    def clear_basket(self, wallet: bt.Wallet) -> bool:
+        """Clear the caller's basket (hotkey signs)."""
+        return self._exec_tx_bool(
+            method_name='clear_basket',
+            args={},
+            keypair=wallet.hotkey,
+            label='Clearing basket',
+            gas_limit=DEFAULT_GAS_LIMIT,
+        )
+
+    # =========================================================================
+    # Raw Extrinsic Execution (Ink! 5 Workaround)
+    # =========================================================================
+
+    def _exec_tx_bool(
+        self,
+        method_name: str,
+        args: dict,
+        keypair,
+        label: str,
+        gas_limit: dict = None,  # type: ignore[assignment]
+    ) -> bool:
+        """Execute a contract transaction and return True on success."""
+        try:
+            bt.logging.info(label)
+            tx_hash, error = self._exec_contract_raw(
+                method_name=method_name,
+                args=args,
+                keypair=keypair,
+                gas_limit=gas_limit,
+            )
+            if tx_hash and not error:
+                bt.logging.info(f'{label} — ok ({tx_hash})')
+                return True
+            bt.logging.error(f'{label} — failed')
+            return False
+        except Exception as e:
+            bt.logging.error(f'{label} — {e}')
+            return False
+
+    def _exec_contract_raw(
+        self,
+        method_name: str,
+        args: dict,
+        keypair,
+        gas_limit: dict = None,  # type: ignore[assignment]
+        value: int = 0,
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Execute a contract method via raw extrinsic. Returns (hash, error).
+
+        Revert: both set. Pre-submission failure: hash is None.
+        """
+        gas_limit = gas_limit or DEFAULT_GAS_LIMIT
+
+        try:
+            selector = CONTRACT_SELECTORS.get(method_name)
+            if not selector:
+                err = f'Method {method_name} not found in CONTRACT_SELECTORS'
+                bt.logging.error(err)
+                return None, err
+
+            encoded_args = self._encode_args(method_name, args)
+            call_data = selector + encoded_args
+
+            call = self.subtensor.substrate.compose_call(
+                call_module='Contracts',
+                call_function='call',
+                call_params={
+                    'dest': {'Id': self.contract_address},
+                    'value': value,
+                    'gas_limit': gas_limit,
+                    'storage_deposit_limit': None,
+                    'data': '0x' + call_data.hex(),
+                },
+            )
+
+            signer_address = keypair.ss58_address
+            account_info = self.subtensor.substrate.query('System', 'Account', [signer_address])
+            if hasattr(account_info, 'value'):
+                account_data = account_info.value  # type: ignore[union-attr]
+            else:
+                account_data = account_info
+            free_balance = account_data.get('data', {}).get('free', 0)  # type: ignore[union-attr]
+            if free_balance < 100_000_000:
+                err = f'{method_name}: insufficient balance for fees'
+                bt.logging.error(err)
+                return None, err
+
+            extrinsic = self.subtensor.substrate.create_signed_extrinsic(
+                call=call,
+                keypair=keypair,
+            )
+
+            result = self.subtensor.substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=True,
+                wait_for_finalization=False,
+            )
+
+            try:
+                if result.is_success:
+                    return result.extrinsic_hash, None
+                err = f'{method_name} failed: {result.error_message}'
+                bt.logging.error(err)
+                return result.extrinsic_hash, err
+            except ExtrinsicNotFound:
+                return result.extrinsic_hash, None
+
+        except Exception as e:
+            err = f'{method_name} error: {e}'
+            bt.logging.error(err)
+            return None, err
+
+    def _encode_args(self, method_name: str, args: dict) -> bytes:
+        """SCALE-encode method arguments using metadata type definitions."""
+        arg_types = CONTRACT_ARG_TYPES.get(method_name, [])
+        encoded = b''
+
+        for arg_name, type_def in arg_types:
+            if arg_name not in args:
+                raise ValueError(f'Missing argument: {arg_name}')
+
+            value = args[arg_name]
+
+            if type_def == 'u16':
+                encoded += struct.pack('<H', value)
+            elif type_def == 'u32':
+                encoded += struct.pack('<I', value)
+            elif type_def == 'u64':
+                encoded += struct.pack('<Q', value)
+            elif type_def == 'u128':
+                encoded += struct.pack('<QQ', value & 0xFFFFFFFFFFFFFFFF, value >> 64)
+            elif type_def == 'str':
+                if not isinstance(value, str):
+                    raise ValueError(f'Expected str for {arg_name}, got {type(value).__name__}')
+                data = value.encode('utf-8')
+                encoded += encode_compact_length(len(data)) + data
+            elif type_def == 'AccountId':
+                if isinstance(value, str):
+                    encoded += bytes.fromhex(self.subtensor.substrate.ss58_decode(value))
+                elif isinstance(value, (list, bytes)):
+                    encoded += bytes(value) if isinstance(value, list) else value
+                else:
+                    raise ValueError(f'Unknown AccountId format: {type(value)}')
+            elif type_def == 'vec_u64_u16':
+                encoded += encode_compact_length(len(value))
+                for item_u64, item_u16 in value:
+                    encoded += struct.pack('<QH', item_u64, item_u16)
+            else:
+                raise ValueError(f'Unsupported type: {type_def} for arg {arg_name}')
+
+        return encoded

--- a/gittensor/validator/repo_registry/metadata.json
+++ b/gittensor/validator/repo_registry/metadata.json
@@ -1,0 +1,30 @@
+{
+  "selectors": {
+    "register": "229b553f",
+    "set_basket": "2f6d1155",
+    "clear_basket": "11cfd99c"
+  },
+  "arg_types": {
+    "register": [
+      [
+        "github_id",
+        "u64"
+      ],
+      [
+        "full_name",
+        "str"
+      ],
+      [
+        "fee_hotkey",
+        "AccountId"
+      ]
+    ],
+    "set_basket": [
+      [
+        "entries",
+        "vec_u64_u16"
+      ]
+    ],
+    "clear_basket": []
+  }
+}

--- a/gittensor/validator/repo_registry/price.py
+++ b/gittensor/validator/repo_registry/price.py
@@ -1,0 +1,60 @@
+"""Exact integer port of the repos-v0 price curve (smart-contracts/repos-v0/price.rs).
+
+Bittensor-style registration price decay: whole halvings by shift plus a Q32
+fractional multiply. Must reproduce the contract's golden vectors byte-for-byte,
+so every operation mirrors the saturating u64/u128 Rust arithmetic — no floats.
+"""
+
+from functools import lru_cache
+
+U64_MAX = (1 << 64) - 1
+
+ONE_Q32 = 1 << 32
+HALF_Q32 = 1 << 31
+
+
+def mul_by_q32(value: int, factor_q32: int) -> int:
+    """Multiply an integer by a Q32 fixed-point factor, saturating into u64."""
+    return min((value * factor_q32) >> 32, U64_MAX)
+
+
+def pow_q32(base_q32: int, exp: int) -> int:
+    """Exponentiation-by-squaring for Q32 values: `base_q32 ^ exp` in Q32."""
+    result = ONE_Q32
+    factor = base_q32
+    power = exp
+    while power > 0:
+        if power & 1:
+            result = mul_by_q32(result, factor)
+        power >>= 1
+        if power > 0:
+            factor = mul_by_q32(factor, factor)
+    return result
+
+
+@lru_cache(maxsize=None)
+def decay_factor_q32(half_life: int) -> int:
+    """Per-block decay factor `f` in Q32 such that `f ^ half_life = 0.5` (bisection)."""
+    if half_life == 0:
+        return ONE_Q32
+    lo = 0
+    hi = ONE_Q32
+    while lo + 1 < hi:
+        mid = lo + ((hi - lo) >> 1)
+        if pow_q32(mid, half_life) > HALF_Q32:
+            hi = mid
+        else:
+            lo = mid
+    return lo
+
+
+def lazy_price(last: int, delta_blocks: int, half_life: int, floor: int, ceiling: int) -> int:
+    """Lazy price quote: `clamp(last * 0.5^(delta/half_life), floor, ceiling)`."""
+    price = last
+    if half_life > 0 and delta_blocks > 0:
+        whole = delta_blocks // half_life
+        frac = delta_blocks % half_life
+        price = price >> whole if whole < 64 else 0
+        if frac > 0:
+            price = mul_by_q32(price, pow_q32(decay_factor_q32(half_life), frac))
+    return max(floor, min(price, ceiling))

--- a/gittensor/validator/repo_registry/storage_utils.py
+++ b/gittensor/validator/repo_registry/storage_utils.py
@@ -1,0 +1,362 @@
+"""Helpers for reading and decoding repos-v0 registry contract storage.
+
+Read path is pure childstate RPC — no chain-extension or dry-run calls — and
+every read accepts an `at` block hash so results pin to a snapshot.
+
+ink! 5 AutoKey mapping root keys are `XXH32('RepoRegistry::<field>')` encoded
+as SCALE little-endian u32 (ink_primitives KeyComposer). The derivation is
+verified against issues-v0's known `IssueBountyManager::issues` -> '52789899'.
+Lazy cell keys then follow the issues-v0 blake2_128concat scheme.
+
+The packed root cell layout (root key 0) is the byte-offset table documented
+on the RepoRegistry struct in smart-contracts/repos-v0/lib.rs.
+"""
+
+import logging
+import struct
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from gittensor.validator.issue_competitions.storage_utils import (
+    compute_ink5_lazy_key,
+    get_contract_child_storage_key,
+)
+
+logger = logging.getLogger(__name__)
+
+_XXH_PRIME1 = 2654435761
+_XXH_PRIME2 = 2246822519
+_XXH_PRIME3 = 3266489917
+_XXH_PRIME4 = 668265263
+_XXH_PRIME5 = 374761393
+_U32 = 0xFFFFFFFF
+
+
+def _rotl32(x: int, r: int) -> int:
+    return ((x << r) | (x >> (32 - r))) & _U32
+
+
+def xxh32(data: bytes, seed: int = 0) -> int:
+    """Pure-python XXH32 (ink! KeyComposer uses seed 0)."""
+    n = len(data)
+    i = 0
+    if n >= 16:
+        v1 = (seed + _XXH_PRIME1 + _XXH_PRIME2) & _U32
+        v2 = (seed + _XXH_PRIME2) & _U32
+        v3 = seed
+        v4 = (seed - _XXH_PRIME1) & _U32
+
+        def _round(acc: int, offset: int) -> int:
+            lane = int.from_bytes(data[offset : offset + 4], 'little')
+            return (_rotl32((acc + lane * _XXH_PRIME2) & _U32, 13) * _XXH_PRIME1) & _U32
+
+        while i <= n - 16:
+            v1 = _round(v1, i)
+            v2 = _round(v2, i + 4)
+            v3 = _round(v3, i + 8)
+            v4 = _round(v4, i + 12)
+            i += 16
+        h = (_rotl32(v1, 1) + _rotl32(v2, 7) + _rotl32(v3, 12) + _rotl32(v4, 18)) & _U32
+    else:
+        h = (seed + _XXH_PRIME5) & _U32
+    h = (h + n) & _U32
+    while i <= n - 4:
+        h = (h + int.from_bytes(data[i : i + 4], 'little') * _XXH_PRIME3) & _U32
+        h = (_rotl32(h, 17) * _XXH_PRIME4) & _U32
+        i += 4
+    while i < n:
+        h = (h + data[i] * _XXH_PRIME5) & _U32
+        h = (_rotl32(h, 11) * _XXH_PRIME1) & _U32
+        i += 1
+    h ^= h >> 15
+    h = (h * _XXH_PRIME2) & _U32
+    h ^= h >> 13
+    h = (h * _XXH_PRIME3) & _U32
+    h ^= h >> 16
+    return h
+
+
+def ink_mapping_root_key(field_name: str) -> str:
+    """AutoKey root for a RepoRegistry mapping field, as SCALE-LE hex."""
+    key = xxh32(f'RepoRegistry::{field_name}'.encode())
+    return key.to_bytes(4, 'little').hex()
+
+
+REPOS_ROOT_KEY = ink_mapping_root_key('repos')
+PARAMS_ROOT_KEY = ink_mapping_root_key('params')
+PARAM_BOUNDS_ROOT_KEY = ink_mapping_root_key('param_bounds')
+LABEL_MULTS_ROOT_KEY = ink_mapping_root_key('label_mults')
+BRANCH_PATTERNS_ROOT_KEY = ink_mapping_root_key('branch_patterns')
+BASKETS_ROOT_KEY = ink_mapping_root_key('baskets')
+
+PACKED_ROOT_STORAGE_KEY = compute_ink5_lazy_key('00000000', b'')
+
+WEIGHT_SUM = 65_535
+
+# owner (32) + paused (1) + netuid (2) + storage_version (4) + price_last (8)
+# + price_last_block (8) + last_reg_block (8) + regs_in_block (4) + constants (68)
+_PACKED_FIXED_SIZE = 32 + 1 + 2 + 4 + 8 + 8 + 8 + 4 + 68
+
+
+@dataclass
+class RegistryConstants:
+    """One-tx adjustable launch constants (Constants in types.rs)."""
+
+    max_repos: int
+    immunity_period: int
+    price_floor: int
+    price_ceiling: int
+    price_half_life: int
+    price_bump_q32: int
+    max_regs_per_block: int
+    param_rate_limit_blocks: int
+    snapshot_interval: int
+    basket_cap: int
+
+
+@dataclass
+class PackedRegistryStorage:
+    """Decoded packed root cell of the RepoRegistry contract."""
+
+    owner: bytes
+    paused: bool
+    netuid: int
+    storage_version: int
+    price_last: int
+    price_last_block: int
+    last_reg_block: int
+    regs_in_block: int
+    constants: RegistryConstants
+    repo_ids: List[int]
+    voters: List[bytes]
+    bound_keys: List[int]
+
+
+@dataclass
+class DecodedRepo:
+    """Decoded repos mapping entry (Repo in types.rs)."""
+
+    github_id: int
+    full_name: str
+    owner: bytes
+    reg_block: int
+    active: bool
+
+
+@dataclass
+class ParamBounds:
+    """Decoded param_bounds mapping entry (Bounds in types.rs)."""
+
+    min: int
+    max: int
+
+
+def encode_compact_length(n: int) -> bytes:
+    """SCALE compact length prefix for Vec/String payloads."""
+    if n < 0:
+        raise ValueError(f'Length must be non-negative: {n}')
+    if n < 1 << 6:
+        return bytes([n << 2])
+    if n < 1 << 14:
+        return ((n << 2) | 1).to_bytes(2, 'little')
+    if n < 1 << 30:
+        return ((n << 2) | 2).to_bytes(4, 'little')
+    raise ValueError(f'Length too large for compact encoding: {n}')
+
+
+def _read_compact(data: bytes, offset: int) -> Tuple[int, int]:
+    """Decode a SCALE compact integer, returning (value, next_offset)."""
+    mode = data[offset] & 0x03
+    if mode == 0:
+        return data[offset] >> 2, offset + 1
+    width = 2 if mode == 1 else 4
+    if mode == 3 or offset + width > len(data):
+        raise ValueError('Unsupported or truncated compact integer')
+    return int.from_bytes(data[offset : offset + width], 'little') >> 2, offset + width
+
+
+def _read_bytes(data: bytes, offset: int, n: int) -> Tuple[bytes, int]:
+    if offset + n > len(data):
+        raise ValueError('Truncated buffer')
+    return data[offset : offset + n], offset + n
+
+
+def _read_bool(data: bytes, offset: int) -> Tuple[bool, int]:
+    raw, offset = _read_bytes(data, offset, 1)
+    if raw[0] > 1:
+        raise ValueError(f'Invalid bool byte: {raw[0]}')
+    return raw[0] == 1, offset
+
+
+def _read_string(data: bytes, offset: int) -> Tuple[str, int]:
+    length, offset = _read_compact(data, offset)
+    raw, offset = _read_bytes(data, offset, length)
+    return raw.decode('utf-8'), offset
+
+
+def _ensure_consumed(data: bytes, offset: int) -> None:
+    if offset != len(data):
+        raise ValueError(f'Trailing bytes: consumed {offset} of {len(data)}')
+
+
+def decode_packed_registry_storage(data: bytes) -> Optional[PackedRegistryStorage]:
+    """Decode the packed root cell per the lib.rs byte-offset table."""
+    if len(data) < _PACKED_FIXED_SIZE:
+        return None
+    try:
+        offset = 0
+        owner, offset = _read_bytes(data, offset, 32)
+        paused, offset = _read_bool(data, offset)
+        netuid, storage_version = struct.unpack_from('<HI', data, offset)
+        offset += 6
+        price_last, price_last_block, last_reg_block = struct.unpack_from('<QQQ', data, offset)
+        offset += 24
+        regs_in_block = struct.unpack_from('<I', data, offset)[0]
+        offset += 4
+        constants = RegistryConstants(*struct.unpack_from('<IQQQQQIQQI', data, offset))
+        offset += 68
+
+        count, offset = _read_compact(data, offset)
+        repo_ids = []
+        for _ in range(count):
+            raw, offset = _read_bytes(data, offset, 8)
+            repo_ids.append(int.from_bytes(raw, 'little'))
+
+        count, offset = _read_compact(data, offset)
+        voters = []
+        for _ in range(count):
+            voter, offset = _read_bytes(data, offset, 32)
+            voters.append(voter)
+
+        count, offset = _read_compact(data, offset)
+        raw, offset = _read_bytes(data, offset, count)
+        bound_keys = list(raw)
+
+        _ensure_consumed(data, offset)
+    except (struct.error, IndexError, ValueError) as e:
+        logger.debug('Failed to decode packed registry storage: %s', e)
+        return None
+
+    return PackedRegistryStorage(
+        owner=owner,
+        paused=paused,
+        netuid=netuid,
+        storage_version=storage_version,
+        price_last=price_last,
+        price_last_block=price_last_block,
+        last_reg_block=last_reg_block,
+        regs_in_block=regs_in_block,
+        constants=constants,
+        repo_ids=repo_ids,
+        voters=voters,
+        bound_keys=bound_keys,
+    )
+
+
+def decode_repo(data: bytes) -> Optional[DecodedRepo]:
+    """Decode one repos mapping value."""
+    try:
+        offset = 0
+        raw, offset = _read_bytes(data, offset, 8)
+        github_id = int.from_bytes(raw, 'little')
+        full_name, offset = _read_string(data, offset)
+        owner, offset = _read_bytes(data, offset, 32)
+        raw, offset = _read_bytes(data, offset, 8)
+        reg_block = int.from_bytes(raw, 'little')
+        active, offset = _read_bool(data, offset)
+        _ensure_consumed(data, offset)
+    except (IndexError, ValueError, UnicodeDecodeError) as e:
+        logger.debug('Failed to decode repo entry: %s', e)
+        return None
+    return DecodedRepo(github_id=github_id, full_name=full_name, owner=owner, reg_block=reg_block, active=active)
+
+
+def decode_param_entries(data: bytes) -> Optional[List[Tuple[int, int]]]:
+    """Decode a params mapping value: Vec<(u8, u64)>."""
+    try:
+        count, offset = _read_compact(data, 0)
+        entries = []
+        for _ in range(count):
+            raw, offset = _read_bytes(data, offset, 9)
+            entries.append((raw[0], int.from_bytes(raw[1:], 'little')))
+        _ensure_consumed(data, offset)
+    except (IndexError, ValueError) as e:
+        logger.debug('Failed to decode param entries: %s', e)
+        return None
+    return entries
+
+
+def decode_bounds(data: bytes) -> Optional[ParamBounds]:
+    """Decode a param_bounds mapping value: Bounds { min: u64, max: u64 }."""
+    if len(data) != 16:
+        return None
+    lo, hi = struct.unpack('<QQ', data)
+    return ParamBounds(min=lo, max=hi)
+
+
+def decode_label_entries(data: bytes) -> Optional[List[Tuple[str, int]]]:
+    """Decode a label_mults mapping value: Vec<(String, u64)>."""
+    try:
+        count, offset = _read_compact(data, 0)
+        entries = []
+        for _ in range(count):
+            label, offset = _read_string(data, offset)
+            raw, offset = _read_bytes(data, offset, 8)
+            entries.append((label, int.from_bytes(raw, 'little')))
+        _ensure_consumed(data, offset)
+    except (IndexError, ValueError, UnicodeDecodeError) as e:
+        logger.debug('Failed to decode label entries: %s', e)
+        return None
+    return entries
+
+
+def decode_string_vec(data: bytes) -> Optional[List[str]]:
+    """Decode a branch_patterns mapping value: Vec<String>."""
+    try:
+        count, offset = _read_compact(data, 0)
+        patterns = []
+        for _ in range(count):
+            pattern, offset = _read_string(data, offset)
+            patterns.append(pattern)
+        _ensure_consumed(data, offset)
+    except (IndexError, ValueError, UnicodeDecodeError) as e:
+        logger.debug('Failed to decode string vec: %s', e)
+        return None
+    return patterns
+
+
+def decode_basket_entries(data: bytes) -> Optional[List[Tuple[int, int]]]:
+    """Decode a baskets mapping value: Vec<(u64, u16)>."""
+    try:
+        count, offset = _read_compact(data, 0)
+        entries = []
+        for _ in range(count):
+            raw, offset = _read_bytes(data, offset, 10)
+            entries.append((int.from_bytes(raw[:8], 'little'), int.from_bytes(raw[8:], 'little')))
+        _ensure_consumed(data, offset)
+    except (IndexError, ValueError) as e:
+        logger.debug('Failed to decode basket entries: %s', e)
+        return None
+    return entries
+
+
+def read_child_storage_bytes(substrate, child_key: str, storage_key: str, at: Optional[str] = None) -> Optional[bytes]:
+    """Read one contract child-storage cell, optionally pinned to a block hash."""
+    result = substrate.rpc_request('childstate_getStorage', [child_key, storage_key, at])
+    raw_hex = result.get('result')
+    if not raw_hex:
+        return None
+    return bytes.fromhex(raw_hex.replace('0x', ''))
+
+
+def read_packed_registry_storage(
+    substrate, contract_addr: str, at: Optional[str] = None
+) -> Optional[PackedRegistryStorage]:
+    """Read and decode the packed root cell for a deployed registry contract."""
+    child_key = get_contract_child_storage_key(substrate, contract_addr)
+    if not child_key:
+        return None
+    data = read_child_storage_bytes(substrate, child_key, PACKED_ROOT_STORAGE_KEY, at)
+    if not data:
+        return None
+    return decode_packed_registry_storage(data)

--- a/gittensor/validator/repo_registry/update_metadata.py
+++ b/gittensor/validator/repo_registry/update_metadata.py
@@ -1,0 +1,72 @@
+"""
+Generate metadata.json for the repos-v0 registry client.
+
+Selectors use ink!'s default derivation — the first 4 bytes of the blake2b-256
+hash of the message label — so no `cargo contract build` is required. When the
+built artifact (target/ink/repo_registry.contract) exists, its selectors are
+cross-checked and any mismatch fails the run. Arg types are declared here;
+source of truth is smart-contracts/repos-v0/lib.rs message signatures.
+
+Mapping root keys are NOT part of this file: ink! 5 AutoKey roots are
+XXH32('RepoRegistry::<field>') per ink_primitives KeyComposer, computed in
+storage_utils.py (derivation verified against issues-v0's '52789899' key).
+
+Usage: python update_metadata.py
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent.parent.parent
+CONTRACT_FILE = REPO_ROOT / 'smart-contracts' / 'repos-v0' / 'target' / 'ink' / 'repo_registry.contract'
+METADATA_FILE = SCRIPT_DIR / 'metadata.json'
+
+# Methods we use in the validator/CLI, with declared arg types (lib.rs signatures)
+METHOD_ARG_TYPES = {
+    'register': [['github_id', 'u64'], ['full_name', 'str'], ['fee_hotkey', 'AccountId']],
+    'set_basket': [['entries', 'vec_u64_u16']],
+    'clear_basket': [],
+}
+
+
+def ink_selector(label: str) -> str:
+    """ink! default message selector: blake2b-256(label)[..4]."""
+    return hashlib.blake2b(label.encode(), digest_size=32).digest()[:4].hex()
+
+
+def verify_against_contract_file(selectors: dict) -> None:
+    """Cross-check derived selectors against a built contract artifact."""
+    with open(CONTRACT_FILE) as f:
+        contract = json.load(f)
+    built = {msg['label']: msg['selector'].replace('0x', '') for msg in contract.get('spec', {}).get('messages', [])}
+    for name, selector in selectors.items():
+        if built.get(name) != selector:
+            raise SystemExit(f'Selector mismatch for {name}: derived {selector}, built {built.get(name)}')
+    print(f'Verified {len(selectors)} selectors against {CONTRACT_FILE}')
+
+
+def main():
+    selectors = {name: ink_selector(name) for name in METHOD_ARG_TYPES}
+
+    if CONTRACT_FILE.exists():
+        verify_against_contract_file(selectors)
+    else:
+        print(f'{CONTRACT_FILE} not built; using derived selectors (blake2b-256(label)[..4])')
+
+    metadata = {
+        'selectors': selectors,
+        'arg_types': METHOD_ARG_TYPES,
+    }
+
+    with open(METADATA_FILE, 'w') as f:
+        json.dump(metadata, f, indent=2)
+        f.write('\n')
+
+    print(f'Updated {METADATA_FILE}')
+    print(f'  {len(selectors)} selectors')
+
+
+if __name__ == '__main__':
+    exit(main() or 0)

--- a/tests/utils/test_repo_registry_storage_utils.py
+++ b/tests/utils/test_repo_registry_storage_utils.py
@@ -1,0 +1,328 @@
+import struct
+
+import pytest
+
+from gittensor.validator.issue_competitions.storage_utils import ISSUES_MAPPING_ROOT_KEY
+from gittensor.validator.repo_registry.storage_utils import (
+    BASKETS_ROOT_KEY,
+    BRANCH_PATTERNS_ROOT_KEY,
+    LABEL_MULTS_ROOT_KEY,
+    PACKED_ROOT_STORAGE_KEY,
+    PARAM_BOUNDS_ROOT_KEY,
+    PARAMS_ROOT_KEY,
+    REPOS_ROOT_KEY,
+    decode_basket_entries,
+    decode_bounds,
+    decode_label_entries,
+    decode_packed_registry_storage,
+    decode_param_entries,
+    decode_repo,
+    decode_string_vec,
+    encode_compact_length,
+    ink_mapping_root_key,
+    read_packed_registry_storage,
+    xxh32,
+)
+
+LAUNCH_CONSTANTS = struct.pack(
+    '<IQQQQQIQQI',
+    32,  # max_repos
+    216_000,  # immunity_period
+    500_000_000_000,  # price_floor
+    500_000_000_000_000,  # price_ceiling
+    100_800,  # price_half_life
+    2 << 32,  # price_bump_q32
+    1,  # max_regs_per_block
+    3_600,  # param_rate_limit_blocks
+    3_600,  # snapshot_interval
+    10,  # basket_cap
+)
+
+
+def _build_packed(
+    owner: bytes = b'\x01' * 32,
+    paused: bool = False,
+    netuid: int = 2,
+    storage_version: int = 1,
+    price_last: int = 500_000_000_000,
+    price_last_block: int = 100,
+    last_reg_block: int = 0,
+    regs_in_block: int = 0,
+    constants: bytes = LAUNCH_CONSTANTS,
+    repo_ids: list = (),
+    voters: list = (),
+    bound_keys: list = (),
+) -> bytes:
+    return b''.join(
+        [
+            owner,
+            bytes([paused]),
+            struct.pack('<H', netuid),
+            struct.pack('<I', storage_version),
+            struct.pack('<QQQ', price_last, price_last_block, last_reg_block),
+            struct.pack('<I', regs_in_block),
+            constants,
+            encode_compact_length(len(repo_ids)),
+            b''.join(struct.pack('<Q', repo_id) for repo_id in repo_ids),
+            encode_compact_length(len(voters)),
+            b''.join(voters),
+            encode_compact_length(len(bound_keys)),
+            bytes(bound_keys),
+        ]
+    )
+
+
+def _build_repo(
+    github_id: int = 42,
+    full_name: str = 'entrius/gittensor',
+    owner: bytes = b'\x07' * 32,
+    reg_block: int = 999,
+    active: bool = True,
+) -> bytes:
+    name_bytes = full_name.encode('utf-8')
+    return b''.join(
+        [
+            struct.pack('<Q', github_id),
+            encode_compact_length(len(name_bytes)),
+            name_bytes,
+            owner,
+            struct.pack('<Q', reg_block),
+            bytes([active]),
+        ]
+    )
+
+
+class _FakeContractInfo:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeSubstrate:
+    def __init__(self, packed_hex):
+        self._packed_hex = packed_hex
+        self.storage_requests = []
+
+    def query(self, module, storage, params):
+        assert module == 'Contracts'
+        assert storage == 'ContractInfoOf'
+        return _FakeContractInfo({'trie_id': '0x0102'})
+
+    def rpc_request(self, method, params):
+        assert method == 'childstate_getStorage'
+        self.storage_requests.append(params)
+        return {'result': self._packed_hex}
+
+
+# ============================================================================
+# Root key derivation
+# ============================================================================
+
+
+def test_xxh32_reproduces_issues_v0_mapping_root_key():
+    # Cross-implementation anchor: ink! KeyComposer produced '52789899' for
+    # issues-v0; the same derivation must reproduce it here.
+    key = xxh32(b'IssueBountyManager::issues')
+    assert key.to_bytes(4, 'little').hex() == ISSUES_MAPPING_ROOT_KEY
+
+
+def test_mapping_root_key_fixtures():
+    assert REPOS_ROOT_KEY == 'cb55726b'
+    assert PARAMS_ROOT_KEY == 'a8c90dad'
+    assert PARAM_BOUNDS_ROOT_KEY == 'a03795cf'
+    assert LABEL_MULTS_ROOT_KEY == '7bba888c'
+    assert BRANCH_PATTERNS_ROOT_KEY == 'f086cc94'
+    assert BASKETS_ROOT_KEY == '5539377f'
+
+
+def test_ink_mapping_root_key_matches_key_composer_formula():
+    assert ink_mapping_root_key('repos') == xxh32(b'RepoRegistry::repos').to_bytes(4, 'little').hex()
+
+
+def test_packed_root_storage_key_is_root_zero_cell():
+    assert PACKED_ROOT_STORAGE_KEY.startswith('0x')
+    assert PACKED_ROOT_STORAGE_KEY.endswith('00000000')
+
+
+# ============================================================================
+# Packed root decode
+# ============================================================================
+
+
+def test_decode_packed_empty_registry():
+    decoded = decode_packed_registry_storage(_build_packed())
+
+    assert decoded is not None
+    assert decoded.owner == b'\x01' * 32
+    assert decoded.paused is False
+    assert decoded.netuid == 2
+    assert decoded.storage_version == 1
+    assert decoded.price_last == 500_000_000_000
+    assert decoded.price_last_block == 100
+    assert decoded.last_reg_block == 0
+    assert decoded.regs_in_block == 0
+    assert decoded.repo_ids == []
+    assert decoded.voters == []
+    assert decoded.bound_keys == []
+
+
+def test_decode_packed_launch_constants():
+    constants = decode_packed_registry_storage(_build_packed()).constants
+
+    assert constants.max_repos == 32
+    assert constants.immunity_period == 216_000
+    assert constants.price_floor == 500_000_000_000
+    assert constants.price_ceiling == 500_000_000_000_000
+    assert constants.price_half_life == 100_800
+    assert constants.price_bump_q32 == 2 << 32
+    assert constants.max_regs_per_block == 1
+    assert constants.param_rate_limit_blocks == 3_600
+    assert constants.snapshot_interval == 3_600
+    assert constants.basket_cap == 10
+
+
+def test_decode_packed_populated_registry():
+    voters = [b'\xaa' * 32, b'\xbb' * 32]
+    data = _build_packed(
+        paused=True,
+        repo_ids=[7, 42, 1_000_000],
+        voters=voters,
+        bound_keys=list(range(1, 27)),
+    )
+
+    decoded = decode_packed_registry_storage(data)
+
+    assert decoded is not None
+    assert decoded.paused is True
+    assert decoded.repo_ids == [7, 42, 1_000_000]
+    assert decoded.voters == voters
+    assert decoded.bound_keys == list(range(1, 27))
+
+
+@pytest.mark.parametrize('length', [0, 32, 134, 135, 137])
+def test_decode_packed_rejects_short_buffers(length):
+    assert decode_packed_registry_storage(b'\x00' * length) is None
+
+
+def test_decode_packed_rejects_trailing_bytes():
+    assert decode_packed_registry_storage(_build_packed() + b'\x00') is None
+
+
+def test_decode_packed_rejects_invalid_paused_byte():
+    data = bytearray(_build_packed())
+    data[32] = 2
+    assert decode_packed_registry_storage(bytes(data)) is None
+
+
+def test_decode_packed_rejects_truncated_voter_list():
+    data = _build_packed(voters=[b'\xaa' * 32])
+    assert decode_packed_registry_storage(data[:-5]) is None
+
+
+# ============================================================================
+# Mapping value decoders
+# ============================================================================
+
+
+def test_decode_repo_roundtrip():
+    decoded = decode_repo(_build_repo())
+
+    assert decoded is not None
+    assert decoded.github_id == 42
+    assert decoded.full_name == 'entrius/gittensor'
+    assert decoded.owner == b'\x07' * 32
+    assert decoded.reg_block == 999
+    assert decoded.active is True
+
+
+def test_decode_repo_inactive():
+    decoded = decode_repo(_build_repo(active=False))
+    assert decoded is not None
+    assert decoded.active is False
+
+
+def test_decode_repo_two_byte_name_length():
+    long_name = 'org/' + 'a' * 90
+    decoded = decode_repo(_build_repo(full_name=long_name))
+    assert decoded is not None
+    assert decoded.full_name == long_name
+
+
+def test_decode_repo_rejects_invalid_bytes():
+    assert decode_repo(b'\x00\x01\x02') is None
+    assert decode_repo(_build_repo() + b'\xff') is None
+    assert decode_repo(_build_repo()[:-1]) is None
+
+
+def test_decode_param_entries():
+    data = encode_compact_length(2) + struct.pack('<BQ', 1, 500_000) + struct.pack('<BQ', 17, 30)
+    assert decode_param_entries(data) == [(1, 500_000), (17, 30)]
+
+
+def test_decode_param_entries_empty_and_invalid():
+    assert decode_param_entries(encode_compact_length(0)) == []
+    assert decode_param_entries(encode_compact_length(2) + struct.pack('<BQ', 1, 500_000)) is None
+
+
+def test_decode_bounds():
+    bounds = decode_bounds(struct.pack('<QQ', 300_000, 1_000_000))
+    assert bounds is not None
+    assert bounds.min == 300_000
+    assert bounds.max == 1_000_000
+
+
+def test_decode_bounds_rejects_wrong_size():
+    assert decode_bounds(b'\x00' * 15) is None
+    assert decode_bounds(b'\x00' * 17) is None
+
+
+def test_decode_label_entries():
+    label = 'bug'.encode()
+    data = encode_compact_length(1) + encode_compact_length(len(label)) + label + struct.pack('<Q', 1_500_000)
+    assert decode_label_entries(data) == [('bug', 1_500_000)]
+
+
+def test_decode_label_entries_rejects_truncated():
+    assert decode_label_entries(encode_compact_length(1) + encode_compact_length(3) + b'bu') is None
+
+
+def test_decode_string_vec():
+    patterns = ['main', 'release/*']
+    data = encode_compact_length(len(patterns))
+    for pattern in patterns:
+        raw = pattern.encode()
+        data += encode_compact_length(len(raw)) + raw
+    assert decode_string_vec(data) == patterns
+
+
+def test_decode_basket_entries():
+    data = encode_compact_length(2) + struct.pack('<QH', 7, 30_000) + struct.pack('<QH', 42, 35_535)
+    assert decode_basket_entries(data) == [(7, 30_000), (42, 35_535)]
+
+
+def test_decode_basket_entries_empty_and_invalid():
+    assert decode_basket_entries(encode_compact_length(0)) == []
+    assert decode_basket_entries(encode_compact_length(1) + struct.pack('<Q', 7)) is None
+    assert decode_basket_entries(encode_compact_length(1) + struct.pack('<QH', 7, 1) + b'\x00') is None
+
+
+# ============================================================================
+# Read plumbing
+# ============================================================================
+
+
+def test_read_packed_registry_storage_decodes_and_pins_block_hash():
+    substrate = _FakeSubstrate('0x' + _build_packed(repo_ids=[42]).hex())
+
+    decoded = read_packed_registry_storage(substrate, '5Contract', at='0xabc123')
+
+    assert decoded is not None
+    assert decoded.repo_ids == [42]
+    child_key, storage_key, at = substrate.storage_requests[0]
+    assert child_key.startswith('0x3a6368696c645f73746f726167653a64656661756c743a')
+    assert storage_key == PACKED_ROOT_STORAGE_KEY
+    assert at == '0xabc123'
+
+
+def test_read_packed_registry_storage_returns_none_when_cell_missing():
+    substrate = _FakeSubstrate(None)
+    assert read_packed_registry_storage(substrate, '5Contract') is None

--- a/tests/validator/test_repo_registry_contract_client.py
+++ b/tests/validator/test_repo_registry_contract_client.py
@@ -1,0 +1,310 @@
+# Entrius 2025
+
+"""Tests for RepoRegistryContractClient reads and transaction methods."""
+
+import struct
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gittensor.validator.issue_competitions.storage_utils import compute_ink5_lazy_key
+from gittensor.validator.repo_registry.contract_client import (
+    DEFAULT_GAS_LIMIT,
+    REGISTER_GAS_LIMIT,
+    RepoRegistryContractClient,
+    validate_basket_entries,
+)
+from gittensor.validator.repo_registry.storage_utils import (
+    BASKETS_ROOT_KEY,
+    PACKED_ROOT_STORAGE_KEY,
+    PARAM_BOUNDS_ROOT_KEY,
+    PARAMS_ROOT_KEY,
+    REPOS_ROOT_KEY,
+    encode_compact_length,
+)
+from tests.utils.test_repo_registry_storage_utils import _build_packed, _build_repo
+
+VOTER_A = b'\xaa' * 32
+VOTER_B = b'\xbb' * 32
+
+
+class _FakeContractInfo:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeSubstrate:
+    """Serves childstate cells from a {storage_key: bytes} store."""
+
+    def __init__(self, cells):
+        self._cells = cells
+        self.storage_requests = []
+
+    def query(self, module, storage, params):
+        assert (module, storage) == ('Contracts', 'ContractInfoOf')
+        return _FakeContractInfo({'trie_id': '0x0102'})
+
+    def rpc_request(self, method, params):
+        assert method == 'childstate_getStorage'
+        self.storage_requests.append(params)
+        value = self._cells.get(params[1])
+        return {'result': '0x' + value.hex() if value else None}
+
+    def ss58_encode(self, account_hex):
+        return f'ss58:{account_hex[:8]}'
+
+    def ss58_decode(self, ss58_address):
+        return {'ss58:aaaaaaaa': VOTER_A.hex(), 'ss58:bbbbbbbb': VOTER_B.hex()}[ss58_address]
+
+    def get_block_number(self, block_hash):
+        return 200
+
+
+def _mapping_key(root_key, encoded_key):
+    return compute_ink5_lazy_key(root_key, encoded_key)
+
+
+def _make_client(cells):
+    client = RepoRegistryContractClient.__new__(RepoRegistryContractClient)
+    client.contract_address = '5FakeContract'
+    substrate = _FakeSubstrate(cells)
+    client.subtensor = SimpleNamespace(substrate=substrate, block=200)
+    return client, substrate
+
+
+@pytest.fixture()
+def wallet():
+    return SimpleNamespace(
+        hotkey=SimpleNamespace(ss58_address='5HotkeyFake'),
+        coldkey=SimpleNamespace(ss58_address='5ColdkeyFake'),
+    )
+
+
+# ============================================================================
+# Reads
+# ============================================================================
+
+
+def test_get_registry_empty_contract_returns_none():
+    client, _ = _make_client({})
+    assert client.get_registry() is None
+    assert client.get_all_repos() == []
+    assert client.get_voters() == []
+    assert client.get_all_baskets() == {}
+    assert client.quote_price() is None
+
+
+def test_get_all_repos_filters_inactive_and_missing():
+    cells = {
+        PACKED_ROOT_STORAGE_KEY: _build_packed(repo_ids=[1, 2, 3]),
+        _mapping_key(REPOS_ROOT_KEY, struct.pack('<Q', 1)): _build_repo(github_id=1, full_name='a/one'),
+        _mapping_key(REPOS_ROOT_KEY, struct.pack('<Q', 2)): _build_repo(github_id=2, full_name='a/two', active=False),
+    }
+    client, _ = _make_client(cells)
+
+    repos = client.get_all_repos()
+
+    assert [(repo.github_id, repo.full_name, repo.active) for repo in repos] == [(1, 'a/one', True)]
+    assert repos[0].owner == 'ss58:07070707'
+
+
+def test_get_all_repos_empty_registry():
+    client, _ = _make_client({PACKED_ROOT_STORAGE_KEY: _build_packed()})
+    assert client.get_all_repos() == []
+
+
+def test_reads_pin_block_hash():
+    cells = {
+        PACKED_ROOT_STORAGE_KEY: _build_packed(repo_ids=[1]),
+        _mapping_key(REPOS_ROOT_KEY, struct.pack('<Q', 1)): _build_repo(github_id=1),
+    }
+    client, substrate = _make_client(cells)
+
+    client.get_all_repos(at='0xsnapshot')
+
+    assert substrate.storage_requests
+    assert all(params[2] == '0xsnapshot' for params in substrate.storage_requests)
+
+
+def test_get_params_and_missing_default():
+    entries = encode_compact_length(1) + struct.pack('<BQ', 4, 100_000)
+    cells = {_mapping_key(PARAMS_ROOT_KEY, struct.pack('<Q', 42)): entries}
+    client, _ = _make_client(cells)
+
+    assert client.get_params(42) == {4: 100_000}
+    assert client.get_params(99) == {}
+
+
+def test_get_all_bounds_walks_bound_keys():
+    cells = {
+        PACKED_ROOT_STORAGE_KEY: _build_packed(bound_keys=[1, 7]),
+        _mapping_key(PARAM_BOUNDS_ROOT_KEY, struct.pack('<B', 1)): struct.pack('<QQ', 0, 1_000_000),
+        _mapping_key(PARAM_BOUNDS_ROOT_KEY, struct.pack('<B', 7)): struct.pack('<QQ', 300_000, 1_000_000),
+    }
+    client, _ = _make_client(cells)
+
+    bounds = client.get_all_bounds()
+
+    assert set(bounds) == {1, 7}
+    assert (bounds[7].min, bounds[7].max) == (300_000, 1_000_000)
+    assert client.get_bounds(99) is None
+
+
+def test_get_all_baskets_walks_voters():
+    basket_a = encode_compact_length(1) + struct.pack('<QH', 1, 65_535)
+    basket_b = encode_compact_length(2) + struct.pack('<QH', 1, 30_000) + struct.pack('<QH', 2, 35_535)
+    cells = {
+        PACKED_ROOT_STORAGE_KEY: _build_packed(voters=[VOTER_A, VOTER_B]),
+        _mapping_key(BASKETS_ROOT_KEY, VOTER_A): basket_a,
+        _mapping_key(BASKETS_ROOT_KEY, VOTER_B): basket_b,
+    }
+    client, _ = _make_client(cells)
+
+    baskets = client.get_all_baskets()
+
+    assert baskets == {
+        'ss58:aaaaaaaa': [(1, 65_535)],
+        'ss58:bbbbbbbb': [(1, 30_000), (2, 35_535)],
+    }
+
+
+def test_get_basket_by_hotkey_and_missing():
+    basket = encode_compact_length(1) + struct.pack('<QH', 7, 65_535)
+    cells = {_mapping_key(BASKETS_ROOT_KEY, VOTER_A): basket}
+    client, _ = _make_client(cells)
+
+    assert client.get_basket('ss58:aaaaaaaa') == [(7, 65_535)]
+    assert client.get_basket('ss58:bbbbbbbb') is None
+
+
+def test_get_voters_encodes_ss58():
+    client, _ = _make_client({PACKED_ROOT_STORAGE_KEY: _build_packed(voters=[VOTER_A])})
+    assert client.get_voters() == ['ss58:aaaaaaaa']
+
+
+def test_quote_price_uses_replica_with_pinned_block():
+    # price_last decayed from block 100 to 200 stays clamped at the floor
+    client, _ = _make_client({PACKED_ROOT_STORAGE_KEY: _build_packed(price_last=500_000_000_000, price_last_block=100)})
+    assert client.quote_price(at='0xsnapshot') == 500_000_000_000
+    assert client.quote_price() == 500_000_000_000
+
+
+def test_quote_price_decays_from_ceiling():
+    packed = _build_packed(price_last=500_000_000_000_000, price_last_block=199)
+    client, _ = _make_client({PACKED_ROOT_STORAGE_KEY: packed})
+    # delta = 1 block at launch constants — golden vector value
+    assert client.quote_price() == 499_996_561_789_885
+
+
+# ============================================================================
+# Basket validation
+# ============================================================================
+
+
+def test_validate_basket_entries_accepts_valid():
+    validate_basket_entries([(1, 30_000), (2, 35_535)])
+
+
+@pytest.mark.parametrize(
+    'entries, match',
+    [
+        ([], 'empty'),
+        ([(1, 0), (2, 65_535)], 'Zero weight'),
+        ([(1, 30_000), (1, 35_535)], 'Duplicate'),
+        ([(1, 30_000), (2, 30_000)], 'sum to 65535'),
+    ],
+)
+def test_validate_basket_entries_rejects_invalid(entries, match):
+    with pytest.raises(ValueError, match=match):
+        validate_basket_entries(entries)
+
+
+# ============================================================================
+# Transactions
+# ============================================================================
+
+
+def test_register_signs_with_coldkey(wallet):
+    client, _ = _make_client({})
+    with patch.object(client, '_exec_contract_raw', return_value=('0xdeadbeef', None)) as mock:
+        result = client.register(github_id=42, full_name='a/one', fee_hotkey='5FeeHot', wallet=wallet)
+
+    assert result == ('0xdeadbeef', None)
+    kw = mock.call_args.kwargs
+    assert kw['method_name'] == 'register'
+    assert kw['args'] == {'github_id': 42, 'full_name': 'a/one', 'fee_hotkey': '5FeeHot'}
+    assert kw['keypair'] is wallet.coldkey
+    assert kw['gas_limit'] == REGISTER_GAS_LIMIT
+
+
+def test_set_basket_signs_with_hotkey(wallet):
+    client, _ = _make_client({})
+    entries = [(1, 30_000), (2, 35_535)]
+    with patch.object(client, '_exec_contract_raw', return_value=('0xdeadbeef', None)) as mock:
+        assert client.set_basket(entries, wallet) is True
+
+    kw = mock.call_args.kwargs
+    assert kw['method_name'] == 'set_basket'
+    assert kw['args'] == {'entries': entries}
+    assert kw['keypair'] is wallet.hotkey
+    assert kw['gas_limit'] == DEFAULT_GAS_LIMIT
+
+
+def test_set_basket_rejects_invalid_entries_before_submission(wallet):
+    client, _ = _make_client({})
+    with patch.object(client, '_exec_contract_raw') as mock:
+        with pytest.raises(ValueError, match='sum to 65535'):
+            client.set_basket([(1, 1)], wallet)
+    mock.assert_not_called()
+
+
+def test_clear_basket_signs_with_hotkey(wallet):
+    client, _ = _make_client({})
+    with patch.object(client, '_exec_contract_raw', return_value=('0xdeadbeef', None)) as mock:
+        assert client.clear_basket(wallet) is True
+
+    kw = mock.call_args.kwargs
+    assert kw['method_name'] == 'clear_basket'
+    assert kw['args'] == {}
+    assert kw['keypair'] is wallet.hotkey
+
+
+@pytest.mark.parametrize('outcome', [(None, 'submission failed'), ('0xdeadbeef', 'ContractReverted')])
+def test_basket_tx_failure_and_revert_return_false(wallet, outcome):
+    client, _ = _make_client({})
+    entries = [(1, 65_535)]
+    with patch.object(client, '_exec_contract_raw', return_value=outcome):
+        assert client.set_basket(entries, wallet) is False
+        assert client.clear_basket(wallet) is False
+
+
+def test_basket_tx_exception_returns_false(wallet):
+    client, _ = _make_client({})
+    with patch.object(client, '_exec_contract_raw', side_effect=RuntimeError('node down')):
+        assert client.set_basket([(1, 65_535)], wallet) is False
+        assert client.clear_basket(wallet) is False
+
+
+# ============================================================================
+# Argument encoding
+# ============================================================================
+
+
+def test_encode_args_register():
+    client, _ = _make_client({})
+    encoded = client._encode_args('register', {'github_id': 42, 'full_name': 'a/one', 'fee_hotkey': 'ss58:aaaaaaaa'})
+    name = b'a/one'
+    assert encoded == struct.pack('<Q', 42) + encode_compact_length(len(name)) + name + VOTER_A
+
+
+def test_encode_args_set_basket():
+    client, _ = _make_client({})
+    encoded = client._encode_args('set_basket', {'entries': [(1, 30_000), (2, 35_535)]})
+    assert encoded == encode_compact_length(2) + struct.pack('<QH', 1, 30_000) + struct.pack('<QH', 2, 35_535)
+
+
+def test_encode_args_missing_argument_raises():
+    client, _ = _make_client({})
+    with pytest.raises(ValueError, match='Missing argument'):
+        client._encode_args('register', {'github_id': 42})

--- a/tests/validator/test_repo_registry_price.py
+++ b/tests/validator/test_repo_registry_price.py
@@ -1,0 +1,82 @@
+# Entrius 2025
+
+"""Golden-vector tests for the repos-v0 price replica (must match tests.rs exactly)."""
+
+import pytest
+
+from gittensor.validator.repo_registry.price import (
+    HALF_Q32,
+    ONE_Q32,
+    U64_MAX,
+    decay_factor_q32,
+    lazy_price,
+    mul_by_q32,
+    pow_q32,
+)
+
+GOLDEN_HALF_LIFE = 100_800
+GOLDEN_FLOOR = 500_000_000_000
+GOLDEN_CEILING = 500_000_000_000_000
+
+# (price_last, delta_blocks, expected_quote) — mirrors PRICE_GOLDEN in
+# smart-contracts/repos-v0/tests.rs byte-for-byte.
+PRICE_GOLDEN = [
+    (500_000_000_000, 0, 500_000_000_000),
+    (500_000_000_000, 100_800, 500_000_000_000),
+    (1_000_000_000_000, 100_800, 500_000_000_000),
+    (500_000_000_000_000, 1, 499_996_561_789_885),
+    (500_000_000_000_000, 50_400, 353_551_803_971_640),
+    (500_000_000_000_000, 100_800, 250_000_000_000_000),
+    (500_000_000_000_000, 201_600, 125_000_000_000_000),
+    (500_000_000_000_000, 252_000, 88_387_950_992_910),
+    (500_000_000_000_000, 6_451_200, 500_000_000_000),
+    (123_456_789_012_345, 12_345, 113_408_938_323_092),
+    (600_000_000_000_000, 0, 500_000_000_000_000),
+    (400_000_000_000, 0, 500_000_000_000),
+    (2_000_000_000_000, 33_600, 1_587_396_302_726),
+    (2_000_000_000_000, 302_400, 500_000_000_000),
+]
+
+# decay_factor_q32(100_800) — golden constant shared with the contract.
+DECAY_FACTOR_GOLDEN = 4_294_937_762
+
+
+@pytest.mark.parametrize('last, delta, expected', PRICE_GOLDEN)
+def test_price_golden_vectors(last, delta, expected):
+    assert lazy_price(last, delta, GOLDEN_HALF_LIFE, GOLDEN_FLOOR, GOLDEN_CEILING) == expected
+
+
+def test_decay_factor_golden():
+    assert decay_factor_q32(GOLDEN_HALF_LIFE) == DECAY_FACTOR_GOLDEN
+
+
+def test_mul_by_q32_basics():
+    assert mul_by_q32(1_000, ONE_Q32) == 1_000
+    assert mul_by_q32(1_000, HALF_Q32) == 500
+    assert mul_by_q32(U64_MAX, U64_MAX) == U64_MAX
+    assert mul_by_q32(0, U64_MAX) == 0
+
+
+def test_pow_q32_basics():
+    assert pow_q32(HALF_Q32, 0) == ONE_Q32
+    assert pow_q32(HALF_Q32, 1) == HALF_Q32
+    assert pow_q32(HALF_Q32, 3) == 1 << 29
+
+
+def test_decay_factor_edge_cases():
+    assert decay_factor_q32(0) == ONE_Q32
+    assert decay_factor_q32(1) == HALF_Q32
+
+
+def test_lazy_price_zero_half_life_only_clamps():
+    assert lazy_price(700, 1_000_000, 0, 100, 500) == 500
+    assert lazy_price(50, 1_000_000, 0, 100, 500) == 100
+
+
+def test_lazy_price_huge_delta_hits_floor():
+    delta = GOLDEN_HALF_LIFE * 64
+    assert lazy_price(GOLDEN_CEILING, delta, GOLDEN_HALF_LIFE, GOLDEN_FLOOR, GOLDEN_CEILING) == GOLDEN_FLOOR
+
+
+def test_price_bump_doubles():
+    assert mul_by_q32(1_000, 2 << 32) == 2_000


### PR DESCRIPTION
Part of repo-registration phase 2a (task 2a-3). Stacked on #1665 (repos-v0 crate) — merge that first; this PR's diff is python-only once #1665 lands.

New package `gittensor/validator/repo_registry/`, lifting issues-v0 patterns:

- `contract_client.py` — `RepoRegistryContractClient`: childstate-only reads (registry config, repos, params, bounds, labels, patterns, baskets, voters), every read accepts an `at` block hash for the 2a-4 ContractBackend's block-pinned determinism; txs `register` (coldkey-signed), `set_basket`/`clear_basket` (hotkey-signed) with pre-flight basket validation
- `price.py` — exact integer port of the contract's Q32 price curve; reproduces all 14 `PRICE_GOLDEN` vectors and `DECAY_FACTOR_GOLDEN` from the crate's test suite
- `storage_utils.py` — packed-root + mapping decoders (strict: truncated/trailing/invalid input decodes to None, never garbage — these values feed consensus), pure-python XXH32 root-key derivation per ink! 5 `KeyComposer` (anchored by a unit test that reproduces issues-v0's hardcoded `52789899` key)
- `update_metadata.py` + `metadata.json` — selectors derived via blake2b(label)[..4] without requiring `cargo contract build`; cross-checks the built artifact when present

Notable divergences from issues-v0 (rationale in code):
- reads are block-hash-pinned; issues-v0 always reads head
- decoders are strict, not tolerant
- `quote_price` computed via the python replica instead of a state_call dry-run (read path stays childstate-only per spec)

Tests: 77 new (golden vectors, byte-fixture decode, `at` propagation, basket validation edges); full repo suite 1037 passed; ruff clean.