### PR TITLE
serving: testnet bring-up fixes, sparkinfer 12954e6 pin, audits decoupled from the OSS round

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -12,7 +12,7 @@ on:
       sparkinfer_ref:
         description: "sparkinfer commit to build (becomes the image tag and runtime_pin). Keep in sync with DEFAULT_SPARKINFER_REF below."
         required: true
-        default: "9e43bfa"
+        default: "12954e6"
       cuda_archs:
         description: "CMAKE_CUDA_ARCHITECTURES"
         required: false
@@ -25,7 +25,7 @@ on:
 
 env:
   # Ref used by the build-only check; dispatch runs use the input instead.
-  DEFAULT_SPARKINFER_REF: "9e43bfa"
+  DEFAULT_SPARKINFER_REF: "12954e6"
 
 jobs:
   image:

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -178,7 +178,7 @@ SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before an audit counts as failed
 # one-GPU-many-hotkeys case, caught by concurrent burst audits (launch plan, gap 0).
 SERVING_LATENCY_FULL_CREDIT_MS = 500.0
 SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
-# Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 9e43bfa, SPARKINFER_DETERMINISTIC=1), so an
+# Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 12954e6, SPARKINFER_DETERMINISTIC=1), so an
 # honest miner reproduces the reference's greedy tokens exactly and its logprobs to float noise; every planted
 # cheater differs on every prompt (measured 2026-08-24, internal serving-experiments notes: honest max |delta| 0.0000,
 # cheapest cheater min mean |delta| 0.0057 / min max |delta| 0.129). Both bands must hold for an audit to pass.

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -195,6 +195,8 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 SERVING_AUDIT_WINDOW = 20
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.85),)
 SERVING_API_DEFAULT_PORT = 8790
+SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
+SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)
 SERVING_REQUEST_LOG_SIZE = 5_000  # in-memory ring of recent API/audit requests (telemetry)
 

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -32,7 +32,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from gittensor.constants import SERVING_MAX_TOKENS
 from gittensor.serving.loadout import ServingRelease
-from gittensor.serving.state import ReadyMiner, RequestRecord, ServingState
+from gittensor.serving.state import ReadyMiner, RequestRecord, ServingState, finite_or_none
 from gittensor.synapses import InferenceSynapse
 
 _bearer = HTTPBearer(auto_error=False)
@@ -171,8 +171,8 @@ def build_app(
             'gittensor': {
                 'served_uid': miner.uid,
                 'latency_ms': round(latency_ms, 1),
-                'ttft_ms': result.ttft_ms,
-                'decode_tps': result.decode_tps,
+                'ttft_ms': finite_or_none(result.ttft_ms),
+                'decode_tps': finite_or_none(result.decode_tps),
             },
         }
 

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -30,7 +30,7 @@ Three references, picked per release by ``reference_for``:
 - ``positional_overlap``: fraction of positions whose token matches the
   reference, ignoring divergence (telemetry).
 
