### PR TITLE
Rework weight_consensus onto contract Backend protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ docker-compose -f docker-compose.vali.yml up -d
 
 See full guide **[here](https://docs.gittensor.io/validator.html)**
 
+### Repository Weight Consensus
+
+Repository emission shares are voted by validators, not hardcoded: each whitelisted validator publishes a basket of up to 10 registered repos to the repos-v0 registry contract (`set_basket`, signed by the hotkey), and every validator applies the stake-weighted mean of all eligible baskets (vpermit + 30k alpha), aggregated at a fixed snapshot block twice a day and pinned to that block's hash, so all validators derive identical weights. Validators without a basket run on the aggregate with a warning. If the contract is paused or unreachable, scoring falls back to the last-good aggregate, then the baked-in repository weights.
+
 ## Reward Algorithm
 
 ### Important Structures

--- a/gittensor/utils/config.py
+++ b/gittensor/utils/config.py
@@ -141,6 +141,20 @@ def add_validator_args(cls, parser):
     )
 
     parser.add_argument(
+        '--neuron.consensus_prefs_path',
+        type=str,
+        help='Path to the repo weight preferences JSON voted on chain. Defaults to <neuron.full_path>/repo_weight_prefs.json.',
+        default=None,
+    )
+
+    parser.add_argument(
+        '--neuron.disable_weight_consensus',
+        action='store_true',
+        help='Disables validator-voted repo weight consensus; scoring uses the baked-in repository weights.',
+        default=False,
+    )
+
+    parser.add_argument(
         '--wandb.project_name',
         type=str,
         help='The name of the project where you are sending the new run.',

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -23,6 +23,7 @@ from gittensor.validator.utils.load_weights import (
     load_programming_language_weights,
     load_token_config,
 )
+from gittensor.validator.weight_consensus import run_weight_consensus
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -40,14 +41,18 @@ async def forward(self: 'Validator') -> None:
 
     Emission blending:
     - Combined scoring pool: 90%, allocated by repository emission_share
+      (validator-voted consensus aggregate when active, baked-in weights otherwise)
     - Maintainer cut:        per-repo carve-out routed to maintainer miner neurons
     - Issue treasury:       10%, flat to UID 111
     - Recycle:              registry slack and inactive repo slices to UID 0
     """
 
+    if self.consensus_manager is not None:
+        self.consensus_manager.maybe_refresh(self.block)
+
     if self.step % VALIDATOR_STEPS_INTERVAL == 0:
         miner_uids = get_all_uids(self)
-        master_repositories = load_master_repo_weights()
+        master_repositories = run_weight_consensus(self, load_master_repo_weights())
         programming_languages = load_programming_language_weights()
         token_config = load_token_config()
 

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -5,6 +5,14 @@ import bittensor as bt
 VALIDATOR_WAIT = 60  # 60 seconds
 VALIDATOR_STEPS_INTERVAL = 120  # 2 hours, every time a scoring round happens
 
+# Weight consensus: validator-voted repository emission shares via the repos-v0 contract.
+# Tunables below are provisional team defaults — each is a one-line change.
+CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS = 3600  # ~12h @ 12s/block, aggregate recomputed 2x/day
+CONSENSUS_MIN_VALIDATOR_STAKE_RAO = 30_000 * 10**9  # 30k alpha voter threshold
+CONSENSUS_MAX_REPOS = 10  # max repos per validator basket
+CONSENSUS_CACHE_KEEP = 8  # snapshots retained in the disk cache
+CONSENSUS_WEIGHT_PRECISION = 10**12  # fixed-point scale for deterministic int math
+
 # required env vars
 GITTENSOR_VALIDATOR_PAT = os.getenv('GITTENSOR_VALIDATOR_PAT')
 WANDB_API_KEY = os.getenv('WANDB_API_KEY')
@@ -13,6 +21,7 @@ WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 
 # optional env vars
 STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'
+REPO_REGISTRY_CONTRACT_ADDRESS = os.getenv('REPO_REGISTRY_CONTRACT_ADDRESS')
 
 # log values
 bt.logging.info(f'VALIDATOR_WAIT: {VALIDATOR_WAIT}')

--- a/gittensor/validator/utils/storage.py
+++ b/gittensor/validator/utils/storage.py
@@ -1,13 +1,17 @@
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import bittensor as bt
 
 from gittensor.classes import Miner, MinerEvaluation
 from gittensor.validator.storage.database import create_database_connection
 from gittensor.validator.storage.repository import Repository
+from gittensor.validator.utils.config import CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS
 from gittensor.validator.utils.load_weights import RepositoryConfig
+
+WEIGHT_CONSENSUS_SNAPSHOT_RETENTION = 30  # snapshots kept for dashboard history
 
 
 @dataclass
@@ -27,6 +31,51 @@ class DatabaseStorage:
 
     def is_enabled(self) -> bool:
         return self.db_connection is not None
+
+    def store_weight_consensus(
+        self, snapshot_block: int, baskets: List[Tuple[str, int, Dict[str, int]]], result
+    ) -> None:
+        """Persist one snapshot's validator baskets + aggregate shares.
+
+        baskets: (hotkey, stake_rao, validated prefs) per eligible voter. Rows
+        are replaced per snapshot and pruned past the retention window.
+        Failures are the caller's to swallow — consensus never depends on this.
+        """
+        if not self.is_enabled():
+            return
+        assert self.db_connection is not None
+
+        cutoff = snapshot_block - WEIGHT_CONSENSUS_SNAPSHOT_RETENTION * CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS
+        try:
+            with self.db_connection.cursor() as cur:
+                cur.execute(
+                    'DELETE FROM validator_weight_baskets WHERE snapshot_block = %s OR snapshot_block < %s',
+                    (snapshot_block, cutoff),
+                )
+                cur.executemany(
+                    'INSERT INTO validator_weight_baskets (snapshot_block, hotkey, stake_rao, basket) VALUES (%s, %s, %s, %s)',
+                    [(snapshot_block, hotkey, stake_rao, json.dumps(prefs)) for hotkey, stake_rao, prefs in baskets],
+                )
+                cur.execute(
+                    'DELETE FROM repo_weight_consensus WHERE snapshot_block = %s OR snapshot_block < %s',
+                    (snapshot_block, cutoff),
+                )
+                cur.execute(
+                    'INSERT INTO repo_weight_consensus (snapshot_block, gate_passed, shares, eligible_stake_rao, valid_stake_rao, voter_count) '
+                    'VALUES (%s, %s, %s, %s, %s, %s)',
+                    (
+                        snapshot_block,
+                        result.shares is not None,
+                        json.dumps(result.shares or {}),
+                        result.eligible_stake_rao,
+                        result.valid_stake_rao,
+                        result.voter_count,
+                    ),
+                )
+            self.db_connection.commit()
+        except Exception:
+            self.db_connection.rollback()
+            raise
 
     def store_evaluation(
         self, miner_eval: MinerEvaluation, master_repositories: Dict[str, RepositoryConfig]

--- a/gittensor/validator/weight_consensus/__init__.py
+++ b/gittensor/validator/weight_consensus/__init__.py
@@ -1,0 +1,9 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+from gittensor.validator.weight_consensus.backend import ConsensusBackend
+from gittensor.validator.weight_consensus.consensus import apply_consensus
+from gittensor.validator.weight_consensus.contract_backend import ContractBackend
+from gittensor.validator.weight_consensus.manager import ConsensusManager, run_weight_consensus
+
+__all__ = ['ConsensusBackend', 'ConsensusManager', 'ContractBackend', 'apply_consensus', 'run_weight_consensus']

--- a/gittensor/validator/weight_consensus/backend.py
+++ b/gittensor/validator/weight_consensus/backend.py
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Transport protocol between the consensus core and its data sources.
+
+Baskets/registry come from the repos-v0 contract; stakes/permits stay a
+runtime (metagraph) concern but sit behind the same protocol for symmetry.
+Snapshot reads MUST be pinned to the snapshot block's hash so every validator
+aggregates over byte-identical state even across reorgs.
+"""
+
+from typing import Dict, Optional, Protocol, Tuple
+
+
+class ConsensusBackend(Protocol):
+    def fetch_registry(self, snapshot: int) -> Dict[int, str]:
+        """Active repos at the snapshot block: github_id -> full_name."""
+        ...
+
+    def fetch_baskets(self, snapshot: int) -> Dict[str, Dict[str, int]]:
+        """All whitelisted voters' baskets at the snapshot block:
+        hotkey_ss58 -> {full_name: weight}."""
+        ...
+
+    def fetch_own_basket(self) -> Optional[Dict[str, int]]:
+        """The validator's currently published basket, name-keyed, if any."""
+        ...
+
+    def publish_basket(self, prefs: Dict[str, int]) -> bool:
+        """Publish the canonical preference vector; True when on-chain state
+        matches the desired prefs on exit."""
+        ...
+
+    def fetch_stakes_and_permits(self, snapshot: int) -> Tuple[Dict[str, int], Dict[str, bool]]:
+        """Metagraph state at the snapshot block: (hotkey -> stake rao,
+        hotkey -> validator permit)."""
+        ...

--- a/gittensor/validator/weight_consensus/codec.py
+++ b/gittensor/validator/weight_consensus/codec.py
@@ -1,0 +1,76 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Canonical form for repo weight preference vectors.
+
+Baskets live on-chain as structured (github_id, u16 weight) arrays in the
+repos-v0 contract — there is no wire codec. This module quantizes local
+preferences into the canonical client-side form and validates structured
+baskets read back from the contract.
+"""
+
+import re
+from typing import Any, Dict, Mapping, Optional
+
+from gittensor.validator.utils.config import CONSENSUS_MAX_REPOS
+
+U16_MAX = 65535
+_REPO_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9\-_.]*/[a-z0-9\-_.]+$')
+
+
+class CodecError(ValueError):
+    """Raised when local preferences cannot be canonicalized into a valid basket."""
+
+
+def canonicalize_prefs(raw: Mapping[str, float]) -> Dict[str, int]:
+    """Normalize local preferences into the canonical on-chain form.
+
+    Lowercases names (merging duplicates), keeps the top CONSENSUS_MAX_REPOS by
+    weight, and quantizes to u16 integers summing exactly U16_MAX via largest
+    remainder. Deterministic: all ties break lexicographically.
+    """
+    merged: Dict[str, float] = {}
+    for name, weight in raw.items():
+        if not isinstance(weight, (int, float)) or weight <= 0:
+            continue
+        key = str(name).strip().lower()
+        merged[key] = merged.get(key, 0.0) + float(weight)
+
+    for name in merged:
+        if not _REPO_NAME_RE.match(name):
+            raise CodecError(f'Invalid repository name: {name!r}')
+
+    top = sorted(merged.items(), key=lambda kv: (-kv[1], kv[0]))[:CONSENSUS_MAX_REPOS]
+    if not top:
+        raise CodecError('No repositories with positive weight to encode')
+
+    total = sum(w for _, w in top)
+    floors = {name: int(w * U16_MAX // total) for name, w in top}
+    remainders = sorted(top, key=lambda kv: (-(kv[1] * U16_MAX / total - floors[kv[0]]), kv[0]))
+    for name, _ in remainders[: U16_MAX - sum(floors.values())]:
+        floors[name] += 1
+
+    return {name: floors[name] for name in sorted(floors) if floors[name] > 0}
+
+
+def validate_prefs(prefs: Any) -> Optional[Dict[str, int]]:
+    """Validate a structured basket into canonical preferences.
+
+    Returns None on ANY invalidity — a bad basket disqualifies the voter,
+    never raises. Zero weights are dropped; an empty result is invalid.
+    """
+    if not isinstance(prefs, Mapping) or not 0 < len(prefs) <= CONSENSUS_MAX_REPOS:
+        return None
+
+    valid: Dict[str, int] = {}
+    seen = set()
+    for name, weight in prefs.items():
+        if not isinstance(name, str) or isinstance(weight, bool) or not isinstance(weight, int):
+            return None
+        name = name.lower()
+        if not _REPO_NAME_RE.match(name) or not 0 <= weight <= U16_MAX or name in seen:
+            return None
+        seen.add(name)
+        if weight > 0:
+            valid[name] = weight
+
+    return {name: valid[name] for name in sorted(valid)} if valid else None

--- a/gittensor/validator/weight_consensus/consensus.py
+++ b/gittensor/validator/weight_consensus/consensus.py
@@ -1,0 +1,113 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Deterministic aggregation of validator repo weight preferences.
+
+Every validator computes this over the identical chain snapshot, so the math
+runs entirely in python big-ints — floats appear only in the final division of
+identical integers, guaranteeing byte-identical shares on every machine.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Dict, Mapping, Optional
+
+from gittensor.validator.utils.config import (
+    CONSENSUS_MIN_VALIDATOR_STAKE_RAO,
+    CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS,
+    CONSENSUS_WEIGHT_PRECISION,
+)
+from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.weight_consensus.codec import validate_prefs
+
+
+@dataclass(frozen=True)
+class AggregateResult:
+    """Outcome of one snapshot aggregation.
+
+    ``shares`` is None when the activation gate failed — callers fall back to
+    the baked-in repository weights. ``numerators`` are the exact integers the
+    disk cache persists so a reload reproduces identical float shares.
+    """
+
+    shares: Optional[Dict[str, float]]
+    numerators: Dict[str, int]
+    eligible_stake_rao: int
+    valid_stake_rao: int
+    voter_count: int
+
+
+def compute_snapshot_block(block: int) -> int:
+    return block - (block % CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS)
+
+
+def aggregate_preferences(
+    baskets: Mapping[str, Mapping[str, int]],
+    stakes_rao: Mapping[str, int],
+    validator_permits: Mapping[str, bool],
+) -> AggregateResult:
+    """Stake-weighted mean of eligible validators' preference vectors.
+
+    Eligible voters hold a validator permit and >= the stake threshold at the
+    snapshot block. Each valid vector is normalized to sum 1.0 in fixed-point
+    (``S_rao * w * PREC // W_v``) before the stake-weighted accumulation, so a
+    voter's influence is exactly proportional to stake. The activation gate
+    passes when valid voters hold at least half the eligible stake.
+    """
+    eligible_stake = 0
+    valid_stake = 0
+    voter_count = 0
+    numerators: Dict[str, int] = {}
+
+    for hotkey in sorted(stakes_rao):
+        stake = stakes_rao[hotkey]
+        if not validator_permits.get(hotkey) or stake < CONSENSUS_MIN_VALIDATOR_STAKE_RAO:
+            continue
+        eligible_stake += stake
+
+        prefs = validate_prefs(baskets.get(hotkey))
+        if prefs is None:
+            continue
+
+        valid_stake += stake
+        voter_count += 1
+        basket_total = sum(prefs.values())
+        for repo, weight in prefs.items():
+            numerators[repo] = numerators.get(repo, 0) + stake * weight * CONSENSUS_WEIGHT_PRECISION // basket_total
+
+    gate_passed = eligible_stake > 0 and valid_stake * 2 >= eligible_stake and numerators
+    return AggregateResult(
+        shares=shares_from_numerators(numerators) if gate_passed else None,
+        numerators=numerators,
+        eligible_stake_rao=eligible_stake,
+        valid_stake_rao=valid_stake,
+        voter_count=voter_count,
+    )
+
+
+def shares_from_numerators(numerators: Mapping[str, int]) -> Dict[str, float]:
+    """Convert integer numerators to float shares summing ~1.0. Deterministic:
+    identical ints divide to identical doubles on every platform."""
+    total = sum(numerators.values())
+    return {repo: numerators[repo] / total for repo in sorted(numerators)}
+
+
+def apply_consensus(
+    master: Dict[str, RepositoryConfig],
+    shares: Optional[Mapping[str, float]],
+) -> Dict[str, RepositoryConfig]:
+    """Overlay consensus shares onto the baked repository registry.
+
+    None shares (gate failed / no aggregate) leaves the registry untouched.
+    Otherwise the aggregate is the complete share vector: registry repos keep
+    their tuned config with the share overridden (0.0 when unvoted — the
+    aggregate sums to 1.0, keeping baked shares would double-count), and novel
+    repos enter with default config.
+    """
+    if shares is None:
+        return master
+
+    return {
+        name: replace(master[name], emission_share=shares.get(name, 0.0))
+        if name in master
+        else RepositoryConfig(emission_share=shares[name])
+        for name in sorted(set(master) | set(shares))
+    }

--- a/gittensor/validator/weight_consensus/contract_backend.py
+++ b/gittensor/validator/weight_consensus/contract_backend.py
@@ -1,0 +1,89 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Contract-backed transport for the weight consensus.
+
+Snapshot reads resolve the snapshot block to its HASH once and pin every
+childstate read to it, so all validators aggregate over byte-identical state
+even across reorgs. Publishing signs ``set_basket`` with the validator hotkey;
+repo names resolve to github ids through the registry at a single head hash.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import bittensor as bt
+
+from gittensor.validator.repo_registry.contract_client import RepoRegistryContractClient
+from gittensor.validator.weight_consensus.codec import canonicalize_prefs
+
+
+class ContractBackend:
+    """ConsensusBackend over the repos-v0 registry contract."""
+
+    def __init__(self, client: RepoRegistryContractClient, subtensor: 'bt.Subtensor', wallet: 'bt.Wallet', netuid: int):
+        self.client = client
+        self.subtensor = subtensor
+        self.wallet = wallet
+        self.netuid = netuid
+
+    def _snapshot_hash(self, snapshot: int) -> str:
+        block_hash = self.subtensor.substrate.get_block_hash(snapshot)
+        if not block_hash:
+            raise RuntimeError(f'No block hash for snapshot block {snapshot}')
+        return block_hash
+
+    def _registry_at(self, at: str) -> Dict[int, str]:
+        return {repo.github_id: repo.full_name for repo in self.client.get_all_repos(at=at)}
+
+    def _resolve_names(self, entries: List[Tuple[int, int]], names: Dict[int, str]) -> Dict[str, int]:
+        """Map basket entries to name-keyed prefs, dropping deregistered ids.
+        Weights accumulate should two ids ever share a name."""
+        prefs: Dict[str, int] = {}
+        for github_id, weight in entries:
+            name = names.get(github_id)
+            if name is not None:
+                prefs[name] = prefs.get(name, 0) + weight
+        return prefs
+
+    def fetch_registry(self, snapshot: int) -> Dict[int, str]:
+        return self._registry_at(self._snapshot_hash(snapshot))
+
+    def fetch_baskets(self, snapshot: int) -> Dict[str, Dict[str, int]]:
+        at = self._snapshot_hash(snapshot)
+        names = self._registry_at(at)
+        baskets = {}
+        for hotkey, entries in self.client.get_all_baskets(at=at).items():
+            prefs = self._resolve_names(entries, names)
+            if prefs:
+                baskets[hotkey] = prefs
+        return baskets
+
+    def fetch_own_basket(self) -> Optional[Dict[str, int]]:
+        at = self.subtensor.substrate.get_chain_head()
+        entries = self.client.get_basket(self.wallet.hotkey.ss58_address, at=at)
+        if not entries:
+            return None
+        return self._resolve_names(entries, self._registry_at(at)) or None
+
+    def publish_basket(self, prefs: Dict[str, int]) -> bool:
+        at = self.subtensor.substrate.get_chain_head()
+        ids = {name: github_id for github_id, name in sorted(self._registry_at(at).items())}
+
+        unknown = sorted(set(prefs) - set(ids))
+        if unknown:
+            bt.logging.warning(f'weight_consensus: dropping unregistered repos from basket: {", ".join(unknown)}')
+            prefs = {name: weight for name, weight in prefs.items() if name in ids}
+            if not prefs:
+                return False
+            prefs = canonicalize_prefs(prefs)
+
+        entries = sorted((ids[name], weight) for name, weight in prefs.items())
+        current = self.client.get_basket(self.wallet.hotkey.ss58_address, at=at)
+        if current is not None and sorted(current) == entries:
+            return True
+        return self.client.set_basket(entries, self.wallet)
+
+    def fetch_stakes_and_permits(self, snapshot: int) -> Tuple[Dict[str, int], Dict[str, bool]]:
+        metagraph = self.subtensor.metagraph(self.netuid, block=snapshot, lite=True)
+        stakes_rao = {hk: int(round(float(metagraph.S[uid]) * 1e9)) for uid, hk in enumerate(metagraph.hotkeys)}
+        permits = {hk: bool(metagraph.validator_permit[uid]) for uid, hk in enumerate(metagraph.hotkeys)}
+        return stakes_rao, permits

--- a/gittensor/validator/weight_consensus/manager.py
+++ b/gittensor/validator/weight_consensus/manager.py
@@ -1,0 +1,147 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Snapshot lifecycle for the repo weight consensus.
+
+Aggregates are computed opportunistically right after each snapshot boundary
+and persisted to disk as integer numerators, so restarts and an unreachable
+contract fall back to the last-good aggregate instead of diverging or
+crashing. Transport problems degrade, never raise.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+import bittensor as bt
+
+from gittensor.validator.utils.config import CONSENSUS_CACHE_KEEP
+from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.weight_consensus.backend import ConsensusBackend
+from gittensor.validator.weight_consensus.consensus import (
+    AggregateResult,
+    aggregate_preferences,
+    apply_consensus,
+    compute_snapshot_block,
+    shares_from_numerators,
+)
+from gittensor.validator.weight_consensus.publisher import maybe_publish_prefs, resolve_local_prefs
+
+StoreHook = Callable[[int, Dict[str, Dict[str, int]], Dict[str, int], Dict[str, bool], AggregateResult], None]
+
+
+class ConsensusManager:
+    """Computes, caches, and serves the per-snapshot aggregate."""
+
+    def __init__(self, backend: ConsensusBackend, cache_dir: Path, store_hook: Optional[StoreHook] = None):
+        self.backend = backend
+        self.cache_path = Path(cache_dir) / 'weight_consensus_cache.json'
+        self.store_hook = store_hook
+        self._failed_snapshots: set = set()
+        self._cache: Dict[str, Any] = self._load_cache()
+
+    def maybe_refresh(self, block: int) -> None:
+        """Cheap per-step tick: compute the current snapshot once, early."""
+        snapshot = compute_snapshot_block(block)
+        if str(snapshot) in self._cache or snapshot in self._failed_snapshots:
+            return
+        try:
+            self._compute_and_persist(snapshot)
+        except Exception as e:
+            bt.logging.debug(f'weight_consensus: snapshot {snapshot} refresh failed ({e}); retrying next step')
+
+    def get_shares(self, block: int) -> Optional[Dict[str, float]]:
+        """Aggregate shares for the current snapshot, last-good when the
+        backend is unreachable, None when nothing is available or the
+        activation gate failed."""
+        snapshot = compute_snapshot_block(block)
+        entry = self._cache.get(str(snapshot))
+
+        if entry is None and snapshot not in self._failed_snapshots:
+            try:
+                entry = self._compute_and_persist(snapshot)
+            except Exception as e:
+                self._failed_snapshots.add(snapshot)
+                bt.logging.warning(f'weight_consensus: snapshot {snapshot} compute failed ({e})')
+
+        if entry is None:
+            previous = [int(b) for b in self._cache if int(b) < snapshot]
+            if previous:
+                entry = self._cache[str(max(previous))]
+                bt.logging.warning(f'weight_consensus: using last-good aggregate from snapshot {max(previous)}')
+
+        if entry is None or not entry['gate_passed']:
+            return None
+        return shares_from_numerators({repo: int(n) for repo, n in entry['numerators'].items()})
+
+    def _compute_and_persist(self, snapshot: int) -> Dict[str, Any]:
+        baskets = self.backend.fetch_baskets(snapshot)
+        stakes_rao, permits = self.backend.fetch_stakes_and_permits(snapshot)
+
+        result = aggregate_preferences(baskets, stakes_rao, permits)
+        entry = {
+            'gate_passed': result.shares is not None,
+            'numerators': result.numerators,
+            'eligible_stake_rao': result.eligible_stake_rao,
+            'valid_stake_rao': result.valid_stake_rao,
+            'voter_count': result.voter_count,
+        }
+        self._cache[str(snapshot)] = entry
+        self._save_cache()
+        bt.logging.info(
+            f'weight_consensus: snapshot {snapshot} aggregated — {result.voter_count} voters, '
+            f'gate {"passed" if entry["gate_passed"] else "FAILED (using baked weights)"}'
+        )
+
+        if self.store_hook is not None:
+            try:
+                self.store_hook(snapshot, baskets, stakes_rao, permits, result)
+            except Exception as e:
+                bt.logging.warning(f'weight_consensus: snapshot store hook failed ({e})')
+        return entry
+
+    def _load_cache(self) -> Dict[str, Any]:
+        try:
+            if self.cache_path.exists():
+                return json.loads(self.cache_path.read_text())
+        except (OSError, ValueError) as e:
+            bt.logging.warning(f'weight_consensus: corrupt cache {self.cache_path} ({e}); starting fresh')
+        return {}
+
+    def _save_cache(self) -> None:
+        keep = sorted(self._cache, key=int)[-CONSENSUS_CACHE_KEEP:]
+        self._cache = {block: self._cache[block] for block in keep}
+        try:
+            tmp_path = self.cache_path.with_suffix('.tmp')
+            tmp_path.write_text(json.dumps(self._cache))
+            os.replace(tmp_path, self.cache_path)
+        except OSError as e:
+            bt.logging.warning(f'weight_consensus: cache write failed ({e})')
+
+
+def run_weight_consensus(validator, master: Dict[str, RepositoryConfig]) -> Dict[str, RepositoryConfig]:
+    """Forward-seam orchestrator: publish own vote, fetch the aggregate, overlay
+    it on the baked registry. Any failure returns the registry untouched."""
+    manager: Optional[ConsensusManager] = getattr(validator, 'consensus_manager', None)
+    if getattr(validator.config.neuron, 'disable_weight_consensus', False) or manager is None:
+        return master
+
+    try:
+        prefs_path = Path(
+            validator.config.neuron.consensus_prefs_path
+            or Path(validator.config.neuron.full_path) / 'repo_weight_prefs.json'
+        )
+        prefs = resolve_local_prefs(prefs_path, master)
+        if not maybe_publish_prefs(manager.backend, prefs):
+            bt.logging.warning(
+                'weight_consensus: no preference vector on chain — running as bystander on the '
+                'aggregate. Future releases may require participation.'
+            )
+
+        shares = manager.get_shares(validator.block)
+        if shares is None:
+            bt.logging.info('weight_consensus: no active aggregate; using baked-in repository weights')
+        return apply_consensus(master, shares)
+    except Exception as e:
+        bt.logging.error(f'weight_consensus: unexpected failure ({e}); using baked-in repository weights')
+        return master

--- a/gittensor/validator/weight_consensus/publisher.py
+++ b/gittensor/validator/weight_consensus/publisher.py
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Publishes the validator's own repo weight preferences to the contract."""
+
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+import bittensor as bt
+
+from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.weight_consensus.backend import ConsensusBackend
+from gittensor.validator.weight_consensus.codec import CodecError, canonicalize_prefs
+
+
+def resolve_local_prefs(prefs_path: Optional[Path], master: Dict[str, RepositoryConfig]) -> Dict[str, int]:
+    """The validator's desired vote in canonical form.
+
+    Reads ``{"version": 1, "repos": {"owner/repo": weight}}`` from prefs_path;
+    a missing or invalid file falls back to voting the baked-in registry shares.
+    """
+    if prefs_path is not None and prefs_path.exists():
+        try:
+            data = json.loads(prefs_path.read_text())
+            return canonicalize_prefs(data['repos'])
+        except (OSError, ValueError, KeyError, TypeError, CodecError) as e:
+            bt.logging.warning(f'weight_consensus: invalid prefs file {prefs_path} ({e}); voting baked-in shares')
+
+    return canonicalize_prefs({name: cfg.emission_share for name, cfg in master.items() if cfg.emission_share > 0})
+
+
+def maybe_publish_prefs(backend: ConsensusBackend, prefs: Dict[str, int]) -> bool:
+    """Publish prefs unless the identical vector is already on chain.
+
+    Returns True when the on-chain basket matches the desired prefs on exit;
+    failures warn and retry next round.
+    """
+    try:
+        if backend.fetch_own_basket() == prefs:
+            return True
+        if backend.publish_basket(prefs):
+            bt.logging.info(f'weight_consensus: published preference vector ({len(prefs)} repos)')
+            return True
+        bt.logging.warning('weight_consensus: basket publish rejected; will retry next round')
+    except Exception as e:
+        bt.logging.warning(f'weight_consensus: basket publish failed ({e}); will retry next round')
+    return False

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -19,11 +19,12 @@
 import os
 import time
 from functools import partial
-from typing import Dict, List, Set
+from pathlib import Path
+from typing import Dict, List, Optional, Set
 
 import bittensor as bt
-import wandb
 
+import wandb
 from gittensor import __version__
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache
 from gittensor.validator import pat_storage
@@ -36,9 +37,18 @@ from gittensor.validator.pat_handler import (
     priority_pat_broadcast,
     priority_pat_check,
 )
-from gittensor.validator.utils.config import STORE_DB_RESULTS, WANDB_PROJECT, WANDB_VALIDATOR_NAME
+from gittensor.validator.repo_registry.contract_client import RepoRegistryContractClient
+from gittensor.validator.utils.config import (
+    CONSENSUS_MIN_VALIDATOR_STAKE_RAO,
+    REPO_REGISTRY_CONTRACT_ADDRESS,
+    STORE_DB_RESULTS,
+    WANDB_PROJECT,
+    WANDB_VALIDATOR_NAME,
+)
 from gittensor.validator.utils.load_weights import RepositoryConfig
 from gittensor.validator.utils.storage import DatabaseStorage
+from gittensor.validator.weight_consensus import ConsensusManager, ContractBackend
+from gittensor.validator.weight_consensus.codec import validate_prefs
 from neurons.base.validator import BaseValidatorNeuron
 
 
@@ -83,6 +93,8 @@ class Validator(BaseValidatorNeuron):
             bt.logging.warning('Validation result storage enabled.')
             self.db_storage = DatabaseStorage()
 
+        self.consensus_manager = self._init_consensus_manager()
+
         # Initialize wandb only if disable_set_weights is False
         if not self.config.neuron.disable_set_weights:
             try:
@@ -98,6 +110,36 @@ class Validator(BaseValidatorNeuron):
 
         bt.logging.info('load_state()')
         self.load_state()
+
+    def _init_consensus_manager(self) -> Optional[ConsensusManager]:
+        """Wire the contract-backed weight consensus; None disables it (baked weights)."""
+        if self.config.neuron.disable_weight_consensus:
+            return None
+        if not REPO_REGISTRY_CONTRACT_ADDRESS:
+            bt.logging.warning('weight_consensus: REPO_REGISTRY_CONTRACT_ADDRESS not set; using baked-in weights')
+            return None
+        try:
+            client = RepoRegistryContractClient(REPO_REGISTRY_CONTRACT_ADDRESS, self.subtensor)
+            backend = ContractBackend(client, self.subtensor, self.wallet, self.config.netuid)
+            return ConsensusManager(
+                backend=backend,
+                cache_dir=Path(self.config.neuron.full_path),
+                store_hook=self._store_weight_consensus if self.db_storage else None,
+            )
+        except Exception as e:
+            bt.logging.warning(f'weight_consensus: backend init failed ({e}); using baked-in weights')
+            return None
+
+    def _store_weight_consensus(self, snapshot_block, baskets, stakes_rao, permits, result) -> None:
+        """Persist eligible voters' baskets and the aggregate for the dashboards."""
+        rows = [
+            (hotkey, stakes_rao[hotkey], prefs)
+            for hotkey, basket in sorted(baskets.items())
+            if permits.get(hotkey)
+            and stakes_rao.get(hotkey, 0) >= CONSENSUS_MIN_VALIDATOR_STAKE_RAO
+            and (prefs := validate_prefs(basket)) is not None
+        ]
+        self.db_storage.store_weight_consensus(snapshot_block, rows, result)
 
     async def bulk_store_evaluation(
         self,

--- a/tests/validator/test_consensus_aggregate.py
+++ b/tests/validator/test_consensus_aggregate.py
@@ -1,0 +1,141 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Tests for deterministic stake-weighted aggregation of repo weight preferences."""
+
+import json
+import random
+
+from gittensor.validator.utils.config import (
+    CONSENSUS_MIN_VALIDATOR_STAKE_RAO,
+    CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS,
+    CONSENSUS_WEIGHT_PRECISION,
+)
+from gittensor.validator.weight_consensus.consensus import aggregate_preferences, compute_snapshot_block
+
+STAKE_30K = CONSENSUS_MIN_VALIDATOR_STAKE_RAO
+
+
+def _aggregate(voters):
+    """voters: list of (hotkey, stake, permit, structured-basket-or-None)."""
+    baskets, stakes, permits = {}, {}, {}
+    for hotkey, stake, permit, prefs in voters:
+        stakes[hotkey] = stake
+        permits[hotkey] = permit
+        if prefs is not None:
+            baskets[hotkey] = prefs
+    return aggregate_preferences(baskets, stakes, permits)
+
+
+class TestSnapshotBlock:
+    def test_boundaries(self):
+        interval = CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS
+        assert compute_snapshot_block(0) == 0
+        assert compute_snapshot_block(interval - 1) == 0
+        assert compute_snapshot_block(interval) == interval
+        assert compute_snapshot_block(2 * interval - 1) == interval
+
+
+class TestAggregation:
+    def test_stake_weighted_mean_golden_vector(self):
+        result = _aggregate(
+            [
+                ('hk1', 3 * STAKE_30K, True, {'a/b': 65535}),
+                ('hk2', STAKE_30K, True, {'a/b': 32768, 'c/d': 32767}),
+            ]
+        )
+        s1, s2, prec = 3 * STAKE_30K, STAKE_30K, CONSENSUS_WEIGHT_PRECISION
+        expected_ab = s1 * 65535 * prec // 65535 + s2 * 32768 * prec // 65535
+        expected_cd = s2 * 32767 * prec // 65535
+        assert result.numerators == {'a/b': expected_ab, 'c/d': expected_cd}
+        total = expected_ab + expected_cd
+        assert result.shares == {'a/b': expected_ab / total, 'c/d': expected_cd / total}
+        assert result.voter_count == 2
+
+    def test_filters_no_permit_and_low_stake(self):
+        result = _aggregate(
+            [
+                ('miner', 100 * STAKE_30K, False, {'m/spam': 65535}),
+                ('small', STAKE_30K - 1, True, {'s/small': 65535}),
+                ('vali', STAKE_30K, True, {'a/b': 65535}),
+            ]
+        )
+        assert set(result.shares) == {'a/b'}
+        assert result.eligible_stake_rao == STAKE_30K
+
+    def test_invalid_basket_counts_toward_eligible_not_valid(self):
+        result = _aggregate(
+            [
+                ('bad', STAKE_30K, True, {'not a repo': 65535}),
+                ('good', STAKE_30K, True, {'a/b': 65535}),
+            ]
+        )
+        assert result.eligible_stake_rao == 2 * STAKE_30K
+        assert result.valid_stake_rao == STAKE_30K
+        assert result.shares == {'a/b': 1.0}
+
+    def test_activation_gate_below_half_returns_none_shares(self):
+        result = _aggregate(
+            [
+                ('silent', 3 * STAKE_30K, True, None),
+                ('voter', STAKE_30K, True, {'a/b': 65535}),
+            ]
+        )
+        assert result.shares is None
+        assert result.numerators  # still computed for the cache
+
+    def test_activation_gate_exact_half_passes(self):
+        result = _aggregate(
+            [
+                ('silent', STAKE_30K, True, None),
+                ('voter', STAKE_30K, True, {'a/b': 65535}),
+            ]
+        )
+        assert result.shares == {'a/b': 1.0}
+
+    def test_zero_eligible_stake_gate_fails(self):
+        result = _aggregate([('miner', STAKE_30K, False, {'a/b': 65535})])
+        assert result.shares is None
+        assert result.eligible_stake_rao == 0
+
+    def test_per_voter_normalization(self):
+        # Same stake, same single repo, wildly different basket totals — equal influence.
+        result = _aggregate(
+            [
+                ('hk1', STAKE_30K, True, {'a/b': 10}),
+                ('hk2', STAKE_30K, True, {'c/d': 65535}),
+            ]
+        )
+        assert abs(result.shares['a/b'] - result.shares['c/d']) < 1e-12
+
+    def test_shares_sum_to_one(self):
+        random.seed(3)
+        voters = [
+            (
+                f'hk{i}',
+                STAKE_30K * random.randint(1, 20),
+                True,
+                {f'o/r{j}': random.randint(1, 65535) for j in range(random.randint(1, 10))},
+            )
+            for i in range(12)
+        ]
+        result = _aggregate(voters)
+        assert abs(sum(result.shares.values()) - 1.0) < 1e-9
+
+    def test_determinism_under_shuffled_input_order(self):
+        random.seed(11)
+        voters = [
+            (
+                f'hk{i:02d}',
+                STAKE_30K * random.randint(1, 50),
+                random.random() > 0.2,
+                {f'own{j}/repo{j}': random.randint(1, 65535) for j in range(random.randint(1, 10))},
+            )
+            for i in range(20)
+        ]
+        baseline = None
+        for _ in range(5):
+            random.shuffle(voters)
+            result = _aggregate(voters)
+            serialized = json.dumps({'shares': result.shares, 'numerators': result.numerators}, sort_keys=True)
+            assert baseline is None or serialized == baseline
+            baseline = serialized

--- a/tests/validator/test_consensus_apply.py
+++ b/tests/validator/test_consensus_apply.py
@@ -1,0 +1,41 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Tests for overlaying consensus shares onto the baked repository registry."""
+
+from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.weight_consensus.consensus import apply_consensus
+
+
+def _master():
+    return {
+        'a/tuned': RepositoryConfig(emission_share=0.6, maintainer_cut=0.2, default_label_multiplier=1.5),
+        'b/plain': RepositoryConfig(emission_share=0.4),
+    }
+
+
+class TestApplyConsensus:
+    def test_overrides_share_keeps_tuned_config(self):
+        result = apply_consensus(_master(), {'a/tuned': 0.7, 'b/plain': 0.3})
+        assert result['a/tuned'].emission_share == 0.7
+        assert result['a/tuned'].maintainer_cut == 0.2
+        assert result['a/tuned'].default_label_multiplier == 1.5
+
+    def test_zeroes_master_repos_absent_from_aggregate(self):
+        result = apply_consensus(_master(), {'a/tuned': 1.0})
+        assert result['b/plain'].emission_share == 0.0
+
+    def test_adds_novel_repo_with_defaults(self):
+        result = apply_consensus(_master(), {'new/comer': 0.5, 'a/tuned': 0.5})
+        novel = result['new/comer']
+        assert novel.emission_share == 0.5
+        assert novel.maintainer_cut == 0.0
+        assert novel.default_label_multiplier == 1.0
+
+    def test_none_shares_returns_master_unchanged(self):
+        master = _master()
+        assert apply_consensus(master, None) is master
+
+    def test_does_not_mutate_master_configs(self):
+        master = _master()
+        apply_consensus(master, {'a/tuned': 1.0})
+        assert master['a/tuned'].emission_share == 0.6

--- a/tests/validator/test_consensus_codec.py
+++ b/tests/validator/test_consensus_codec.py
@@ -1,0 +1,66 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Tests for canonical preference quantization and structured basket validation."""
+
+import pytest
+
+from gittensor.validator.weight_consensus.codec import (
+    U16_MAX,
+    CodecError,
+    canonicalize_prefs,
+    validate_prefs,
+)
+
+
+class TestCanonicalize:
+    def test_top10_by_weight_quantized_to_u16_sum(self):
+        raw = {f'a/repo{i:02d}': float(i + 1) for i in range(15)}
+        prefs = canonicalize_prefs(raw)
+        assert len(prefs) == 10
+        assert sum(prefs.values()) == U16_MAX
+        assert set(prefs) == {f'a/repo{i:02d}' for i in range(5, 15)}
+
+    def test_deterministic_ties_and_duplicate_merge(self):
+        assert canonicalize_prefs({'A/B': 1.0, 'a/b': 1.0, 'c/d': 2.0}) == canonicalize_prefs({'a/b': 2.0, 'c/d': 2.0})
+
+    def test_raises_on_empty_or_nonpositive(self):
+        with pytest.raises(CodecError):
+            canonicalize_prefs({})
+        with pytest.raises(CodecError):
+            canonicalize_prefs({'a/b': 0.0, 'c/d': -1.0})
+
+    def test_raises_on_invalid_name(self):
+        with pytest.raises(CodecError):
+            canonicalize_prefs({'not a repo': 1.0})
+
+
+class TestValidatePrefs:
+    def test_valid_basket_returned_sorted(self):
+        assert validate_prefs({'c/d': 100, 'a/b': 200}) == {'a/b': 200, 'c/d': 100}
+        assert list(validate_prefs({'c/d': 1, 'a/b': 2})) == ['a/b', 'c/d']
+
+    def test_lowercases_repo_names(self):
+        assert validate_prefs({'Owner/Repo': 100}) == {'owner/repo': 100}
+
+    def test_rejects_duplicates_after_lowercasing(self):
+        assert validate_prefs({'a/b': 100, 'A/B': 200}) is None
+
+    def test_drops_zero_weights_and_rejects_empty_result(self):
+        assert validate_prefs({'a/b': 0, 'c/d': 100}) == {'c/d': 100}
+        assert validate_prefs({'a/b': 0}) is None
+
+    @pytest.mark.parametrize('name', ['not a repo', 'noslash', '/leading', 'UPPER CASE/x', ''])
+    def test_rejects_malformed_names(self, name):
+        assert validate_prefs({name: 100}) is None
+
+    @pytest.mark.parametrize('weight', [-1, U16_MAX + 1, 1.5, '100', True, None])
+    def test_rejects_non_u16_weights(self, weight):
+        assert validate_prefs({'a/b': weight}) is None
+
+    def test_rejects_too_many_repos(self):
+        assert validate_prefs({f'a/repo{i}': 100 for i in range(11)}) is None
+
+    def test_rejects_non_mapping_and_empty(self):
+        assert validate_prefs(None) is None
+        assert validate_prefs([('a/b', 100)]) is None
+        assert validate_prefs({}) is None

--- a/tests/validator/test_consensus_manager.py
+++ b/tests/validator/test_consensus_manager.py
@@ -1,0 +1,181 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Tests for snapshot lifecycle: warm compute, numerator cache, fallback ladder."""
+
+import json
+from types import SimpleNamespace
+
+from gittensor.validator.utils.config import (
+    CONSENSUS_CACHE_KEEP,
+    CONSENSUS_MIN_VALIDATOR_STAKE_RAO,
+    CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS,
+)
+from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.weight_consensus.manager import ConsensusManager, run_weight_consensus
+
+INTERVAL = CONSENSUS_SNAPSHOT_INTERVAL_BLOCKS
+STAKE = CONSENSUS_MIN_VALIDATOR_STAKE_RAO
+
+
+class FakeBackend:
+    """Serves canned baskets/stakes per snapshot; optionally unreachable."""
+
+    def __init__(self, voters, reachable: bool = True):
+        # voters: list of (hotkey, stake_rao, permit, structured-basket-or-None)
+        self.voters = voters
+        self.reachable = reachable
+        self.fetch_calls = 0
+        self.published = []
+
+    def _check(self):
+        if not self.reachable:
+            raise RuntimeError('contract unreachable')
+
+    def fetch_registry(self, snapshot):
+        self._check()
+        return {}
+
+    def fetch_baskets(self, snapshot):
+        self._check()
+        self.fetch_calls += 1
+        return {hotkey: prefs for hotkey, _, _, prefs in self.voters if prefs is not None}
+
+    def fetch_own_basket(self):
+        self._check()
+        return None
+
+    def publish_basket(self, prefs):
+        self._check()
+        self.published.append(prefs)
+        return True
+
+    def fetch_stakes_and_permits(self, snapshot):
+        self._check()
+        return (
+            {hotkey: stake for hotkey, stake, _, _ in self.voters},
+            {hotkey: permit for hotkey, _, permit, _ in self.voters},
+        )
+
+
+def _voters():
+    return [
+        ('hk1', 3 * STAKE, True, {'a/b': 65535}),
+        ('hk2', STAKE, True, {'c/d': 65535}),
+    ]
+
+
+class TestConsensusManager:
+    def test_fresh_compute_persists_and_reload_is_byte_identical(self, tmp_path):
+        manager = ConsensusManager(backend=FakeBackend(_voters()), cache_dir=tmp_path)
+        shares = manager.get_shares(INTERVAL + 10)
+
+        reloaded = ConsensusManager(backend=FakeBackend([], reachable=False), cache_dir=tmp_path)
+        assert json.dumps(reloaded.get_shares(INTERVAL + 50)) == json.dumps(shares)
+
+    def test_cache_hit_makes_no_backend_calls(self, tmp_path):
+        backend = FakeBackend(_voters())
+        manager = ConsensusManager(backend=backend, cache_dir=tmp_path)
+        manager.maybe_refresh(INTERVAL)
+        calls = backend.fetch_calls
+        manager.maybe_refresh(INTERVAL + 5)
+        assert manager.get_shares(INTERVAL + 10) is not None
+        assert backend.fetch_calls == calls
+
+    def test_unreachable_backend_falls_back_to_last_good(self, tmp_path):
+        backend = FakeBackend(_voters())
+        manager = ConsensusManager(backend=backend, cache_dir=tmp_path)
+        manager.maybe_refresh(INTERVAL)
+        backend.reachable = False
+        assert manager.get_shares(2 * INTERVAL + 10) == {'a/b': 0.75, 'c/d': 0.25}
+
+    def test_unreachable_backend_no_cache_returns_none(self, tmp_path):
+        manager = ConsensusManager(backend=FakeBackend([], reachable=False), cache_dir=tmp_path)
+        assert manager.get_shares(INTERVAL + 10) is None
+
+    def test_gate_failed_interval_cached_and_returns_none(self, tmp_path):
+        voters = [('hk1', 3 * STAKE, True, None), ('hk2', STAKE, True, {'a/b': 65535})]
+        backend = FakeBackend(voters)
+        manager = ConsensusManager(backend=backend, cache_dir=tmp_path)
+        assert manager.get_shares(INTERVAL) is None
+        calls = backend.fetch_calls
+        assert manager.get_shares(INTERVAL + 1) is None
+        assert backend.fetch_calls == calls
+
+    def test_cache_trims_and_tolerates_corrupt_file(self, tmp_path):
+        (tmp_path / 'weight_consensus_cache.json').write_text('{corrupt')
+        manager = ConsensusManager(backend=FakeBackend(_voters()), cache_dir=tmp_path)
+        for i in range(CONSENSUS_CACHE_KEEP + 3):
+            manager.maybe_refresh((i + 1) * INTERVAL)
+        assert len(manager._cache) == CONSENSUS_CACHE_KEEP
+
+    def test_maybe_refresh_retries_until_get_shares_marks_failed(self, tmp_path):
+        backend = FakeBackend([], reachable=False)
+        manager = ConsensusManager(backend=backend, cache_dir=tmp_path)
+        manager.maybe_refresh(INTERVAL + 10)
+        assert INTERVAL not in manager._failed_snapshots  # transient: retry next step
+        assert manager.get_shares(INTERVAL + 20) is None
+        assert INTERVAL in manager._failed_snapshots
+        backend.reachable = True
+        manager.maybe_refresh(INTERVAL + 30)
+        assert backend.fetch_calls == 0  # marked failed: no more attempts this snapshot
+
+    def test_store_hook_failure_does_not_break_compute(self, tmp_path):
+        def broken_hook(*args):
+            raise RuntimeError('db down')
+
+        manager = ConsensusManager(backend=FakeBackend(_voters()), cache_dir=tmp_path, store_hook=broken_hook)
+        assert manager.get_shares(INTERVAL) is not None
+
+    def test_store_hook_receives_structured_baskets(self, tmp_path):
+        seen = {}
+
+        def hook(snapshot, baskets, stakes_rao, permits, result):
+            seen.update(snapshot=snapshot, baskets=baskets, stakes=stakes_rao, permits=permits, result=result)
+
+        manager = ConsensusManager(backend=FakeBackend(_voters()), cache_dir=tmp_path, store_hook=hook)
+        manager.maybe_refresh(INTERVAL + 1)
+        assert seen['snapshot'] == INTERVAL
+        assert seen['baskets'] == {'hk1': {'a/b': 65535}, 'hk2': {'c/d': 65535}}
+        assert seen['stakes']['hk1'] == 3 * STAKE
+        assert seen['result'].voter_count == 2
+
+
+class TestRunWeightConsensus:
+    def _validator(self, tmp_path, backend):
+        manager = ConsensusManager(backend=backend, cache_dir=tmp_path)
+        return SimpleNamespace(
+            config=SimpleNamespace(
+                netuid=74,
+                neuron=SimpleNamespace(
+                    disable_weight_consensus=False, consensus_prefs_path=None, full_path=str(tmp_path)
+                ),
+            ),
+            block=INTERVAL + 10,
+            consensus_manager=manager,
+        )
+
+    def test_publishes_own_vote_and_overlays_aggregate(self, tmp_path):
+        backend = FakeBackend(_voters())
+        master = {'a/b': RepositoryConfig(emission_share=0.9), 'x/y': RepositoryConfig(emission_share=0.1)}
+        result = run_weight_consensus(self._validator(tmp_path, backend), master)
+        assert backend.published == [{'a/b': 58982, 'x/y': 6553}]
+        assert result['a/b'].emission_share == 0.75
+        assert result['x/y'].emission_share == 0.0
+        assert result['c/d'].emission_share == 0.25
+
+    def test_never_raises_and_falls_back_to_master(self, tmp_path):
+        master = {'a/b': RepositoryConfig(emission_share=1.0)}
+        validator = self._validator(tmp_path, FakeBackend([], reachable=False))
+        assert run_weight_consensus(validator, master) is master
+
+    def test_disable_flag_bypasses_everything(self, tmp_path):
+        master = {'a/b': RepositoryConfig(emission_share=1.0)}
+        validator = self._validator(tmp_path, FakeBackend(_voters()))
+        validator.config.neuron.disable_weight_consensus = True
+        assert run_weight_consensus(validator, master) is master
+
+    def test_missing_manager_bypasses_everything(self, tmp_path):
+        master = {'a/b': RepositoryConfig(emission_share=1.0)}
+        validator = self._validator(tmp_path, FakeBackend(_voters()))
+        validator.consensus_manager = None
+        assert run_weight_consensus(validator, master) is master

--- a/tests/validator/test_consensus_publisher.py
+++ b/tests/validator/test_consensus_publisher.py
@@ -1,0 +1,70 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Tests for local preference resolution and backend publishing."""
+
+import json
+
+from gittensor.validator.utils.load_weights import RepositoryConfig
+from gittensor.validator.weight_consensus.publisher import maybe_publish_prefs, resolve_local_prefs
+
+MASTER = {
+    'a/big': RepositoryConfig(emission_share=0.6),
+    'b/small': RepositoryConfig(emission_share=0.4),
+    'c/zero': RepositoryConfig(emission_share=0.0),
+}
+
+
+class FakeBackend:
+    def __init__(self, own_basket=None, publish_ok=True):
+        self.own_basket = own_basket
+        self.publish_ok = publish_ok
+        self.published = []
+
+    def fetch_own_basket(self):
+        return self.own_basket
+
+    def publish_basket(self, prefs):
+        if isinstance(self.publish_ok, Exception):
+            raise self.publish_ok
+        if self.publish_ok:
+            self.published.append(prefs)
+        return bool(self.publish_ok)
+
+
+class TestResolveLocalPrefs:
+    def test_default_vote_from_baked_master_shares(self, tmp_path):
+        prefs = resolve_local_prefs(tmp_path / 'missing.json', MASTER)
+        assert set(prefs) == {'a/big', 'b/small'}
+        assert prefs['a/big'] > prefs['b/small']
+
+    def test_prefs_file_parsed(self, tmp_path):
+        path = tmp_path / 'prefs.json'
+        path.write_text(json.dumps({'version': 1, 'repos': {'X/Y': 3, 'z/w': 1}}))
+        prefs = resolve_local_prefs(path, MASTER)
+        assert set(prefs) == {'x/y', 'z/w'}
+
+    def test_invalid_file_falls_back_to_default(self, tmp_path):
+        path = tmp_path / 'prefs.json'
+        path.write_text('{not json')
+        assert set(resolve_local_prefs(path, MASTER)) == {'a/big', 'b/small'}
+
+
+class TestMaybePublish:
+    def test_skips_when_onchain_basket_equal(self):
+        prefs = {'a/b': 60000, 'c/d': 5535}
+        backend = FakeBackend(own_basket={'a/b': 60000, 'c/d': 5535})
+        assert maybe_publish_prefs(backend, prefs) is True
+        assert backend.published == []
+
+    def test_publishes_when_onchain_differs(self):
+        backend = FakeBackend(own_basket={'a/b': 65535})
+        assert maybe_publish_prefs(backend, {'c/d': 65535}) is True
+        assert backend.published == [{'c/d': 65535}]
+
+    def test_publish_rejection_returns_false(self):
+        backend = FakeBackend(publish_ok=False)
+        assert maybe_publish_prefs(backend, {'a/b': 65535}) is False
+
+    def test_publish_exception_returns_false(self):
+        backend = FakeBackend(publish_ok=RuntimeError('rate limited'))
+        assert maybe_publish_prefs(backend, {'a/b': 65535}) is False

--- a/tests/validator/test_contract_backend.py
+++ b/tests/validator/test_contract_backend.py
@@ -1,0 +1,137 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+"""Tests for the contract-backed consensus transport: block-hash pinning,
+id -> name resolution, and the set_basket publish path."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gittensor.validator.weight_consensus.contract_backend import ContractBackend
+
+SNAPSHOT_HASH = '0xsnap'
+HEAD_HASH = '0xhead'
+
+
+def _repo(github_id, full_name):
+    return SimpleNamespace(github_id=github_id, full_name=full_name)
+
+
+class FakeClient:
+    def __init__(self, repos, baskets=None, own_basket=None):
+        self.repos = repos  # [(github_id, full_name)]
+        self.baskets = baskets or {}  # hotkey -> [(github_id, weight)]
+        self.own_basket = own_basket
+        self.read_ats = []
+        self.set_basket_calls = []
+
+    def get_all_repos(self, at=None):
+        self.read_ats.append(at)
+        return [_repo(gid, name) for gid, name in self.repos]
+
+    def get_all_baskets(self, at=None):
+        self.read_ats.append(at)
+        return dict(self.baskets)
+
+    def get_basket(self, hotkey, at=None):
+        self.read_ats.append(at)
+        return self.own_basket
+
+    def set_basket(self, entries, wallet):
+        self.set_basket_calls.append((entries, wallet))
+        return True
+
+
+class FakeSubstrate:
+    def __init__(self, block_hash=SNAPSHOT_HASH):
+        self.block_hash = block_hash
+        self.get_block_hash_calls = []
+
+    def get_block_hash(self, block):
+        self.get_block_hash_calls.append(block)
+        return self.block_hash
+
+    def get_chain_head(self):
+        return HEAD_HASH
+
+
+def _backend(client, substrate=None, metagraph=None):
+    subtensor = SimpleNamespace(
+        substrate=substrate or FakeSubstrate(),
+        metagraph=lambda netuid, block, lite: metagraph,
+    )
+    wallet = SimpleNamespace(hotkey=SimpleNamespace(ss58_address='hk-self'))
+    return ContractBackend(client, subtensor, wallet, netuid=74)
+
+
+class TestSnapshotReads:
+    def test_fetch_baskets_pins_all_reads_to_snapshot_hash(self):
+        client = FakeClient(repos=[(1, 'a/b')], baskets={'hk1': [(1, 65535)]})
+        substrate = FakeSubstrate()
+        backend = _backend(client, substrate)
+        assert backend.fetch_baskets(3600) == {'hk1': {'a/b': 65535}}
+        assert substrate.get_block_hash_calls == [3600]
+        assert set(client.read_ats) == {SNAPSHOT_HASH}
+
+    def test_fetch_baskets_drops_deregistered_ids_and_empty_baskets(self):
+        client = FakeClient(
+            repos=[(1, 'a/b')],
+            baskets={'hk1': [(1, 60000), (99, 5535)], 'hk2': [(99, 65535)]},
+        )
+        assert _backend(client).fetch_baskets(3600) == {'hk1': {'a/b': 60000}}
+
+    def test_fetch_registry_pinned(self):
+        client = FakeClient(repos=[(1, 'a/b'), (2, 'c/d')])
+        substrate = FakeSubstrate()
+        assert _backend(client, substrate).fetch_registry(7200) == {1: 'a/b', 2: 'c/d'}
+        assert substrate.get_block_hash_calls == [7200]
+        assert client.read_ats == [SNAPSHOT_HASH]
+
+    def test_missing_block_hash_raises(self):
+        backend = _backend(FakeClient(repos=[]), FakeSubstrate(block_hash=None))
+        with pytest.raises(RuntimeError):
+            backend.fetch_baskets(3600)
+
+    def test_fetch_stakes_and_permits_from_metagraph(self):
+        metagraph = SimpleNamespace(hotkeys=['hk1', 'hk2'], S=[3.0, 1.5], validator_permit=[True, False])
+        stakes, permits = _backend(FakeClient(repos=[]), metagraph=metagraph).fetch_stakes_and_permits(3600)
+        assert stakes == {'hk1': 3_000_000_000, 'hk2': 1_500_000_000}
+        assert permits == {'hk1': True, 'hk2': False}
+
+
+class TestOwnBasket:
+    def test_resolved_at_head(self):
+        client = FakeClient(repos=[(1, 'a/b'), (2, 'c/d')], own_basket=[(2, 5535), (1, 60000)])
+        assert _backend(client).fetch_own_basket() == {'a/b': 60000, 'c/d': 5535}
+        assert set(client.read_ats) == {HEAD_HASH}
+
+    def test_none_when_no_basket(self):
+        assert _backend(FakeClient(repos=[(1, 'a/b')])).fetch_own_basket() is None
+
+
+class TestPublishBasket:
+    def test_publishes_entries_sorted_by_id(self):
+        client = FakeClient(repos=[(7, 'c/d'), (3, 'a/b')])
+        backend = _backend(client)
+        assert backend.publish_basket({'c/d': 5535, 'a/b': 60000}) is True
+        entries, wallet = client.set_basket_calls[0]
+        assert entries == [(3, 60000), (7, 5535)]
+        assert wallet.hotkey.ss58_address == 'hk-self'
+
+    def test_skips_tx_when_onchain_entries_match(self):
+        client = FakeClient(repos=[(3, 'a/b'), (7, 'c/d')], own_basket=[(7, 5535), (3, 60000)])
+        assert _backend(client).publish_basket({'a/b': 60000, 'c/d': 5535}) is True
+        assert client.set_basket_calls == []
+
+    def test_filters_unregistered_names_and_requantizes(self):
+        client = FakeClient(repos=[(3, 'a/b'), (7, 'c/d')])
+        backend = _backend(client)
+        assert backend.publish_basket({'a/b': 30000, 'c/d': 30000, 'x/gone': 5535}) is True
+        entries, _ = client.set_basket_calls[0]
+        assert sorted(gid for gid, _ in entries) == [3, 7]
+        assert sum(w for _, w in entries) == 65535
+
+    def test_all_unregistered_returns_false_without_tx(self):
+        client = FakeClient(repos=[(3, 'a/b')])
+        assert _backend(client).publish_basket({'x/gone': 65535}) is False
+        assert client.set_basket_calls == []


### PR DESCRIPTION
Part of repo-registration phase 2a (task 2a-4). Stacked on #1666 (python client) — merge order #1665 -> #1666 -> this.

Re-lands the consensus core from the closed commitments-based attempt (#1651's successor branch) reworked onto an injected Backend protocol with the repos-v0 contract as transport:

- `backend.py` — `ConsensusBackend` protocol: fetch_registry / fetch_baskets / fetch_own_basket / publish_basket / fetch_stakes_and_permits (spec S4; metagraph reads behind the same protocol per S5)
- `contract_backend.py` — `ContractBackend` over `RepoRegistryContractClient`; snapshot block number resolves to a block **hash** once and every childstate read pins to it (S1 — closes the reorg gap the spec calls out), publish via `set_basket` signed by hotkey (S3)
- `consensus.py` — cherry-picked verbatim except the input seam: structured baskets + `validate_prefs` replace bytes + `decode_prefs` (R3: second decode site is now validate-only)
- `codec.py` — `canonicalize_prefs` kept verbatim (R4); zlib wire format, SCALE payload walker, `CONSENSUS_MAX_PAYLOAD_BYTES`, `CONSENSUS_FRESH_WINDOW_BLOCKS` deleted
- `chain.py` (commitments transport) deleted; `mirror_sync.py` NOT re-landed — mirror reconciliation moved to das-github-mirror #229; validator has zero mirror-write responsibilities, `MirrorClient` stays read-only
- `neurons/validator.py` — consensus manager init is failure-safe: missing contract address or init error degrades to baked weights, never blocks startup
- Manager cache/fallback ladder, `apply_consensus`, postgres storage unchanged per spec

Decisions flagged for review (details in code):
- basket github_id -> name resolution happens inside ContractBackend at the same pinned hash (deterministic across validators); deregistered ids dropped, per-voter renormalization absorbs the weight
- publish filters unregistered repo names with a warning and re-quantizes survivors; skip-if-equal prevents tx spam

Tests: +67 (golden aggregation vectors, fallback ladder via FakeBackend, pinned-hash propagation, validate-only decode, publisher edges); full suite 1104 passed; ruff clean.