### PR TITLE
serving: audit loop on its own thread, READY TTL, per-axon audits

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
     inputs:
       sparkinfer_ref:
-        description: "sparkinfer commit to build (becomes the image tag and runtime_pin). Keep in sync with DEFAULT_SPARKINFER_REF below."
-        required: true
-        default: "12954e6"
+        description: "sparkinfer commit to build (becomes the image tag). Empty = the runtime_pin in serving_loadout.json."
+        required: false
+        default: ""
       cuda_archs:
         description: "CMAKE_CUDA_ARCHITECTURES"
         required: false
@@ -23,10 +23,6 @@ on:
       - docker/sparkinfer.Dockerfile
       - .github/workflows/sparkinfer-image.yml
 
-env:
-  # Ref used by the build-only check; dispatch runs use the input instead.
-  DEFAULT_SPARKINFER_REF: "12954e6"
-
 jobs:
   image:
     # push-triggered runs (Dockerfile/workflow changed) only BUILD, to catch Dockerfile breakage in CI;
@@ -36,6 +32,16 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
+      - name: Resolve the sparkinfer ref (input, else runtime_pin in serving_loadout.json)
+        id: ref
+        run: |
+          REF="${{ inputs.sparkinfer_ref }}"
+          if [ -z "$REF" ]; then
+            REF=$(jq -r '.releases[0].runtime_pin' gittensor/validator/weights/serving_loadout.json | sed 's/.*@//')
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "building sparkinfer@$REF"
 
       - name: Free disk space (CUDA devel image is large)
         run: |
@@ -59,9 +65,9 @@ jobs:
           file: docker/sparkinfer.Dockerfile
           push: ${{ github.event_name == 'workflow_dispatch' }}
           build-args: |
-            SPARKINFER_REF=${{ inputs.sparkinfer_ref || env.DEFAULT_SPARKINFER_REF }}
+            SPARKINFER_REF=${{ steps.ref.outputs.ref }}
             CUDA_ARCHS=${{ inputs.cuda_archs || '120' }}
           tags: |
-            entrius/sparkinfer:${{ inputs.sparkinfer_ref || env.DEFAULT_SPARKINFER_REF }}
+            entrius/sparkinfer:${{ steps.ref.outputs.ref }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -170,6 +170,8 @@ assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE - 1.0) < EMISSION_SHARE_T
 )
 SERVING_CHALLENGES_PER_ROUND = 4  # audit prompts sent to each serving miner per scoring round
 SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before an audit counts as failed
+SERVING_AUDIT_CONCURRENCY = 32  # serving axons audited in parallel per round
+SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
 # Latency credit for a 64-token audit (release.max_tokens). An honest 5090 answers in ~165 ms on-box
 # (measured 2026-08-22/24: p95 166 ms); add validator<->miner RTT and an
 # honest miner anywhere on earth lands under ~450 ms. Credit is flat to FULL and falls linearly to 0 at

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -15,11 +15,11 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Deque, Dict, List, Optional
+from typing import Deque, Dict, List, Optional, Sequence
 
 import bittensor as bt
 
-from gittensor.constants import SERVING_REQUEST_LOG_SIZE
+from gittensor.constants import SERVING_READY_TTL_S, SERVING_REQUEST_LOG_SIZE
 from gittensor.serving.audit import AuditWindow
 
 
@@ -61,21 +61,38 @@ class ServingState:
     _inflight: Dict[int, int] = field(default_factory=dict)
     _log: Deque[RequestRecord] = field(default_factory=lambda: deque(maxlen=SERVING_REQUEST_LOG_SIZE))
     audits: AuditWindow = field(default_factory=AuditWindow)  # audit-loop thread only; persisted by the validator
+    _scores: Dict[str, float] = field(default_factory=dict)  # hotkey -> serving score from the last round
     last_round_ts: float = 0.0
+    ready_ttl_s: float = SERVING_READY_TTL_S
 
-    def publish_ready(self, miners: List[ReadyMiner]) -> None:
+    def publish_round(self, miners: List[ReadyMiner], scores: Dict[str, float]) -> None:
+        """Audit thread: publish the READY set for the gateway and the per-hotkey scores for the next OSS round."""
         with self._lock:
             self._ready = {m.uid: m for m in miners}
             self._inflight = {uid: self._inflight.get(uid, 0) for uid in self._ready}
+            self._scores = dict(scores)
             self.last_round_ts = time.time()
