### PR TITLE
serving: concurrent capacity probe (one GPU, one payout)

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -205,6 +205,9 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 SERVING_AUDIT_WINDOW = 20
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.85),)
 SERVING_API_DEFAULT_PORT = 8790
+SERVING_MIN_CALLER_STAKE = (
+    1_000.0  # miner: callers need a validator permit AND at least this stake (TAO); env SERVING_MIN_CALLER_STAKE
+)
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -179,9 +179,10 @@ SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round i
 # SERVING_PROBE_TARGET_TPS, capped at 1, is the miner's capacity. One RTX 5090 delivers a fixed throughput however many
 # hotkeys front it, so N hotkeys on one card share one card's pay; a hotkey with more than one card is capped at one
 # card's worth (register one hotkey per GPU). Target = what one honest 5090 delivers under this probe as measured by the
-# validator (RTT included); calibrated on testnet 2026-08-25 with one and two miners on one card.
+# validator (RTT included). Calibrated on testnet 2026-08-25 (validator on a DO droplet, card in Romania): one miner alone
+# 183-186 tok/s; two hotkeys on the same card 104-115 tok/s each (sum 210-227) -> capacities ~1.0 vs ~0.6.
 SERVING_PROBE_REQUESTS = 6
-SERVING_PROBE_TARGET_TPS = 200.0
+SERVING_PROBE_TARGET_TPS = 180.0
 # Latency credit for a 64-token audit (release.max_tokens). An honest 5090 answers in ~165 ms on-box
 # (measured 2026-08-22/24: p95 166 ms); add validator<->miner RTT and an
 # honest miner anywhere on earth lands under ~450 ms. Credit is flat to FULL and falls linearly to 0 at

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -205,9 +205,9 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 SERVING_AUDIT_WINDOW = 20
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.85),)
 SERVING_API_DEFAULT_PORT = 8790
-SERVING_MIN_CALLER_STAKE = (
-    1_000.0  # miner: callers need a validator permit AND at least this stake (TAO); env SERVING_MIN_CALLER_STAKE
-)
+# Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Same
+# rule as allways: validators and builders with skin in the game get to use the product. Env SERVING_MIN_CALLER_STAKE.
+SERVING_MIN_CALLER_STAKE = 250_000.0
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -172,6 +172,14 @@ SERVING_CHALLENGES_PER_ROUND = 4  # audit prompts sent to each serving miner per
 SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before an audit counts as failed
 SERVING_AUDIT_CONCURRENCY = 32  # serving axons audited in parallel per round
 SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
+# Capacity probe: after the correctness audits, every miner whose window passed is sent SERVING_PROBE_REQUESTS audit
+# prompts at the same instant as every other miner. Verified tokens delivered per wall-clock second, over
+# SERVING_PROBE_TARGET_TPS, capped at 1, is the miner's capacity. One RTX 5090 delivers a fixed throughput however many
+# hotkeys front it, so N hotkeys on one card share one card's pay; a hotkey with more than one card is capped at one
+# card's worth (register one hotkey per GPU). Target = what one honest 5090 delivers under this probe as measured by the
+# validator (RTT included); calibrated on testnet 2026-08-25 with one and two miners on one card.
+SERVING_PROBE_REQUESTS = 6
+SERVING_PROBE_TARGET_TPS = 200.0
 # Latency credit for a 64-token audit (release.max_tokens). An honest 5090 answers in ~165 ms on-box
 # (measured 2026-08-22/24: p95 166 ms); add validator<->miner RTT and an
 # honest miner anywhere on earth lands under ~450 ms. Credit is flat to FULL and falls linearly to 0 at

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -170,7 +170,9 @@ assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE - 1.0) < EMISSION_SHARE_T
 )
 SERVING_CHALLENGES_PER_ROUND = 4  # audit prompts sent to each serving miner per scoring round
 SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before an audit counts as failed
