### PR TITLE
fix: return bare None when close event selection fails

### DIFF
--- a/gittensor/utils/github_api_tools.py
+++ b/gittensor/utils/github_api_tools.py
@@ -509,7 +509,7 @@ def find_solver_from_closure_event(
 
     close_event = _select_current_close_event(issue_data)
     if close_event is None:
-        return None, None
+        return None  # lookup unresolved — retry later
 
     solver_github_id, pr_number = _solver_from_closed_event(f'{owner}/{name}', close_event)
     bt.logging.debug(


### PR DESCRIPTION
## Fix

When `_select_current_close_event` returns `None`, `find_solver_from_closure_event` was returning `(None, None)` — the same sentinel used for "no valid closing PR." This caused `solver_lookup_failed=False` and an on-chain cancel vote, instead of treating it as an unresolved lookup that should be retried later.

**Fix:** return bare `None` so `solver_lookup_failed=True` and forward skips.

```python
# Before
if close_event is None:
    return None, None

# After
if close_event is None:
    return None  # lookup unresolved — retry later
```

Fixes #1684