### PR TITLE
serving: miners answer only callers staked >= 1M alpha

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -210,9 +210,10 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 SERVING_AUDIT_WINDOW = 10
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.8),)
 SERVING_API_DEFAULT_PORT = 8790
-# Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Same
-# rule as allways: validators and builders with skin in the game get to use the product. Env SERVING_MIN_CALLER_STAKE.
-SERVING_MIN_CALLER_STAKE = 250_000.0
+# Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Set so
+# that only the reference-running validator clears it (2026-08-26: one hotkey holds >1M alpha, the next 0.27M); every
+# other caller goes through that validator's gateway. Env SERVING_MIN_CALLER_STAKE.
+SERVING_MIN_CALLER_STAKE = 1_000_000.0
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -171,8 +171,8 @@ def min_caller_stake() -> float:
 async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
     """Only hotkeys staked at least SERVING_MIN_CALLER_STAKE alpha on the subnet may query.
 
-    Otherwise any registered hotkey could use the miner's GPU for free inference; the stake floor means validators
-    and builders with skin in the game get to use the product.
+    Otherwise any registered hotkey could use the miner's GPU for free inference; the floor is set so only the
+    reference-running validator clears it and everyone else goes through its gateway.
     """
     hotkey = synapse.dendrite.hotkey if synapse.dendrite else None
     if not hotkey or hotkey not in miner.metagraph.hotkeys:


### PR DESCRIPTION
\`SERVING_MIN_CALLER_STAKE\` 250k → 1,000,000 alpha. On SN74 today one hotkey holds ≥1M (UID 181, ~3.0M); the next is 0.27M, so compute miners answer only the reference-running validator and every other caller goes through its gateway. Still env-overridable.

Docs-ui \`compute-serving.md\` line 130 (\`≥ 250,000 alpha\`) to be updated alongside.