### PR TITLE
fix(scoring): skip base_ref gate when mirror omits base_ref

### DIFF
--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -207,14 +207,15 @@ def check_merged_branch_eligibility(
     issue discovery so both reject the same non-acceptable-branch merges.
 
     Returns ``(skip, reason)``. Missing ``default_branch`` falls back to
-    ``main``; missing ``head_ref``/``head_repo_full_name`` skips the head_ref
-    check rather than false-positive-blocking on older data.
+    ``main``; missing ``base_ref``/``head_ref``/``head_repo_full_name`` skips
+    the corresponding check rather than false-positive-blocking on older data.
     """
     additional = repo_config.additional_acceptable_branches or []
     acceptable = [default_branch or 'main'] + additional
 
-    # base_ref check.
-    if not branch_matches_pattern(base_ref or '', acceptable):
+    # base_ref check — gate only when present. Pre-backfill mirror rows carry no
+    # branch metadata; fall through rather than block, as issue discovery does.
+    if base_ref is not None and not branch_matches_pattern(base_ref, acceptable):
         return True, (f'PR #{pr_number} merged to {base_ref!r} not in acceptable branches={acceptable}')
 
     # head_ref check — block PRs whose source branch is itself an acceptable

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -54,7 +54,7 @@ def _pr(
     author_login: str = 'bittoby',
     merged_by_login: str | None = 'anderdc',
     author_association: str = 'CONTRIBUTOR',
-    base_ref: str = 'main',
+    base_ref: str | None = 'main',
     head_ref: str | None = 'feature/foo',
     head_repo_full_name: str | None = 'entrius/gittensor-ui',
     default_branch: str | None = 'main',
@@ -260,6 +260,14 @@ class TestEligibilityGate:
             scored,
             _config(additional_branches=['test']),
         )
+        assert skip is False
+
+    def test_null_base_ref_skips_check(self):
+        # Pre-backfill mirror rows may have NULL base_ref — fall through rather
+        # than blocking a valid merge on missing metadata. Parity with issue
+        # discovery (test_missing_base_ref_falls_through_to_solved).
+        scored = ScoredPR(pr=_pr(base_ref=None, default_branch='main'))
+        skip, reason = _should_skip_merged_mirror_pr(scored, _config(additional_branches=None))
         assert skip is False
 
     def test_null_head_ref_skips_check(self):


### PR DESCRIPTION
## Summary

`check_merged_branch_eligibility` gated the base-ref check on `base_ref or ''`. When the mirror omits `base_ref`, that becomes `''`, which never matches the acceptable branch set — so the PR is rejected at load time by `_should_skip_merged_mirror_pr`, never enters `merged_prs`, and earns no OSS contribution score.

Pre-backfill mirror rows legitimately carry no branch metadata. `MirrorPullRequest` declares `base_ref: Optional[str]` and populates it with `data.get('base_ref')`, so `None` is an expected runtime value, not a corrupt row.

Two places in the codebase already treat missing branch metadata as fall-through rather than grounds for rejection:

- **Issue discovery** — `issue_discovery/scan.py` gates on `sp.base_ref is not None`, with a comment stating that a missing `base_ref` means pre-backfill data and should fall through. Covered by `test_missing_base_ref_falls_through_to_solved`.
- **This same function** — the `head_ref` check falls through on missing `head_ref` / `head_repo_full_name`, and the docstring documents that as intended behavior.

The base_ref gate was the odd one out. This changes it to gate on presence, restoring parity across the two paths. An explicitly malformed (empty-string) `base_ref` is still rejected — only genuinely absent metadata falls through.

Also widens `base_ref` on the `_pr` test helper from `str` to `str | None`. It had drifted from the model, which is why the null case had no coverage — the helper couldn't express it. `head_ref` was already `str | None` there.

## Related Issues

Fixes #1636

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

Added `test_null_base_ref_skips_check`, mirroring the existing `test_null_head_ref_skips_check`. Confirmed it fails on `test` without the source change and passes with it.

Full suite: 893 passed. `pre-commit run --all-files` and `--hook-stage pre-push` (ruff, pyright, vulture, pytest) all pass.

No CLI output changes.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
