### PR TITLE
serving: permitted validators may audit inside a per-tempo token budget; staggered probe clocks

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -210,9 +210,10 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 SERVING_AUDIT_WINDOW = 10
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.8),)
 SERVING_API_DEFAULT_PORT = 8790
-# Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Same
-# rule as allways: validators and builders with skin in the game get to use the product. Env SERVING_MIN_CALLER_STAKE.
-SERVING_MIN_CALLER_STAKE = 250_000.0
+# Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Set so
+# that only the reference-running validator clears it (2026-08-26: one hotkey holds >1M alpha, the next 0.27M); every
+# other caller goes through that validator's gateway. Env SERVING_MIN_CALLER_STAKE.
+SERVING_MIN_CALLER_STAKE = 1_000_000.0
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -214,6 +214,12 @@ SERVING_API_DEFAULT_PORT = 8790
 # that only the reference-running validator clears it (2026-08-26: one hotkey holds >1M alpha, the next 0.27M); every
 # other caller goes through that validator's gateway. Env SERVING_MIN_CALLER_STAKE.
 SERVING_MIN_CALLER_STAKE = 1_000_000.0
+# Any hotkey holding a validator permit may also query, any request shape, up to this many completion tokens per
+# tempo (metagraph.block // BLOCKS_PER_TEMPO): enough to run an independent reference and audit a fleet of ~100
+# miners several times over, worthless as free inference (~$0.05 of tokens). No shape limit, so a smaller
+# validator's audits look like any other request.
+SERVING_VALIDATOR_TOKENS_PER_TEMPO = 50_000
+BLOCKS_PER_TEMPO = 360
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -32,6 +32,7 @@ probe tokens simply count 0).
 """
 
 import asyncio
+import hashlib
 import math
 import threading
 import time
@@ -220,6 +221,9 @@ class ServingAuditThread:
         # connector caps a session at 100 connections, which would queue late miners on the validator and skew
         # their measured throughput. Uncapped connector for the audit dendrite only.
         dendrite._session = loop.run_until_complete(_unlimited_session())
+        # Validators probe on the same interval; a per-hotkey phase offset keeps their bursts from landing on a
+        # miner at the same instant and each reading half a card.
+        self._stop.wait(probe_phase_offset(self.validator.wallet.hotkey.ss58_address, self.interval_s))
         while not self._stop.is_set():
             started = time.monotonic()
             try:
@@ -235,6 +239,11 @@ class ServingAuditThread:
                 except OSError as e:
                     bt.logging.warning(f'Serving: could not persist audit window to {path}: {e}')
             self._stop.wait(max(0.0, self.interval_s - (time.monotonic() - started)))
+
+
+def probe_phase_offset(hotkey: str, interval_s: float) -> float:
+    """Deterministic start offset in [0, interval) for this validator's audit clock."""
+    return (int(hashlib.sha256(hotkey.encode()).hexdigest()[:8], 16) % 1_000_000) / 1_000_000 * interval_s
 
 
 def audit_window_path(self: 'Validator') -> Optional[Path]:

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -171,8 +171,8 @@ def min_caller_stake() -> float:
 async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
     """Only hotkeys staked at least SERVING_MIN_CALLER_STAKE alpha on the subnet may query.
 
-    Otherwise any registered hotkey could use the miner's GPU for free inference; the stake floor means validators
-    and builders with skin in the game get to use the product.
+    Otherwise any registered hotkey could use the miner's GPU for free inference; the floor is set so only the
+    reference-running validator clears it and everyone else goes through its gateway.
     """
     hotkey = synapse.dendrite.hotkey if synapse.dendrite else None
     if not hotkey or hotkey not in miner.metagraph.hotkeys:

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -36,7 +36,7 @@ import os
 import time
 from collections import OrderedDict
 from functools import partial
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import bittensor as bt
 from bittensor.core.stream import StreamingSynapse