-The blessed runtime is bit-reproducible (sparkinfer 9e43bfa with
+The blessed runtime is bit-reproducible (sparkinfer 12954e6 with
 ``SPARKINFER_DETERMINISTIC=1``), so an honest miner reproduces the reference
 exactly and ``passed`` is decisive per audit: all tokens match and logprobs
 agree to float noise (``SERVING_AUDIT_*`` bands in constants.py, calibrated in

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -10,6 +10,7 @@ which is the seed of every later phase: miner speed scoring on organic
 traffic, the router competition's replay dataset, and usage telemetry.
 """
 
+import math
 import threading
 import time
 from collections import deque
@@ -42,6 +43,15 @@ class RequestRecord:
     ttft_ms: Optional[float] = None
     decode_tps: Optional[float] = None
     detail: str = ''
+
+    def __post_init__(self) -> None:
+        for name in ('latency_ms', 'ttft_ms', 'decode_tps'):
+            self.__dict__[name] = finite_or_none(getattr(self, name))
+
+
+def finite_or_none(value: Optional[float]) -> Optional[float]:
+    """Miner-reported floats go into JSON responses, which reject NaN/inf."""
+    return float(value) if value is not None and math.isfinite(value) else None
 
 
 @dataclass

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -37,7 +37,7 @@ class RequestRecord:
     kind: str  # 'audit' | 'gateway'
     uid: Optional[int]
     ok: bool
-    latency_ms: float
+    latency_ms: Optional[float]  # None when the request produced no response
     completion_tokens: int = 0
     ttft_ms: Optional[float] = None
     decode_tps: Optional[float] = None

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -1,5 +1,5 @@
 # Entrius 2025
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 
 import bittensor as bt
 from pydantic import Field
@@ -42,6 +42,8 @@ class InferenceSynapse(bt.Synapse):
     returns per-token logprobs of the greedy completion, which the validator
     checks against its reference (``gittensor/serving/audit.py``).
     """
+
+    required_hash_fields: ClassVar[tuple[str, ...]] = ('messages', 'model_id', 'max_tokens', 'logprobs')
 
     # Request
     messages: List[Dict[str, str]]

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -15,6 +15,7 @@ from gittensor.validator.oss_contributions.reward import get_rewards
 from gittensor.validator.serving.forward import serving_challenges
 from gittensor.validator.utils.config import (
     SERVING_ENABLED,
+    SERVING_STEPS_INTERVAL,
     VALIDATOR_STEPS_INTERVAL,
     VALIDATOR_WAIT,
 )
@@ -32,13 +33,14 @@ if TYPE_CHECKING:
 async def forward(self: 'Validator') -> None:
     """Execute the validator's forward pass.
 
+    Serving audits run every SERVING_STEPS_INTERVAL steps (SERVING_ENABLED only) so the gateway's READY set
+    stays fresh; the latest serving scores are kept on the validator and blended at the next OSS round.
+
     Performs the core validation cycle every VALIDATOR_STEPS_INTERVAL steps:
     1. Score OSS contributions (mirror PR scoring)
     2. Score issue discovery
-    3. Run issue bounties verification
-    4. Run serving challenges (SERVING_ENABLED only; shadow mode at 0% share)
-    5. Store all evaluations to DB
-    6. Blend emission pools and update scores
+    3. Store all evaluations to DB
+    4. Blend emission pools (with the latest serving scores) and update scores
 
     Emission blending:
     - Combined scoring pool: 90%, allocated by repository emission_share
@@ -47,6 +49,14 @@ async def forward(self: 'Validator') -> None:
     - Serving pool:          SERVING_EMISSION_SHARE (0% shadow-mode beta) by serving score
     - Recycle:              registry slack and inactive repo slices to UID 0
     """
+
+    if SERVING_ENABLED and self.step % SERVING_STEPS_INTERVAL == 0:
+        try:
+            self.serving_scores = await serving_challenges(self, get_all_uids(self))
+        except Exception as e:  # a serving fault must never take the OSS round (or the validator) down
+            bt.logging.error(f'Serving round failed, no serving scores this round: {e!r}')
+            self.serving_state.publish_ready([])
+            self.serving_scores = {}
 
     if self.step % VALIDATOR_STEPS_INTERVAL == 0:
         miner_uids = get_all_uids(self)
@@ -71,22 +81,13 @@ async def forward(self: 'Validator') -> None:
         # cached UIDs now have fresh issue-discovery fields — persist them
         cached_uids.clear()
 
-        # 4. Serving challenges (sub-subnet B beta; scores are telemetry until SERVING_EMISSION_SHARE > 0)
-        serving_scores: Dict[int, float] = {}
-        if SERVING_ENABLED:
-            try:
-                serving_scores = await serving_challenges(self, miner_uids)
-            except Exception as e:  # a serving fault must never take the OSS round (or the validator) down
-                bt.logging.error(f'Serving round failed, no serving scores this round: {e!r}')
-                self.serving_state.publish_ready([])
-
-        # 5. Store all evaluations to DB (includes issue discovery fields)
+        # 4. Store all evaluations to DB (includes issue discovery fields)
         await self.bulk_store_evaluation(miner_evaluations, master_repositories, skip_uids=cached_uids)
 
-        # 6. Allocate repo-bounded emission shares into final rewards
+        # 5. Allocate repo-bounded emission shares into final rewards
         maintainer_uids_by_repo = build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
         rewards = blend_emission_pools(
-            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, serving_scores
+            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, self.serving_scores
         )
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -153,7 +153,9 @@ def score_response(
         )
 
     if getattr(response, 'completion', None) is None:
-        return AuditVerdict(False, 0.0, float('inf'), 'no response'), float('inf'), rec(False, 'no response')
+        dendrite = getattr(response, 'dendrite', None)
+        reason = f'no response ({getattr(dendrite, "status_code", None)} {getattr(dendrite, "status_message", None)})'
+        return AuditVerdict(False, 0.0, float('inf'), reason), float('inf'), rec(False, reason)
     served = getattr(response, 'served_model_id', None)
     if served != release.model_id:
         reason = f'wrong model {served!r}'

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -18,6 +18,7 @@ their release) to the gateway for the next round.
 Misses count as 0 in the window and latency credit 0 in the round.
 """
 
+import math
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
@@ -144,7 +145,7 @@ def score_response(
             kind='audit',
             uid=uid,
             ok=ok,
-            latency_ms=elapsed_ms,
+            latency_ms=elapsed_ms if math.isfinite(elapsed_ms) else None,
             completion_tokens=len(getattr(response, 'tokens', None) or []),
             ttft_ms=getattr(response, 'ttft_ms', None),
             decode_tps=getattr(response, 'decode_tps', None),

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -5,7 +5,9 @@ import bittensor as bt
 from gittensor.constants import SERVING_API_DEFAULT_PORT
 
 VALIDATOR_WAIT = 60  # 60 seconds
-VALIDATOR_STEPS_INTERVAL = 120  # 2 hours, every time a scoring round happens
+VALIDATOR_STEPS_INTERVAL = int(
+    os.getenv('VALIDATOR_STEPS_INTERVAL', '120')
+)  # steps (~minutes) between scoring rounds; 120 = 2 hours
 
 # required env vars
 WANDB_API_KEY = os.getenv('WANDB_API_KEY')

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -17,6 +17,7 @@ WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 # optional env vars
 STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'
 SERVING_ENABLED = os.getenv('SERVING_ENABLED', 'false').lower() == 'true'
+SERVING_STEPS_INTERVAL = int(os.getenv('SERVING_STEPS_INTERVAL', '5'))  # steps (~minutes) between serving audit rounds
 # Serving inference API: off unless keys are set; loopback by default (0.0.0.0 inside docker), front it with the host proxy.
 SERVING_API_KEYS = os.getenv('SERVING_API_KEYS', '')
 SERVING_API_HOST = os.getenv('SERVING_API_HOST', '127.0.0.1')
@@ -27,3 +28,4 @@ bt.logging.info(f'VALIDATOR_WAIT: {VALIDATOR_WAIT}')
 bt.logging.info(f'VALIDATOR_STEPS_INTERVAL: {VALIDATOR_STEPS_INTERVAL}')
 bt.logging.info(f'WANDB_PROJECT: {WANDB_PROJECT}')
 bt.logging.info(f'SERVING_ENABLED: {SERVING_ENABLED}')
+bt.logging.info(f'SERVING_STEPS_INTERVAL: {SERVING_STEPS_INTERVAL}')

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -18,6 +18,8 @@ WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'
 SERVING_ENABLED = os.getenv('SERVING_ENABLED', 'false').lower() == 'true'
 SERVING_STEPS_INTERVAL = int(os.getenv('SERVING_STEPS_INTERVAL', '5'))  # steps (~minutes) between serving audit rounds
+if VALIDATOR_STEPS_INTERVAL < 1 or SERVING_STEPS_INTERVAL < 1:
+    raise ValueError('VALIDATOR_STEPS_INTERVAL and SERVING_STEPS_INTERVAL must be >= 1')
 # Serving inference API: off unless keys are set; loopback by default (0.0.0.0 inside docker), front it with the host proxy.
 SERVING_API_KEYS = os.getenv('SERVING_API_KEYS', '')
 SERVING_API_HOST = os.getenv('SERVING_API_HOST', '127.0.0.1')

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -6,7 +6,7 @@
       "base_url": "http://127.0.0.1:8080",
       "max_tokens": 64,
       "request_timeout": 60,
-      "runtime_pin": "gittensor-ai-lab/sparkinfer@9e43bfa",
+      "runtime_pin": "gittensor-ai-lab/sparkinfer@12954e6",
       "model_file": "unsloth/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
       "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
       "audit_bank": "serving_audit_bank.json"

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -31,12 +31,15 @@ Miners run this blessed neuron unmodified — serving reward is availability
 and correctness based, so there is nothing to gain by editing it.
 """
 
+import asyncio
 import os
 import time
 from functools import partial
 from typing import Tuple
 
 import bittensor as bt
+from bittensor.utils.axon_utils import allowed_nonce_window_ns, calculate_diff_seconds
+from bittensor_wallet import Keypair
 
 from gittensor.constants import SERVING_MAX_TOKENS
 from gittensor.serving.backends import InferenceBackend, load_backend
@@ -63,6 +66,7 @@ class ServingMiner(BaseNeuron):
             forward_fn=partial(handle_inference, self),
             blacklist_fn=partial(blacklist_inference, self),
             priority_fn=partial(priority_inference, self),
+            verify_fn=partial(verify_inference, self),
         )
         bt.logging.info(f'ServingMiner axon: {self.axon}')
 
