### PR TITLE
fix(issue-discovery): skip unscored OSS PRs in solving-PR cache

### DIFF
--- a/gittensor/validator/issue_discovery/scan.py
+++ b/gittensor/validator/issue_discovery/scan.py
@@ -399,13 +399,20 @@ def _build_solving_pr_cache(
 ) -> Dict[Tuple[str, int], CachedSolvingPR]:
     """Pre-populate the cross-miner cache from already-scored mirror PRs.
 
-    Any PR that was scored during OSS (in any miner's merged_prs) is
-    keyed by (repo, pr_number) → CachedSolvingPR. Issue-discovery lookups hit
-    this cache instead of re-fetching for miners' own PRs or other miners' PRs.
+    Any PR that completed OSS scoring (``ScoredPR.oss_scored``) in any miner's
+    ``merged_prs`` is keyed by (repo, pr_number) → CachedSolvingPR.
+    Issue-discovery lookups hit this cache instead of re-fetching for miners'
+    own PRs or other miners' PRs.
+
+    Incomplete OSS early-returns (mirror file data pending/failed) keep the
+    default ``oss_scored=False`` and must stay cache misses so
+    ``_resolve_solving_pr_score`` can still fetch files (#1677).
     """
     cache: Dict[Tuple[str, int], CachedSolvingPR] = {}
     for evaluation in miner_evaluations.values():
         for scored in evaluation.merged_prs:
+            if not scored.oss_scored:
+                continue
             key = (scored.pr.repo_full_name, scored.pr.pr_number)
             if key in cache:
                 continue  # first miner wins — values are the same PR's fields

--- a/gittensor/validator/oss_contributions/mirror/scored_pr.py
+++ b/gittensor/validator/oss_contributions/mirror/scored_pr.py
@@ -50,6 +50,10 @@ class ScoredPR:
     # Files fetched lazily via MirrorClient.get_pr_files for eligible PRs
     files: Optional[List[MirrorFile]] = None
 
+    # True only after ``score_pr`` finishes multipliers (not early-return).
+    # Distinguishes genuine token_score=0 from unscored defaults still in merged_prs.
+    oss_scored: bool = False
+
     @property
     def number(self) -> int:
         """Alias for ``self.pr.pr_number`` — matches the ``PullRequest`` field

--- a/gittensor/validator/oss_contributions/mirror/scoring.py
+++ b/gittensor/validator/oss_contributions/mirror/scoring.py
@@ -181,6 +181,7 @@ async def score_pr(
         scored.base_score = repo_config.fixed_base_score
 
     _calculate_pr_multipliers(scored, repo_config, scoring_cfg)
+    scored.oss_scored = True
 
     if pr.state == 'MERGED':
         eval_.unique_repos_contributed_to.add(pr.repo_full_name)

--- a/tests/validator/issue_discovery/test_scan.py
+++ b/tests/validator/issue_discovery/test_scan.py
@@ -84,6 +84,8 @@ def _scored_mirror_pr(repo: str, pr_number: int, token_score: float = 100.0, bas
     scored = ScoredPR(pr=pr)
     scored.token_score = token_score
     scored.base_score = base_score
+    # Cache helpers represent PRs that finished OSS scoring (even at token_score=0).
+    scored.oss_scored = True
     return scored
 
 
@@ -961,6 +963,46 @@ class TestSolvingPrCache:
         cache = _build_solving_pr_cache({1: e1})
         assert ('foo/tiny', 1) in cache
         assert ('foo/healthy', 2) in cache
+
+    def test_unscored_oss_prs_excluded_from_cache(self):
+        # Regression for #1677: incomplete OSS early-returns leave defaults
+        # (token_score=0, oss_scored=False) and must not poison the cache.
+        incomplete = _scored_mirror_pr('foo/pending', 1, token_score=0.0, base_score=0.0)
+        incomplete.oss_scored = False
+        scored_zero = _scored_mirror_pr('foo/tiny', 2, token_score=0.0, base_score=0.0)
+        healthy = _scored_mirror_pr('foo/healthy', 3, token_score=50, base_score=10)
+
+        e1 = MinerEvaluation(uid=1, hotkey='hk1', github_id='g1')
+        e1.merged_prs = [incomplete, scored_zero, healthy]
+        cache = _build_solving_pr_cache({1: e1})
+
+        assert ('foo/pending', 1) not in cache
+        assert ('foo/tiny', 2) in cache
+        assert cache[('foo/tiny', 2)].token_score == 0.0
+        assert ('foo/healthy', 3) in cache
+
+    def test_unscored_oss_pr_remains_cache_miss_for_discovery(self):
+        # Incomplete merged_prs entry must not suppress get_pr_files on discovery.
+        client = Mock()
+        client.get_miner_issues.return_value = _response([_issue_dict()])
+        client.get_pr_files.return_value = _empty_files_response('entrius/gittensor-ui', 100)
+
+        eval_ = _eval()
+        incomplete = _scored_mirror_pr('entrius/gittensor-ui', 100, token_score=0.0, base_score=0.0)
+        incomplete.oss_scored = False
+        eval_.merged_prs = [incomplete]
+
+        _run(
+            run_issue_discovery(
+                {1: eval_},
+                _mirror_repos('entrius/gittensor-ui'),
+                _EMPTY_LANGS,
+                _EMPTY_TOKEN_CONFIG,
+                client=client,
+            )
+        )
+
+        client.get_pr_files.assert_called_once_with('entrius/gittensor-ui', 100)
 
     def test_cache_hit_reuses_base_score_no_fetch(self):
         """A solving PR already in cache must not trigger a get_pr_files call."""

--- a/tests/validator/oss_contributions/mirror/test_scored_pr.py
+++ b/tests/validator/oss_contributions/mirror/test_scored_pr.py
@@ -74,6 +74,7 @@ class TestComposition:
         assert scored.earned_score == 0.0
         assert scored.token_score == 0.0
         assert scored.files is None
+        assert scored.oss_scored is False
 
 
 class TestCalculateFinalEarnedScore:

--- a/tests/validator/oss_contributions/mirror/test_scoring.py
+++ b/tests/validator/oss_contributions/mirror/test_scoring.py
@@ -362,6 +362,7 @@ class TestScoringDataStoredGate:
         client.get_pr_files.assert_not_called()
         assert scored.files is None
         assert scored.base_score == 0.0
+        assert scored.oss_scored is False
 
     def test_fixed_base_score_scores_without_stored_files(self):
         scored = ScoredPR(pr=_pr())
@@ -381,6 +382,7 @@ class TestScoringDataStoredGate:
 
         client.get_pr_files.assert_not_called()
         assert scored.base_score == pytest.approx(7.5)
+        assert scored.oss_scored is True
 
 
 class TestFixedBaseScore:


### PR DESCRIPTION
## Summary
- Add `ScoredPR.oss_scored`, set only when `score_pr` finishes multipliers (not on early-return).
- `_build_solving_pr_cache` caches only `oss_scored` PRs so incomplete OSS defaults (`token_score=0`) no longer suppress `get_pr_files` during issue discovery.
- Regression tests cover unscored exclusion while preserving intentional caching of genuine zero-token scored PRs.

## Related Issues
Fixes #1677

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [x] Tests added/updated
- [x] Manually tested
  - `uv run pre-commit run --all-files`
  - `uv run pre-commit run --all-files --hook-stage pre-push` (pyright, vulture, full pytest)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