+
+    def scores_for(self, hotkeys: Sequence[str]) -> Dict[int, float]:
+        """Scores keyed by current UID; a UID whose hotkey changed since the round carries nothing over."""
+        with self._lock:
+            return {uid: self._scores[hk] for uid, hk in enumerate(hotkeys) if hk in self._scores}
+
+    def _fresh(self) -> bool:
+        return time.time() - self.last_round_ts <= self.ready_ttl_s
 
     def ready_miners(self) -> List[ReadyMiner]:
         with self._lock:
-            return list(self._ready.values())
+            return list(self._ready.values()) if self._fresh() else []
 
     def acquire(self, model_id: Optional[str] = None) -> Optional[ReadyMiner]:
-        """Pick the READY miner (for ``model_id`` if given) with the fewest in-flight requests (ties -> higher score)."""
+        """Pick the READY miner (for ``model_id`` if given) with the fewest in-flight requests (ties -> higher score).
+
+        Returns None when there is no capacity or the last audit round is older than the READY TTL.
+        """
         with self._lock:
+            if not self._fresh():
+                return None
             candidates = [u for u, m in self._ready.items() if model_id is None or m.model_id == model_id]
             if not candidates:
                 return None

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -69,7 +69,8 @@ def blend_emission_pools(
             rewards[uid_index[uid]] += reward
         recycle_share += serving_unallocated
         bt.logging.info(
-            f'Serving pool: {SERVING_EMISSION_SHARE * 100:.0f}% across {len(serving_rewards)} serving miners'
+            f'Serving pool: {SERVING_EMISSION_SHARE * 100:.0f}% across '
+            f'{sum(1 for r in serving_rewards.values() if r > 0)} serving miners'
         )
 
     # Recycle receives registry slack and empty repo slices.

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -12,10 +12,8 @@ from gittensor.utils.uids import get_all_uids
 from gittensor.validator.emission_allocation import blend_emission_pools
 from gittensor.validator.issue_discovery.scan import run_issue_discovery
 from gittensor.validator.oss_contributions.reward import get_rewards
-from gittensor.validator.serving.forward import serving_challenges
 from gittensor.validator.utils.config import (
     SERVING_ENABLED,
-    SERVING_STEPS_INTERVAL,
     VALIDATOR_STEPS_INTERVAL,
     VALIDATOR_WAIT,
 )
@@ -33,8 +31,8 @@ if TYPE_CHECKING:
 async def forward(self: 'Validator') -> None:
     """Execute the validator's forward pass.
 
-    Serving audits run every SERVING_STEPS_INTERVAL steps (SERVING_ENABLED only) so the gateway's READY set
-    stays fresh; the latest serving scores are kept on the validator and blended at the next OSS round.
+    Serving audits run on their own wall-clock thread (``ServingAuditThread``, SERVING_ENABLED only); the OSS
+    round blends the scores from the latest audit round.
 
     Performs the core validation cycle every VALIDATOR_STEPS_INTERVAL steps:
     1. Score OSS contributions (mirror PR scoring)
@@ -49,14 +47,6 @@ async def forward(self: 'Validator') -> None:
     - Serving pool:          SERVING_EMISSION_SHARE (0% shadow-mode beta) by serving score
     - Recycle:              registry slack and inactive repo slices to UID 0
     """
-
-    if SERVING_ENABLED and self.step % SERVING_STEPS_INTERVAL == 0:
-        try:
-            self.serving_scores = await serving_challenges(self, get_all_uids(self))
-        except Exception as e:  # a serving fault must never take the OSS round (or the validator) down
-            bt.logging.error(f'Serving round failed, no serving scores this round: {e!r}')
-            self.serving_state.publish_ready([])
-            self.serving_scores = {}
 
     if self.step % VALIDATOR_STEPS_INTERVAL == 0:
         miner_uids = get_all_uids(self)
@@ -86,8 +76,9 @@ async def forward(self: 'Validator') -> None:
 
         # 5. Allocate repo-bounded emission shares into final rewards
         maintainer_uids_by_repo = build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
+        serving_scores = self.serving_state.scores_for(self.metagraph.hotkeys) if SERVING_ENABLED else {}
         rewards = blend_emission_pools(
-            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, self.serving_scores
+            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, serving_scores
         )
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -3,29 +3,38 @@
 
 """Serving verification loop (sub-subnet B beta).
 
+``ServingAuditThread`` runs ``audit_round`` on its own wall clock (every
+``SERVING_AUDIT_INTERVAL_S``), independent of the validator's step loop, so
+the gateway's READY set stays fresh while an OSS round takes hours.
+
 Each round, for every blessed release, the validator sends audit prompts from
 that release's reference (live runtime on its own GPU, or a bank snapshot) to
 every serving axon over the same ``InferenceSynapse`` the gateway uses for
 user traffic, verifies each response against the reference (exact tokens,
 logprobs to float noise — the runtime is deterministic) and records the
-outcome into the miner's rolling ``AuditWindow``, and produces a per-UID serving score.
-A miner serves one release, so its score is the best it achieved across
-releases; miners whose window passes are published as READY (tagged with
-their release) to the gateway for the next round.
+outcome into the miner's rolling ``AuditWindow``, and produces a per-hotkey
+serving score. Axons are audited concurrently; an axon that does not answer
+the first prompt is not sent the rest (the misses still count). A miner
+serves one release, so its score is the best it achieved across releases;
+miners whose window passes are published as READY (tagged with their release)
+to the gateway, and the scores are picked up by the next OSS round.
 
     score = window passes (0/1) x mean over this round's audits of latency_credit
 
 Misses count as 0 in the window and latency credit 0 in the round.
 """
 
+import asyncio
 import math
+import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 import bittensor as bt
 
 from gittensor.constants import (
+    SERVING_AUDIT_CONCURRENCY,
     SERVING_CHALLENGE_TIMEOUT,
     SERVING_CHALLENGES_PER_ROUND,
 )
@@ -39,20 +48,51 @@ if TYPE_CHECKING:
     from neurons.validator import Validator
 
 
-async def serving_challenges(self: 'Validator', miner_uids: set[int]) -> Dict[int, float]:
-    """Audit each serving axon against every release and return UID -> serving score in [0, 1]."""
-    loadout = load_serving_loadout()
-    state: ServingState = getattr(self, 'serving_state', None) or ServingState()
-    serving = get_serving_axons(self, miner_uids)
+async def audit_axon(
+    dendrite: bt.Dendrite, uid: int, axon: bt.AxonInfo, release: ServingRelease, cases: Sequence[AuditCase]
+) -> List[Tuple[AuditVerdict, float, RequestRecord]]:
+    """Audit one axon with every case in order; stop after the first case that gets no response at all."""
+    results: List[Tuple[AuditVerdict, float, RequestRecord]] = []
+    for i, case in enumerate(cases):
+        synapse = InferenceSynapse(
+            messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens, logprobs=True
+        )
+        responses = await dendrite(axons=[axon], synapse=synapse, deserialize=False, timeout=SERVING_CHALLENGE_TIMEOUT)
+        response = responses[0] if responses else synapse
+        scored = score_response(uid, response, case, release)
+        results.append(scored)
+        if i == 0 and getattr(response, 'completion', None) is None:
+            for later in cases[1:]:
+                results.append(score_response(uid, synapse.model_copy(), later, release))
+            break
+    return results
+
+
+async def audit_round(
+    state: ServingState,
+    dendrite: bt.Dendrite,
+    serving: Sequence[Tuple[int, str, bt.AxonInfo]],
+    loadout=None,
+) -> Dict[str, float]:
+    """Audit every serving axon against every release; publish READY + scores; return hotkey -> score."""
+    loadout = loadout or load_serving_loadout()
     if not serving:
         bt.logging.info('Serving: no serving axons found this round')
-        state.publish_ready([])
+        state.publish_round([], {})
         return {}
 
-    uids = [uid for uid, _ in serving]
-    hotkeys = {uid: self.metagraph.hotkeys[uid] for uid in uids}
-    axons = [axon for _, axon in serving]
-    best: Dict[int, Tuple[float, str]] = {uid: (0.0, '') for uid in uids}
+    best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in serving}
+    slots = asyncio.Semaphore(SERVING_AUDIT_CONCURRENCY)
+
+    async def audit_one(uid: int, hotkey: str, axon: bt.AxonInfo, release: ServingRelease, cases) -> float:
+        async with slots:
+            results = await audit_axon(dendrite, uid, axon, release, cases)
+        credit = 0.0
+        for verdict, elapsed_ms, record in results:
+            state.audits.record(hotkey, release.model_id, verdict.value)
+            credit += latency_credit(elapsed_ms)
+            state.record(record)
+        return credit / len(cases)
 
     for release in loadout.releases:
         try:
@@ -64,46 +104,66 @@ async def serving_challenges(self: 'Validator', miner_uids: set[int]) -> Dict[in
                 'set SERVING_REFERENCE_URL to a conformant runtime or build its audit bank'
             )
             continue
-        credit: Dict[int, float] = {uid: 0.0 for uid in uids}
-        for case in cases:
-            synapse = InferenceSynapse(
-                messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens, logprobs=True
-            )
-            responses = await self.dendrite(
-                axons=axons, synapse=synapse, deserialize=False, timeout=SERVING_CHALLENGE_TIMEOUT
-            )
-            for uid, response in zip(uids, responses):
-                verdict, elapsed_ms, record = score_response(uid, response, case, release)
-                state.audits.record(hotkeys[uid], release.model_id, verdict.value)
-                credit[uid] += latency_credit(elapsed_ms)
-                state.record(record)
-        for uid in uids:
-            window = state.audits.verdict(hotkeys[uid], release.model_id)
-            score = (credit[uid] / SERVING_CHALLENGES_PER_ROUND) if window.passed else 0.0
+        credits = await asyncio.gather(*(audit_one(uid, hotkey, axon, release, cases) for uid, hotkey, axon in serving))
+        for (uid, hotkey, _), credit in zip(serving, credits):
+            window = state.audits.verdict(hotkey, release.model_id)
+            score = credit if window.passed else 0.0
             bt.logging.debug(f'Serving: UID {uid} {release.model_id} window {window.as_dict()} score {score:.3f}')
