### PR TITLE
serving: probe results affect capacity only, not the audit window

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -181,6 +181,7 @@ SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round i
 # card's worth (register one hotkey per GPU). Target = what one honest 5090 delivers under this probe as measured by the
 # validator (RTT included). Calibrated on testnet 2026-08-25 (validator on a DO droplet, card in Romania): one miner alone
 # 183-186 tok/s; two hotkeys on the same card 104-115 tok/s each (sum 210-227) -> capacities ~1.0 vs ~0.6.
+# Probe outcomes affect capacity only, never the audit window (a slow host halves its pay; it does not flap out of READY).
 SERVING_PROBE_REQUESTS = 6
 SERVING_PROBE_TARGET_TPS = 180.0
 # Latency credit for a 64-token audit (release.max_tokens). An honest 5090 answers in ~165 ms on-box

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -26,6 +26,9 @@ comes from the round's load probe: every miner whose window passed gets
 ``SERVING_PROBE_REQUESTS`` prompts at the same instant as every other miner,
 and verified tokens per wall-clock second over ``SERVING_PROBE_TARGET_TPS``
 (capped at 1) is its capacity — so hotkeys sharing one GPU share one GPU's pay.
+Probe outcomes never enter the audit window: a host that cannot take the
+burst loses capacity this round, not its READY status (unverified or missing
+probe tokens simply count 0).
 """
 
 import asyncio
@@ -99,7 +102,6 @@ async def probe_axon(
     wall_s = max(time.monotonic() - started, 1e-3)
     tokens = 0
     for verdict, _, record, n_tokens in results:
-        state.audits.record(hotkey, release.model_id, verdict.value)
         state.record(RequestRecord(**{**record.__dict__, 'kind': 'probe'}))
         if verdict.passed:
             tokens += n_tokens
@@ -165,7 +167,7 @@ async def audit_round(
             rates = [SERVING_PROBE_TARGET_TPS] * len(passing)
         for (uid, hotkey, _, credit), tps in zip(passing, rates):
             capacity = min(1.0, tps / SERVING_PROBE_TARGET_TPS)
-            score = credit * capacity if state.audits.verdict(hotkey, release.model_id).passed else 0.0
+            score = credit * capacity
             bt.logging.info(
                 f'Serving: UID {uid} {release.model_id} probe {tps:.0f} tok/s capacity {capacity:.2f} '
                 f'latency credit {credit:.2f} score {score:.3f}'

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -629,6 +629,39 @@ def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
     assert scores['a'] + scores['b'] == pytest.approx(scores['lone'], abs=0.2)
 
 
+def test_probe_misses_cost_capacity_not_the_window(monkeypatch):
+    """A miner that answers every audit but chokes on the burst keeps a clean window and is probed again next round."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 4)
+    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', 6)
+    axon = SimpleNamespace(is_serving=True)
+    dendrite, calls = _dendrite_echoing(good)
+    real_stream = dendrite.call_stream
+
+    async def call_stream(target_axon, synapse, timeout, deserialize):
+        if calls.get(id(target_axon), 0) % 10 >= 4:  # per round: 4 audits answered, 6 probe requests dropped
+            calls[id(target_axon)] += 1
+            yield synapse.model_copy()
+            return
+        async for chunk in real_stream(target_axon, synapse, timeout, deserialize):
+            yield chunk
+
+    dendrite.call_stream = call_stream
+    state = ServingState()
+    for _ in range(2):
+        scores = asyncio.run(fwd.audit_round(state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[good])))  # type: ignore[arg-type]
+        assert scores == {'hk1': 0.0}
+    assert calls == {id(axon): 20}
+    window = state.audits.verdict('hk1', good.model_id)
+    assert window.passed and window.n_audits == 8 and window.mean == 1.0
+    assert sum(1 for r in state.recent(50) if r.kind == 'probe' and not r.ok) == 12
+
+
 def test_ready_set_expires_after_ttl():
     from types import SimpleNamespace
 


### PR DESCRIPTION
Probe misses/timeouts were recorded into the correctness window (\`probe_axon\` → \`state.audits.record\`). A host that cannot take 6 concurrent requests inside 30 s therefore failed the window, dropped out of READY, was not probed the next round, passed on 4 audits, was probed again, failed… = flapping.

Seen in the 12 h soak (2026-08-25/26, one 5090 in Romania, weak host): 7 window fails, every one from probe timeouts, never from a wrong answer; e.g. 08:45 UTC probe 6 tok/s → \`0 READY []\` for two rounds, back at 08:55.

Now probe outcomes only set \`capacity\` (unverified/missing tokens count 0). The window is correctness-only, so a slow host halves its pay instead of losing READY. Drops the now-redundant window re-check in the score line.

Test: miner answers every audit but every probe request times out → window stays \`passed\`, \`mean 1.0\`, and it is probed again next round.