-SERVING_AUDIT_CONCURRENCY = 32  # serving axons audited in parallel per round
+SERVING_AUDIT_CONCURRENCY = (
+    256  # serving axons audited in parallel per round (sockets are cheap; dead axons hold a slot 30 s)
+)
 SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
 # Capacity probe: after the correctness audits, every miner whose window passed is sent SERVING_PROBE_REQUESTS audit
 # prompts at the same instant as every other miner. Verified tokens delivered per wall-clock second, over

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -35,6 +35,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
+import aiohttp
 import bittensor as bt
 
 from gittensor.constants import (
@@ -187,6 +188,10 @@ async def audit_round(
     return scores
 
 
+async def _unlimited_session() -> aiohttp.ClientSession:
+    return aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=0))
+
+
 class ServingAuditThread:
     """Runs ``audit_round`` every ``interval_s`` seconds on a private event loop in a daemon thread."""
 
@@ -209,6 +214,10 @@ class ServingAuditThread:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         dendrite = bt.Dendrite(wallet=self.validator.wallet)
+        # The probe streams from every READY miner at once (fleet x SERVING_PROBE_REQUESTS); aiohttp's default
+        # connector caps a session at 100 connections, which would queue late miners on the validator and skew
+        # their measured throughput. Uncapped connector for the audit dendrite only.
+        dendrite._session = loop.run_until_complete(_unlimited_session())
         while not self._stop.is_set():
             started = time.monotonic()
             try:

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -19,9 +19,13 @@ serves one release, so its score is the best it achieved across releases;
 miners whose window passes are published as READY (tagged with their release)
 to the gateway, and the scores are picked up by the next OSS round.
 
-    score = window passes (0/1) x mean over this round's audits of latency_credit
+    score = window passes (0/1) x mean over this round's audits of latency_credit x capacity
 
-Misses count as 0 in the window and latency credit 0 in the round.
+Misses count as 0 in the window and latency credit 0 in the round. ``capacity``
+comes from the round's load probe: every miner whose window passed gets
+``SERVING_PROBE_REQUESTS`` prompts at the same instant as every other miner,
+and verified tokens per wall-clock second over ``SERVING_PROBE_TARGET_TPS``
+(capped at 1) is its capacity — so hotkeys sharing one GPU share one GPU's pay.
 """
 
 import asyncio
@@ -37,6 +41,8 @@ from gittensor.constants import (
     SERVING_AUDIT_CONCURRENCY,
     SERVING_CHALLENGE_TIMEOUT,
     SERVING_CHALLENGES_PER_ROUND,
+    SERVING_PROBE_REQUESTS,
+    SERVING_PROBE_TARGET_TPS,
 )
 from gittensor.serving.audit import AuditCase, AuditVerdict, reference_for, verify_response
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
@@ -66,6 +72,37 @@ async def audit_axon(
                 results.append(score_response(uid, synapse.model_copy(), later, release))
             break
     return results
+
+
+async def probe_axon(
+    state: ServingState,
+    dendrite: bt.Dendrite,
+    uid: int,
+    hotkey: str,
+    axon: bt.AxonInfo,
+    release: ServingRelease,
+    cases: Sequence[AuditCase],
+) -> float:
+    """Fire all ``cases`` at once; return verified tokens per wall-clock second (0 when nothing verified)."""
+
+    async def one(case: AuditCase) -> Tuple[AuditVerdict, float, RequestRecord, int]:
+        synapse = InferenceSynapse(
+            messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens, logprobs=True
+        )
+        response = await consume_stream(dendrite, axon, synapse, SERVING_CHALLENGE_TIMEOUT)
+        verdict, elapsed_ms, record = score_response(uid, response, case, release)
+        return verdict, elapsed_ms, record, len(getattr(response, 'tokens', None) or [])
+
+    started = time.monotonic()
+    results = await asyncio.gather(*(one(case) for case in cases))
+    wall_s = max(time.monotonic() - started, 1e-3)
+    tokens = 0
+    for verdict, _, record, n_tokens in results:
+        state.audits.record(hotkey, release.model_id, verdict.value)
+        state.record(RequestRecord(**{**record.__dict__, 'kind': 'probe'}))
+        if verdict.passed:
+            tokens += n_tokens
+    return tokens / wall_s
 
 
 async def audit_round(
@@ -105,10 +142,33 @@ async def audit_round(
             )
             continue
         credits = await asyncio.gather(*(audit_one(uid, hotkey, axon, release, cases) for uid, hotkey, axon in serving))
+        passing = [
+            (uid, hotkey, axon, credit)
+            for (uid, hotkey, axon), credit in zip(serving, credits)
+            if credit > 0.0 and state.audits.verdict(hotkey, release.model_id).passed
+        ]
         for (uid, hotkey, _), credit in zip(serving, credits):
             window = state.audits.verdict(hotkey, release.model_id)
-            score = credit if window.passed else 0.0
-            bt.logging.debug(f'Serving: UID {uid} {release.model_id} window {window.as_dict()} score {score:.3f}')
+            bt.logging.debug(f'Serving: UID {uid} {release.model_id} window {window.as_dict()} credit {credit:.3f}')
+        if not passing:
+            continue
+        probe_cases = [reference.sample() for _ in range(SERVING_PROBE_REQUESTS)]
+        if probe_cases:
+            rates = await asyncio.gather(
+                *(
+                    probe_axon(state, dendrite, uid, hotkey, axon, release, probe_cases)
+                    for uid, hotkey, axon, _ in passing
+                )
+            )
+        else:  # probe disabled: capacity is not measured
+            rates = [SERVING_PROBE_TARGET_TPS] * len(passing)
+        for (uid, hotkey, _, credit), tps in zip(passing, rates):
+            capacity = min(1.0, tps / SERVING_PROBE_TARGET_TPS)
+            score = credit * capacity if state.audits.verdict(hotkey, release.model_id).passed else 0.0
+            bt.logging.info(
+                f'Serving: UID {uid} {release.model_id} probe {tps:.0f} tok/s capacity {capacity:.2f} '
+                f'latency credit {credit:.2f} score {score:.3f}'
+            )
             if score > best[hotkey][0]:
                 best[hotkey] = (score, release.model_id)
 

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -169,24 +169,21 @@ def min_caller_stake() -> float:
 
 
 async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
-    """Only validators may query: a registered hotkey with a validator permit and at least the stake floor.
+    """Only hotkeys staked at least SERVING_MIN_CALLER_STAKE alpha on the subnet may query.
 
-    Otherwise any registered hotkey could use the miner's GPU for free inference.
+    Otherwise any registered hotkey could use the miner's GPU for free inference; the stake floor means validators
+    and builders with skin in the game get to use the product.
     """
     hotkey = synapse.dendrite.hotkey if synapse.dendrite else None
     if not hotkey or hotkey not in miner.metagraph.hotkeys:
         return True, 'Unrecognized hotkey'