-            if score > best[uid][0]:
-                best[uid] = (score, release.model_id)
+            if score > best[hotkey][0]:
+                best[hotkey] = (score, release.model_id)
 
-    path = audit_window_path(self)
-    if path is not None:
-        try:
-            state.audits.save(path)
-        except OSError as e:
-            bt.logging.warning(f'Serving: could not persist audit window to {path}: {e}')
-
-    scores = {uid: score for uid, (score, _) in best.items()}
+    scores = {hotkey: score for hotkey, (score, _) in best.items()}
     ready: List[ReadyMiner] = []
-    for uid, axon in serving:
-        score, model_id = best[uid]
+    for uid, hotkey, axon in serving:
+        score, model_id = best[hotkey]
         bt.logging.info(
             f'Serving: UID {uid} score {score:.3f} over {SERVING_CHALLENGES_PER_ROUND} audits'
             + (f' ({model_id})' if model_id else '')
         )
         if score > 0.0:
-            ready.append(ReadyMiner(uid=uid, hotkey=hotkeys[uid], axon=axon, score=score, model_id=model_id))
-    state.publish_ready(ready)
+            ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, model_id=model_id))
+    state.publish_round(ready, scores)
     bt.logging.info(f'Serving: {len(ready)} READY miner(s) published to gateway: {[m.uid for m in ready]}')
     return scores
+
+
+class ServingAuditThread:
+    """Runs ``audit_round`` every ``interval_s`` seconds on a private event loop in a daemon thread."""
+
+    def __init__(self, validator: 'Validator', state: ServingState, interval_s: float):
+        self.validator = validator
+        self.state = state
+        self.interval_s = interval_s
+        self._stop = threading.Event()
+        self.thread = threading.Thread(target=self._run, name='serving-audits', daemon=True)
+
+    def start(self) -> None:
+        self.thread.start()
+        bt.logging.success(f'Serving audit loop started (every {self.interval_s:.0f}s)')
+
+    def stop(self) -> None:
+        self._stop.set()
+        self.thread.join(5)
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        dendrite = bt.Dendrite(wallet=self.validator.wallet)
+        while not self._stop.is_set():
+            started = time.monotonic()
+            try:
+                serving = get_serving_axons(self.validator)
+                loop.run_until_complete(audit_round(self.state, dendrite, serving))
+            except Exception as e:  # a serving fault must never take the validator down
+                bt.logging.error(f'Serving round failed, no serving scores this round: {e!r}')
+                self.state.publish_round([], {})
+            path = audit_window_path(self.validator)
+            if path is not None:
+                try:
+                    self.state.audits.save(path)
+                except OSError as e:
+                    bt.logging.warning(f'Serving: could not persist audit window to {path}: {e}')
+            self._stop.wait(max(0.0, self.interval_s - (time.monotonic() - started)))
 
 
 def audit_window_path(self: 'Validator') -> Optional[Path]:
@@ -112,20 +172,21 @@ def audit_window_path(self: 'Validator') -> Optional[Path]:
     return Path(full_path) / 'serving_audits.json' if full_path else None
 
 
-def get_serving_axons(self: 'Validator', miner_uids: set[int]) -> List[Tuple[int, bt.AxonInfo]]:
-    """UIDs (excluding self) whose axon is serving — the candidate serving miners.
+def get_serving_axons(self: 'Validator') -> List[Tuple[int, str, bt.AxonInfo]]:
+    """(uid, hotkey, axon) for every UID (excluding self) whose axon is serving — the candidate serving miners.
 
-    Beta heuristic: axon.is_serving is the only signal. Validators also serve
-    axons (for PAT handling), so they will appear here and simply score zero on
-    audits; a serving-miner registry replaces this later.
+    Snapshot of the metagraph taken on the audit thread. Beta heuristic: axon.is_serving is the only signal.
+    Validators also serve axons (for PAT handling), so they appear here and score zero on the first prompt;
+    a serving-miner registry replaces this later.
     """
-    serving: List[Tuple[int, bt.AxonInfo]] = []
-    for uid in sorted(miner_uids):
+    hotkeys = list(self.metagraph.hotkeys)
+    axons = list(self.metagraph.axons)
+    serving: List[Tuple[int, str, bt.AxonInfo]] = []
+    for uid, (hotkey, axon) in enumerate(zip(hotkeys, axons)):
         if uid == self.uid:
             continue
-        axon = self.metagraph.axons[uid]
         if axon is not None and axon.is_serving:
-            serving.append((uid, axon))
+            serving.append((uid, hotkey, axon))
     return serving
 
 

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -17,9 +17,11 @@ WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 # optional env vars
 STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'
 SERVING_ENABLED = os.getenv('SERVING_ENABLED', 'false').lower() == 'true'
-SERVING_STEPS_INTERVAL = int(os.getenv('SERVING_STEPS_INTERVAL', '5'))  # steps (~minutes) between serving audit rounds
-if VALIDATOR_STEPS_INTERVAL < 1 or SERVING_STEPS_INTERVAL < 1:
-    raise ValueError('VALIDATOR_STEPS_INTERVAL and SERVING_STEPS_INTERVAL must be >= 1')
+SERVING_AUDIT_INTERVAL_S = float(
+    os.getenv('SERVING_AUDIT_INTERVAL_S', '300')
+)  # wall-clock seconds between audit rounds
+if VALIDATOR_STEPS_INTERVAL < 1 or SERVING_AUDIT_INTERVAL_S <= 0:
+    raise ValueError('VALIDATOR_STEPS_INTERVAL must be >= 1 and SERVING_AUDIT_INTERVAL_S > 0')
 # Serving inference API: off unless keys are set; loopback by default (0.0.0.0 inside docker), front it with the host proxy.
 SERVING_API_KEYS = os.getenv('SERVING_API_KEYS', '')
 SERVING_API_HOST = os.getenv('SERVING_API_HOST', '127.0.0.1')
@@ -30,4 +32,4 @@ bt.logging.info(f'VALIDATOR_WAIT: {VALIDATOR_WAIT}')
 bt.logging.info(f'VALIDATOR_STEPS_INTERVAL: {VALIDATOR_STEPS_INTERVAL}')
 bt.logging.info(f'WANDB_PROJECT: {WANDB_PROJECT}')
 bt.logging.info(f'SERVING_ENABLED: {SERVING_ENABLED}')
-bt.logging.info(f'SERVING_STEPS_INTERVAL: {SERVING_STEPS_INTERVAL}')
+bt.logging.info(f'SERVING_AUDIT_INTERVAL_S: {SERVING_AUDIT_INTERVAL_S}')

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -40,11 +40,12 @@ from gittensor.validator.pat_handler import (
     priority_pat_broadcast,
     priority_pat_check,
 )
-from gittensor.validator.serving.forward import audit_window_path
+from gittensor.validator.serving.forward import ServingAuditThread, audit_window_path
 from gittensor.validator.utils.config import (
     SERVING_API_HOST,
     SERVING_API_KEYS,
     SERVING_API_PORT,
+    SERVING_AUDIT_INTERVAL_S,
     SERVING_ENABLED,
     STORE_DB_RESULTS,
     WANDB_PROJECT,
@@ -93,7 +94,6 @@ class Validator(BaseValidatorNeuron):
         # Serving sub-mechanism (beta): audit loop publishes READY miners here; the inference API dispatches to them.
         # The API starts only when SERVING_API_KEYS is set.
         self.serving_state = ServingState()
-        self.serving_scores: Dict[int, float] = {}
         audits_path = audit_window_path(self)
         if audits_path is not None:
             self.serving_state.audits = AuditWindow.load(audits_path)
@@ -113,6 +113,8 @@ class Validator(BaseValidatorNeuron):
                 )
             else:
                 bt.logging.info('Serving: SERVING_API_KEYS unset — audits only, no API')
+            self.serving_audits = ServingAuditThread(self, self.serving_state, SERVING_AUDIT_INTERVAL_S)
+            self.serving_audits.start()
 
         # DB connection for validation result storage.
         # Requires STORE_DB_RESULTS=true in .env

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1,6 +1,7 @@
 """Tests for the serving beta: deterministic backend, audit verification, gateway dispatch, emission pool blending."""
 
 import json
+from typing import Dict
 
 import pytest
 from fastapi.testclient import TestClient
@@ -197,7 +198,7 @@ def _ready(uid: int, score: float = 1.0) -> ReadyMiner:
 def test_state_least_inflight_dispatch():
     state = ServingState()
     assert state.acquire() is None
-    state.publish_ready([_ready(1, 0.5), _ready(2, 1.0)])
+    state.publish_round([_ready(1, 0.5), _ready(2, 1.0)], {})
     first = state.acquire()
     assert first is not None and first.uid == 2  # tie on inflight -> higher score
     second = state.acquire()
@@ -208,7 +209,7 @@ def test_state_least_inflight_dispatch():
     state.release(2)
     again = state.acquire()
     assert again is not None and again.uid == 2
-    state.publish_ready([_ready(1)])
+    state.publish_round([_ready(1)], {})
     only = state.acquire()
     assert only is not None and only.uid == 1
     state.record(RequestRecord(ts=0, kind='gateway', uid=1, ok=True, latency_ms=10))
@@ -218,7 +219,7 @@ def test_state_least_inflight_dispatch():
 def test_acquire_filters_by_release():
     state = ServingState()
     other = ReadyMiner(uid=9, hotkey='hk9', axon=None, score=1.0, model_id='other-model')  # type: ignore[arg-type]
-    state.publish_ready([_ready(1), other])
+    state.publish_round([_ready(1), other], {})
     assert state.acquire('other-model') is other
     assert state.acquire('missing') is None
     picked = state.acquire('echo-v0')
@@ -268,7 +269,7 @@ def test_gateway_429_without_ready_miners(monkeypatch):
 
 def test_gateway_chat_completion_roundtrip(monkeypatch):
     state = ServingState()
-    state.publish_ready([_ready(7)])
+    state.publish_round([_ready(7)], {})
     client = _gateway_client(state, monkeypatch)
     r = client.post(
         '/v1/chat/completions',
@@ -463,7 +464,7 @@ def test_verify_rejects_malformed_reference():
 
 def test_gateway_400_on_user_shaped_bad_input(monkeypatch):
     state = ServingState()
-    state.publish_ready([_ready(7)])
+    state.publish_round([_ready(7)], {})
     client = _gateway_client(state, monkeypatch)
     h = {'Authorization': 'Bearer k1'}
     assert (
@@ -475,23 +476,17 @@ def test_gateway_400_on_user_shaped_bad_input(monkeypatch):
     assert state.inflight() == {7: 0}
 
 
-def test_serving_round_skips_release_without_reference(monkeypatch, tmp_path):
-    """A release whose reference is unreachable is skipped and logged; the round still completes."""
-    import asyncio
-    from types import SimpleNamespace
-
-    from gittensor.validator.serving import forward as fwd
-
-    good = _echo_release()
-    bad = ServingRelease(
-        model_id='ghost', backend='openai-compat', base_url='http://x', reference_url='http://127.0.0.1:1'
-    )
-    monkeypatch.setattr(fwd, 'load_serving_loadout', lambda: ServingLoadout(releases=[bad, good]))
-    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 2)
+def _dendrite_echoing(good: ServingRelease, dead_axons=()):
+    """Fake dendrite: honest echo answers for every axon, no response for `dead_axons`; counts calls per axon."""
+    calls: Dict[int, int] = {}  # id(axon) -> requests sent
 
     async def dendrite(axons, synapse, deserialize, timeout):
         out = []
-        for _ in axons:
+        for axon in axons:
+            calls[id(axon)] = calls.get(id(axon), 0) + 1
+            if any(axon is d for d in dead_axons):
+                out.append(synapse.model_copy())
+                continue
             ref = expected_completion(synapse.messages, synapse.max_tokens, good.model_id)
             resp = synapse.model_copy(
                 update={
@@ -505,53 +500,113 @@ def test_serving_round_skips_release_without_reference(monkeypatch, tmp_path):
             out.append(resp)
         return out
 
-    axon = SimpleNamespace(is_serving=True)
-    vali = SimpleNamespace(
-        uid=0,
-        metagraph=SimpleNamespace(hotkeys=['v', 'hk1'], axons=[axon, axon]),
-        dendrite=dendrite,
-        serving_state=ServingState(),
-        config=SimpleNamespace(neuron=SimpleNamespace(full_path=str(tmp_path))),
+    return dendrite, calls
+
+
+def test_audit_round_skips_release_without_reference(monkeypatch):
+    """A release whose reference is unreachable is skipped and logged; the round still completes."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    bad = ServingRelease(
+        model_id='ghost', backend='openai-compat', base_url='http://x', reference_url='http://127.0.0.1:1'
     )