@@ -44,10 +44,12 @@ from bittensor.utils.axon_utils import allowed_nonce_window_ns, calculate_diff_s
 from bittensor_wallet import Keypair
 
 from gittensor.constants import (
+    BLOCKS_PER_TEMPO,
     SERVING_BACKEND_CONCURRENCY,
     SERVING_MAX_TOKENS,
     SERVING_MIN_CALLER_STAKE,
     SERVING_SEEN_NONCES,
+    SERVING_VALIDATOR_TOKENS_PER_TEMPO,
 )
 from gittensor.serving.backends import InferenceBackend, load_backend
 from gittensor.serving.loadout import load_serving_loadout
@@ -79,6 +81,7 @@ class ServingMiner(BaseNeuron):
         )
         self.backend_slots = asyncio.Semaphore(SERVING_BACKEND_CONCURRENCY)
         self.seen_nonces: 'OrderedDict[str, None]' = OrderedDict()
+        self.audit_budget: Dict[str, Tuple[int, int]] = {}  # validator hotkey -> (tempo, completion tokens used)
         bt.logging.info(f'ServingMiner axon: {self.axon}')
 
     async def forward(self, synapse: bt.Synapse) -> bt.Synapse:
@@ -168,22 +171,50 @@ def min_caller_stake() -> float:
     return float(os.getenv('SERVING_MIN_CALLER_STAKE', SERVING_MIN_CALLER_STAKE))
 
 
-async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
-    """Only hotkeys staked at least SERVING_MIN_CALLER_STAKE alpha on the subnet may query.
+def validator_tokens_per_tempo() -> int:
+    return int(os.getenv('SERVING_VALIDATOR_TOKENS_PER_TEMPO', SERVING_VALIDATOR_TOKENS_PER_TEMPO))
 
-    Otherwise any registered hotkey could use the miner's GPU for free inference; the floor is set so only the
-    reference-running validator clears it and everyone else goes through its gateway.
+
+def reserve_audit_budget(miner: ServingMiner, hotkey: str, tokens: int) -> bool:
+    """Charge ``tokens`` to a permitted validator's per-tempo budget; False when it would overrun."""
+    tempo = int(getattr(miner.metagraph, 'block', 0) or 0) // BLOCKS_PER_TEMPO
+    spent_tempo, used = miner.audit_budget.get(hotkey, (tempo, 0))
+    if spent_tempo != tempo:
+        used = 0
+    if used + tokens > validator_tokens_per_tempo():
+        return False
+    miner.audit_budget[hotkey] = (tempo, used + tokens)
+    return True
+
+
+async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
+    """Who may query: hotkeys staked at least SERVING_MIN_CALLER_STAKE alpha without limit (the gateway validator),
+    and any validator-permit holder inside a per-tempo completion-token budget (an independent auditor).
+
+    Otherwise any registered hotkey could use the miner's GPU for free inference. The floor is set so only the
+    reference-running validator clears it and everyone else goes through its gateway; the permit budget keeps the
+    subnet's other validators able to verify without the fleet becoming their free API.
     """
     hotkey = synapse.dendrite.hotkey if synapse.dendrite else None
     if not hotkey or hotkey not in miner.metagraph.hotkeys:
         return True, 'Unrecognized hotkey'
     try:
-        stake = float(miner.metagraph.S[miner.metagraph.hotkeys.index(hotkey)])
+        uid = miner.metagraph.hotkeys.index(hotkey)
+        stake = float(miner.metagraph.S[uid])
     except (ValueError, IndexError):  # metagraph mid-sync; refuse rather than guess
         return True, 'Metagraph out of date'
-    if stake < min_caller_stake():
+    if stake >= min_caller_stake():
+        return False, 'Staked caller'
+    permits = getattr(miner.metagraph, 'validator_permit', None)
+    try:
+        permitted = bool(permits[uid]) if permits is not None else False
+    except (IndexError, TypeError):
+        permitted = False
+    if not permitted:
         return True, f'Stake {stake:.0f} below {min_caller_stake():.0f}'
