### PR TITLE
serving: stream inference end to end (stream: true on the gateway)

### DIFF
--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -22,18 +22,21 @@ import asyncio
 import threading
 import time
 import uuid
-from typing import Dict, List, Optional, Set
+from typing import Awaitable, Callable, Dict, List, Optional, Set
 
 import bittensor as bt
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from gittensor.constants import SERVING_MAX_TOKENS
 from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServingState, finite_or_none
+from gittensor.serving.stream import SSE_DONE, Event, consume_stream, sse_event
 from gittensor.synapses import InferenceSynapse
+
+_END = object()  # end-of-stream marker on the relay queue
 
 _bearer = HTTPBearer(auto_error=False)
 
@@ -110,8 +113,6 @@ def build_app(
             raise HTTPException(
                 status_code=400, detail='each message needs string role and content (no array content yet)'
             )
-        if body.get('stream'):
-            raise HTTPException(status_code=400, detail='streaming is not supported yet')
         if body.get('n', 1) != 1:
             raise HTTPException(status_code=400, detail='n must be 1')
         try:
@@ -120,37 +121,84 @@ def build_app(
             raise HTTPException(status_code=400, detail='max_tokens must be an integer')
         max_tokens = max(1, min(max_tokens, SERVING_MAX_TOKENS))
         want_logprobs = bool(body.get('logprobs', False))
+        want_stream = bool(body.get('stream', False))
 
         miner = state.acquire(release.model_id)
         if miner is None:
             raise HTTPException(status_code=429, detail='no READY serving capacity')
 
         request_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
+        created = int(time.time())
         start = time.monotonic()
-        try:
-            result = await _dispatch(get_dendrite(), miner, messages, max_tokens, release, request_timeout)
-        finally:
-            state.release(miner.uid)
-        latency_ms = (time.monotonic() - start) * 1000.0
 
-        ok = result is not None and result.completion is not None
-        state.record(
-            RequestRecord(
-                ts=time.time(),
-                kind='gateway',
-                uid=miner.uid,
-                ok=ok,
-                latency_ms=latency_ms,
-                completion_tokens=(result.usage or {}).get('completion_tokens', 0) if result else 0,
-                ttft_ms=result.ttft_ms if result else None,
-                decode_tps=result.decode_tps if result else None,
-                detail='' if ok else 'miner returned no completion',
+        def finish(result: Optional[InferenceSynapse]) -> bool:
+            state.release(miner.uid)
+            ok = result is not None and result.completion is not None
+            state.record(
+                RequestRecord(
+                    ts=time.time(),
+                    kind='gateway',
+                    uid=miner.uid,
+                    ok=ok,
+                    latency_ms=(time.monotonic() - start) * 1000.0,
+                    completion_tokens=(result.usage or {}).get('completion_tokens', 0) if result else 0,
+                    ttft_ms=result.ttft_ms if result else None,
+                    decode_tps=result.decode_tps if result else None,
+                    detail='' if ok else 'miner returned no completion',
+                )
             )
-        )
-        if result is None or not ok:
+            return ok
+
+        def failed() -> JSONResponse:
             return JSONResponse(
                 status_code=502, content={'error': {'message': 'serving miner failed', 'uid': miner.uid}}
             )
+
+        def reshape(event: dict) -> dict:
+            """Relay a miner chunk to the client under our request id, without logprobs unless asked for."""
+            out = dict(event)
+            out['id'] = request_id
+            if not want_logprobs:
+                out['choices'] = [{k: v for k, v in c.items() if k != 'logprobs'} for c in event.get('choices') or []]
+            if 'usage' in event:
+                out['gittensor'] = {'served_uid': miner.uid, 'latency_ms': round((time.monotonic() - start) * 1000, 1)}
+            return out
+
+        if want_stream:
+            queue: 'asyncio.Queue[object]' = asyncio.Queue()
+
+            async def relay(event: Event) -> None:
+                await queue.put(event)
+
+            async def run() -> Optional[InferenceSynapse]:
+                try:
+                    return await _dispatch(get_dendrite(), miner, messages, max_tokens, release, request_timeout, relay)
+                finally:
+                    await queue.put(_END)
+
+            task = asyncio.create_task(run())
+            first = await queue.get()
+            if first is _END or first is None:  # nothing streamed before the miner gave up
+                finish(await task)
+                return failed()
+
+            async def body_iter():
+                event = first
+                try:
+                    while event is not _END:
+                        yield SSE_DONE if event is None else sse_event(reshape(event))  # type: ignore[arg-type]
+                        event = await queue.get()
+                finally:
+                    finish(await task)
+
+            return StreamingResponse(body_iter(), media_type='text/event-stream')
+
+        try:
+            result = await _dispatch(get_dendrite(), miner, messages, max_tokens, release, request_timeout)
+        except Exception:
+            result = None
+        if not finish(result) or result is None:
+            return failed()
 
         choice: Dict = {
             'index': 0,
@@ -164,13 +212,13 @@ def build_app(
         return {
             'id': request_id,
             'object': 'chat.completion',
-            'created': int(time.time()),
+            'created': created,
             'model': result.served_model_id or release.model_id,
             'choices': [choice],
             'usage': result.usage or {},
             'gittensor': {
                 'served_uid': miner.uid,
-                'latency_ms': round(latency_ms, 1),
+                'latency_ms': round((time.monotonic() - start) * 1000.0, 1),
                 'ttft_ms': finite_or_none(result.ttft_ms),
                 'decode_tps': finite_or_none(result.decode_tps),
             },
@@ -186,11 +234,11 @@ async def _dispatch(
     max_tokens: int,
     release: ServingRelease,
     timeout: float,
-) -> Optional[InferenceSynapse]:
+    on_event: Optional[Callable[[Event], Awaitable[None]]] = None,
+) -> InferenceSynapse:
     # logprobs always requested so organic traffic is indistinguishable from audits on the wire.
     synapse = InferenceSynapse(messages=messages, model_id=release.model_id, max_tokens=max_tokens, logprobs=True)
-    responses = await dendrite(axons=[miner.axon], synapse=synapse, deserialize=False, timeout=timeout)
-    return responses[0] if responses else None
+    return await consume_stream(dendrite, miner.axon, synapse, timeout, on_event)
 
 
 class ServingApiThread:

--- a/gittensor/serving/backends.py
+++ b/gittensor/serving/backends.py
@@ -19,7 +19,7 @@ interchangeable:
 import hashlib
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Protocol
+from typing import Dict, Iterator, List, Optional, Protocol
 
 import requests
 
@@ -48,6 +48,10 @@ class InferenceBackend(Protocol):
     model_id: str
 
     def generate(self, messages: List[Message], max_tokens: int, logprobs: bool = False) -> GenerationResult: ...
+
+    def stream(self, messages: List[Message], max_tokens: int, logprobs: bool = False) -> Iterator[bytes]:
+        """The same generation as OpenAI ``chat.completion.chunk`` SSE bytes, ending with ``data: [DONE]``."""
+        ...
 
 
 def flatten_messages(messages: List[Message]) -> str:
@@ -97,6 +101,11 @@ class EchoBackend:
             result.token_logprobs = None
         return result
 
+    def stream(self, messages: List[Message], max_tokens: int, logprobs: bool = False) -> Iterator[bytes]:
+        from gittensor.serving.stream import result_to_sse
+
+        return result_to_sse(self.generate(messages, max_tokens, logprobs), 'chatcmpl-echo', int(time.time()), logprobs)
+
 
 class OpenAICompatBackend:
     """Backend for a local OpenAI-compatible chat server (sparkinfer_server).
@@ -113,17 +122,31 @@ class OpenAICompatBackend:
         self.base_url = release.base_url.rstrip('/')
         self.timeout = release.request_timeout
 
-    def generate(self, messages: List[Message], max_tokens: int, logprobs: bool = False) -> GenerationResult:
+    def _body(self, messages: List[Message], max_tokens: int, logprobs: bool, stream: bool) -> Dict:
         body: Dict = {
             'model': self.model_id,
             'messages': messages,
             'max_tokens': max_tokens,
             'temperature': 0,
-            'stream': False,
+            'stream': stream,
         }
+        if stream:
+            body['stream_options'] = {'include_usage': True}
         if logprobs:
             body['logprobs'] = True
             body['top_logprobs'] = 1
+        return body
+
+    def stream(self, messages: List[Message], max_tokens: int, logprobs: bool = False) -> Iterator[bytes]:
+        body = self._body(messages, max_tokens, logprobs, stream=True)
+        with requests.post(
+            f'{self.base_url}/v1/chat/completions', json=body, timeout=self.timeout, stream=True
+        ) as response:
+            response.raise_for_status()
+            yield from response.iter_content(chunk_size=None)
+
+    def generate(self, messages: List[Message], max_tokens: int, logprobs: bool = False) -> GenerationResult:
+        body = self._body(messages, max_tokens, logprobs, stream=False)
         start = time.monotonic()
         response = requests.post(f'{self.base_url}/v1/chat/completions', json=body, timeout=self.timeout)
         response.raise_for_status()

--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -1,0 +1,150 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Server-sent-event plumbing for serving inference.
+
+Every inference — audit or user traffic — travels validator -> miner as one
+``InferenceSynapse`` streamed back as OpenAI ``chat.completion.chunk`` events,
+so the miner can't tell the two apart and users get tokens as they decode.
+
+- miner: ``OpenAICompatBackend.stream`` proxies the runtime's SSE bytes as-is;
+  ``EchoBackend.stream`` and ``result_to_sse`` synthesise the same shape.
+- validator: ``SSEParser`` splits bytes into events, ``StreamAssembler`` folds
+  them into the completion / tokens / logprobs / usage the verifier and the
+  non-streaming gateway path need, and ``consume_stream`` drives a dendrite
+  ``call_stream`` to a filled synapse, optionally relaying each event.
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Dict, Iterator, List, Optional
+
+import bittensor as bt
+
+from gittensor.serving.backends import GenerationResult
+from gittensor.synapses import InferenceSynapse
+
+SSE_DONE = b'data: [DONE]\n\n'
+Event = Optional[dict]  # None marks [DONE]
+
+
+def sse_event(payload: dict) -> bytes:
+    return b'data: ' + json.dumps(payload, separators=(',', ':')).encode() + b'\n\n'
+
+
+class SSEParser:
+    """Splits a byte stream into ``data:`` events; ``[DONE]`` is yielded as None."""
+
+    def __init__(self) -> None:
+        self._buf = b''
+
+    def feed(self, chunk: bytes) -> List[Event]:
+        self._buf += chunk
+        events: List[Event] = []
+        while b'\n\n' in self._buf:
+            raw, self._buf = self._buf.split(b'\n\n', 1)
+            for line in raw.split(b'\n'):
+                if not line.startswith(b'data:'):
+                    continue
+                data = line[5:].strip()
+                if data == b'[DONE]':
+                    events.append(None)
+                    continue
+                try:
+                    events.append(json.loads(data))
+                except ValueError:
+                    continue
+        return events
+
+
+@dataclass
+class StreamAssembler:
+    """Folds chunk events into the response fields of ``InferenceSynapse``."""
+
+    content: str = ''
+    tokens: List[str] = field(default_factory=list)
+    token_logprobs: List[float] = field(default_factory=list)
+    model_id: Optional[str] = None
+    finish_reason: Optional[str] = None
+    usage: Dict[str, int] = field(default_factory=dict)
+    ttft_ms: Optional[float] = None
+    generation_ms: Optional[float] = None
+    decode_tps: Optional[float] = None
+    done: bool = False
+
+    def feed(self, event: Event) -> None:
+        if event is None:
+            self.done = True
+            return
+        if event.get('model'):
+            self.model_id = event['model']
+        for choice in event.get('choices') or []:
+            delta = choice.get('delta') or {}
+            if delta.get('content'):
+                self.content += delta['content']
+            for entry in (choice.get('logprobs') or {}).get('content') or []:
+                self.tokens.append(entry['token'])
+                self.token_logprobs.append(float(entry['logprob']))
+            if choice.get('finish_reason'):
+                self.finish_reason = choice['finish_reason']
+        usage = event.get('usage')
+        if isinstance(usage, dict):
+            self.usage = {k: v for k, v in usage.items() if isinstance(v, int)}
+            for name in ('ttft_ms', 'generation_ms', 'decode_tps'):
+                if usage.get(name) is not None:
+                    setattr(self, name, float(usage[name]))
+
+    def apply(self, synapse: InferenceSynapse) -> InferenceSynapse:
+        """Write the assembled response onto ``synapse``; an unfinished stream leaves ``completion`` None (a miss)."""
+        if not self.done:
+            return synapse
+        synapse.completion = self.content
+        synapse.served_model_id = self.model_id
+        synapse.tokens = self.tokens or None
+        synapse.token_logprobs = self.token_logprobs or None
+        synapse.finish_reason = self.finish_reason
+        synapse.usage = self.usage
+        synapse.ttft_ms = self.ttft_ms
+        synapse.generation_ms = self.generation_ms
+        synapse.decode_tps = self.decode_tps
+        return synapse
+
+
+def result_to_sse(result: GenerationResult, request_id: str, created: int, logprobs: bool) -> Iterator[bytes]:
+    """One completed generation as the chunk sequence a streaming runtime would have sent."""
+    base = {'id': request_id, 'object': 'chat.completion.chunk', 'created': created, 'model': result.model_id}
+    delta: dict = {'index': 0, 'delta': {'role': 'assistant', 'content': result.completion}, 'finish_reason': None}
+    if logprobs and result.tokens and result.token_logprobs:
+        delta['logprobs'] = {
+            'content': [{'token': t, 'logprob': lp} for t, lp in zip(result.tokens, result.token_logprobs)]
+        }
+    yield sse_event({**base, 'choices': [delta]})
+    yield sse_event({**base, 'choices': [{'index': 0, 'delta': {}, 'finish_reason': result.finish_reason or 'stop'}]})
+    usage: dict = dict(result.usage or {})
+    for name in ('ttft_ms', 'generation_ms', 'decode_tps'):
+        value = getattr(result, name, None)
+        if value is not None:
+            usage[name] = value
+    yield sse_event({**base, 'choices': [], 'usage': usage})
+    yield SSE_DONE
+
+
+async def consume_stream(
+    dendrite: bt.Dendrite,
+    axon: bt.AxonInfo,
+    synapse: InferenceSynapse,
+    timeout: float,
+    on_event: Optional[Callable[[Event], Awaitable[None]]] = None,
+) -> InferenceSynapse:
+    """Stream one inference from ``axon`` and return the filled synapse; relay each event to ``on_event`` if given."""
+    parser, assembler = SSEParser(), StreamAssembler()
+    final: Optional[InferenceSynapse] = None
+    async for chunk in dendrite.call_stream(target_axon=axon, synapse=synapse, timeout=timeout, deserialize=False):
+        if isinstance(chunk, (bytes, bytearray)):
+            for event in parser.feed(bytes(chunk)):
+                assembler.feed(event)
+                if on_event is not None:
+                    await on_event(event)
+        else:
+            final = chunk  # the dendrite yields the header-filled synapse last
+    return assembler.apply(final if final is not None else synapse)

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -33,14 +33,16 @@ class PatBroadcastSynapse(bt.Synapse):
     __str__ = __repr__
 
 
-class InferenceSynapse(bt.Synapse):
+class InferenceSynapse(bt.StreamingSynapse):
     """Inference request for serving miners (sub-subnet B beta).
 
     Carries one OpenAI-style chat request from validator to miner. The same
     synapse is used for validator audit prompts and for gateway (user) traffic,
-    so a miner cannot tell them apart. When ``logprobs`` is set the miner
-    returns per-token logprobs of the greedy completion, which the validator
-    checks against its reference (``gittensor/serving/audit.py``).
+    so a miner cannot tell them apart. The miner answers with a stream of
+    OpenAI ``chat.completion.chunk`` events (``gittensor/serving/stream.py``);
+    the validator folds them into the response fields below. When ``logprobs``
+    is set the chunks carry per-token logprobs of the greedy completion, which
+    the validator checks against its reference (``gittensor/serving/audit.py``).
     """
 
     required_hash_fields: ClassVar[tuple[str, ...]] = ('messages', 'model_id', 'max_tokens', 'logprobs')
@@ -61,6 +63,29 @@ class InferenceSynapse(bt.Synapse):
     token_logprobs: Optional[List[float]] = None
     finish_reason: Optional[str] = None
     usage: Optional[Dict[str, int]] = None
+
+    async def process_streaming_response(self, response):  # aiohttp ClientResponse
+        async for chunk in response.content.iter_any():
+            yield chunk
+
+    def extract_response_json(self, response) -> dict:
+        headers = {k.decode('utf-8'): v.decode('utf-8') for k, v in response.__dict__['_raw_headers']}
+
+        def section(prefix: str) -> Dict[str, str]:
+            return {k[len(prefix) :]: v for k, v in headers.items() if k.startswith(prefix)}
+
+        return {
+            'name': headers.get('name', ''),
+            'timeout': float(headers.get('timeout', 0)),
+            'total_size': int(headers.get('total_size', 0)),
+            'header_size': int(headers.get('header_size', 0)),
+            'dendrite': section('bt_header_dendrite_'),
+            'axon': section('bt_header_axon_'),
+            'messages': self.messages,
+            'model_id': self.model_id,
+            'max_tokens': self.max_tokens,
+            'logprobs': self.logprobs,
+        }
 
 
 class PatCheckSynapse(bt.Synapse):

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -41,6 +41,7 @@ from gittensor.constants import (
 from gittensor.serving.audit import AuditCase, AuditVerdict, reference_for, verify_response
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServingState
+from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
 from gittensor.validator.serving.scoring import latency_credit
 
@@ -57,8 +58,7 @@ async def audit_axon(
         synapse = InferenceSynapse(
             messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens, logprobs=True
         )
-        responses = await dendrite(axons=[axon], synapse=synapse, deserialize=False, timeout=SERVING_CHALLENGE_TIMEOUT)
-        response = responses[0] if responses else synapse
+        response = await consume_stream(dendrite, axon, synapse, SERVING_CHALLENGE_TIMEOUT)
         scored = score_response(uid, response, case, release)
         results.append(scored)
         if i == 0 and getattr(response, 'completion', None) is None:

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -36,9 +36,10 @@ import os
 import time
 from collections import OrderedDict
 from functools import partial
-from typing import Tuple
+from typing import Optional, Tuple
 
 import bittensor as bt
+from bittensor.core.stream import StreamingSynapse
 from bittensor.utils.axon_utils import allowed_nonce_window_ns, calculate_diff_seconds
 from bittensor_wallet import Keypair
 
@@ -47,6 +48,8 @@ from gittensor.serving.backends import InferenceBackend, load_backend
 from gittensor.serving.loadout import load_serving_loadout
 from gittensor.synapses import InferenceSynapse
 from neurons.base.neuron import BaseNeuron
+
+BTStreamingResponse = StreamingSynapse.BTStreamingResponse
 
 
 class ServingMiner(BaseNeuron):
@@ -99,25 +102,34 @@ class ServingMiner(BaseNeuron):
             raise
 
 
-async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> InferenceSynapse:
-    """Generate a completion for a challenge (or, later, real traffic)."""
+async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BTStreamingResponse:
+    """Stream the backend's completion for an audit or user request through the axon.
+
+    Backend errors end the stream without ``[DONE]``; the validator scores that as a miss.
+    """
     max_tokens = max(1, min(int(synapse.max_tokens), SERVING_MAX_TOKENS))
-    try:
+    messages, logprobs = synapse.messages, synapse.logprobs
+
+    async def token_streamer(send) -> None:
+        loop = asyncio.get_running_loop()
+        queue: 'asyncio.Queue[Optional[bytes]]' = asyncio.Queue()
+
+        def produce() -> None:
+            try:
+                for chunk in miner.backend.stream(messages, max_tokens, logprobs):
+                    loop.call_soon_threadsafe(queue.put_nowait, chunk)
+            except Exception as e:  # backend down/overloaded: the stream ends unfinished
+                bt.logging.warning(f'ServingMiner backend error: {e}')
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, None)
+
         async with miner.backend_slots:
-            result = await asyncio.to_thread(miner.backend.generate, synapse.messages, max_tokens, synapse.logprobs)
-    except Exception as e:  # backend down/overloaded: answer empty, validator scores it 0
-        bt.logging.warning(f'ServingMiner backend error: {e}')
-        return synapse
-    synapse.completion = result.completion
-    synapse.served_model_id = result.model_id
-    synapse.generation_ms = result.generation_ms
-    synapse.ttft_ms = result.ttft_ms
-    synapse.decode_tps = result.decode_tps
-    synapse.tokens = result.tokens
-    synapse.token_logprobs = result.token_logprobs
-    synapse.finish_reason = result.finish_reason
-    synapse.usage = result.usage or None
-    return synapse
+            producer = loop.run_in_executor(None, produce)
+            while (chunk := await queue.get()) is not None:
+                await send({'type': 'http.response.body', 'body': chunk, 'more_body': True})
+            await producer
+
+    return synapse.create_streaming_response(token_streamer)
 
 
 async def verify_inference(miner: ServingMiner, synapse: InferenceSynapse) -> None:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -244,8 +244,16 @@ class _FakeResponse:
 def _gateway_client(state: ServingState, monkeypatch):
     loadout = _echo_release()
 
-    async def fake_dispatch(dendrite, miner, messages, max_tokens, lo, timeout):
-        return _FakeResponse(expected_completion(messages, max_tokens, lo.model_id), lo.model_id)
+    async def fake_dispatch(dendrite, miner, messages, max_tokens, lo, timeout, on_event=None):
+        result = expected_completion(messages, max_tokens, lo.model_id)
+        if on_event is not None:  # replay the chunk sequence a miner would stream
+            from gittensor.serving.stream import SSEParser, result_to_sse
+
+            parser = SSEParser()
+            for chunk in result_to_sse(result, 'chatcmpl-miner', 0, logprobs=True):
+                for event in parser.feed(chunk):
+                    await on_event(event)
+        return _FakeResponse(result, lo.model_id)
 
     monkeypatch.setattr('gittensor.serving.api._dispatch', fake_dispatch)
     app = build_app(state, loadout, parse_api_keys('k1, k2'), lambda: None, request_timeout=5)
@@ -284,10 +292,32 @@ def test_gateway_chat_completion_roundtrip(monkeypatch):
     assert body['gittensor']['served_uid'] == 7
     assert state.inflight() == {7: 0}
     assert state.snapshot()['gateway_ok'] == 1
-    bad = client.post(
-        '/v1/chat/completions', json={'messages': MSGS, 'stream': True}, headers={'Authorization': 'Bearer k1'}
-    )
-    assert bad.status_code == 400
+
+
+def test_gateway_streams_sse(monkeypatch):
+    state = ServingState()
+    state.publish_round([_ready(7)], {})
+    client = _gateway_client(state, monkeypatch)
+    with client.stream(
+        'POST',
+        '/v1/chat/completions',
+        json={'messages': MSGS, 'max_tokens': 4, 'stream': True},
+        headers={'Authorization': 'Bearer k1'},
+    ) as r:
+        assert r.status_code == 200
+        assert r.headers['content-type'].startswith('text/event-stream')
+        raw = b''.join(r.iter_bytes())
+    from gittensor.serving.stream import SSEParser
+
+    events = SSEParser().feed(raw)
+    assert events[-1] is None  # [DONE]
+    chunks = [e for e in events if e is not None]
+    assert {e['id'] for e in chunks} == {chunks[0]['id']} and chunks[0]['id'].startswith('chatcmpl-')
+    content = ''.join(c['delta'].get('content', '') for e in chunks for c in e['choices'])
+    assert content == expected_completion(MSGS, 4, 'echo-v0').completion
+    assert all('logprobs' not in c for e in chunks for c in e['choices'])  # not requested
+    assert chunks[-1]['usage']['completion_tokens'] == 4 and chunks[-1]['gittensor']['served_uid'] == 7
+    assert state.inflight() == {7: 0} and state.snapshot()['gateway_ok'] == 1
 
 
 def test_latency_credit_bands(monkeypatch):
@@ -477,30 +507,25 @@ def test_gateway_400_on_user_shaped_bad_input(monkeypatch):
 
 
 def _dendrite_echoing(good: ServingRelease, dead_axons=()):
-    """Fake dendrite: honest echo answers for every axon, no response for `dead_axons`; counts calls per axon."""
+    """Fake streaming dendrite: honest echo chunks for every axon, nothing for `dead_axons`; counts calls per axon."""
+    from types import SimpleNamespace
+
+    from gittensor.serving.stream import result_to_sse
+
     calls: Dict[int, int] = {}  # id(axon) -> requests sent
 
-    async def dendrite(axons, synapse, deserialize, timeout):
-        out = []
-        for axon in axons:
-            calls[id(axon)] = calls.get(id(axon), 0) + 1
-            if any(axon is d for d in dead_axons):
-                out.append(synapse.model_copy())
-                continue
+    async def call_stream(target_axon, synapse, timeout, deserialize):
+        calls[id(target_axon)] = calls.get(id(target_axon), 0) + 1
+        final = synapse.model_copy()
+        if not any(target_axon is d for d in dead_axons):
             ref = expected_completion(synapse.messages, synapse.max_tokens, good.model_id)
-            resp = synapse.model_copy(
-                update={
-                    'completion': ref.completion,
-                    'served_model_id': good.model_id,
-                    'tokens': ref.tokens,
-                    'token_logprobs': ref.token_logprobs,
-                }
-            )
-            resp.dendrite.process_time = 0.05  # 50 ms -> full latency credit
-            out.append(resp)
-        return out
+            ref.model_id = good.model_id
+            for chunk in result_to_sse(ref, 'chatcmpl-miner', 0, logprobs=True):
+                yield chunk
+            final.dendrite.process_time = 0.05  # 50 ms -> full latency credit
+        yield final
 
-    return dendrite, calls
+    return SimpleNamespace(call_stream=call_stream), calls
 
 
 def test_audit_round_skips_release_without_reference(monkeypatch):

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -14,6 +14,7 @@ chat_completions
 _close_dendrite
 serving_api
 completion_tokens
+latency_ms
 inflight
 as_dict
 reference_completion
@@ -23,6 +24,9 @@ ECHO_LOADOUT_PATH
 # ServingMiner.resync_metagraph is dispatched by BaseNeuron.sync(); required_hash_fields is read by bt.Synapse
 resync_metagraph
 required_hash_fields
+# bt.StreamingSynapse hooks called by the dendrite
+process_streaming_response
+extract_response_json
 
 # `__exit__(self, exc_type, exc, tb)` - PEP 343 signature, body unused args
 exc_type


### PR DESCRIPTION
## Summary

Rebased onto `test` after #1696 merged.

Real streaming, not generate-then-chunk: `InferenceSynapse` is now a `bt.StreamingSynapse`; the miner proxies sparkinfer's SSE bytes straight through the axon (`OpenAICompatBackend.stream`, `stream_options.include_usage`), the validator folds the chunks into the same completion/tokens/logprobs the verifier already checks (`gittensor/serving/stream.py`), and the gateway relays them to the client as `text/event-stream` when `stream: true` (under our request id, logprobs stripped unless requested, `gittensor.served_uid` on the usage chunk, then `data: [DONE]`). Non-streaming requests and audits ride the exact same stream and assemble at the end, so audit and user traffic remain indistinguishable on the wire.

A miner backend error ends the stream without `[DONE]`; the validator scores that as a miss and the gateway returns 502 if nothing was streamed yet. `EchoBackend.stream` synthesises the same chunk shape so localnet still needs no GPU.

## Related Issues

Follow-up to #1695 / #1696.

## Type of Change

- [x] New feature

## Testing

- [x] Tests added/updated (SSE parse/assemble, gateway stream roundtrip, audits over the stream)
- [x] Manually tested on testnet (2026-08-25): audits pass over the stream (UID 27 score 0.941 first round); `stream: true` returns `text/event-stream` with progressive chunks (50 chunks / 48 tokens), one request id, `[DONE]`, logprobs only when requested, usage + `gittensor.served_uid` on the last chunk; non-streaming path unchanged (200, 0.45 s); 6 concurrent streams all complete. Time-to-first-chunk 0.37–0.8 s = dendrite + droplet→GPU overhead (runtime TTFT 25 ms).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)