@@ -96,7 +100,7 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> In
     """Generate a completion for a challenge (or, later, real traffic)."""
     max_tokens = max(1, min(int(synapse.max_tokens), SERVING_MAX_TOKENS))
     try:
-        result = miner.backend.generate(synapse.messages, max_tokens, logprobs=synapse.logprobs)
+        result = await asyncio.to_thread(miner.backend.generate, synapse.messages, max_tokens, synapse.logprobs)
     except Exception as e:  # backend down/overloaded: answer empty, validator scores it 0
         bt.logging.warning(f'ServingMiner backend error: {e}')
         return synapse
@@ -110,6 +114,26 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> In
     synapse.finish_reason = result.finish_reason
     synapse.usage = result.usage or None
     return synapse
+
+
+async def verify_inference(miner: ServingMiner, synapse: InferenceSynapse) -> None:
+    """Signature + freshness check without the strictly increasing nonce the default verify enforces.
+
+    A validator gateway dispatches concurrent requests from one dendrite; they arrive out of order and the
+    default verify rejects every request whose nonce is older than the newest one processed.
+    """
+    d = synapse.dendrite
+    if d is None or d.nonce is None or d.hotkey is None:
+        raise Exception('Missing dendrite headers')
+    now_ns = time.time_ns()
+    if d.nonce <= allowed_nonce_window_ns(now_ns, synapse.timeout):
+        diff, allowed = calculate_diff_seconds(now_ns, synapse.timeout, d.nonce)
+        raise Exception(
+            f'Nonce is too old: acceptable delta is {allowed:.2f} seconds but request was {diff:.2f} seconds old'
+        )
+    message = f'{d.nonce}.{d.hotkey}.{miner.wallet.hotkey.ss58_address}.{d.uuid}.{synapse.computed_body_hash}'
+    if not d.signature or not Keypair(ss58_address=d.hotkey).verify(message, d.signature):
+        raise Exception('Signature mismatch')
 
 
 async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -70,6 +70,9 @@ class ServingMiner(BaseNeuron):
         # Satisfies the BaseNeuron ABC; axon requests route through handle_inference.
         return synapse
 
