### PR TITLE
serving: served traffic is the audit; pay verified GPU-hours at $0.70/h inside a 7% cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,17 @@ STORE_DB_RESULTS=false
 # DB_PASSWORD=
 
 # ******* SERVING SUB-MECHANISM (beta, validator-only, opt-in) *******
-# Run the inference audit loop against serving miners. Scores are telemetry until SERVING_EMISSION_SHARE > 0.
+# Run the serving loop: verify served traffic against the reference, probe capacity, price verified GPU-hours.
 SERVING_ENABLED=false
 # OpenAI-compatible inference API served by the validator (POST /v1/chat/completions, Bearer key).
 # Off unless SERVING_API_KEYS is set. Comma-separated keys. Inside docker set SERVING_API_HOST=0.0.0.0 so the
 # compose port mapping can reach it; expose it through your reverse proxy / TLS like any other service.
 # SERVING_API_KEYS=key-one,key-two
+# Keys whose requests may be routed to not-yet-READY (probation) miners: the baseline-traffic client
+# (scripts/serving_baseline_traffic.py). User keys only ever reach READY miners.
+# SERVING_BASELINE_API_KEYS=baseline-key
+# TAO/USD override for the serving GPU-hour price (default: `pricing.tao_usd` in serving_loadout.json).
+# SERVING_TAO_USD=228.79
 # SERVING_API_HOST=0.0.0.0
 # SERVING_API_PORT=8790
 # Host-side bind for the API port mapping in docker-compose.vali.yml (default 127.0.0.1:8790; 0.0.0.0:8790 = public).

--- a/gittensor/classes.py
+++ b/gittensor/classes.py
@@ -708,3 +708,15 @@ def _scored_mirror_pr_for_cache(scored: 'ScoredPR') -> 'ScoredPR':
     scored_copy = copy.copy(scored)
     scored_copy.files = None
     return scored_copy
+
+
+@dataclass
+class ServingPricing:
+    """What one alpha is worth and how much alpha miners receive per hour; sizes the serving emission share."""
+
+    alpha_per_hour_to_miners: float
+    alpha_usd: float
+
+    @property
+    def usable(self) -> bool:
+        return self.alpha_per_hour_to_miners > 0 and self.alpha_usd > 0

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -152,7 +152,7 @@ RECYCLE_UID = 0
 
 # Combined scoring pool distributed by repository emission_share, then by per-repo PR/issue split.
 # Pools (OSS + SERVING) must sum to 1.0; anything unallocated within them recycles to RECYCLE_UID.
-OSS_EMISSION_SHARE = 0.50  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 20% of total)
+OSS_EMISSION_SHARE = 0.83  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 33% of total)
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
 MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
@@ -160,22 +160,24 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # =============================================================================
 # Serving (sub-subnet B beta)
 # =============================================================================
-# Share of emissions paid to inference-serving miners, pro-rata by serving score. With no miner
-# passing audits the whole pool recycles to RECYCLE_UID, so this is safe to hold above 0 before
-# miners exist. 0.0 would be shadow mode (scores computed and logged, nothing paid). Move
-# OSS_EMISSION_SHARE in the same commit so the pools still sum to 1.0.
-SERVING_EMISSION_SHARE = 0.50
-assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE - 1.0) < EMISSION_SHARE_TOLERANCE, (
+# Serving miners are paid an accounting price per verified GPU-hour, not a fixed slice: each READY card-equivalent
+# (capacity-weighted, so N hotkeys on one card sum to one card) earns SERVING_GPU_HOUR_USD, converted to an emission
+# share through the on-chain alpha/TAO price and the TAO/USD rate published in serving_loadout.json (`pricing`).
+# The share is capped at SERVING_EMISSION_SHARE_CAP; what the fleet does not earn recycles to RECYCLE_UID, never to
+# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~25 cards inside the 17% cap. With no
+# price data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
+SERVING_GPU_HOUR_USD = 0.70
+SERVING_EMISSION_SHARE_CAP = 0.17
+assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )
-SERVING_CHALLENGES_PER_ROUND = 4  # audit prompts sent to each serving miner per scoring round
-SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before an audit counts as failed
-SERVING_AUDIT_CONCURRENCY = (
-    256  # serving axons audited in parallel per round (sockets are cheap; dead axons hold a slot 30 s)
-)
+# Settlement is over the trailing hour: a miner's serving score is the mean of its last SERVING_SETTLEMENT_ROUNDS
+# round scores (missing rounds count 0), so a card verified for 45 of the last 60 minutes earns 75% of the price.
+SERVING_SETTLEMENT_ROUNDS = 12  # 12 x 5-minute audit rounds
+SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before a probe request counts as failed
 SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
-# Capacity probe: after the correctness audits, every miner whose window passed is sent SERVING_PROBE_REQUESTS audit
-# prompts at the same instant as every other miner. Verified tokens delivered per wall-clock second, over
+# Capacity probe: after settling the window, every READY miner is sent SERVING_PROBE_REQUESTS reference prompts at the
+# same instant as every other miner. Verified tokens delivered per wall-clock second, over
 # SERVING_PROBE_TARGET_TPS, capped at 1, is the miner's capacity. One RTX 5090 delivers a fixed throughput however many
 # hotkeys front it, so N hotkeys on one card share one card's pay; a hotkey with more than one card is capped at one
 # card's worth (register one hotkey per GPU). Target = what one honest 5090 delivers under this probe as measured by the
@@ -199,16 +201,20 @@ SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
 SERVING_AUDIT_MIN_PREFIX_AGREEMENT = 1.0  # fraction of reference greedy tokens reproduced before first divergence
 SERVING_AUDIT_MAX_MEAN_ABS_LOGPROB_DIFF = 0.005  # mean |logprob delta| over the agreed prefix
 SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob delta|
-# Rolling window: the mean of per-audit outcomes (1 pass / 0 fail; misses and wrong model are 0) over the last
-# SERVING_AUDIT_WINDOW audits of a (hotkey, release) must reach the threshold for the number of audits seen so
-# far (rows are (k, threshold), linearly interpolated, flat beyond the last row). With a deterministic runtime the
-# honest mean is 1.0, so the bar only leaves room for transient misses. At 4 audits per 5-minute round, one missed
-# round (4/10 = 0.6 < 0.8) costs ~10 minutes out of the READY set; a single missed audit does not.
+# Every request served through the gateway is the audit: the validator teacher-forces the miner's completion under
+# its reference and checks the tokens/logprobs (no synthetic audit prompts, nothing for a miner to fingerprint).
+# Rolling window: the mean of per-request outcomes (1 pass / 0 fail; misses, timeouts and wrong model are 0) over
+# the last SERVING_AUDIT_WINDOW verified requests of a (hotkey, release) must reach the threshold for the number
+# seen so far (rows are (k, threshold), linearly interpolated, flat beyond the last row). With a deterministic
+# runtime the honest mean is 1.0, so the bar only leaves room for transient misses. A *wrong answer* (tokens or
+# logprobs outside the bands with aligned lengths) is not a miss: it wipes the window and quarantines the hotkey for
+# SERVING_QUARANTINE_S — there is no honest way to produce one on the blessed pin.
 # History: the 1b8b962 pin needed a positional-overlap window with a calibrated ramp (0.016 at k=1 .. 0.415 at
 # k=20; 2026-08-22 notes). Recalibrate with
 #   python scripts/serving_cheat_experiment.py analyze --honest <honest rows> --cheaters <cheater rows>
 SERVING_AUDIT_WINDOW = 10
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.8),)
+SERVING_QUARANTINE_S = 3600.0
 SERVING_API_DEFAULT_PORT = 8790
 # Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Same
 # rule as allways: validators and builders with skin in the game get to use the product. Env SERVING_MIN_CALLER_STAKE.

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -152,7 +152,7 @@ RECYCLE_UID = 0
 
 # Combined scoring pool distributed by repository emission_share, then by per-repo PR/issue split.
 # Pools (OSS + SERVING) must sum to 1.0; anything unallocated within them recycles to RECYCLE_UID.
-OSS_EMISSION_SHARE = 0.83  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 33% of total)
+OSS_EMISSION_SHARE = 0.93  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 37% of total)
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
 MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
@@ -164,10 +164,10 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # (capacity-weighted, so N hotkeys on one card sum to one card) earns SERVING_GPU_HOUR_USD, converted to an emission
 # share through the on-chain alpha/TAO price and the TAO/USD rate published in serving_loadout.json (`pricing`).
 # The share is capped at SERVING_EMISSION_SHARE_CAP; what the fleet does not earn recycles to RECYCLE_UID, never to
-# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~25 cards inside the 17% cap. With no
+# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~10 cards inside the 7% cap. With no
 # price data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
 SERVING_GPU_HOUR_USD = 0.70
-SERVING_EMISSION_SHARE_CAP = 0.17
+SERVING_EMISSION_SHARE_CAP = 0.07
 assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -6,14 +6,16 @@
     POST /v1/chat/completions   Authorization: Bearer <key>
 
 The validator serves this; each request is forwarded to the READY miner with
-the fewest in-flight requests as the same ``InferenceSynapse`` the audit loop
-uses, so miners cannot tell audits from real traffic. Keys are a static list
-in ``SERVING_API_KEYS`` for now (a DB table once keys need minting/credits).
-Off unless keys are set. Binds loopback by default; put it behind the host
-reverse proxy / TLS like any other service (see docker-compose.vali.yml).
+the fewest in-flight requests and, once served, handed to the audit loop to be
+verified against the reference — served traffic is the only audit there is.
+Keys are a static list in ``SERVING_API_KEYS`` for now (the product front door
+owns users/credits). Requests from ``SERVING_BASELINE_API_KEYS`` may be routed
+to probation (not yet READY) miners so new miners can earn a window; user keys
+only ever reach READY miners. Off unless keys are set. Binds loopback by
+default; put it behind the host reverse proxy / TLS like any other service.
 
 No queue: with no READY capacity it returns 429 so rejected demand stays