-    scores = asyncio.run(fwd.serving_challenges(vali, {0, 1}))  # type: ignore[arg-type]
-    assert scores == {1: 1.0}
-    assert [m.uid for m in vali.serving_state.ready_miners()] == [1]
-    assert (tmp_path / 'serving_audits.json').exists()
+    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 2)
+    dendrite, _ = _dendrite_echoing(good)
+    axon = SimpleNamespace(is_serving=True)
+    state = ServingState()
+    scores = asyncio.run(
+        fwd.audit_round(state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[bad, good]))  # type: ignore[arg-type]
+    )
+    assert scores == {'hk1': 1.0}
+    assert [m.uid for m in state.ready_miners()] == [1]
+    assert state.scores_for(['v', 'hk1']) == {1: 1.0}
+    assert state.scores_for(['v', 'other']) == {}  # UID 1's hotkey changed since the round: nothing carries over
 
 
-def test_serving_audits_run_between_oss_rounds(monkeypatch):
-    """A serving step audits and caches scores without running the OSS round; the OSS round blends the cache."""
+def test_audit_round_stops_after_first_unanswered_prompt(monkeypatch):
+    """A dead axon costs one timeout, not one per case; the unsent cases still count as misses."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 4)
+    live, dead = SimpleNamespace(is_serving=True), SimpleNamespace(is_serving=True)
+    dendrite, calls = _dendrite_echoing(good, dead_axons=(dead,))
+    state = ServingState()
+    scores = asyncio.run(
+        fwd.audit_round(state, dendrite, [(1, 'hk1', live), (2, 'hk2', dead)], ServingLoadout(releases=[good]))  # type: ignore[arg-type]
+    )
+    assert calls == {id(live): 4, id(dead): 1}
+    assert scores == {'hk1': 1.0, 'hk2': 0.0}
+    assert state.audits.verdict('hk2', good.model_id).n_audits == 4
+    assert [m.uid for m in state.ready_miners()] == [1]
+
+
+def test_ready_set_expires_after_ttl():
+    from types import SimpleNamespace
+
+    state = ServingState(ready_ttl_s=10.0)
+    miner = ReadyMiner(uid=1, hotkey='hk1', axon=SimpleNamespace(), score=1.0, model_id='m')  # type: ignore[arg-type]
+    state.publish_round([miner], {'hk1': 1.0})
+    assert state.acquire('m') is miner
+    state.last_round_ts -= 11.0  # the audit thread stopped publishing
+    assert state.ready_miners() == [] and state.acquire('m') is None
+    assert state.scores_for(['hk1']) == {0: 1.0}  # scores still blend; only routing stops
+
+
+def test_oss_round_blends_latest_serving_scores(monkeypatch):
+    """The OSS round reads the audit thread's scores by current hotkey instead of running audits itself."""
     import asyncio
     from types import SimpleNamespace
 
     from gittensor.validator import forward as top
 