+    def resync_metagraph(self):
+        self.metagraph.sync(subtensor=self.subtensor)
+
     def run(self):
         self.subtensor.serve_axon(netuid=self.config.netuid, axon=self.axon)
         self.axon.start()

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -34,6 +34,7 @@ and correctness based, so there is nothing to gain by editing it.
 import asyncio
 import os
 import time
+from collections import OrderedDict
 from functools import partial
 from typing import Tuple
 
@@ -41,7 +42,7 @@ import bittensor as bt
 from bittensor.utils.axon_utils import allowed_nonce_window_ns, calculate_diff_seconds
 from bittensor_wallet import Keypair
 
-from gittensor.constants import SERVING_MAX_TOKENS
+from gittensor.constants import SERVING_BACKEND_CONCURRENCY, SERVING_MAX_TOKENS, SERVING_SEEN_NONCES
 from gittensor.serving.backends import InferenceBackend, load_backend
 from gittensor.serving.loadout import load_serving_loadout
 from gittensor.synapses import InferenceSynapse
@@ -68,6 +69,8 @@ class ServingMiner(BaseNeuron):
             priority_fn=partial(priority_inference, self),
             verify_fn=partial(verify_inference, self),
         )
+        self.backend_slots = asyncio.Semaphore(SERVING_BACKEND_CONCURRENCY)
+        self.seen_nonces: 'OrderedDict[str, None]' = OrderedDict()
         bt.logging.info(f'ServingMiner axon: {self.axon}')
 
     async def forward(self, synapse: bt.Synapse) -> bt.Synapse:
