### PR TITLE
Increase SparkInfer emission share to 40%

### DIFF
--- a/gittensor/validator/weights/master_repositories.json
+++ b/gittensor/validator/weights/master_repositories.json
@@ -7,7 +7,7 @@
       "min_valid_merged_prs": 0,
       "min_valid_solved_issues": 0
     },
-    "emission_share": 0.3,
+    "emission_share": 0.4,
     "fixed_base_score": 1.0,
     "issue_discovery_share": 0.0,
     "label_multipliers": {


### PR DESCRIPTION
## Summary

- Increase `gittensor-ai-lab/sparkinfer`'s configured emission share from 30% to 40%.
- Leave its scoring, eligibility, label multipliers, and maintainer cut unchanged.

## Emission share

| Repo | Before | After | Change |
| --- | ---: | ---: | ---: |
| `gittensor-ai-lab/sparkinfer` | 30% | 40% | +10 pp |

Total configured emission share moves from 30% to 40%.

## Impact

SparkInfer receives a larger bounded share of the repository emissions pool. The registry remains within the allowed total of 100%.

## Validation

- `uv run --extra dev pytest tests/validator/test_load_weights.py` (64 passed)