-visible. Streaming is a later phase.
+visible.
 
     OPENAI_BASE_URL=http://<host>:8790/v1 OPENAI_API_KEY=<key> ...
 """
@@ -32,7 +34,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from gittensor.constants import SERVING_MAX_TOKENS
 from gittensor.serving.loadout import ServingRelease
-from gittensor.serving.state import ReadyMiner, RequestRecord, ServingState, finite_or_none
+from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState, finite_or_none
 from gittensor.serving.stream import SSE_DONE, Event, consume_stream, sse_event
 from gittensor.synapses import InferenceSynapse
 
@@ -52,7 +54,9 @@ def build_app(
     api_keys: Set[str],
     dendrite_factory,
     request_timeout: float,
+    baseline_keys: Optional[Set[str]] = None,
 ) -> FastAPI:
+    baseline = set(baseline_keys or ())
     app = FastAPI(title='Gittensor Serving API', version='0.1.0-beta')
     dendrite_holder: Dict[str, bt.Dendrite] = {}
 
@@ -101,7 +105,7 @@ def build_app(
         return snap
 
     @app.post('/v1/chat/completions')
-    async def chat_completions(request: Request, _: str = Depends(require_key)):
+    async def chat_completions(request: Request, key: str = Depends(require_key)):
         body = await request.json()
         messages = body.get('messages')
         if not isinstance(messages, list) or not messages:
@@ -123,7 +127,7 @@ def build_app(
         want_logprobs = bool(body.get('logprobs', False))
         want_stream = bool(body.get('stream', False))
 
-        miner = state.acquire(release.model_id)
+        miner = state.acquire(release.model_id, probation=key in baseline)
         if miner is None:
             raise HTTPException(status_code=429, detail='no READY serving capacity')
 
@@ -134,13 +138,28 @@ def build_app(
         def finish(result: Optional[InferenceSynapse]) -> bool:
             state.release(miner.uid)
             ok = result is not None and result.completion is not None
+            latency_ms = (time.monotonic() - start) * 1000.0
+            state.enqueue_served(
+                ServedRequest(
+                    ts=time.time(),
+                    uid=miner.uid,
+                    hotkey=miner.hotkey,
+                    model_id=release.model_id,
+                    messages=messages,
+                    ok=ok and (result.served_model_id == release.model_id if result else False),
+                    latency_ms=latency_ms,
+                    completion=result.completion if result else None,
+                    tokens=list(result.tokens) if result and result.tokens else None,
+                    token_logprobs=list(result.token_logprobs) if result and result.token_logprobs else None,
+                )
+            )
             state.record(
                 RequestRecord(
                     ts=time.time(),
                     kind='gateway',
                     uid=miner.uid,
                     ok=ok,
-                    latency_ms=(time.monotonic() - start) * 1000.0,
+                    latency_ms=latency_ms,
                     completion_tokens=(result.usage or {}).get('completion_tokens', 0) if result else 0,
                     ttft_ms=result.ttft_ms if result else None,
                     decode_tps=result.decode_tps if result else None,
@@ -273,10 +292,18 @@ def start_serving_api(
     host: str,
     port: int,
     request_timeout: float,
+    baseline_keys: Optional[Set[str]] = None,
 ) -> ServingApiThread:
     if not api_keys:
         raise ValueError('SERVING_API_KEYS is empty; refusing to start without API keys')
-    app = build_app(state, release, api_keys, lambda: bt.Dendrite(wallet=wallet), request_timeout)
+    app = build_app(
+        state,
+        release,
+        api_keys | set(baseline_keys or ()),
+        lambda: bt.Dendrite(wallet=wallet),
+        request_timeout,
+        baseline_keys=baseline_keys,
+    )
     api = ServingApiThread(app, host, port)
     api.start()
     return api

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -39,16 +39,23 @@ keeps the last ``SERVING_AUDIT_WINDOW`` outcomes per (hotkey, release) and
 publishes the miner while their mean clears ``SERVING_AUDIT_WINDOW_THRESHOLDS``
 — it absorbs transient misses; it is not there to average out model noise (that
 was the 1b8b962 design, 2026-08-22 notes).
-Missed or malformed audits enter the window as 0. The validator persists the
+Missed or malformed responses enter the window as 0. The validator persists the
 window (``serving_audits.json`` next to ``state.npz``) so a restart is not a
-reset. ``LiveReference.score`` exposes teacher-forced scoring (R8) for text the
-reference did not generate — the primitive for auditing organic, non-greedy
-traffic later. Every audit requests ``logprobs=True``; the gateway does the same
-for organic traffic so the flag is not a tell.
+reset.
+
+There are no synthetic audit prompts: every request served through the gateway
+*is* the audit. ``verify_served`` teacher-forces the miner's completion under
+the reference (``Reference.score_served``, contract R8) and compares the miner's
+tokens/logprobs to the reference's argmax/logprobs position by position — one
+prefill pass, no generation, and nothing on the wire that a miner could tell
+apart from unaudited traffic. A verdict with ``hard`` set (tokens or logprobs
+outside the bands with aligned lengths) is a wrong answer, not a miss:
+``AuditWindow.strike`` wipes the window and quarantines the hotkey.
 """
 
 import json
 import secrets
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -60,6 +67,7 @@ from gittensor.constants import (
     SERVING_AUDIT_MIN_PREFIX_AGREEMENT,
     SERVING_AUDIT_WINDOW,
     SERVING_AUDIT_WINDOW_THRESHOLDS,
+    SERVING_QUARANTINE_S,
 )
 from gittensor.serving.backends import Message, expected_completion
 from gittensor.serving.loadout import WEIGHTS_DIR, ServingRelease
@@ -85,6 +93,7 @@ class AuditVerdict:
     reason: str
     positional_overlap: float = 0.0
     max_abs_logprob_diff: float = float('inf')
+    hard: bool = False  # a wrong answer (bands failed with aligned lengths), not a miss
 
     @property
     def value(self) -> float:
@@ -99,6 +108,7 @@ class AuditVerdict:
             'positional_overlap': round(self.positional_overlap, 4),
             'max_abs_logprob_diff': round(self.max_abs_logprob_diff, 4),
             'reason': self.reason,
+            'hard': self.hard,
         }
 
 
@@ -121,6 +131,7 @@ class WindowVerdict:
     n_audits: int
     mean: float
     threshold: float
+    quarantined_until: float = 0.0
 
     def as_dict(self) -> dict:
         return {
@@ -128,6 +139,7 @@ class WindowVerdict:
             'n_audits': self.n_audits,
             'mean': round(self.mean, 4),
             'threshold': round(self.threshold, 4),
+            'quarantined_until': round(self.quarantined_until, 1),
         }
 
 
@@ -140,7 +152,9 @@ class AuditWindow:
 
     size: int = SERVING_AUDIT_WINDOW
     thresholds: Sequence[Tuple[int, float]] = SERVING_AUDIT_WINDOW_THRESHOLDS
+    quarantine_s: float = SERVING_QUARANTINE_S
     _values: Dict[Tuple[str, str], Deque[float]] = field(default_factory=dict)
+    _quarantine: Dict[Tuple[str, str], float] = field(default_factory=dict)  # (hotkey, model) -> until ts
 
     def record(self, hotkey: str, model_id: str, value: float) -> None:
         key = (hotkey, model_id)
@@ -148,8 +162,24 @@ class AuditWindow:
             self._values[key] = deque(maxlen=self.size)
         self._values[key].append(max(0.0, min(1.0, float(value))))
 
+    def strike(self, hotkey: str, model_id: str, now: Optional[float] = None) -> float:
+        """A wrong answer: wipe the window and quarantine the (hotkey, release) until the returned timestamp."""
+        key = (hotkey, model_id)
+        self._values.pop(key, None)
+        until = (now if now is not None else time.time()) + self.quarantine_s
+        self._quarantine[key] = until
+        return until
+
+    def quarantined_until(self, hotkey: str, model_id: str, now: Optional[float] = None) -> float:
+        until = self._quarantine.get((hotkey, model_id), 0.0)
+        return until if until > (now if now is not None else time.time()) else 0.0
+
     def to_dict(self) -> dict:
-        return {'size': self.size, 'values': [[hk, mid, list(xs)] for (hk, mid), xs in self._values.items()]}
+        return {
+            'size': self.size,
+            'values': [[hk, mid, list(xs)] for (hk, mid), xs in self._values.items()],
+            'quarantine': [[hk, mid, until] for (hk, mid), until in self._quarantine.items()],
+        }
 
     @classmethod
     def from_dict(cls, raw: dict, **kwargs) -> 'AuditWindow':
@@ -157,6 +187,8 @@ class AuditWindow:
         for hk, mid, xs in raw.get('values', []):
             for x in xs[-window.size :]:
                 window.record(str(hk), str(mid), float(x))
+        for hk, mid, until in raw.get('quarantine', []):
+            window._quarantine[(str(hk), str(mid))] = float(until)
         return window
 
     def save(self, path: Path) -> None:
@@ -173,16 +205,19 @@ class AuditWindow:
         except (OSError, ValueError, TypeError):
             return cls(**kwargs)
 
-    def verdict(self, hotkey: str, model_id: str) -> WindowVerdict:
+    def verdict(self, hotkey: str, model_id: str, now: Optional[float] = None) -> WindowVerdict:
+        until = self.quarantined_until(hotkey, model_id, now)
         xs = self._values.get((hotkey, model_id))
         if not xs:
-            return WindowVerdict(False, 0, 0.0, float('inf'))
+            return WindowVerdict(False, 0, 0.0, float('inf'), until)
         mean = sum(xs) / len(xs)
         threshold = window_threshold(len(xs), self.thresholds)
-        return WindowVerdict(mean >= threshold, len(xs), mean, threshold)
+        return WindowVerdict(mean >= threshold and until == 0.0, len(xs), mean, threshold, until)
 
 
 class Reference(Protocol):
+    def score_served(self, messages: List[Message], completion: str) -> dict: ...
+
     model_id: str
 
     def sample(self) -> AuditCase: ...
@@ -219,6 +254,9 @@ class BankReference:
     def sample(self) -> AuditCase:
         return secrets.choice(self.cases)
 
+    def score_served(self, messages: List[Message], completion: str) -> dict:
+        raise NotImplementedError('a bank reference cannot verify served traffic; run a live reference')
+
     def __len__(self) -> int:
         return len(self.cases)
 
@@ -240,6 +278,15 @@ class EchoReference:
             reference_logprobs=ref.token_logprobs or [],
             reference_completion=ref.completion,
         )
+
+    def score_served(self, messages: List[Message], completion: str) -> dict:
+        """Teacher-forced scoring for the echo backend: the argmax is the expected token at every position."""
+        tokens = completion.split(' ') if completion else []
+        ref = expected_completion(messages, max(1, len(tokens)), self.model_id)
+        argmax = list(ref.tokens or [])[: len(tokens)]
+        ref_lp = list(ref.token_logprobs or [])
+        logprobs = [ref_lp[i] if i < len(ref_lp) and tokens[i] == argmax[i] else -20.0 for i in range(len(tokens))]
+        return {'tokens': tokens, 'logprobs': logprobs, 'argmax': argmax, 'usage': {}}
 
     def __len__(self) -> int:
         return 1