@@ -100,7 +103,8 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> In
     """Generate a completion for a challenge (or, later, real traffic)."""
     max_tokens = max(1, min(int(synapse.max_tokens), SERVING_MAX_TOKENS))
     try:
-        result = await asyncio.to_thread(miner.backend.generate, synapse.messages, max_tokens, synapse.logprobs)
+        async with miner.backend_slots:
+            result = await asyncio.to_thread(miner.backend.generate, synapse.messages, max_tokens, synapse.logprobs)
     except Exception as e:  # backend down/overloaded: answer empty, validator scores it 0
         bt.logging.warning(f'ServingMiner backend error: {e}')
         return synapse
@@ -117,10 +121,11 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> In
 
 
 async def verify_inference(miner: ServingMiner, synapse: InferenceSynapse) -> None:
-    """Signature + freshness check without the strictly increasing nonce the default verify enforces.
+    """Signature + freshness + no-replay check without the strictly increasing nonce the default verify enforces.
 
     A validator gateway dispatches concurrent requests from one dendrite; they arrive out of order and the
-    default verify rejects every request whose nonce is older than the newest one processed.
+    default verify rejects every request whose nonce is older than the newest one processed. Exact repeats of a
+    (hotkey, uuid, nonce) within the freshness window are rejected instead.
     """
     d = synapse.dendrite
     if d is None or d.nonce is None or d.hotkey is None:
@@ -134,6 +139,12 @@ async def verify_inference(miner: ServingMiner, synapse: InferenceSynapse) -> No
     message = f'{d.nonce}.{d.hotkey}.{miner.wallet.hotkey.ss58_address}.{d.uuid}.{synapse.computed_body_hash}'
     if not d.signature or not Keypair(ss58_address=d.hotkey).verify(message, d.signature):
         raise Exception('Signature mismatch')
+    key = f'{d.hotkey}:{d.uuid}:{d.nonce}'
+    if key in miner.seen_nonces:
+        raise Exception('Nonce replayed')
+    miner.seen_nonces[key] = None
+    while len(miner.seen_nonces) > SERVING_SEEN_NONCES:
+        miner.seen_nonces.popitem(last=False)
 
 
 async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
@@ -148,8 +159,10 @@ async def priority_inference(miner: ServingMiner, synapse: InferenceSynapse) -> 
     hotkey = synapse.dendrite.hotkey if synapse.dendrite else None
     if not hotkey or hotkey not in miner.metagraph.hotkeys:
         return 0.0
-    uid = miner.metagraph.hotkeys.index(hotkey)
-    return float(miner.metagraph.S[uid])
+    try:  # hotkeys and S are refreshed separately by metagraph.sync() on the main thread
+        return float(miner.metagraph.S[miner.metagraph.hotkeys.index(hotkey)])
+    except (ValueError, IndexError):
+        return 0.0
 
 
 def main():

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -93,6 +93,7 @@ class Validator(BaseValidatorNeuron):
         # Serving sub-mechanism (beta): audit loop publishes READY miners here; the inference API dispatches to them.
         # The API starts only when SERVING_API_KEYS is set.
         self.serving_state = ServingState()
+        self.serving_scores: Dict[int, float] = {}
         audits_path = audit_window_path(self)
         if audits_path is not None:
             self.serving_state.audits = AuditWindow.load(audits_path)

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -121,12 +121,13 @@ def check_completion_shape(rep: Report, base_url: str, model_id: str, max_tokens
         assert lp is not None
         rep.add('R2 logprob values <= 0', MUST, all(float(e['logprob']) <= 1e-6 for e in lp))
         n_ct = usage.get('completion_tokens') or 0
+        # OpenAI counts the stop token in completion_tokens but omits it from logprobs.content (sparkinfer >= 12954e6).
+        eos_omitted = choice.get('finish_reason') == 'stop' and len(lp) == n_ct - 1
         rep.add(
-            'R2 entries == completion_tokens',
+            'R2 entries == completion_tokens (or one fewer on stop: EOS omitted)',
             MUST,
-            len(lp) == n_ct,
-            f'{len(lp)} vs {n_ct}'
-            + (' (first-token logprob missing — fixed upstream in 9e43bfa)' if len(lp) == n_ct - 1 else ''),
+            len(lp) == n_ct or eos_omitted,
+            f'{len(lp)} vs {n_ct}' + (' (EOS omitted)' if eos_omitted else ''),
         )
     rep.add(
         'R4 max_tokens honoured',

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -517,3 +517,38 @@ def test_serving_round_skips_release_without_reference(monkeypatch, tmp_path):
     assert scores == {1: 1.0}
     assert [m.uid for m in vali.serving_state.ready_miners()] == [1]
     assert (tmp_path / 'serving_audits.json').exists()
+
+
+def test_serving_audits_run_between_oss_rounds(monkeypatch):
+    """A serving step audits and caches scores without running the OSS round; the OSS round blends the cache."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.validator import forward as top
+
+    calls = []
+    monkeypatch.setattr(top, 'SERVING_ENABLED', True)
+    monkeypatch.setattr(top, 'SERVING_STEPS_INTERVAL', 5)
+    monkeypatch.setattr(top, 'VALIDATOR_STEPS_INTERVAL', 120)
+    monkeypatch.setattr(top, 'VALIDATOR_WAIT', 0)
+    monkeypatch.setattr(top, 'get_all_uids', lambda self: {1})
+
+    async def audits(self, uids):
+        calls.append(('serving', uids))
+        return {1: 0.5}
+
+    def oss(*a, **k):
+        raise AssertionError('OSS round must not run on a serving-only step')
+
+    monkeypatch.setattr(top, 'serving_challenges', audits)
+    monkeypatch.setattr(top, 'load_master_repo_weights', oss)
+
+    vali = SimpleNamespace(step=5, serving_state=ServingState(), serving_scores={})
+    asyncio.run(top.forward(vali))  # type: ignore[arg-type]
+    assert calls == [('serving', {1})]
+    assert vali.serving_scores == {1: 0.5}
+
+    vali.step = 7
+    asyncio.run(top.forward(vali))  # type: ignore[arg-type]
+    assert calls == [('serving', {1})]  # off-cadence step: no audit, cache untouched
+    assert vali.serving_scores == {1: 0.5}

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -363,6 +363,7 @@ def test_score_response_feeds_window_metrics():
     miss = InferenceSynapse(messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens)
     verdict, ms, rec = score_response(3, miss, case, release)
     assert verdict.positional_overlap == 0.0 and ms == float('inf') and not rec.ok