-    uid = miner.metagraph.hotkeys.index(hotkey)
     try:
-        permitted = bool(miner.metagraph.validator_permit[uid])
-        stake = float(miner.metagraph.S[uid])
-    except IndexError:  # metagraph mid-sync; refuse rather than guess
+        stake = float(miner.metagraph.S[miner.metagraph.hotkeys.index(hotkey)])
+    except (ValueError, IndexError):  # metagraph mid-sync; refuse rather than guess
         return True, 'Metagraph out of date'
-    if not permitted:
-        return True, 'No validator permit'
     if stake < min_caller_stake():
         return True, f'Stake {stake:.0f} below {min_caller_stake():.0f}'
-    return False, 'Validator'
+    return False, 'Staked caller'
 
 
 async def priority_inference(miner: ServingMiner, synapse: InferenceSynapse) -> float:

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -43,7 +43,12 @@ from bittensor.core.stream import StreamingSynapse
 from bittensor.utils.axon_utils import allowed_nonce_window_ns, calculate_diff_seconds
 from bittensor_wallet import Keypair
 
-from gittensor.constants import SERVING_BACKEND_CONCURRENCY, SERVING_MAX_TOKENS, SERVING_SEEN_NONCES
+from gittensor.constants import (
+    SERVING_BACKEND_CONCURRENCY,
+    SERVING_MAX_TOKENS,
+    SERVING_MIN_CALLER_STAKE,
+    SERVING_SEEN_NONCES,
+)
 from gittensor.serving.backends import InferenceBackend, load_backend
 from gittensor.serving.loadout import load_serving_loadout
 from gittensor.synapses import InferenceSynapse
