### PR TITLE
Repository emission adjustments

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -154,6 +154,7 @@ RECYCLE_UID = 0
 OSS_EMISSION_SHARE = 0.90
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
+MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
 
 # =============================================================================
 # Spam & Gaming Mitigation

--- a/gittensor/validator/utils/load_weights.py
+++ b/gittensor/validator/utils/load_weights.py
@@ -12,6 +12,7 @@ from gittensor.constants import (
     EMISSION_SHARE_TOLERANCE,
     EXCESSIVE_PR_PENALTY_BASE_THRESHOLD,
     MAINTAINER_ISSUE_MULTIPLIER,
+    MAX_MAINTAINER_CUT,
     MAX_OPEN_ISSUE_THRESHOLD,
     MAX_OPEN_PR_THRESHOLD,
     MIN_CREDIBILITY,
@@ -159,9 +160,10 @@ class RepositoryConfig:
             ``resolve_eligibility``.
         scoring: Per-repo overrides for the scoring knobs. Unset fields fall
             back to the global default constants — see ``resolve_scoring``.
-        maintainer_cut: Fraction [0.0, 1.0] of this repo's emission slice
-            routed directly to its maintainer miner neurons, split evenly,
-            before normal scoring. Defaults to 0.0 (no carve-out).
+        maintainer_cut: Fraction [0.0, MAX_MAINTAINER_CUT] of this repo's
+            emission slice routed directly to its maintainer miner neurons,
+            split evenly, before normal scoring. Clamped to the ceiling at
+            load time. Defaults to 0.0 (no carve-out).
 
     """
 
@@ -556,7 +558,10 @@ def load_master_repo_weights() -> Dict[str, RepositoryConfig]:
                     fixed_base_score=metadata.get('fixed_base_score'),
                     eligibility=_parse_eligibility(repo_name, metadata.get('eligibility')),
                     scoring=_parse_scoring(repo_name, metadata.get('scoring')),
-                    maintainer_cut=_coerce_share(repo_name, 'maintainer_cut', metadata.get('maintainer_cut', 0.0)),
+                    maintainer_cut=min(
+                        MAX_MAINTAINER_CUT,
+                        _coerce_share(repo_name, 'maintainer_cut', metadata.get('maintainer_cut', 0.0)),
+                    ),
                 )
                 normalized_data[repo_name.lower()] = config
             except RepositoryRegistryError:

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -251,7 +251,7 @@
   "JSONbored/loopover": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.0,
+    "emission_share": 0.048119,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -280,7 +280,7 @@
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.0,
+    "emission_share": 0.089453,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -291,7 +291,7 @@
     "eligibility": {
       "min_credibility": 0.5
     },
-    "maintainer_cut": 0.66,
+    "maintainer_cut": 0.5,
     "scoring": {
       "pr_lookback_days": 5,
       "open_pr_collateral_percent": 0.2,

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,6 +1,6 @@
 {
   "Autovara/kata": {
-    "emission_share": 0.044763,
+    "emission_share": 0.036706,
     "issue_discovery_share": 0.0,
     "trusted_label_pipeline": true,
     "fixed_base_score": 1.0,
@@ -36,7 +36,7 @@
     }
   },
   "DPBG/Engram.AI": {
-    "emission_share": 0.001594,
+    "emission_share": 0.001307,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1,
@@ -48,7 +48,7 @@
     "maintainer_cut": 0.2
   },
   "entrius/das-github-mirror": {
-    "emission_share": 0.003113,
+    "emission_share": 0.002553,
     "issue_discovery_share": 0.5,
     "label_multipliers": {
       "bug": 1.25,
@@ -59,7 +59,7 @@
     "trusted_label_pipeline": true
   },
   "entrius/gittensor": {
-    "emission_share": 0.009002,
+    "emission_share": 0.007382,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,
@@ -76,7 +76,7 @@
     "eligibility": {
       "max_open_pr_threshold": 2
     },
-    "emission_share": 0.011477,
+    "emission_share": 0.009411,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "maintainer-issue": 3.0,
@@ -94,7 +94,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.151636,
+    "emission_share": 0.124342,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -118,7 +118,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.151636,
+    "emission_share": 0.124342,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
@@ -142,7 +142,7 @@
     "trusted_label_pipeline": true
   },
   "gittensor-vanguard/vanguarstew": {
-    "emission_share": 0.071449,
+    "emission_share": 0.058588,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "maintainer_cut": 0.5,
@@ -199,7 +199,7 @@
     }
   },
   "James-CUDA/Gittensor-TinyRouter": {
-    "emission_share": 0.009284,
+    "emission_share": 0.007613,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 0.1,
@@ -222,7 +222,7 @@
   "JSONbored/awesome-claude": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.003189,
+    "emission_share": 0.002615,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -251,7 +251,7 @@
   "JSONbored/loopover": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.048119,
+    "emission_share": 0.039458,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -280,7 +280,7 @@
   "JSONbored/metagraphed": {
     "default_label_multiplier": 0.0,
     "trusted_label_pipeline": true,
-    "emission_share": 0.089453,
+    "emission_share": 0.073351,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "gittensor:bug": 0.05,
@@ -307,7 +307,7 @@
     }
   },
   "mini-router/minirouter": {
-    "emission_share": 0.009284,
+    "emission_share": 0.007613,
     "issue_discovery_share": 0.0,
     "additional_acceptable_branches": ["sn74*"],
     "default_label_multiplier": 0.0,
@@ -327,7 +327,7 @@
     "maintainer_cut": 0.3
   },
   "vouchdev/vouch": {
-    "emission_share": 0.014001,
+    "emission_share": 0.011481,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "feature": 1.5,
@@ -352,7 +352,7 @@
     "maintainer_cut": 0.5
   },
   "phase-rs/phase": {
-    "emission_share": 0.009336,
+    "emission_share": 0.007656,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "bug": 1.2,
@@ -373,7 +373,7 @@
     }
   },
   "we-promise/sure": {
-    "emission_share": 0.001594,
+    "emission_share": 0.001307,
     "issue_discovery_share": 0.0,
     "label_multipliers": {
       "performance": 1.5,
@@ -382,7 +382,7 @@
     "maintainer_cut": 0.3
   },
   "zeokin/Cuda-Compute-OSS": {
-    "emission_share": 0.008642,
+    "emission_share": 0.007086,
     "issue_discovery_share": 0.0,
     "trusted_label_pipeline": true,
     "default_label_multiplier": 0.0,

--- a/tests/validator/test_load_weights.py
+++ b/tests/validator/test_load_weights.py
@@ -12,6 +12,7 @@ import json
 
 import pytest
 
+from gittensor.constants import MAX_MAINTAINER_CUT
 from gittensor.validator.utils.load_weights import (
     LanguageConfig,
     RepoEligibilityConfig,
@@ -533,12 +534,26 @@ class TestRepositoryConfigMaintainerCut:
         assert repos['foo/with-cut'].maintainer_cut == pytest.approx(0.3)
         assert repos['foo/defaults'].maintainer_cut == pytest.approx(0.0)
 
+    def test_loader_clamps_maintainer_cut_to_ceiling(self, tmp_path, monkeypatch):
+        from gittensor.validator.utils import load_weights as lw
+
+        (tmp_path / 'master_repositories.json').write_text(
+            json.dumps({'foo/greedy': {'emission_share': 0.5, 'maintainer_cut': 0.66}})
+        )
+        monkeypatch.setattr(lw, '_get_weights_dir', lambda: tmp_path)
+
+        repos = lw.load_master_repo_weights()
+
+        assert repos['foo/greedy'].maintainer_cut == pytest.approx(MAX_MAINTAINER_CUT)
+
     @pytest.mark.parametrize('repo_name,metadata', _live_master_repo_metadata())
     def test_live_maintainer_cut_is_in_range(self, repo_name, metadata):
         if 'maintainer_cut' not in metadata:
             return
 
-        assert 0.0 <= float(metadata['maintainer_cut']) <= 1.0, f'{repo_name} maintainer_cut must be within [0.0, 1.0]'
+        assert 0.0 <= float(metadata['maintainer_cut']) <= MAX_MAINTAINER_CUT, (
+            f'{repo_name} maintainer_cut must be within [0.0, {MAX_MAINTAINER_CUT}]'
+        )
 
 
 class TestRepositoryEmissionShare:
@@ -597,7 +612,6 @@ class TestRepositoryEmissionShare:
             {'emission_share': 0.5, 'issue_discovery_share': -0.01},
             {'emission_share': 0.5, 'issue_discovery_share': 1.01},
             {'emission_share': 0.5, 'maintainer_cut': -0.01},
-            {'emission_share': 0.5, 'maintainer_cut': 1.01},
         ],
     )
     def test_loader_rejects_out_of_range_values(self, tmp_path, monkeypatch, metadata):


### PR DESCRIPTION
## Summary
- Cap maintainer cut at 50%: load-time clamp plus registry normalization. Maintaining is only half of the problem to software, at maximum.
- Repository emission adjustments.
- Cut all non-zero repo shares 18% to raise burn.

Per spec 440 changes and further considerations.