+    assert rec.latency_ms is None  # inf is not JSON; /v1/serving/status must serialize the record
 
     honest = InferenceSynapse(
         messages=case.messages,

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -552,3 +552,18 @@ def test_serving_audits_run_between_oss_rounds(monkeypatch):
     asyncio.run(top.forward(vali))  # type: ignore[arg-type]
     assert calls == [('serving', {1})]  # off-cadence step: no audit, cache untouched
     assert vali.serving_scores == {1: 0.5}
+
+
+def test_request_record_drops_non_finite_telemetry():
+    rec = RequestRecord(ts=0.0, kind='gateway', uid=1, ok=True, latency_ms=float('inf'), ttft_ms=float('nan'))
+    assert rec.latency_ms is None and rec.ttft_ms is None and rec.decode_tps is None
+    assert RequestRecord(ts=0.0, kind='gateway', uid=1, ok=True, latency_ms=12.5).latency_ms == 12.5
+
+
+def test_inference_synapse_hashes_request_fields():
+    from gittensor.synapses import InferenceSynapse
+
+    a = InferenceSynapse(messages=[{'role': 'user', 'content': 'x'}], model_id='m', max_tokens=8)
+    b = InferenceSynapse(messages=[{'role': 'user', 'content': 'y'}], model_id='m', max_tokens=8)
+    assert a.body_hash != b.body_hash
+    assert a.body_hash == InferenceSynapse(messages=a.messages, model_id='m', max_tokens=8).body_hash

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -20,8 +20,9 @@ reference_completion
 should_exit
 ts
 ECHO_LOADOUT_PATH
-# ServingMiner.resync_metagraph is dispatched by BaseNeuron.sync()
+# ServingMiner.resync_metagraph is dispatched by BaseNeuron.sync(); required_hash_fields is read by bt.Synapse
 resync_metagraph
+required_hash_fields
 
 # `__exit__(self, exc_type, exc, tb)` - PEP 343 signature, body unused args
 exc_type

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -20,6 +20,8 @@ reference_completion
 should_exit
 ts
 ECHO_LOADOUT_PATH
+# ServingMiner.resync_metagraph is dispatched by BaseNeuron.sync()
+resync_metagraph
 
 # `__exit__(self, exc_type, exc, tb)` - PEP 343 signature, body unused args
 exc_type


### PR DESCRIPTION
## Summary

Fixes found during the two serving step-0 testnet runs (8/24, 8/25) on netuid 422, plus the runtime pin bump to the sparkinfer commit that fixes the concurrent-logprob crash.

- serving miner: add the missing `resync_metagraph` (miner died every 60 s), custom axon `verify_fn` that accepts out-of-order nonces from one dendrite (concurrent gateway requests → `Nonce is too old` → 502), backend call moved off the event loop
- `/v1/serving/status`: failed audits stored `latency_ms=inf` (not JSON) → `None`; missed audits log the dendrite status
- validator: serving audits now run every `SERVING_STEPS_INTERVAL` steps (default 5) independently of the OSS round, so the gateway's READY set refreshes in minutes instead of the 2 h OSS cadence; latest scores are cached and blended at the next OSS round. `VALIDATOR_STEPS_INTERVAL` is env-overridable (testnet).
- `runtime_pin` → `gittensor-ai-lab/sparkinfer@12954e6` (upstream fix: unsynchronized global tokenizer under concurrent `logprobs:true` requests). Conformance script accepts the runtime's OpenAI-style EOS omission from `logprobs.content`. Image `entrius/sparkinfer:12954e6` is on Docker Hub; workflow defaults bumped.

## Related Issues

Follow-up to #1691 / #1694.

## Type of Change

- [x] Bug fix
- [x] New feature

## Testing

- [x] Tests added/updated
- [x] Manually tested

Testnet (netuid 422): validator at mainnet OSS cadence, two miners (UID 27, 16) proxying to one rented 5090, independent reference on a second 5090. Step 0: both miners 4/4 audits, weights on chain; step 5: serving round runs alone. Gateway: bursts of 4 and 8 all 200, requests split 7/6 across the two miners. New image: `check_serving_runtime.py` CONFORMANT (determinism exact), identical-pair / ×8 / ×16 / ×24 bursts all 200 with no crash.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)