### PR TITLE
chore(weights): set vouchdev/vouch issue_discovery_share to 0.3

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -327,7 +327,7 @@
   },
   "vouchdev/vouch": {
     "emission_share": 0.011481,
-    "issue_discovery_share": 0.0,
+    "issue_discovery_share": 0.3,
     "label_multipliers": {
       "feature": 1.5,
       "bug": 1.1


### PR DESCRIPTION
## Summary

Follow-up to #1672. Sets `issue_discovery_share` for `vouchdev/vouch` from `0.0` to `0.3`, routing 30% of the repo's scoring slice to issue-discovery rewards while PR-contribution rewards keep the remaining 70%.

Total repo emission is unchanged (`emission_share` stays `0.011481`) — this only changes the split between the two reward paths. Per `emission_allocation.py`, in rounds where only one side has eligible scorers the full scoring slice still collapses to that side, so nothing recycles as a result of this change.