-    calls = []
     monkeypatch.setattr(top, 'SERVING_ENABLED', True)
-    monkeypatch.setattr(top, 'SERVING_STEPS_INTERVAL', 5)
-    monkeypatch.setattr(top, 'VALIDATOR_STEPS_INTERVAL', 120)
+    monkeypatch.setattr(top, 'VALIDATOR_STEPS_INTERVAL', 1)
     monkeypatch.setattr(top, 'VALIDATOR_WAIT', 0)
     monkeypatch.setattr(top, 'get_all_uids', lambda self: {1})
+    monkeypatch.setattr(top, 'load_master_repo_weights', lambda: {})
+    monkeypatch.setattr(top, 'load_programming_language_weights', lambda: {})
+    monkeypatch.setattr(top, 'load_token_config', lambda: {})
 
-    async def audits(self, uids):
-        calls.append(('serving', uids))
-        return {1: 0.5}
+    async def oss(self, *a):
+        return {}, set(), set()
 
-    def oss(*a, **k):
-        raise AssertionError('OSS round must not run on a serving-only step')
+    async def issues(*a, **k):
+        return None
 
-    monkeypatch.setattr(top, 'serving_challenges', audits)
-    monkeypatch.setattr(top, 'load_master_repo_weights', oss)
+    async def store(*a, **k):
+        return None
 
