### PR TITLE
emissions: 50/50 OSS/serving split; audit window 10 @ 0.8

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -152,7 +152,7 @@ RECYCLE_UID = 0
 
 # Combined scoring pool distributed by repository emission_share, then by per-repo PR/issue split.
 # Pools (OSS + SERVING) must sum to 1.0; anything unallocated within them recycles to RECYCLE_UID.
-OSS_EMISSION_SHARE = 0.80  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 32% of total)
+OSS_EMISSION_SHARE = 0.50  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 20% of total)
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
 MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
@@ -164,7 +164,7 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # passing audits the whole pool recycles to RECYCLE_UID, so this is safe to hold above 0 before
 # miners exist. 0.0 would be shadow mode (scores computed and logged, nothing paid). Move
 # OSS_EMISSION_SHARE in the same commit so the pools still sum to 1.0.
-SERVING_EMISSION_SHARE = 0.20
+SERVING_EMISSION_SHARE = 0.50
 assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )
@@ -190,12 +190,13 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 # Rolling window: the mean of per-audit outcomes (1 pass / 0 fail; misses and wrong model are 0) over the last
 # SERVING_AUDIT_WINDOW audits of a (hotkey, release) must reach the threshold for the number of audits seen so
 # far (rows are (k, threshold), linearly interpolated, flat beyond the last row). With a deterministic runtime the
-# honest mean is 1.0, so the bar only leaves room for transient misses: one miss costs a round at 4 audits/round.
+# honest mean is 1.0, so the bar only leaves room for transient misses. At 4 audits per 5-minute round, one missed
+# round (4/10 = 0.6 < 0.8) costs ~10 minutes out of the READY set; a single missed audit does not.
 # History: the 1b8b962 pin needed a positional-overlap window with a calibrated ramp (0.016 at k=1 .. 0.415 at
 # k=20; 2026-08-22 notes). Recalibrate with
 #   python scripts/serving_cheat_experiment.py analyze --honest <honest rows> --cheaters <cheater rows>
-SERVING_AUDIT_WINDOW = 20
-SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.85),)
+SERVING_AUDIT_WINDOW = 10
+SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.8),)
 SERVING_API_DEFAULT_PORT = 8790
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -371,16 +371,19 @@ def test_audit_bands_match_measured_calibration():
 
 
 def test_audit_window_tolerates_one_miss_per_round():
-    """With a deterministic runtime the bar is 0.85: a single miss in the last 20 is fine, two in a row of 4 is not."""
+    """Bar is 0.8 over the last 10: one miss in a round of 4 is fine, a whole missed round is not, and it clears
+    once a clean round pushes the misses below 20% of the window."""
     w = AuditWindow()
     hk = 'hk'
     for _ in range(4):
         w.record(hk, 'm', 1.0)
     assert w.verdict(hk, 'm').passed
-    w.record(hk, 'm', 0.0)  # 4/5 = 0.8 < 0.85 -> drops this round
+    w.record(hk, 'm', 0.0)  # 4/5 = 0.8 -> still READY
+    assert w.verdict(hk, 'm').passed
+    w.record(hk, 'm', 0.0)  # 4/6 < 0.8 -> drops
     assert not w.verdict(hk, 'm').passed
-    for _ in range(3):
-        w.record(hk, 'm', 1.0)  # 7/8 = 0.875 -> back
+    for _ in range(4):
+        w.record(hk, 'm', 1.0)  # 8/10 = 0.8 -> back after one clean round
     assert w.verdict(hk, 'm').passed
     assert window_threshold(1, SERVING_AUDIT_WINDOW_THRESHOLDS) == window_threshold(SERVING_AUDIT_WINDOW)
 


### PR DESCRIPTION
## Summary

- `OSS_EMISSION_SHARE` 0.80 → **0.50**, `SERVING_EMISSION_SHARE` 0.20 → **0.50**. Repo `emission_share` values stay fractions of the OSS pool (sparkinfer 0.4 → 20% of total).
- Audit window 20 @ 0.85 → **10 @ 0.8**: a single missed audit no longer drops a miner; a whole missed round (4/10) does, and one clean round restores it (~10 min at the 5-minute cadence instead of ~25).

## Related Issues

Follow-up to #1695–#1697; matches the launch plan's stated intent of a large serving share (this is the first step toward it).

## Type of Change

- [x] Other: emission / scoring parameters

## Testing

- [x] Tests added/updated (window test rewritten for the new bar; pool-sum assertion unchanged)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable) — miner-facing pay docs are landing in gittensor-docs-ui