### PR TITLE
Allow manual dispatch of docker image build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Adds workflow_dispatch to docker-publish so the image build can be re-run manually.

Yesterday's 20:41 UTC release promoted main during the GitHub Actions incident (webhook triggers throttled to ~15%), so the push event was dropped and no image was built or deployed. Merging this and promoting gives the release a real commit to push, which triggers the build; the dispatch trigger covers this scenario next time.