### PR TITLE
ci: pre-fill the sparkinfer ref in the Run workflow form

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -1,6 +1,6 @@
 name: sparkinfer image
 
-# Builds the blessed serving runtime (docs/serving-runtime-contract.md) from a pinned upstream commit and
+# Builds the blessed serving runtime (see the Serving Runtime Contract in the miner docs) from a pinned upstream commit and
 # publishes it as entrius/sparkinfer:<ref>. Run manually with the commit you intend to bless; the
 # resulting tag is what goes into `runtime_pin` in gittensor/validator/weights/serving_loadout.json.
 # No GPU in CI: this only proves the release builds. Conformance (scripts/check_serving_runtime.py) runs
@@ -10,8 +10,9 @@ on:
   workflow_dispatch:
     inputs:
       sparkinfer_ref:
-        description: "sparkinfer commit/tag to build (becomes the image tag and runtime_pin)"
+        description: "sparkinfer commit to build (becomes the image tag and runtime_pin). Keep in sync with DEFAULT_SPARKINFER_REF below."
         required: true
+        default: "9e43bfa"
       cuda_archs:
         description: "CMAKE_CUDA_ARCHITECTURES"
         required: false


### PR DESCRIPTION
The Run workflow dialog showed an empty required field; it now defaults to `9e43bfa` (same value as `DEFAULT_SPARKINFER_REF`). Workflow-only change.