### PR TITLE
emissions: 20% to the serving (compute) pool

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -152,7 +152,7 @@ RECYCLE_UID = 0
 
 # Combined scoring pool distributed by repository emission_share, then by per-repo PR/issue split.
 # Pools (OSS + SERVING) must sum to 1.0; anything unallocated within them recycles to RECYCLE_UID.
-OSS_EMISSION_SHARE = 1.00
+OSS_EMISSION_SHARE = 0.80  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 32% of total)
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
 MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
@@ -160,10 +160,11 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # =============================================================================
 # Serving (sub-subnet B beta)
 # =============================================================================
-# Share of emissions paid to inference-serving miners, pro-rata by serving score.
-# 0.0 = shadow mode: scores are computed and logged but nothing is paid. When
-# raising above 0, shrink OSS_EMISSION_SHARE so all pools still sum to 1.0.
-SERVING_EMISSION_SHARE = 0.0
+# Share of emissions paid to inference-serving miners, pro-rata by serving score. With no miner
+# passing audits the whole pool recycles to RECYCLE_UID, so this is safe to hold above 0 before
+# miners exist. 0.0 would be shadow mode (scores computed and logged, nothing paid). Move
+# OSS_EMISSION_SHARE in the same commit so the pools still sum to 1.0.
+SERVING_EMISSION_SHARE = 0.20
 assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )

--- a/tests/validator/test_blend_emission_pools.py
+++ b/tests/validator/test_blend_emission_pools.py
@@ -9,6 +9,7 @@ weight to fill the configured pool, PR/issue sub-slices spill only within a repo
 registry slack recycles, and the fixed recycle baseline is gone.
 """
 
+import sys
 from datetime import datetime, timezone
 
 import pytest
@@ -19,9 +20,20 @@ from gittensor.constants import (
     RECYCLE_UID,
 )
 from gittensor.utils.mirror.models import MirrorPullRequest, MirrorReviewSummary
+from gittensor.validator import emission_allocation
 from gittensor.validator.emission_allocation import blend_emission_pools, calculate_repo_emission_breakdown
 from gittensor.validator.oss_contributions.mirror.scored_pr import ScoredPR
 from gittensor.validator.utils.load_weights import RepositoryConfig, load_master_repo_weights
+
+
+@pytest.fixture(autouse=True)
+def _oss_pool_only(monkeypatch):
+    """These tests cover the OSS pool's own allocation; the serving pool (which recycles whenever no
+    serving miner passes audits) is pinned to 0 so recycle expectations stay about OSS slack only.
+    (and OSS to the full round, so round totals stay 1.0). The serving pool is covered in test_serving.py."""
+    monkeypatch.setattr(emission_allocation, 'SERVING_EMISSION_SHARE', 0.0)
+    monkeypatch.setattr(emission_allocation, 'OSS_EMISSION_SHARE', 1.0)
+    monkeypatch.setattr(sys.modules[__name__], 'OSS_EMISSION_SHARE', 1.0)
 
 
 def _uids(*extra: int) -> set[int]:


### PR DESCRIPTION
`SERVING_EMISSION_SHARE` 0.0 → **0.20**, `OSS_EMISSION_SHARE` 1.00 → **0.80**. Two constants, nothing else.

- sparkinfer's `master_repositories.json` entry is untouched at 0.4 — that's 0.4 of the OSS pool, so 32% of total emissions (was 40%); the remaining 48% of the OSS pool still recycles.
- The serving pool is paid pro-rata by serving score to miners whose audit window passes. With zero such miners the pool recycles to UID 0 (`test_blend_recycles_serving_pool_without_scorers`), so this is safe to merge before any miner is running; the point is to watch compute emissions flow on testnet.
- Validators need a reachable reference for the release (`SERVING_REFERENCE_URL` to their own or a rented 5090 running `entrius/sparkinfer:9e43bfa`) or the serving round is skipped with a log line and the pool recycles.

Tests: 687 pass (the pool-sum assertion in constants guards the pair).