@@ -159,12 +164,29 @@ async def verify_inference(miner: ServingMiner, synapse: InferenceSynapse) -> No
         miner.seen_nonces.popitem(last=False)
 
 
+def min_caller_stake() -> float:
+    return float(os.getenv('SERVING_MIN_CALLER_STAKE', SERVING_MIN_CALLER_STAKE))
+
+
 async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
-    """Only registered hotkeys may query; validators are the expected callers."""
+    """Only validators may query: a registered hotkey with a validator permit and at least the stake floor.
+
+    Otherwise any registered hotkey could use the miner's GPU for free inference.
+    """
     hotkey = synapse.dendrite.hotkey if synapse.dendrite else None
     if not hotkey or hotkey not in miner.metagraph.hotkeys:
         return True, 'Unrecognized hotkey'
-    return False, 'Registered hotkey'
+    uid = miner.metagraph.hotkeys.index(hotkey)
+    try:
+        permitted = bool(miner.metagraph.validator_permit[uid])
+        stake = float(miner.metagraph.S[uid])
+    except IndexError:  # metagraph mid-sync; refuse rather than guess
+        return True, 'Metagraph out of date'
+    if not permitted:
+        return True, 'No validator permit'
+    if stake < min_caller_stake():
+        return True, f'Stake {stake:.0f} below {min_caller_stake():.0f}'
+    return False, 'Validator'
 
 
 async def priority_inference(miner: ServingMiner, synapse: InferenceSynapse) -> float:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -710,18 +710,14 @@ def test_serving_miner_blacklists_non_validators(monkeypatch):
     from neurons.serving_miner import blacklist_inference
 
     monkeypatch.setenv('SERVING_MIN_CALLER_STAKE', '100')
-    miner = SimpleNamespace(
-        metagraph=SimpleNamespace(
-            hotkeys=['vali', 'rich-miner', 'small-vali'], validator_permit=[True, False, True], S=[5000.0, 9000.0, 10.0]
-        )
-    )
+    miner = SimpleNamespace(metagraph=SimpleNamespace(hotkeys=['vali', 'builder', 'small'], S=[5000.0, 100.0, 99.0]))
 
     def call(hotkey):
         syn = InferenceSynapse(messages=MSGS, model_id='m')
         syn.dendrite.hotkey = hotkey
         return asyncio.run(blacklist_inference(miner, syn))  # type: ignore[arg-type]
 
-    assert call('vali') == (False, 'Validator')
-    assert call('rich-miner')[0] and 'permit' in call('rich-miner')[1]
-    assert call('small-vali')[0] and 'Stake' in call('small-vali')[1]
+    assert call('vali') == (False, 'Staked caller')
+    assert call('builder') == (False, 'Staked caller')
+    assert call('small')[0] and 'Stake 99 below 100' in call('small')[1]
     assert call('stranger') == (True, 'Unrecognized hotkey')

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -714,6 +714,7 @@ def test_serving_miner_blacklists_non_validators(monkeypatch):
 
     def call(hotkey):
         syn = InferenceSynapse(messages=MSGS, model_id='m')
+        assert syn.dendrite is not None
         syn.dendrite.hotkey = hotkey
         return asyncio.run(blacklist_inference(miner, syn))  # type: ignore[arg-type]
 

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -700,3 +700,28 @@ def test_inference_synapse_hashes_request_fields():
     b = InferenceSynapse(messages=[{'role': 'user', 'content': 'y'}], model_id='m', max_tokens=8)
     assert a.body_hash != b.body_hash
     assert a.body_hash == InferenceSynapse(messages=a.messages, model_id='m', max_tokens=8).body_hash