@@ -274,9 +321,12 @@ class LiveReference:
 
     def score(self, messages: List[Message], completion: str) -> dict:
         """Teacher-forced logprobs of ``completion`` under the reference (R8): verifies text the reference
-        did not generate, e.g. a miner's sampled answer to an organic request. A trailing end-of-turn token
-        in the miner's token list is not part of the text; strip it before comparing lengths."""
+        did not generate. A trailing end-of-turn token in the miner's token list is not part of the text;
+        ``verify_served`` strips it before comparing lengths."""
         return score(self.base_url, self.model_id, messages, completion, self.timeout, self.api_key)
+
+    def score_served(self, messages: List[Message], completion: str) -> dict:
+        return self.score(messages, completion)
 
     def __len__(self) -> int:
         return 1
@@ -317,11 +367,41 @@ def verify_response(
 
     if agreement < min_prefix_agreement:
         reason = f'prefix agreement {agreement:.2f} < {min_prefix_agreement}'
-        return AuditVerdict(False, agreement, mean_diff, reason, overlap, max_diff)
+        return AuditVerdict(False, agreement, mean_diff, reason, overlap, max_diff, hard=True)
     if mean_diff > max_mean_abs_logprob_diff:
         reason = f'logprob drift {mean_diff:.4f} > {max_mean_abs_logprob_diff}'
-        return AuditVerdict(False, agreement, mean_diff, reason, overlap, max_diff)
+        return AuditVerdict(False, agreement, mean_diff, reason, overlap, max_diff, hard=True)
     if max_diff > max_abs_logprob_diff:
         reason = f'logprob outlier {max_diff:.4f} > {max_abs_logprob_diff}'
-        return AuditVerdict(False, agreement, mean_diff, reason, overlap, max_diff)
+        return AuditVerdict(False, agreement, mean_diff, reason, overlap, max_diff, hard=True)
     return AuditVerdict(True, agreement, mean_diff, 'ok', overlap, max_diff)
+
+
+def verify_served(
+    reference: Reference,
+    messages: List[Message],
+    completion: Optional[str],
+    tokens: Optional[Sequence[str]],
+    token_logprobs: Optional[Sequence[float]],
+    end_of_turn: Sequence[str] = ('<|im_end|>', '<|endoftext|>', '</s>'),
+) -> AuditVerdict:
+    """Verify a served (greedy) completion by teacher forcing it under the reference.
+
+    The reference's argmax at each position is what an honest copy would have generated, so the miner's tokens
+    must match it and the miner's logprobs must match the reference's logprob of that same token. A completion
+    that re-tokenizes to a different length is not comparable position by position and counts as a soft miss;
+    the bands failing on aligned lengths is a wrong answer (``hard``).
+    """
+    if completion is None or not tokens or token_logprobs is None or len(tokens) != len(token_logprobs):
+        return AuditVerdict(False, 0.0, float('inf'), 'missing or malformed logprobs')
+    mine, mine_lp = list(tokens), list(token_logprobs)
+    if mine and mine[-1] in end_of_turn:
+        mine, mine_lp = mine[:-1], mine_lp[:-1]
+    if not mine:
+        return AuditVerdict(False, 0.0, float('inf'), 'empty completion')
+    ref = reference.score_served(messages, completion)
+    argmax, ref_lp = ref.get('argmax') or [], ref.get('logprobs') or []
+    if len(argmax) != len(mine) or len(ref_lp) != len(mine):
+        return AuditVerdict(False, 0.0, float('inf'), f'tokenization mismatch ({len(mine)} vs {len(argmax)})')
+    case = AuditCase(messages=list(messages), max_tokens=len(mine), reference_tokens=argmax, reference_logprobs=ref_lp)
+    return verify_response(case, mine, mine_lp)

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -67,6 +67,7 @@ class ServingRelease:
 @dataclass
 class ServingLoadout:
     releases: List[ServingRelease]
+    tao_usd: Optional[float] = None  # published TAO/USD rate (`pricing.tao_usd`); sizes the serving emission share
 
     def __post_init__(self) -> None:
         if not self.releases:
@@ -99,7 +100,10 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
     with open(loadout_path) as f:
         raw = json.load(f)
     entries = raw['releases'] if isinstance(raw, dict) and 'releases' in raw else [raw]
-    loadout = ServingLoadout(releases=[ServingRelease.from_dict(entry) for entry in entries])
+    pricing = raw.get('pricing') or {} if isinstance(raw, dict) else {}
+    tao_usd_env = os.getenv('SERVING_TAO_USD')
+    tao_usd = float(tao_usd_env) if tao_usd_env else (float(pricing['tao_usd']) if pricing.get('tao_usd') else None)
+    loadout = ServingLoadout(releases=[ServingRelease.from_dict(entry) for entry in entries], tao_usd=tao_usd)
 
     reference_override = os.getenv('SERVING_REFERENCE_URL')
     if reference_override:

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -130,10 +130,6 @@ class ServingState:
             self._served.clear()
             return items
 
-    def probation_miners(self) -> List[ReadyMiner]:
-        with self._lock:
-            return list(self._probation.values()) if self._fresh() else []
-
     def _fresh(self) -> bool:
         return time.time() - self.last_round_ts <= self.ready_ttl_s
 

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -5,9 +5,13 @@
 
 The audit loop (validator thread) publishes which miners are READY — their
 rolling ``AuditWindow`` passes — and the gateway thread dispatches user traffic
-to them, least-in-flight first. Both threads also append to one request log,
-which is the seed of every later phase: miner speed scoring on organic
-traffic, the router competition's replay dataset, and usage telemetry.
+to them, least-in-flight first. Every request the gateway serves is handed back
+to the audit loop (``enqueue_served`` / ``drain_served``) to be verified against
+the reference: served traffic *is* the audit. Miners that are not yet READY sit
+in *probation* and only receive traffic from baseline keys, so a new miner can
+earn a window without a real user ever hitting an unverified card. Per-round
+scores are settled over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds.
+Both threads also append to one request log (telemetry).
 """
 
 import math
@@ -19,7 +23,7 @@ from typing import Deque, Dict, List, Optional, Sequence
 
 import bittensor as bt
 
-from gittensor.constants import SERVING_READY_TTL_S, SERVING_REQUEST_LOG_SIZE
+from gittensor.constants import SERVING_READY_TTL_S, SERVING_REQUEST_LOG_SIZE, SERVING_SETTLEMENT_ROUNDS
 from gittensor.serving.audit import AuditWindow
 
 
@@ -33,9 +37,25 @@ class ReadyMiner:
 
 
 @dataclass
+class ServedRequest:
+    """One gateway request as served, queued for verification by the audit loop."""
+
+    ts: float
+    uid: int
+    hotkey: str
+    model_id: str
+    messages: List[Dict[str, str]]
+    ok: bool
+    latency_ms: Optional[float]
+    completion: Optional[str] = None
+    tokens: Optional[List[str]] = None
+    token_logprobs: Optional[List[float]] = None
+
+
+@dataclass
 class RequestRecord:
     ts: float
-    kind: str  # 'audit' | 'gateway'
+    kind: str  # 'probe' | 'gateway'
     uid: Optional[int]
     ok: bool
     latency_ms: Optional[float]  # None when the request produced no response
@@ -58,25 +78,61 @@ def finite_or_none(value: Optional[float]) -> Optional[float]:
 class ServingState:
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     _ready: Dict[int, ReadyMiner] = field(default_factory=dict)
+    _probation: Dict[int, ReadyMiner] = field(default_factory=dict)
     _inflight: Dict[int, int] = field(default_factory=dict)
     _log: Deque[RequestRecord] = field(default_factory=lambda: deque(maxlen=SERVING_REQUEST_LOG_SIZE))
+    _served: Deque[ServedRequest] = field(default_factory=lambda: deque(maxlen=SERVING_REQUEST_LOG_SIZE))
     audits: AuditWindow = field(default_factory=AuditWindow)  # audit-loop thread only; persisted by the validator
-    _scores: Dict[str, float] = field(default_factory=dict)  # hotkey -> serving score from the last round
+    _history: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> last N round scores
+    settlement_rounds: int = SERVING_SETTLEMENT_ROUNDS
     last_round_ts: float = 0.0
     ready_ttl_s: float = SERVING_READY_TTL_S
 
-    def publish_round(self, miners: List[ReadyMiner], scores: Dict[str, float]) -> None:
-        """Audit thread: publish the READY set for the gateway and the per-hotkey scores for the next OSS round."""
+    def publish_round(
+        self, miners: List[ReadyMiner], scores: Dict[str, float], probation: Optional[List[ReadyMiner]] = None
+    ) -> None:
+        """Audit thread: publish the READY and probation sets for the gateway and settle this round's scores.
+
+        Every hotkey with history and no score this round records a 0, so a miner that vanishes stops earning
+        within one settlement window.
+        """
         with self._lock:
             self._ready = {m.uid: m for m in miners}
-            self._inflight = {uid: self._inflight.get(uid, 0) for uid in self._ready}
-            self._scores = dict(scores)
+            self._probation = {m.uid: m for m in (probation or []) if m.uid not in self._ready}
+            live = set(self._ready) | set(self._probation)
+            self._inflight = {uid: self._inflight.get(uid, 0) for uid in live}
+            for hotkey in set(self._history) | set(scores):
+                if hotkey not in self._history:
+                    self._history[hotkey] = deque(maxlen=self.settlement_rounds)
+                self._history[hotkey].append(float(scores.get(hotkey, 0.0)))
+            for hotkey in [hk for hk, xs in self._history.items() if not any(xs)]:
+                del self._history[hotkey]
             self.last_round_ts = time.time()
 
     def scores_for(self, hotkeys: Sequence[str]) -> Dict[int, float]:
-        """Scores keyed by current UID; a UID whose hotkey changed since the round carries nothing over."""
+        """Trailing-window settled scores keyed by current UID (missing rounds count 0); a UID whose hotkey
+        changed since the rounds carries nothing over."""
         with self._lock:
-            return {uid: self._scores[hk] for uid, hk in enumerate(hotkeys) if hk in self._scores}
+            return {
+                uid: sum(self._history[hk]) / self.settlement_rounds
+                for uid, hk in enumerate(hotkeys)
+                if hk in self._history
+            }
+
+    def enqueue_served(self, served: ServedRequest) -> None:
+        with self._lock:
+            self._served.append(served)
+
+    def drain_served(self) -> List[ServedRequest]:
+        """Audit thread: take every request served since the last round."""
+        with self._lock:
+            items = list(self._served)
+            self._served.clear()
+            return items
+
+    def probation_miners(self) -> List[ReadyMiner]:
+        with self._lock:
+            return list(self._probation.values()) if self._fresh() else []
 
     def _fresh(self) -> bool:
         return time.time() - self.last_round_ts <= self.ready_ttl_s
@@ -85,14 +141,26 @@ class ServingState:
         with self._lock:
             return list(self._ready.values()) if self._fresh() else []
 
-    def acquire(self, model_id: Optional[str] = None) -> Optional[ReadyMiner]:
+    def acquire(self, model_id: Optional[str] = None, probation: bool = False) -> Optional[ReadyMiner]:
         """Pick the READY miner (for ``model_id`` if given) with the fewest in-flight requests (ties -> higher score).
 
+        With ``probation`` (baseline traffic) an idle probation miner is preferred, at most one request in flight
+        each, so unverified miners get exactly the traffic they need to earn a window and no more.
         Returns None when there is no capacity or the last audit round is older than the READY TTL.
         """
         with self._lock:
             if not self._fresh():
                 return None