-    vali = SimpleNamespace(step=5, serving_state=ServingState(), serving_scores={})
+    seen = {}
+
+    def blend(evals, repos, uids, maintainers, serving_scores):
+        seen['serving'] = serving_scores
+        return [0.0]
+
+    monkeypatch.setattr(top, 'oss_contributions', oss)
+    monkeypatch.setattr(top, 'issue_discovery', issues)
+    monkeypatch.setattr(top, 'build_maintainer_uids_by_repo', lambda *a: {})
+    monkeypatch.setattr(top, 'blend_emission_pools', blend)
+
+    state = ServingState()
+    state.publish_round([], {'hk1': 0.5, 'gone': 0.9})
+    vali = SimpleNamespace(
+        step=0,
+        serving_state=state,
+        metagraph=SimpleNamespace(hotkeys=['v', 'hk1']),
+        evaluation_cache=None,
+        bulk_store_evaluation=store,
+        update_scores=lambda *a, **k: None,
+    )
     asyncio.run(top.forward(vali))  # type: ignore[arg-type]
-    assert calls == [('serving', {1})]
-    assert vali.serving_scores == {1: 0.5}
-
-    vali.step = 7
-    asyncio.run(top.forward(vali))  # type: ignore[arg-type]
-    assert calls == [('serving', {1})]  # off-cadence step: no audit, cache untouched
-    assert vali.serving_scores == {1: 0.5}
+    assert seen['serving'] == {1: 0.5}
 
 
 def test_request_record_drops_non_finite_telemetry():


### PR DESCRIPTION
## Summary

- **`ServingAuditThread`**: serving audits run on a private event loop/dendrite every `SERVING_AUDIT_INTERVAL_S` (default 300 s) instead of inside the step loop. On mainnet the OSS round takes hours during which `self.step` does not advance, so the previous step-cadence never audited mid-round and the gateway routed to a stale READY set.
- **READY TTL** (`SERVING_READY_TTL_S`, 900 s): the gateway returns 429 when the last audit round is older than the TTL — a dead audit loop stops routing rather than serving stale.
- **Per-axon audits**: axons are audited concurrently (`SERVING_AUDIT_CONCURRENCY`), each with its cases in sequence; an axon that does not answer the first prompt is not sent the rest (misses still count). Dead axons cost one 30 s timeout per round instead of one per case.
- **Scores keyed by hotkey**: `ServingState.scores_for(metagraph.hotkeys)` re-keys at blend time, so a UID whose hotkey changed since the round carries nothing over.
- Housekeeping: `Serving pool` log counts paid miners only; `sparkinfer-image.yml` derives the ref from `serving_loadout.json`'s `runtime_pin` when the input is empty (was hand-synced in two places).
- Removes `SERVING_STEPS_INTERVAL` (introduced in #1695).

## Related Issues

Follow-up to #1695.

## Type of Change

- [x] Bug fix
- [x] Refactor

## Testing

- [x] Tests added/updated
- [x] Manually tested on testnet (netuid 422, 2026-08-25): audit rounds at a strict 300 s wall clock independent of the step loop (18:16:48, :21:48, :26:48, :31:48); round wall-clock ~34 s with 21 axons (was ~2 min); both miners READY on the first round with the reference up; gateway bursts of 4/8 all 200; first rounds with the reference down published 0 READY cleanly.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)