### PR TITLE
chore(weights): drop the linked-issue bonus for sparkinfer

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -21,6 +21,10 @@
       "eval:REJECT": 0.0
     },
     "maintainer_cut": 0.4,
+    "scoring": {
+      "standard_issue_multiplier": 1.0,
+      "maintainer_issue_multiplier": 1.0
+    },
     "trusted_label_pipeline": true
   }
 }


### PR DESCRIPTION
Follow-up to #1682.

## Summary

- Add a `scoring` block to `gittensor-ai-lab/sparkinfer` pinning `standard_issue_multiplier` and `maintainer_issue_multiplier` to `1.0`.

## Why

#1682 carried the K3 settings over to `gittensor-ai-lab/sparkinfer` but left both issue multipliers unset, so the repo silently inherited the platform defaults from `gittensor/constants.py`:

| Knob | Before (inherited default) | After |
|---|---:|---:|
| `scoring.standard_issue_multiplier` | 1.33 | 1.0 |
| `scoring.maintainer_issue_multiplier` | 1.66 | 1.0 |

Under those defaults, `_calculate_issue_multiplier` in `gittensor/validator/oss_contributions/mirror/scoring.py` scores a PR with a valid linked issue 33–66% above an otherwise identical PR with no linked issue. That is a bonus SparkInfer does not want: the repo already sets `issue_discovery_share` to `0.0`, so the issue channel is intended to be off here, and PR value is already expressed through the `eval:*` label multipliers applied by the trusted label pipeline. Leaving the linked-issue bonus on adds a scoring axis unrelated to the measured performance win, and rewards linking an issue rather than the contribution itself.

`1.0` is neutral (no bonus) and is the floor of the `[1, 5]` range enforced by `_validate_scoring_configs`, so this is the minimum the registry permits. Every other knob — `emission_share`, `maintainer_cut`, eligibility, labels, and the platform-default time decay restored in #1682 — is unchanged.

## Validation

- `jq empty gittensor/validator/weights/master_repositories.json`
- `uv run --extra dev pytest tests/validator/test_load_weights.py` (64 passed)
- `uv run --extra dev pytest tests/validator/oss_contributions/mirror/` (117 passed)
- Resolved config confirms the override lands: `resolve_scoring` returns `standard_issue_multiplier=1.0`, `maintainer_issue_multiplier=1.0`.