+
+
+def test_serving_miner_blacklists_non_validators(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.synapses import InferenceSynapse
+    from neurons.serving_miner import blacklist_inference
+
+    monkeypatch.setenv('SERVING_MIN_CALLER_STAKE', '100')
+    miner = SimpleNamespace(
+        metagraph=SimpleNamespace(
+            hotkeys=['vali', 'rich-miner', 'small-vali'], validator_permit=[True, False, True], S=[5000.0, 9000.0, 10.0]
+        )
+    )
+
+    def call(hotkey):
+        syn = InferenceSynapse(messages=MSGS, model_id='m')
+        syn.dendrite.hotkey = hotkey
+        return asyncio.run(blacklist_inference(miner, syn))  # type: ignore[arg-type]
+
+    assert call('vali') == (False, 'Validator')
+    assert call('rich-miner')[0] and 'permit' in call('rich-miner')[1]
+    assert call('small-vali')[0] and 'Stake' in call('small-vali')[1]
+    assert call('stranger') == (True, 'Unrecognized hotkey')

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -506,18 +506,30 @@ def test_gateway_400_on_user_shaped_bad_input(monkeypatch):
     assert state.inflight() == {7: 0}
 
 
-def _dendrite_echoing(good: ServingRelease, dead_axons=()):
-    """Fake streaming dendrite: honest echo chunks for every axon, nothing for `dead_axons`; counts calls per axon."""
+def _dendrite_echoing(good: ServingRelease, dead_axons=(), gpu_of=None, token_s: float = 0.0):
+    """Fake streaming dendrite: honest echo chunks for every axon, nothing for `dead_axons`; counts calls per axon.
+
+    ``gpu_of`` maps id(axon) -> a GPU key; when set, a request takes ``token_s`` per token times the number of
+    requests in flight on that GPU, so hotkeys sharing a card slow each other down the way one real card does.
+    """
+    import asyncio
     from types import SimpleNamespace
 
     from gittensor.serving.stream import result_to_sse
 
     calls: Dict[int, int] = {}  # id(axon) -> requests sent
+    inflight: Dict[object, int] = {}
 
     async def call_stream(target_axon, synapse, timeout, deserialize):
         calls[id(target_axon)] = calls.get(id(target_axon), 0) + 1
         final = synapse.model_copy()
         if not any(target_axon is d for d in dead_axons):
+            gpu = (gpu_of or {}).get(id(target_axon))
+            if gpu is not None:
+                inflight[gpu] = inflight.get(gpu, 0) + 1
+                await asyncio.sleep(0)  # let the other concurrent requests register before we measure load
+                await asyncio.sleep(token_s * synapse.max_tokens * inflight[gpu])
+                inflight[gpu] -= 1
             ref = expected_completion(synapse.messages, synapse.max_tokens, good.model_id)
             ref.model_id = good.model_id
             for chunk in result_to_sse(ref, 'chatcmpl-miner', 0, logprobs=True):
@@ -561,6 +573,7 @@ def test_audit_round_stops_after_first_unanswered_prompt(monkeypatch):
 
     good = _echo_release()
     monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 4)
+    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', 0)
     live, dead = SimpleNamespace(is_serving=True), SimpleNamespace(is_serving=True)
     dendrite, calls = _dendrite_echoing(good, dead_axons=(dead,))
     state = ServingState()
@@ -571,6 +584,46 @@ def test_audit_round_stops_after_first_unanswered_prompt(monkeypatch):
     assert scores == {'hk1': 1.0, 'hk2': 0.0}
     assert state.audits.verdict('hk2', good.model_id).n_audits == 4
     assert [m.uid for m in state.ready_miners()] == [1]