+            if probation:
+                idle = [
+                    u
+                    for u, m in self._probation.items()
+                    if (model_id is None or m.model_id == model_id) and self._inflight.get(u, 0) == 0
+                ]
+                if idle:
+                    uid = min(idle)
+                    self._inflight[uid] = 1
+                    return self._probation[uid]
             candidates = [u for u, m in self._ready.items() if model_id is None or m.model_id == model_id]
             if not candidates:
                 return None
@@ -122,6 +190,8 @@ class ServingState:
             log = list(self._log)
             return {
                 'ready_uids': sorted(self._ready),
+                'probation_uids': sorted(self._probation),
+                'pending_verification': len(self._served),
                 'inflight': dict(self._inflight),
                 'last_round_ts': self.last_round_ts,
                 'requests_logged': len(log),

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -37,7 +37,7 @@ class InferenceSynapse(bt.StreamingSynapse):
     """Inference request for serving miners (sub-subnet B beta).
 
     Carries one OpenAI-style chat request from validator to miner. The same
-    synapse is used for validator audit prompts and for gateway (user) traffic,
+    synapse is used for validator capacity probes and for gateway (user) traffic,
     so a miner cannot tell them apart. The miner answers with a stream of
     OpenAI ``chat.completion.chunk`` events (``gittensor/serving/stream.py``);
     the validator folds them into the response fields below. When ``logprobs``

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -8,12 +8,13 @@ from typing import Dict, Iterator, Optional
 import bittensor as bt
 import numpy as np
 
-from gittensor.classes import MinerEvaluation, RepoEmissionAllocation
+from gittensor.classes import MinerEvaluation, RepoEmissionAllocation, ServingPricing
 from gittensor.constants import (
     EMISSION_SHARE_TOLERANCE,
     OSS_EMISSION_SHARE,
     RECYCLE_UID,
-    SERVING_EMISSION_SHARE,
+    SERVING_EMISSION_SHARE_CAP,
+    SERVING_GPU_HOUR_USD,
 )
 from gittensor.validator.utils.load_weights import RepositoryConfig
 
@@ -24,6 +25,7 @@ def blend_emission_pools(
     miner_uids: set[int],
     maintainer_uids_by_repo: Optional[Dict[str, list[int]]] = None,
     serving_scores: Optional[Dict[int, float]] = None,
+    serving_pricing: Optional[ServingPricing] = None,
 ) -> np.ndarray:
     """Allocate the combined scoring pool by bounded repository emission_share.
 
@@ -38,9 +40,9 @@ def blend_emission_pools(
     is carved off the top and split evenly among those maintainers; the
     remainder scores normally. Repos with no listed maintainers are unaffected.
 
-    ``serving_scores`` distributes the ``SERVING_EMISSION_SHARE`` pool pro-rata
-    to serving miners; the pool recycles when no miner scored. At the current
-    share of 0.0 this is shadow mode and pays nothing.
+    ``serving_scores`` are settled card-equivalents per UID; ``serving_share``
+    prices them at ``SERVING_GPU_HOUR_USD`` inside ``SERVING_EMISSION_SHARE_CAP``
+    and the pool is split pro-rata. Whatever the fleet does not earn recycles.
     """
     sorted_uids = sorted(miner_uids)
     uid_index = {uid: idx for idx, uid in enumerate(sorted_uids)}
@@ -60,16 +62,17 @@ def blend_emission_pools(
         for uid, reward in allocation.issue_discovery_rewards.items():
             rewards[uid_index[uid]] += reward
 
-    # Serving pool (sub-subnet B beta): pro-rata by serving score; unclaimed recycles.
-    if SERVING_EMISSION_SHARE > 0:
-        serving_rewards, serving_unallocated = _calculate_score_rewards(
-            serving_scores or {}, SERVING_EMISSION_SHARE, miner_uids
-        )
+    # Serving pool: priced per verified GPU-hour inside the cap; unclaimed recycles.
+    if SERVING_EMISSION_SHARE_CAP > 0:
+        card_equiv = sum(serving_scores.values()) if serving_scores else 0.0
+        share = serving_share(card_equiv, serving_pricing)
+        serving_rewards, serving_unallocated = _calculate_score_rewards(serving_scores or {}, share, miner_uids)
         for uid, reward in serving_rewards.items():
             rewards[uid_index[uid]] += reward
-        recycle_share += serving_unallocated
+        recycle_share += serving_unallocated + (SERVING_EMISSION_SHARE_CAP - share)
         bt.logging.info(
-            f'Serving pool: {SERVING_EMISSION_SHARE * 100:.0f}% across '
+            f'Serving pool: {card_equiv:.2f} card-equivalents x ${SERVING_GPU_HOUR_USD:.2f}/h = '
+            f'{share * 100:.2f}% of emissions (cap {SERVING_EMISSION_SHARE_CAP * 100:.0f}%) across '
             f'{sum(1 for r in serving_rewards.values() if r > 0)} serving miners'
         )
 
@@ -196,6 +199,19 @@ def _repo_has_scorers(
     if issue_share > 0.0 and _collect_repo_issue_discovery_scores(miner_evaluations, repo_name, miner_uids):
         return True
     return False
+
+
+def serving_share(card_equiv: float, pricing: Optional[ServingPricing]) -> float:
+    """Emission share that pays ``card_equiv`` verified cards ``SERVING_GPU_HOUR_USD`` each, capped.
+
+    Without usable pricing (no chain price, no published TAO/USD — testnet) the whole cap is paid pro-rata.
+    """
+    if card_equiv <= 0:
+        return 0.0
+    if pricing is None or not pricing.usable:
+        return SERVING_EMISSION_SHARE_CAP
+    want = card_equiv * SERVING_GPU_HOUR_USD / (pricing.alpha_per_hour_to_miners * pricing.alpha_usd)
+    return min(SERVING_EMISSION_SHARE_CAP, want)
 
 
 def _calculate_score_rewards(

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -12,6 +12,7 @@ from gittensor.utils.uids import get_all_uids
 from gittensor.validator.emission_allocation import blend_emission_pools
 from gittensor.validator.issue_discovery.scan import run_issue_discovery
 from gittensor.validator.oss_contributions.reward import get_rewards
+from gittensor.validator.serving.pricing import serving_pricing
 from gittensor.validator.utils.config import (
     SERVING_ENABLED,
     VALIDATOR_STEPS_INTERVAL,
@@ -44,7 +45,7 @@ async def forward(self: 'Validator') -> None:
     - Combined scoring pool: 90%, allocated by repository emission_share
     - Maintainer cut:        per-repo carve-out routed to maintainer miner neurons
     - Issue treasury:       10%, flat to UID 111
-    - Serving pool:          SERVING_EMISSION_SHARE (0% shadow-mode beta) by serving score
+    - Serving pool:          SERVING_GPU_HOUR_USD per settled card-equivalent, capped at SERVING_EMISSION_SHARE_CAP
     - Recycle:              registry slack and inactive repo slices to UID 0
     """
 
@@ -77,8 +78,9 @@ async def forward(self: 'Validator') -> None:
         # 5. Allocate repo-bounded emission shares into final rewards
         maintainer_uids_by_repo = build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
         serving_scores = self.serving_state.scores_for(self.metagraph.hotkeys) if SERVING_ENABLED else {}
+        pricing = serving_pricing(self) if SERVING_ENABLED and serving_scores else None
         rewards = blend_emission_pools(
-            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, serving_scores
+            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, serving_scores, pricing
         )
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -7,28 +7,23 @@
 ``SERVING_AUDIT_INTERVAL_S``), independent of the validator's step loop, so
 the gateway's READY set stays fresh while an OSS round takes hours.
 
-Each round, for every blessed release, the validator sends audit prompts from
-that release's reference (live runtime on its own GPU, or a bank snapshot) to
-every serving axon over the same ``InferenceSynapse`` the gateway uses for
-user traffic, verifies each response against the reference (exact tokens,
-logprobs to float noise — the runtime is deterministic) and records the
-outcome into the miner's rolling ``AuditWindow``, and produces a per-hotkey
-serving score. Axons are audited concurrently; an axon that does not answer
-the first prompt is not sent the rest (the misses still count). A miner
-serves one release, so its score is the best it achieved across releases;
-miners whose window passes are published as READY (tagged with their release)
-to the gateway, and the scores are picked up by the next OSS round.
+There are no audit prompts. Every request the gateway served since the last
+round is verified against the release's reference by teacher forcing the
+miner's completion (``verify_served``): tokens must match the reference's
+argmax and logprobs must agree to float noise. Each verdict enters the miner's
+rolling ``AuditWindow``: misses/timeouts as 0, a wrong answer as a strike that
+wipes the window and quarantines the hotkey. Miners whose window passes are
+published READY; serving axons that are not READY (and not quarantined) are
+published as *probation* so baseline traffic can give them a window.
 
-    score = window passes (0/1) x mean over this round's audits of latency_credit x capacity
+    round score = window passes (0/1) x mean latency credit over this round's served requests x capacity
 
-Misses count as 0 in the window and latency credit 0 in the round. ``capacity``
-comes from the round's load probe: every miner whose window passed gets
-``SERVING_PROBE_REQUESTS`` prompts at the same instant as every other miner,
-and verified tokens per wall-clock second over ``SERVING_PROBE_TARGET_TPS``
+``capacity`` comes from the round's load probe: every READY miner gets
+``SERVING_PROBE_REQUESTS`` reference prompts at the same instant as every other
+miner, and verified tokens per wall-clock second over ``SERVING_PROBE_TARGET_TPS``
 (capped at 1) is its capacity — so hotkeys sharing one GPU share one GPU's pay.
-Probe outcomes never enter the audit window: a host that cannot take the
-burst loses capacity this round, not its READY status (unverified or missing
-probe tokens simply count 0).
+Probe outcomes affect capacity only, never the window. Round scores are settled
+over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
 """
 
 import asyncio
@@ -42,40 +37,19 @@ import aiohttp
 import bittensor as bt
 
 from gittensor.constants import (
-    SERVING_AUDIT_CONCURRENCY,
     SERVING_CHALLENGE_TIMEOUT,
-    SERVING_CHALLENGES_PER_ROUND,
     SERVING_PROBE_REQUESTS,
     SERVING_PROBE_TARGET_TPS,
 )
-from gittensor.serving.audit import AuditCase, AuditVerdict, reference_for, verify_response
+from gittensor.serving.audit import AuditCase, AuditVerdict, Reference, reference_for, verify_response, verify_served
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
-from gittensor.serving.state import ReadyMiner, RequestRecord, ServingState
+from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
 from gittensor.validator.serving.scoring import latency_credit
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
-
-
-async def audit_axon(
-    dendrite: bt.Dendrite, uid: int, axon: bt.AxonInfo, release: ServingRelease, cases: Sequence[AuditCase]
-) -> List[Tuple[AuditVerdict, float, RequestRecord]]:
-    """Audit one axon with every case in order; stop after the first case that gets no response at all."""
-    results: List[Tuple[AuditVerdict, float, RequestRecord]] = []
-    for i, case in enumerate(cases):
-        synapse = InferenceSynapse(
-            messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens, logprobs=True
-        )
-        response = await consume_stream(dendrite, axon, synapse, SERVING_CHALLENGE_TIMEOUT)
-        scored = score_response(uid, response, case, release)
-        results.append(scored)
-        if i == 0 and getattr(response, 'completion', None) is None:
-            for later in cases[1:]:
-                results.append(score_response(uid, synapse.model_copy(), later, release))
-            break
-    return results
 
 
 async def probe_axon(
@@ -102,10 +76,51 @@ async def probe_axon(
     wall_s = max(time.monotonic() - started, 1e-3)
     tokens = 0
     for verdict, _, record, n_tokens in results:
-        state.record(RequestRecord(**{**record.__dict__, 'kind': 'probe'}))
+        state.record(record)
         if verdict.passed:
             tokens += n_tokens
     return tokens / wall_s
+
+
+def verify_served_round(
+    state: ServingState, reference: Reference, release: ServingRelease, served: Sequence[ServedRequest]
+) -> Dict[str, List[float]]:
+    """Verify every served request for ``release`` into the window; return latency credits per hotkey."""
+    credits: Dict[str, List[float]] = {}
+    for req in served:
+        if req.model_id != release.model_id:
+            continue
+        if not req.ok:
+            verdict = AuditVerdict(False, 0.0, float('inf'), 'no completion')
+        else:
+            try:
+                verdict = verify_served(reference, req.messages, req.completion, req.tokens, req.token_logprobs)
+            except Exception as e:  # reference hiccup: neither credit nor blame
+                bt.logging.warning(f'Serving: could not verify a request served by UID {req.uid}: {e!r}')
+                continue
+        if verdict.hard:
+            until = state.audits.strike(req.hotkey, release.model_id)
+            bt.logging.warning(
+                f'Serving: UID {req.uid} served a WRONG answer ({verdict.reason}); window wiped, '
+                f'quarantined until {time.strftime("%H:%M:%S", time.gmtime(until))} UTC'
+            )
+        else:
+            state.audits.record(req.hotkey, release.model_id, verdict.value)
+        credits.setdefault(req.hotkey, []).append(
+            latency_credit(req.latency_ms) if verdict.passed and req.latency_ms is not None else 0.0
+        )
+        state.record(
+            RequestRecord(
+                ts=time.time(),
+                kind='verify',
+                uid=req.uid,
+                ok=verdict.passed,
+                latency_ms=req.latency_ms,
+                completion_tokens=len(req.tokens or []),
+                detail=verdict.reason,
+            )
+        )
+    return credits
 
 
 async def audit_round(
@@ -114,45 +129,40 @@ async def audit_round(
     serving: Sequence[Tuple[int, str, bt.AxonInfo]],
     loadout=None,
 ) -> Dict[str, float]:
-    """Audit every serving axon against every release; publish READY + scores; return hotkey -> score."""
+    """Verify served traffic, settle windows, probe READY miners; publish READY/probation; return hotkey -> score."""
     loadout = loadout or load_serving_loadout()
+    served = state.drain_served()
     if not serving:
         bt.logging.info('Serving: no serving axons found this round')
         state.publish_round([], {})
         return {}
 
     best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in serving}
-    slots = asyncio.Semaphore(SERVING_AUDIT_CONCURRENCY)
-
-    async def audit_one(uid: int, hotkey: str, axon: bt.AxonInfo, release: ServingRelease, cases) -> float:
-        async with slots:
-            results = await audit_axon(dendrite, uid, axon, release, cases)
-        credit = 0.0
-        for verdict, elapsed_ms, record in results:
-            state.audits.record(hotkey, release.model_id, verdict.value)
-            credit += latency_credit(elapsed_ms)
-            state.record(record)
-        return credit / len(cases)
+    probation: Dict[int, ReadyMiner] = {}
 
     for release in loadout.releases:
         try:
             reference = reference_for(release)
-            cases = [reference.sample() for _ in range(SERVING_CHALLENGES_PER_ROUND)]
-        except Exception as e:  # reference down / bank missing: skip this release, keep auditing the others
+        except Exception as e:  # reference down / bank missing: skip this release, keep the others
             bt.logging.error(
                 f'Serving: no reference for {release.model_id} this round ({e!r}); '
-                'set SERVING_REFERENCE_URL to a conformant runtime or build its audit bank'
+                'set SERVING_REFERENCE_URL to a conformant runtime'
             )
             continue
-        credits = await asyncio.gather(*(audit_one(uid, hotkey, axon, release, cases) for uid, hotkey, axon in serving))
-        passing = [
-            (uid, hotkey, axon, credit)
-            for (uid, hotkey, axon), credit in zip(serving, credits)
-            if credit > 0.0 and state.audits.verdict(hotkey, release.model_id).passed
-        ]
-        for (uid, hotkey, _), credit in zip(serving, credits):
+        credits = verify_served_round(state, reference, release, served)
+        passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
+        for uid, hotkey, axon in serving:
             window = state.audits.verdict(hotkey, release.model_id)
-            bt.logging.debug(f'Serving: UID {uid} {release.model_id} window {window.as_dict()} credit {credit:.3f}')
+            round_credits = credits.get(hotkey)
+            credit = sum(round_credits) / len(round_credits) if round_credits else 1.0
+            bt.logging.debug(
+                f'Serving: UID {uid} {release.model_id} window {window.as_dict()} '
+                f'served {len(round_credits or [])} credit {credit:.3f}'
+            )
+            if window.passed and credit > 0.0:
+                passing.append((uid, hotkey, axon, credit))
+            elif window.quarantined_until == 0.0 and uid not in probation:
+                probation[uid] = ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=0.0, model_id=release.model_id)
         if not passing:
             continue
         probe_cases = [reference.sample() for _ in range(SERVING_PROBE_REQUESTS)]
@@ -179,14 +189,14 @@ async def audit_round(
     ready: List[ReadyMiner] = []
     for uid, hotkey, axon in serving:
         score, model_id = best[hotkey]
-        bt.logging.info(
-            f'Serving: UID {uid} score {score:.3f} over {SERVING_CHALLENGES_PER_ROUND} audits'
-            + (f' ({model_id})' if model_id else '')
-        )
         if score > 0.0:
             ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, model_id=model_id))
-    state.publish_round(ready, scores)
-    bt.logging.info(f'Serving: {len(ready)} READY miner(s) published to gateway: {[m.uid for m in ready]}')
+            probation.pop(uid, None)
+    state.publish_round(ready, scores, list(probation.values()))
+    bt.logging.info(
+        f'Serving: verified {len(served)} served request(s); {len(ready)} READY miner(s) published to gateway: '
+        f'{[m.uid for m in ready]}; {len(probation)} on probation'
+    )
     return scores
 
 
@@ -264,9 +274,9 @@ def get_serving_axons(self: 'Validator') -> List[Tuple[int, str, bt.AxonInfo]]:
 def score_response(
     uid: int, response: InferenceSynapse, case: AuditCase, release: ServingRelease
 ) -> Tuple[AuditVerdict, float, RequestRecord]:
-    """Measure one audit response: (verdict, elapsed ms, telemetry record).
+    """Measure one probe response: (verdict, elapsed ms, telemetry record).
 
-    A missing response or a wrong model is a failed audit with infinite latency.
+    A missing response or a wrong model is a failed probe request with infinite latency.
     """
     process_time = getattr(getattr(response, 'dendrite', None), 'process_time', None)
     elapsed_ms = float(process_time) * 1000.0 if process_time is not None else float('inf')
@@ -274,7 +284,7 @@ def score_response(
     def rec(ok: bool, detail: str) -> RequestRecord:
         return RequestRecord(
             ts=time.time(),
-            kind='audit',
+            kind='probe',
             uid=uid,
             ok=ok,
             latency_ms=elapsed_ms if math.isfinite(elapsed_ms) else None,

--- a/gittensor/validator/serving/pricing.py
+++ b/gittensor/validator/serving/pricing.py
@@ -1,0 +1,45 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""What the serving pool has to pay with: alpha/hour flowing to miners and what one alpha is worth in USD.
+
+Both inputs are ones every validator observes identically — the metagraph emission column and the subnet's
+on-chain alpha/TAO price — plus the TAO/USD rate published in the loadout, so validators agree on the share.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+import bittensor as bt
+
+from gittensor.classes import ServingPricing
+from gittensor.serving.loadout import load_serving_loadout
+
+if TYPE_CHECKING:
+    from neurons.validator import Validator
+
+MINER_FRACTION_OF_NEURON_EMISSION = 0.5  # metagraph.E covers miners + validators (41% + 41%); miners get half
+MINUTES_PER_TEMPO = 72.0  # 360 blocks x 12 s
+
+
+def serving_pricing(self: 'Validator') -> Optional[ServingPricing]:
+    try:
+        alpha_per_tempo = float(sum(float(e) for e in self.metagraph.E)) * MINER_FRACTION_OF_NEURON_EMISSION
+        alpha_per_hour = alpha_per_tempo * 60.0 / MINUTES_PER_TEMPO
+        info = self.subtensor.subnet(int(self.metagraph.netuid))
+        alpha_tao = float(getattr(info, 'price', 0.0) or 0.0)
+        tao_usd = load_serving_loadout().tao_usd or 0.0
+    except Exception as e:
+        bt.logging.warning(f'Serving: pricing unavailable ({e!r}); paying the cap pro-rata')
+        return None
+    pricing = ServingPricing(alpha_per_hour_to_miners=alpha_per_hour, alpha_usd=alpha_tao * tao_usd)
+    if not pricing.usable:
+        bt.logging.warning(
+            f'Serving: pricing incomplete (alpha/h {alpha_per_hour:.1f}, alpha/TAO {alpha_tao:.6f}, '
+            f'TAO/USD {tao_usd:.2f}); paying the cap pro-rata'
+        )
+        return None
+    bt.logging.info(
+        f'Serving: pricing {alpha_per_hour:.1f} alpha/h to miners, ${pricing.alpha_usd:.3f}/alpha '
+        f'(alpha/TAO {alpha_tao:.6f} x TAO/USD {tao_usd:.2f})'
+    )
+    return pricing

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -24,6 +24,9 @@ if VALIDATOR_STEPS_INTERVAL < 1 or SERVING_AUDIT_INTERVAL_S <= 0:
     raise ValueError('VALIDATOR_STEPS_INTERVAL must be >= 1 and SERVING_AUDIT_INTERVAL_S > 0')
 # Serving inference API: off unless keys are set; loopback by default (0.0.0.0 inside docker), front it with the host proxy.
 SERVING_API_KEYS = os.getenv('SERVING_API_KEYS', '')
+# Keys whose traffic may be routed to not-yet-READY miners (probation). The baseline-traffic client uses one of
+# these; user keys only ever reach READY miners.
+SERVING_BASELINE_API_KEYS = os.getenv('SERVING_BASELINE_API_KEYS', '')
 SERVING_API_HOST = os.getenv('SERVING_API_HOST', '127.0.0.1')
 SERVING_API_PORT = int(os.getenv('SERVING_API_PORT', str(SERVING_API_DEFAULT_PORT)))
 

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -1,4 +1,5 @@
 {
+  "pricing": { "tao_usd": 228.79, "updated": "2026-08-26" },
   "releases": [
     {
       "model_id": "qwen3.6-35b-a3b",

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -46,6 +46,7 @@ from gittensor.validator.utils.config import (
     SERVING_API_KEYS,
     SERVING_API_PORT,
     SERVING_AUDIT_INTERVAL_S,
+    SERVING_BASELINE_API_KEYS,
     SERVING_ENABLED,
     STORE_DB_RESULTS,
     WANDB_PROJECT,
@@ -110,6 +111,7 @@ class Validator(BaseValidatorNeuron):
                     host=SERVING_API_HOST,
                     port=SERVING_API_PORT,
                     request_timeout=release.request_timeout,
+                    baseline_keys=parse_api_keys(SERVING_BASELINE_API_KEYS),
                 )
             else:
                 bt.logging.info('Serving: SERVING_API_KEYS unset — audits only, no API')

--- a/scripts/serving_baseline_traffic.py
+++ b/scripts/serving_baseline_traffic.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Baseline traffic for the serving gateway: keeps every miner audited when real traffic is quiet.
+
+Served traffic is the only audit the validator runs, so with no users a miner would coast on a stale window and a
+new miner could never earn one. This client sends realistic, varied prompts through the gateway at a steady rate
+using a key from SERVING_BASELINE_API_KEYS, which lets the gateway route to probation (not yet READY) miners too.
+
+    export KEY=<baseline key>
+    python3 scripts/serving_baseline_traffic.py --base-url http://127.0.0.1:8790 --rate 12 --duration 300
+
+Cron it on the validator host (e.g. every 5 minutes with --duration 290). Stdlib only.
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+import urllib.error
+import urllib.request
+
+TOPICS = [
+    'a rate limiter for an HTTP API',
+    'retry with exponential backoff',
+    'a LRU cache',
+    'parsing a CSV with quotes',
+    'a binary search over a sorted list',
+    'merging two sorted iterators',
+    'a token bucket',
+    'validating an email',
+    'a background job queue',
+    'reading a large file in chunks',
+    'a simple state machine',
+    'a debounce helper',
+]
+LANGS = ['Python', 'TypeScript', 'Go', 'Rust']
+SNIPPET = (
+    'def handle(req):\n    if not req.ok:\n        return None\n    items = [x for x in req.items if x.active]\n'
+    '    return sorted(items, key=lambda x: x.ts)\n'
+)
+
+
+def make_prompt(rng: random.Random) -> list:
+    kind = rng.random()
+    topic, lang = rng.choice(TOPICS), rng.choice(LANGS)
+    if kind < 0.35:
+        content = f'Write {topic} in {lang}. Include a short docstring and one example call.'
+    elif kind < 0.7:
+        filler = ' '.join(f'line {i}: {SNIPPET.strip()}' for i in range(rng.randint(5, 60)))
+        content = f'Here is a file:\n{filler}\n\nExplain what handle() does and list two bugs.'
+    else:
+        content = (
+            f'You are reviewing a pull request that adds {topic} in {lang}. The diff touches '
+            f'{rng.randint(2, 9)} files. Summarize the risks in three bullet points.'
+        )
+    return [{'role': 'user', 'content': content}]
+
+
+def one(base: str, key: str, rng: random.Random, timeout: float) -> dict:
+    body = json.dumps(
+        {
+            'messages': make_prompt(rng),
+            'max_tokens': rng.choice([64, 128, 256, 512]),
+            'stream': True,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        base.rstrip('/') + '/v1/chat/completions',
+        body,
+        {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + key},
+    )
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            served = None
+            for raw in r:
+                if raw.startswith(b'data:') and b'served_uid' in raw:
+                    served = json.loads(raw[5:]).get('gittensor', {}).get('served_uid')
+            return {'status': r.status, 's': round(time.time() - t0, 2), 'uid': served}
+    except urllib.error.HTTPError as e:
+        return {'status': e.code, 's': round(time.time() - t0, 2)}
+    except Exception as e:
+        return {'status': type(e).__name__, 's': round(time.time() - t0, 2)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--base-url', default='http://127.0.0.1:8790')
+    ap.add_argument('--rate', type=float, default=12.0, help='requests per minute')
+    ap.add_argument('--duration', type=float, default=290.0, help='seconds to run; 0 = one request')
+    ap.add_argument('--timeout', type=float, default=120.0)
+    ap.add_argument('--seed', type=int, default=None)
+    args = ap.parse_args()
+    key = os.environ.get('KEY')
+    if not key:
+        print('set KEY to a SERVING_BASELINE_API_KEYS key', file=sys.stderr)
+        return 2
+    rng = random.Random(args.seed)
+    started = time.time()
+    interval = 60.0 / max(args.rate, 1e-9)
+    while True:
+        res = one(args.base_url, key, rng, args.timeout)
+        print(json.dumps({'ts': round(time.time(), 1), **res}), flush=True)
+        if args.duration <= 0 or time.time() - started + interval > args.duration:
+            return 0
+        time.sleep(interval)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/validator/test_blend_emission_pools.py
+++ b/tests/validator/test_blend_emission_pools.py
@@ -31,7 +31,7 @@ def _oss_pool_only(monkeypatch):
     """These tests cover the OSS pool's own allocation; the serving pool (which recycles whenever no
     serving miner passes audits) is pinned to 0 so recycle expectations stay about OSS slack only.
     (and OSS to the full round, so round totals stay 1.0). The serving pool is covered in test_serving.py."""
-    monkeypatch.setattr(emission_allocation, 'SERVING_EMISSION_SHARE', 0.0)
+    monkeypatch.setattr(emission_allocation, 'SERVING_EMISSION_SHARE_CAP', 0.0)
     monkeypatch.setattr(emission_allocation, 'OSS_EMISSION_SHARE', 1.0)
     monkeypatch.setattr(sys.modules[__name__], 'OSS_EMISSION_SHARE', 1.0)
 

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -19,7 +19,7 @@ from gittensor.serving.audit import (
 )
 from gittensor.serving.backends import EchoBackend, GenerationResult, expected_completion
 from gittensor.serving.loadout import ECHO_LOADOUT_PATH, ServingLoadout, ServingRelease, load_serving_loadout
-from gittensor.serving.state import ReadyMiner, RequestRecord, ServingState
+from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
 from gittensor.validator.serving.scoring import latency_credit
 
 MSGS = [{'role': 'user', 'content': 'prompt'}]
@@ -484,9 +484,9 @@ def test_probe_score_parses_teacher_forced_response(monkeypatch):
 
 
 def test_emission_pools_sum_to_one():
-    from gittensor.constants import EMISSION_SHARE_TOLERANCE, OSS_EMISSION_SHARE, SERVING_EMISSION_SHARE
+    from gittensor.constants import EMISSION_SHARE_TOLERANCE, OSS_EMISSION_SHARE, SERVING_EMISSION_SHARE_CAP
 
-    assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE - 1.0) < EMISSION_SHARE_TOLERANCE
+    assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE
 
 
 def test_verify_rejects_malformed_reference():
@@ -543,21 +543,179 @@ def _dendrite_echoing(good: ServingRelease, dead_axons=(), gpu_of=None, token_s:
     return SimpleNamespace(call_stream=call_stream), calls
 
 
-def test_audit_round_skips_release_without_reference(monkeypatch):
-    """A release whose reference is unreachable is skipped and logged; the round still completes."""
+def _served(uid: int, release: ServingRelease, ok: bool = True, wrong: bool = False, latency_ms: float = 50.0):
+    """A gateway request as served by an honest echo miner (or a dead / wrong-model one)."""
+    import secrets
+
+    messages = [{'role': 'user', 'content': secrets.token_hex(8)}]
+    ref = expected_completion(messages, release.max_tokens, release.model_id)
+    tokens = list(ref.tokens or [])
+    logprobs = list(ref.token_logprobs or [])
+    if wrong:
+        tokens[len(tokens) // 2] = 'xxxxxxxx'
+    return ServedRequest(
+        ts=0.0,
+        uid=uid,
+        hotkey=f'hk{uid}',
+        model_id=release.model_id,
+        messages=messages,
+        ok=ok,
+        latency_ms=latency_ms if ok else None,
+        completion=' '.join(tokens) if ok else None,
+        tokens=tokens if ok else None,
+        token_logprobs=logprobs if ok else None,
+    )
+
+
+def _round(state, dendrite, serving, release, monkeypatch, probes: int = 0):
     import asyncio
-    from types import SimpleNamespace
 
     from gittensor.validator.serving import forward as fwd
+
+    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', probes)
+    return asyncio.run(fwd.audit_round(state, dendrite, serving, ServingLoadout(releases=[release])))  # type: ignore[arg-type]
+
+
+def test_verify_served_teacher_forces_the_completion():
+    """An honest served answer passes; a changed token is a hard failure; a bad re-tokenization is a soft miss."""
+    from gittensor.serving.audit import verify_served
+
+    release = _echo_release()
+    ref = EchoReference(release)
+    good = _served(1, release)
+    tokens, logprobs = list(good.tokens or []), list(good.token_logprobs or [])
+    v = verify_served(ref, good.messages, good.completion, tokens, logprobs)
+    assert v.passed and not v.hard
+    eos = verify_served(ref, good.messages, good.completion, tokens + ['<|im_end|>'], logprobs + [0.0])
+    assert eos.passed  # trailing end-of-turn token is stripped before comparing
+    bad = _served(1, release, wrong=True)
+    v = verify_served(ref, bad.messages, bad.completion, bad.tokens, bad.token_logprobs)
+    assert not v.passed and v.hard and 'prefix agreement' in v.reason
+    short = verify_served(ref, good.messages, good.completion, tokens[:-1], logprobs[:-1])
+    assert not short.passed and not short.hard and 'tokenization mismatch' in short.reason
+    assert not verify_served(ref, good.messages, None, None, None).passed
+
+
+def test_audit_window_strike_wipes_and_quarantines(tmp_path):
+    w = AuditWindow(quarantine_s=100.0)
+    for _ in range(5):
+        w.record('hk', 'm', 1.0)
+    assert w.verdict('hk', 'm').passed
+    until = w.strike('hk', 'm', now=1000.0)
+    assert until == 1100.0
+    v = w.verdict('hk', 'm', now=1050.0)
+    assert not v.passed and v.n_audits == 0 and v.quarantined_until == 1100.0
+    w.record('hk', 'm', 1.0)
+    assert not w.verdict('hk', 'm', now=1050.0).passed  # still quarantined even with a clean record
+    assert w.verdict('hk', 'm', now=1101.0).passed and w.verdict('hk', 'm', now=1101.0).quarantined_until == 0.0
+    path = tmp_path / 'audits.json'
+    w.save(path)
+    again = AuditWindow.load(path, quarantine_s=100.0)
+    assert again.verdict('hk', 'm', now=1050.0).quarantined_until == 1100.0
+
+
+def test_state_settles_over_trailing_rounds_and_serves_probation():
+    from types import SimpleNamespace
+
+    state = ServingState(settlement_rounds=4)
+    axon = SimpleNamespace()
+    new = ReadyMiner(uid=5, hotkey='hk5', axon=axon, score=0.0, model_id='echo-v0')  # type: ignore[arg-type]
+    state.publish_round([_ready(1)], {'hk1': 1.0}, probation=[new])
+    assert state.scores_for(['v', 'hk1', 'hk5']) == {1: 0.25}  # one clean round out of four
+    user = state.acquire('echo-v0')
+    assert user is not None and user.uid == 1  # users: READY only
+    assert state.acquire('echo-v0', probation=True) is new  # baseline: the idle probation miner first
+    busy = state.acquire('echo-v0', probation=True)
+    assert busy is not None and busy.uid == 1  # one in flight on probation -> back to READY
+    state.release(5)
+    for _ in range(3):
+        state.publish_round([_ready(1)], {'hk1': 1.0})
+    assert state.scores_for(['v', 'hk1']) == {1: 1.0}
+    state.publish_round([], {})  # miner vanished: the missing round counts 0
+    assert state.scores_for(['v', 'hk1']) == {1: 0.75}
+    for _ in range(3):
+        state.publish_round([], {})
+    assert state.scores_for(['v', 'hk1']) == {}  # fully settled out; no stale hotkeys kept
+    state.enqueue_served(_served(1, _echo_release()))
+    assert state.snapshot()['pending_verification'] == 1
+    assert len(state.drain_served()) == 1 and state.drain_served() == []
+
+
+def test_gateway_enqueues_served_requests_and_routes_baseline_to_probation(monkeypatch):
+    from types import SimpleNamespace
+
+    from gittensor.serving.api import build_app
+
+    loadout = _echo_release()
+    state = ServingState()
+    probation = ReadyMiner(uid=9, hotkey='hk9', axon=SimpleNamespace(), score=0.0, model_id='echo-v0')  # type: ignore[arg-type]
+    state.publish_round([_ready(7)], {}, probation=[probation])
+
+    async def fake_dispatch(dendrite, miner, messages, max_tokens, lo, timeout, on_event=None):
+        return _FakeResponse(expected_completion(messages, max_tokens, lo.model_id), lo.model_id)
+
+    monkeypatch.setattr('gittensor.serving.api._dispatch', fake_dispatch)
+    app = build_app(
+        state, loadout, parse_api_keys('user,base'), lambda: None, request_timeout=5, baseline_keys={'base'}
+    )
+    client = TestClient(app)
+    for key, uid in (('user', 7), ('base', 9), ('base', 9), ('user', 7)):
+        r = client.post(
+            '/v1/chat/completions', json={'messages': MSGS, 'max_tokens': 4}, headers={'Authorization': f'Bearer {key}'}
+        )
+        assert r.status_code == 200 and r.json()['gittensor']['served_uid'] == uid, (key, r.text)
+    served = state.drain_served()
+    assert [q.uid for q in served] == [7, 9, 9, 7]
+    assert all(q.ok and q.tokens and q.token_logprobs and q.completion for q in served)
+    assert served[0].messages == MSGS and served[0].hotkey == 'hk7'
+
+
+def test_audit_round_verifies_served_traffic(monkeypatch):
+    """Served requests build the window; misses count 0; a wrong answer strikes; unverified axons go to probation."""
+    from types import SimpleNamespace
+
+    good = _echo_release()
+    honest, cheater, fresh = (SimpleNamespace(is_serving=True) for _ in range(3))
+    dendrite, _ = _dendrite_echoing(good)
+    state = ServingState(settlement_rounds=1)
+    serving = [(1, 'hk1', honest), (2, 'hk2', cheater), (3, 'hk3', fresh)]
+    for _ in range(4):
+        state.enqueue_served(_served(1, good))
+    state.enqueue_served(_served(1, good, ok=False))
+    state.enqueue_served(_served(2, good))
+    state.enqueue_served(_served(2, good, wrong=True))
+
+    scores = _round(state, dendrite, serving, good, monkeypatch)
+    assert scores['hk1'] == pytest.approx(0.8)  # 4 of 5 served requests earned full latency credit
+    assert scores['hk2'] == 0.0 and scores['hk3'] == 0.0
+    w1, w2 = state.audits.verdict('hk1', good.model_id), state.audits.verdict('hk2', good.model_id)
+    assert w1.passed and w1.n_audits == 5 and w1.mean == 0.8
+    assert not w2.passed and w2.n_audits == 0 and w2.quarantined_until > 0  # struck
+    assert [m.uid for m in state.ready_miners()] == [1]
+    assert [m.uid for m in state.probation_miners()] == [3]  # the cheater is quarantined, not on probation
+    assert sum(1 for r in state.recent(50) if r.kind == 'verify') == 7
+
+    scores = _round(state, dendrite, serving, good, monkeypatch)  # quiet round: READY on the window, credit 1.0
+    assert scores['hk1'] == 1.0 and [m.uid for m in state.ready_miners()] == [1]
+
+
+def test_audit_round_skips_release_without_reference(monkeypatch):
+    """A release whose reference is unreachable is skipped and logged; the round still completes."""
+    from types import SimpleNamespace
 
     good = _echo_release()
     bad = ServingRelease(
         model_id='ghost', backend='openai-compat', base_url='http://x', reference_url='http://127.0.0.1:1'
     )
-    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 2)
     dendrite, _ = _dendrite_echoing(good)
     axon = SimpleNamespace(is_serving=True)
-    state = ServingState()
+    state = ServingState(settlement_rounds=1)
+    state.enqueue_served(_served(1, good))
+    monkeypatch.setattr('gittensor.validator.serving.forward.SERVING_PROBE_REQUESTS', 0)
+    import asyncio
+
+    from gittensor.validator.serving import forward as fwd
+
     scores = asyncio.run(
         fwd.audit_round(state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[bad, good]))  # type: ignore[arg-type]
     )
@@ -567,42 +725,16 @@ def test_audit_round_skips_release_without_reference(monkeypatch):
     assert state.scores_for(['v', 'other']) == {}  # UID 1's hotkey changed since the round: nothing carries over
 
 
-def test_audit_round_stops_after_first_unanswered_prompt(monkeypatch):
-    """A dead axon costs one timeout, not one per case; the unsent cases still count as misses."""
-    import asyncio
-    from types import SimpleNamespace
-
-    from gittensor.validator.serving import forward as fwd
-
-    good = _echo_release()
-    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 4)
-    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', 0)
-    live, dead = SimpleNamespace(is_serving=True), SimpleNamespace(is_serving=True)
-    dendrite, calls = _dendrite_echoing(good, dead_axons=(dead,))
-    state = ServingState()
-    scores = asyncio.run(
-        fwd.audit_round(state, dendrite, [(1, 'hk1', live), (2, 'hk2', dead)], ServingLoadout(releases=[good]))  # type: ignore[arg-type]
-    )
-    assert calls == {id(live): 4, id(dead): 1}
-    assert scores == {'hk1': 1.0, 'hk2': 0.0}
-    assert state.audits.verdict('hk2', good.model_id).n_audits == 4
-    assert [m.uid for m in state.ready_miners()] == [1]
-
-
 def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
     """Two hotkeys on one card each get about half the capacity a lone card gets; a lone card gets ~1."""
-    import asyncio
     from types import SimpleNamespace
 
     from gittensor.validator.serving import forward as fwd
 
     good = _echo_release()
-    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 2)
-    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', 4)
     lone, a, b = (SimpleNamespace(is_serving=True) for _ in range(3))
     gpu_of = {id(lone): 'gpu-1', id(a): 'gpu-2', id(b): 'gpu-2'}
     dendrite, _ = _dendrite_echoing(good, gpu_of=gpu_of, token_s=0.0005)
-    # calibrate the target from what the lone card delivers under this fake's timing
     rates = []
     real_probe = fwd.probe_axon
 
@@ -612,60 +744,96 @@ def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
         return rate
 
     monkeypatch.setattr(fwd, 'probe_axon', spy)
-    state = ServingState()
     monkeypatch.setattr(fwd, 'SERVING_PROBE_TARGET_TPS', 1e-9)
-    asyncio.run(fwd.audit_round(state, dendrite, [(1, 'lone', lone)], ServingLoadout(releases=[good])))  # type: ignore[arg-type]
+    state = ServingState(settlement_rounds=1)
+    state.enqueue_served(_served(1, good))
+    _round(state, dendrite, [(1, 'hk1', lone)], good, monkeypatch, probes=4)
     probe = [r for r in state.recent(50) if r.kind == 'probe']
     assert len(probe) == 4 and all(r.ok for r in probe)
     lone_tps = rates[0]
 
     monkeypatch.setattr(fwd, 'SERVING_PROBE_TARGET_TPS', lone_tps)
-    state = ServingState()
-    scores = asyncio.run(
-        fwd.audit_round(state, dendrite, [(1, 'lone', lone), (2, 'a', a), (3, 'b', b)], ServingLoadout(releases=[good]))  # type: ignore[arg-type]
-    )
-    assert scores['lone'] == pytest.approx(1.0, abs=0.15)
-    assert scores['a'] == pytest.approx(0.5, abs=0.15) and scores['b'] == pytest.approx(0.5, abs=0.15)
-    assert scores['a'] + scores['b'] == pytest.approx(scores['lone'], abs=0.2)
+    state = ServingState(settlement_rounds=1)
+    for uid in (1, 2, 3):
+        state.enqueue_served(_served(uid, good))
+    serving = [(1, 'hk1', lone), (2, 'hk2', a), (3, 'hk3', b)]
+    scores = _round(state, dendrite, serving, good, monkeypatch, probes=4)
+    assert scores['hk1'] == pytest.approx(1.0, abs=0.15)
+    assert scores['hk2'] == pytest.approx(0.5, abs=0.15) and scores['hk3'] == pytest.approx(0.5, abs=0.15)
+    assert scores['hk2'] + scores['hk3'] == pytest.approx(scores['hk1'], abs=0.2)
 
 
 def test_probe_misses_cost_capacity_not_the_window(monkeypatch):
-    """A miner that answers every audit but chokes on the burst keeps a clean window and is probed again next round."""
-    import asyncio
+    """A miner that serves traffic honestly but chokes on the burst keeps its window and is probed again."""
     from types import SimpleNamespace
 
-    from gittensor.validator.serving import forward as fwd
-
     good = _echo_release()
-    monkeypatch.setattr(fwd, 'SERVING_CHALLENGES_PER_ROUND', 4)
-    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', 6)
     axon = SimpleNamespace(is_serving=True)
-    dendrite, calls = _dendrite_echoing(good)
-    real_stream = dendrite.call_stream
-
-    async def call_stream(target_axon, synapse, timeout, deserialize):
-        if calls.get(id(target_axon), 0) % 10 >= 4:  # per round: 4 audits answered, 6 probe requests dropped
-            calls[id(target_axon)] += 1
-            yield synapse.model_copy()
-            return
-        async for chunk in real_stream(target_axon, synapse, timeout, deserialize):
-            yield chunk
-
-    dendrite.call_stream = call_stream
-    state = ServingState()
+    dendrite, calls = _dendrite_echoing(good, dead_axons=(axon,))  # every probe request dropped
+    state = ServingState(settlement_rounds=1)
     for _ in range(2):
-        scores = asyncio.run(fwd.audit_round(state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[good])))  # type: ignore[arg-type]
+        state.enqueue_served(_served(1, good))
+        scores = _round(state, dendrite, [(1, 'hk1', axon)], good, monkeypatch, probes=6)
         assert scores == {'hk1': 0.0}
-    assert calls == {id(axon): 20}
+    assert calls == {id(axon): 12}
     window = state.audits.verdict('hk1', good.model_id)
-    assert window.passed and window.n_audits == 8 and window.mean == 1.0
+    assert window.passed and window.n_audits == 2 and window.mean == 1.0
     assert sum(1 for r in state.recent(50) if r.kind == 'probe' and not r.ok) == 12
+
+
+def test_serving_share_prices_gpu_hours_inside_the_cap(monkeypatch):
+    from gittensor.classes import ServingPricing
+    from gittensor.validator import emission_allocation as ea
+
+    monkeypatch.setattr(ea, 'SERVING_GPU_HOUR_USD', 0.70)
+    monkeypatch.setattr(ea, 'SERVING_EMISSION_SHARE_CAP', 0.17)
+    # 2026-08-26: ~123 alpha/h to miners at $0.847/alpha -> one card is 0.70 / 104.2 = 0.67% of emissions
+    pricing = ServingPricing(alpha_per_hour_to_miners=123.0, alpha_usd=0.847)
+    assert ea.serving_share(0.0, pricing) == 0.0
+    assert ea.serving_share(1.0, pricing) == pytest.approx(0.70 / (123.0 * 0.847))
+    assert ea.serving_share(25.0, pricing) == pytest.approx(0.168, abs=0.001)
+    assert ea.serving_share(100.0, pricing) == 0.17  # capped: 100 cards dilute
+    assert ea.serving_share(1.0, None) == 0.17  # no pricing (testnet): pay the cap pro-rata
+    assert ea.serving_share(1.0, ServingPricing(0.0, 0.847)) == 0.17
+
+
+def test_blend_pays_serving_by_price_and_recycles_the_rest(monkeypatch):
+    from gittensor.classes import ServingPricing
+    from gittensor.validator import emission_allocation as ea
+
+    monkeypatch.setattr(ea, 'SERVING_GPU_HOUR_USD', 0.70)
+    monkeypatch.setattr(ea, 'SERVING_EMISSION_SHARE_CAP', 0.17)
+    monkeypatch.setattr(ea, 'OSS_EMISSION_SHARE', 0.83)
+    pricing = ServingPricing(alpha_per_hour_to_miners=100.0, alpha_usd=0.7)  # one card = exactly 1% of emissions
+    uids = {0, 1, 2}
+    rewards = ea.blend_emission_pools({}, {}, uids, None, {1: 1.0, 2: 0.5}, pricing)
+    assert rewards[1] == pytest.approx(0.010) and rewards[2] == pytest.approx(0.005)
+    assert rewards[0] == pytest.approx(1.0 - 0.015)  # OSS slack (no repos) + the unfunded serving cap recycle
+    assert sum(rewards) == pytest.approx(1.0)
+
+
+def test_serving_pricing_reads_chain_and_loadout(monkeypatch):
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import pricing as pr
+
+    vali = SimpleNamespace(
+        metagraph=SimpleNamespace(E=[100.0, 200.0], netuid=74),
+        subtensor=SimpleNamespace(subnet=lambda netuid: SimpleNamespace(price=0.004)),
+    )
+    monkeypatch.setattr(pr, 'load_serving_loadout', lambda: SimpleNamespace(tao_usd=250.0))
+    p = pr.serving_pricing(vali)  # type: ignore[arg-type]
+    assert p is not None and p.alpha_per_hour_to_miners == pytest.approx(150.0 * 60 / 72) and p.alpha_usd == 1.0
+    monkeypatch.setattr(pr, 'load_serving_loadout', lambda: SimpleNamespace(tao_usd=None))
+    assert pr.serving_pricing(vali) is None  # type: ignore[arg-type]
+    vali.subtensor = SimpleNamespace(subnet=lambda netuid: (_ for _ in ()).throw(RuntimeError('rpc')))
+    assert pr.serving_pricing(vali) is None  # type: ignore[arg-type]
 
 
 def test_ready_set_expires_after_ttl():
     from types import SimpleNamespace
 
-    state = ServingState(ready_ttl_s=10.0)
+    state = ServingState(ready_ttl_s=10.0, settlement_rounds=1)
     miner = ReadyMiner(uid=1, hotkey='hk1', axon=SimpleNamespace(), score=1.0, model_id='m')  # type: ignore[arg-type]
     state.publish_round([miner], {'hk1': 1.0})
     assert state.acquire('m') is miner
@@ -700,16 +868,18 @@ def test_oss_round_blends_latest_serving_scores(monkeypatch):
 
     seen = {}
 
-    def blend(evals, repos, uids, maintainers, serving_scores):
+    def blend(evals, repos, uids, maintainers, serving_scores, pricing=None):
         seen['serving'] = serving_scores
+        seen['pricing'] = pricing
         return [0.0]
 
     monkeypatch.setattr(top, 'oss_contributions', oss)
     monkeypatch.setattr(top, 'issue_discovery', issues)
     monkeypatch.setattr(top, 'build_maintainer_uids_by_repo', lambda *a: {})
     monkeypatch.setattr(top, 'blend_emission_pools', blend)
+    monkeypatch.setattr(top, 'serving_pricing', lambda self: 'priced')
 
-    state = ServingState()
+    state = ServingState(settlement_rounds=1)
     state.publish_round([], {'hk1': 0.5, 'gone': 0.9})
     vali = SimpleNamespace(
         step=0,
@@ -720,7 +890,7 @@ def test_oss_round_blends_latest_serving_scores(monkeypatch):
         update_scores=lambda *a, **k: None,
     )
     asyncio.run(top.forward(vali))  # type: ignore[arg-type]
-    assert seen['serving'] == {1: 0.5}
+    assert seen['serving'] == {1: 0.5} and seen['pricing'] == 'priced'
 
 
 def test_request_record_drops_non_finite_telemetry():

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -692,7 +692,7 @@ def test_audit_round_verifies_served_traffic(monkeypatch):
     assert w1.passed and w1.n_audits == 5 and w1.mean == 0.8
     assert not w2.passed and w2.n_audits == 0 and w2.quarantined_until > 0  # struck
     assert [m.uid for m in state.ready_miners()] == [1]
-    assert [m.uid for m in state.probation_miners()] == [3]  # the cheater is quarantined, not on probation
+    assert state.snapshot()['probation_uids'] == [3]  # the cheater is quarantined, not on probation
     assert sum(1 for r in state.recent(50) if r.kind == 'verify') == 7
 
     scores = _round(state, dendrite, serving, good, monkeypatch)  # quiet round: READY on the window, credit 1.0


### PR DESCRIPTION
## Verification: served traffic is the audit

- No more synthetic audit prompts. Every request the gateway serves is handed to the audit loop (`ServingState.enqueue_served`) and verified by teacher-forcing the miner's completion under the reference (`verify_served`, contract R8): tokens must equal the reference argmax, logprobs within the existing bands. One prefill pass, no generation, and nothing on the wire a miner can tell apart from unaudited traffic.
- Gateway misses/timeouts/wrong-model now count as 0 in the window (they were only logged).
- **Hard punishment:** a wrong answer (bands fail with aligned lengths) is not a miss — `AuditWindow.strike` wipes the window and quarantines the (hotkey, release) for `SERVING_QUARANTINE_S` (1 h), persisted with the window. Re-tokenization mismatches are soft.
- **Probation:** serving axons that are not READY (and not quarantined) are published as probation; requests from `SERVING_BASELINE_API_KEYS` are routed to an idle probation miner first (one in flight each). User keys only ever reach READY miners. New miners earn a window without a real user hitting an unverified card.
- `scripts/serving_baseline_traffic.py`: stdlib client that keeps realistic, varied-length prompts flowing (cron it on the validator host) so quiet hours are not a free period and new miners get probed.
- Capacity probe unchanged (still the one synthetic burst; capacity only, never the window). `audit_axon` removed; `SERVING_CHALLENGES_PER_ROUND` / `SERVING_AUDIT_CONCURRENCY` gone.

## Emissions: price per verified GPU-hour, capped

- `SERVING_GPU_HOUR_USD = 0.70`, `SERVING_EMISSION_SHARE_CAP = 0.07` (OSS 0.93). Each settled card-equivalent earns $0.70/h, converted through the on-chain alpha/TAO price × `pricing.tao_usd` published in `serving_loadout.json` (override `SERVING_TAO_USD`); share = min(cap, cost). Unfunded cap recycles to UID 0, never to OSS. 2026-08-26 numbers (2,950 alpha/day to miners, $0.85/alpha): 10 cards ≈ 6.7% (cap funds ~10.4).
- Without usable pricing (testnet, no chain price) the cap is paid pro-rata, as before.
- **Trailing-hour settlement:** `ServingState` keeps the last `SERVING_SETTLEMENT_ROUNDS` (12 × 5 min) round scores per hotkey; the OSS round reads the mean (missing rounds = 0). A card verified 45 of the last 60 minutes earns 75%.
- `gittensor/validator/serving/pricing.py` derives alpha/h to miners from `metagraph.E` and alpha/TAO from `subtensor.subnet().price` — inputs every validator sees identically.

Tests: verify_served (pass / hard / soft / EOS strip), strike+quarantine+persistence, trailing settlement + probation dispatch, gateway enqueue + baseline routing, audit round from served traffic (miss, strike, probation), probe tests re-seeded from traffic, `serving_share` math + cap + fallback, blend recycle, pricing helper. 703 passed; ruff/format/pyright clean.

Follow-ups (not here): docs-ui compute page (50% pool → $0.70/h, cap, probation, baseline); tiered validator caller gate.