### PR TITLE
SparkDistill: 3x faster time-decay for merged-PR scores

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -139,7 +139,15 @@
       "dataset:REJECT": 0.0
     },
     "maintainer_cut": 0.5,
-    "trusted_label_pipeline": true
+    "trusted_label_pipeline": true,
+    "scoring": {
+      "time_decay": {
+        "grace_period_hours": 4,
+        "sigmoid_midpoint_days": 3.33,
+        "sigmoid_steepness": 1.2,
+        "min_multiplier": 0.05
+      }
+    }
   },
   "gittensor-vanguard/vanguarstew": {
     "emission_share": 0.058588,


### PR DESCRIPTION
## What

Add a `scoring.time_decay` override for `gittensor-model-hub/SparkDistill` so a merged PR's score multiplier decays **3x faster in time** than the org default. Grace period, sigmoid midpoint, and sigmoid steepness are all scaled by 3x, which is an exact time-compression of the curve (`g(t) == f(3t)` against the previous curve) — the floor value is unchanged.

| param | before (org default) | after |
|---|:---:|:---:|
| grace_period_hours | 12 | **4** |
| sigmoid_midpoint_days | 10 | **3.33** |
| sigmoid_steepness | 0.4 | **1.2** |
| min_multiplier (floor) | 0.05 | 0.05 (unchanged) |

Milestones (days since merge):

| | before | after |
|---|:---:|:---:|
| 50% of score remaining | day 10 | **day 3.33** |
| ~10% remaining | day 15.5 | **day 5.2** |
| 5% floor reached | day 17.4 | **day 5.8** |

## Why

SparkDistill currently has no `scoring.time_decay` override, so a merged PR's score decays on the org-wide default curve (50% loss by day 10). That's slower than SparkDistill wants: verified distillation-quality improvements should reward *fresh* contributions more sharply, so miners are incentivized toward a steady stream of new verified improvements rather than living for a long time off one old merge.

## Scope / safety

- Only `gittensor-model-hub/SparkDistill`'s `scoring.time_decay` block is added — no other repo's config changes.
- `emission_share`, `maintainer_cut`, `label_multipliers`, and eligibility are untouched.
- All new values are within `load_weights.py`'s live bounds (`grace_period_hours` in `[0,168]`, `sigmoid_midpoint_days` in `[1,90]`, `sigmoid_steepness` in `[0.01,5]`, `min_multiplier` in `[0,1]`) — `test_load_weights.py` passes (132 passed).
- 9-line diff, JSON validates.