### PR TITLE
sparkinfer-k3: 3x faster time-decay for merged-PR scores

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -21,6 +21,14 @@
       "eval:REJECT": 0.0
     },
     "maintainer_cut": 0.4,
-    "trusted_label_pipeline": true
+    "trusted_label_pipeline": true,
+    "scoring": {
+      "time_decay": {
+        "grace_period_hours": 4,
+        "sigmoid_midpoint_days": 3.33,
+        "sigmoid_steepness": 1.2,
+        "min_multiplier": 0.05
+      }
+    }
   }
 }


### PR DESCRIPTION
## What

Add a `scoring.time_decay` override for `gittensor-ai-lab/sparkinfer-k3` (the repo #1675 pointed all subnet emissions at) so a merged PR's score multiplier decays **3x faster in time** than the org default. Grace period, sigmoid midpoint, and sigmoid steepness are all scaled by 3x, which is an exact time-compression of the curve (`g(t) == f(3t)` against the previous curve) — the floor value is unchanged.

| param | before (org default) | after |
|---|:---:|:---:|
| grace_period_hours | 12 | **4** |
| sigmoid_midpoint_days | 10 | **3.33** |
| sigmoid_steepness | 0.4 | **1.2** |
| min_multiplier (floor) | 0.05 | 0.05 (unchanged) |

Milestones (days since merge):

| | before | after |
|---|:---:|:---:|
| 50% of score remaining | day 10 | **day 3.33** |
| ~10% remaining | day 15.5 | **day 5.2** |
| 5% floor reached | day 17.4 | **day 5.8** |

## Why

`sparkinfer-k3` currently has no `scoring.time_decay` override, so a merged PR's score decays on the org-wide default curve (50% loss by day 10). Since #1675, sparkinfer-k3 is the only funded repo in the registry — verified improvements should reward *fresh* contributions more sharply, incentivizing miners toward a steady stream of new verified merges rather than living for a long time off one old one.

Same transform as #1673 (SparkDistill), applied here to sparkinfer-k3.

## Scope / safety

- Only `gittensor-ai-lab/sparkinfer-k3`'s `scoring.time_decay` block is added — no other field changes.
- All new values are within `load_weights.py`'s live bounds (`grace_period_hours` in `[0,168]`, `sigmoid_midpoint_days` in `[1,90]`, `sigmoid_steepness` in `[0.01,5]`, `min_multiplier` in `[0,1]`).
- Full suite passes, 892 tests.
- 9-line diff, JSON validates.