### PR TITLE
chore(weights): replace sparkinfer-k3 with sparkinfer

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,5 +1,5 @@
 {
-  "gittensor-ai-lab/sparkinfer-k3": {
+  "gittensor-ai-lab/sparkinfer": {
     "default_label_multiplier": 0.0,
     "eligibility": {
       "min_credibility": 0.2,
@@ -7,7 +7,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 1.0,
+    "emission_share": 0.1,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,5 +1,26 @@
 {
   "gittensor-ai-lab/sparkinfer": {
-    "emission_share": 0.1
+    "default_label_multiplier": 0.0,
+    "eligibility": {
+      "min_credibility": 0.2,
+      "min_issue_credibility": 0.0,
+      "min_valid_merged_prs": 0,
+      "min_valid_solved_issues": 0
+    },
+    "emission_share": 0.1,
+    "fixed_base_score": 1.0,
+    "issue_discovery_share": 0.0,
+    "label_multipliers": {
+      "eval:XL": 4.0,
+      "eval:L": 2.5,
+      "eval:M": 1.5,
+      "eval:S": 1.0,
+      "eval:XS": 0.5,
+      "eval:BASELINE": 1.0,
+      "eval:none": 0.0,
+      "eval:REJECT": 0.0
+    },
+    "maintainer_cut": 0.4,
+    "trusted_label_pipeline": true
   }
 }

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,7 +7,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.1,
+    "emission_share": 0.3,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {

--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -1,34 +1,5 @@
 {
   "gittensor-ai-lab/sparkinfer": {
-    "default_label_multiplier": 0.0,
-    "eligibility": {
-      "min_credibility": 0.2,
-      "min_issue_credibility": 0.0,
-      "min_valid_merged_prs": 0,
-      "min_valid_solved_issues": 0
-    },
-    "emission_share": 0.1,
-    "fixed_base_score": 1.0,
-    "issue_discovery_share": 0.0,
-    "label_multipliers": {
-      "eval:XL": 4.0,
-      "eval:L": 2.5,
-      "eval:M": 1.5,
-      "eval:S": 1.0,
-      "eval:XS": 0.5,
-      "eval:BASELINE": 1.0,
-      "eval:none": 0.0,
-      "eval:REJECT": 0.0
-    },
-    "maintainer_cut": 0.4,
-    "trusted_label_pipeline": true,
-    "scoring": {
-      "time_decay": {
-        "grace_period_hours": 4,
-        "sigmoid_midpoint_days": 3.33,
-        "sigmoid_steepness": 1.2,
-        "min_multiplier": 0.05
-      }
-    }
+    "emission_share": 0.1
   }
 }


### PR DESCRIPTION
## Summary

- Remove `gittensor-ai-lab/sparkinfer-k3` from the repository registry.
- Add `gittensor-ai-lab/sparkinfer` with `emission_share` set to `0.3`.
- Carry over the former K3 eligibility, label, base-score, issue-discovery, maintainer-cut, and trusted-label settings.
- Remove the K3-specific `scoring.time_decay` override so SparkInfer uses the platform default time decay.

## Emission share

| Repository | Before | After |
|---|---:|---:|
| `gittensor-ai-lab/sparkinfer-k3` | 1.0 | Removed |
| `gittensor-ai-lab/sparkinfer` | Not registered | 0.3 |

## Why

This moves Gittensor incentives from the K3-specific repository to the main SparkInfer repository and applies the requested 0.3 emission allocation. The configuration incorporates the repository owner's PR feedback while returning time-decay behavior to the [platform defaults](https://docs.gittensor.io/repository-hyperparameters.html).

## Validation

- `jq empty gittensor/validator/weights/master_repositories.json`
- `uv run --extra dev pytest tests/validator/test_load_weights.py` (64 passed)