-    return False, 'Staked caller'
+    if not reserve_audit_budget(miner, hotkey, int(synapse.max_tokens)):
+        return True, f'Validator audit budget spent ({validator_tokens_per_tempo()} tokens per tempo)'
+    return False, 'Permitted validator'
 
 
 async def priority_inference(miner: ServingMiner, synapse: InferenceSynapse) -> float:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -746,10 +746,19 @@ def test_serving_miner_blacklists_non_validators(monkeypatch):
     from neurons.serving_miner import blacklist_inference
 
     monkeypatch.setenv('SERVING_MIN_CALLER_STAKE', '100')
-    miner = SimpleNamespace(metagraph=SimpleNamespace(hotkeys=['vali', 'builder', 'small'], S=[5000.0, 100.0, 99.0]))
+    monkeypatch.setenv('SERVING_VALIDATOR_TOKENS_PER_TEMPO', '150')
+    miner = SimpleNamespace(
+        metagraph=SimpleNamespace(
+            hotkeys=['vali', 'builder', 'small', 'permitted'],
+            S=[5000.0, 100.0, 99.0, 50.0],
+            validator_permit=[True, False, False, True],
+            block=720,
+        ),
+        audit_budget={},
+    )
 
-    def call(hotkey):
-        syn = InferenceSynapse(messages=MSGS, model_id='m')
+    def call(hotkey, max_tokens=64):
+        syn = InferenceSynapse(messages=MSGS, model_id='m', max_tokens=max_tokens)
         assert syn.dendrite is not None
         syn.dendrite.hotkey = hotkey
         return asyncio.run(blacklist_inference(miner, syn))  # type: ignore[arg-type]
@@ -758,3 +767,18 @@ def test_serving_miner_blacklists_non_validators(monkeypatch):
     assert call('builder') == (False, 'Staked caller')
     assert call('small')[0] and 'Stake 99 below 100' in call('small')[1]
     assert call('stranger') == (True, 'Unrecognized hotkey')
+    # a permit holder below the floor gets a per-tempo token budget, any request shape
+    assert call('permitted', 100) == (False, 'Permitted validator')
+    assert call('permitted', 50) == (False, 'Permitted validator')
+    refused = call('permitted', 1)
+    assert refused[0] and 'budget spent' in refused[1]
+    miner.metagraph.block = 1080  # next tempo: budget resets
+    assert call('permitted', 150) == (False, 'Permitted validator')
+    assert call('permitted', 1)[0]
+
+
+def test_probe_phase_offset_is_deterministic_and_spread():
+    from gittensor.validator.serving.forward import probe_phase_offset
+
+    a, b = probe_phase_offset('5Gjr7VuY', 300.0), probe_phase_offset('5E2LP6En', 300.0)
+    assert a == probe_phase_offset('5Gjr7VuY', 300.0) and 0.0 <= a < 300.0 and 0.0 <= b < 300.0 and a != b


### PR DESCRIPTION
Stacked on #1701 (retargets to `test` when it merges).

**Caller gate, three tiers** (`blacklist_inference`):
- stake ≥ `SERVING_MIN_CALLER_STAKE` (1M alpha): unlimited — the gateway validator.
- any `validator_permit` holder below the floor: **any request shape**, charged against `SERVING_VALIDATOR_TOKENS_PER_TEMPO` (50k completion tokens per tempo, `metagraph.block // 360`) per hotkey. Enough to run an independent reference and audit ~100 miners several times per tempo; worthless as free inference. No `max_tokens` cap so an auditor's requests are not distinguishable by shape from traffic.
- everyone else: refused.

A permitted validator that has budget but doesn't audit sets serving weights against consensus and loses vtrust on its own — no mechanism needed.

**Probe contention:** with several validators bursting the same miner at the same instant each would read a fraction of a card. `ServingAuditThread` now starts on a deterministic per-hotkey phase offset within the audit interval (`probe_phase_offset`), so validators' 5-minute clocks don't line up. A residual collision costs one round's capacity out of the trailing-hour settlement.

Tests: tiered gate incl. budget exhaustion and tempo reset; offset determinism/spread. 697 passed; ruff/format/pyright clean.