+
+
+def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
+    """Two hotkeys on one card each get about half the capacity a lone card gets; a lone card gets ~1."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 2)
+    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', 4)
+    lone, a, b = (SimpleNamespace(is_serving=True) for _ in range(3))
+    gpu_of = {id(lone): 'gpu-1', id(a): 'gpu-2', id(b): 'gpu-2'}
+    dendrite, _ = _dendrite_echoing(good, gpu_of=gpu_of, token_s=0.0005)
+    # calibrate the target from what the lone card delivers under this fake's timing
+    rates = []
+    real_probe = fwd.probe_axon
+
+    async def spy(*args, **kwargs):
+        rate = await real_probe(*args, **kwargs)
+        rates.append(rate)
+        return rate
+
+    monkeypatch.setattr(fwd, 'probe_axon', spy)
+    state = ServingState()
+    monkeypatch.setattr(fwd, 'SERVING_PROBE_TARGET_TPS', 1e-9)
+    asyncio.run(fwd.audit_round(state, dendrite, [(1, 'lone', lone)], ServingLoadout(releases=[good])))  # type: ignore[arg-type]
+    probe = [r for r in state.recent(50) if r.kind == 'probe']
+    assert len(probe) == 4 and all(r.ok for r in probe)
+    lone_tps = rates[0]
+
+    monkeypatch.setattr(fwd, 'SERVING_PROBE_TARGET_TPS', lone_tps)
+    state = ServingState()
+    scores = asyncio.run(
+        fwd.audit_round(state, dendrite, [(1, 'lone', lone), (2, 'a', a), (3, 'b', b)], ServingLoadout(releases=[good]))  # type: ignore[arg-type]
+    )
+    assert scores['lone'] == pytest.approx(1.0, abs=0.15)
+    assert scores['a'] == pytest.approx(0.5, abs=0.15) and scores['b'] == pytest.approx(0.5, abs=0.15)
+    assert scores['a'] + scores['b'] == pytest.approx(scores['lone'], abs=0.2)
 
 
 def test_ready_set_expires_after_ttl():

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -24,6 +24,8 @@ ECHO_LOADOUT_PATH
 # ServingMiner.resync_metagraph is dispatched by BaseNeuron.sync(); required_hash_fields is read by bt.Synapse
 resync_metagraph
 required_hash_fields
+# bt.Dendrite's lazily-created aiohttp session, preset by the audit thread with an uncapped connector
+_session
 # bt.StreamingSynapse hooks called by the dendrite
 process_streaming_response
 extract_response_json


### PR DESCRIPTION
## Summary

Makes multi-hotkey farming of one GPU pointless instead of policing it. After the correctness audits each round, every miner whose window passed is sent `SERVING_PROBE_REQUESTS` (6) fresh audit prompts **at the same instant as every other miner**. Verified tokens delivered per wall-clock second, over `SERVING_PROBE_TARGET_TPS`, capped at 1, is the miner's `capacity`:

```
score = window_passes × mean(latency_credit) × capacity
```

One RTX 5090 delivers a fixed throughput however many hotkeys front it, so N hotkeys on one card split one card's pay; a hotkey fronting more than one card is capped at one card's worth (one hotkey per GPU). Probe responses are verified against the reference like any audit and feed the window, so answering the probe with garbage is a fail, not free capacity. `SERVING_PROBE_REQUESTS = 0` disables the probe (capacity 1).

`SERVING_PROBE_TARGET_TPS = 180`, calibrated on testnet 2026-08-25 (validator on a DO droplet, one rented 5090 in Romania, independent reference on a second card): **one miner alone 186 / 183 tok/s**; **two hotkeys on the same card 104+106 and 112+115 tok/s** (each ~0.55–0.6 of a lone card; sum 210–227 because the card batches two streams slightly better than one). So one card behind two hotkeys earns ~1.15 cards' worth, not 2.

Also: **miner access control** — `blacklist_inference` now admits only hotkeys staked at least `SERVING_MIN_CALLER_STAKE` = **250,000 alpha** on the subnet (env-overridable) — the allways rule: validators and builders with stake get to use the product directly. Before this any registered hotkey could use a miner's GPU for free inference.

**Scale.** The probe must hit the whole fleet at once, so the audit dendrite gets an uncapped aiohttp connector (the default caps a session at 100 connections — at 256 miners x 6 requests, late miners would queue on the validator and measure slow) and audit concurrency goes to 256. Reference load is unchanged (probe/audit prompts are shared by all miners). **Not yet verified at fleet scale:** validator-side event-loop overhead parsing ~100k SSE events per round inflates every miner's measured wall-clock equally; the target may need re-calibration once there are tens of miners (or timing moved to first-byte→last-byte per miner).

## Related Issues

Follow-up to #1696–#1698; launch-plan gap #3 (hardware / one-GPU-many-hotkeys, "mainnet gate").

## Type of Change

- [x] New feature

## Testing

- [x] Tests added/updated — fake dendrite with per-GPU contention: lone card ≈ 1.0, two hotkeys on one card ≈ 0.5 each, sum ≈ lone.
- [x] Manually tested — testnet calibration above; audits, probe and gateway ran for ~1 h with no errors.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable) — described on the Compute Serving page (gittensor-docs-ui #29)