### PR TITLE
serving: validator sends its own baseline prompts in-process; miner budget refusals are neutral

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,8 @@ SERVING_ENABLED=false
 # Keys whose requests may be routed to not-yet-READY (probation) miners: the baseline-traffic client
 # (scripts/serving_baseline_traffic.py). User keys only ever reach READY miners.
 # SERVING_BASELINE_API_KEYS=baseline-key
+# Baseline prompts the validator itself sends each serving miner per round (spread at random over the round).
+# SERVING_BASELINE_PER_ROUND=2
 # TAO/USD override for the serving GPU-hour price (default: `pricing.tao_usd` in serving_loadout.json).
 # SERVING_TAO_USD=228.79
 # SERVING_API_HOST=0.0.0.0

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -215,6 +215,12 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 SERVING_AUDIT_WINDOW = 10
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.8),)
 SERVING_QUARANTINE_S = 3600.0
+# Baseline traffic: every round the validator sends each serving axon this many baseline prompts of its own, at
+# random moments spread over the round (so they do not mark the round boundary), over the same path as user
+# traffic. Real traffic does not displace them — 2 x ~256 tokens per miner per round is noise for a card and well
+# inside the permitted-validator budget — it just adds to the evidence. This is what lets a validator with no users
+# verify miners at all, and keeps quiet hours from being a free period.
+SERVING_BASELINE_PER_ROUND = 2
 SERVING_API_DEFAULT_PORT = 8790
 # Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Set so
 # that only the reference-running validator clears it (2026-08-26: one hotkey holds >1M alpha, the next 0.27M); every

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -151,6 +151,9 @@ def build_app(
                     completion=result.completion if result else None,
                     tokens=list(result.tokens) if result and result.tokens else None,
                     token_logprobs=list(result.token_logprobs) if result and result.token_logprobs else None,
+                    detail=str(getattr(getattr(result, 'dendrite', None), 'status_message', None) or '')
+                    if not ok
+                    else '',
                 )
             )
             state.record(

--- a/gittensor/serving/baseline.py
+++ b/gittensor/serving/baseline.py
@@ -106,8 +106,10 @@ def make_baseline_prompt(rng: random.Random) -> List[Message]:
             f'{rng.randint(2, 12)} files and {rng.randint(20, 900)} lines. Summarize the risks in three bullet points.'
         )
     else:
-        content = rng.choice(PROSE) + (
-            f' Keep it under {rng.choice([80, 150, 300])} words.' if rng.random() < 0.5 else ''
+        content = (
+            f'Context: the {project} service, {rng.randint(2, 40)} engineers. '
+            + rng.choice(PROSE)
+            + (f' Keep it under {rng.choice([80, 150, 300])} words.' if rng.random() < 0.5 else '')
         )
     return [{'role': 'user', 'content': content}]
 

--- a/gittensor/serving/baseline.py
+++ b/gittensor/serving/baseline.py
@@ -1,0 +1,117 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Baseline prompts: what the validator sends serving miners when real traffic does not cover them.
+
+Served traffic is the only audit, so every miner needs a few verified requests per round whether or not a user
+showed up. These prompts only have to satisfy two things: the reference can answer them (any text can be greedy
+decoded) and a miner cannot pick them out of real traffic. The second is a matter of entropy and shape — random
+combinations, random lengths, random pasted code, prose as well as code — not of realism in any deeper sense; a
+small fixed bank and a fixed length were the tells the old synthetic audits had. Once real prompts exist, the
+validator with users can mix them in (``ServingState`` keeps them); validators without users run 100% baseline.
+"""
+
+import random
+from typing import Dict, List
+
+Message = Dict[str, str]
+
+TOPICS = [
+    'a rate limiter for an HTTP API',
+    'retry with exponential backoff',
+    'an LRU cache',
+    'parsing a CSV with quotes',
+    'binary search over a sorted list',
+    'merging two sorted iterators',
+    'a token bucket',
+    'validating an email',
+    'a background job queue',
+    'reading a large file in chunks',
+    'a simple state machine',
+    'a debounce helper',
+    'a connection pool',
+    'a trie for prefix search',
+    'topological sort of a dependency graph',
+    'a bloom filter',
+    'a priority queue with decrease-key',
+    'a sliding-window rate counter',
+    'a cron expression parser',
+    'a JSON pointer resolver',
+    'a diff of two dictionaries',
+    'a circuit breaker',
+    'a retry-safe idempotency key',
+    'a fixed-point number type',
+    'a pagination cursor',
+    'a semantic version comparator',
+    'a URL router',
+    'a streaming SSE parser',
+    'an interval tree',
+    'a consistent-hash ring',
+]
+LANGS = ['Python', 'TypeScript', 'Go', 'Rust', 'Java', 'C#', 'Kotlin', 'Ruby']
+SNIPPETS = [
+    'def handle(req):\n    if not req.ok:\n        return None\n    items = [x for x in req.items if x.active]\n'
+    '    return sorted(items, key=lambda x: x.ts)',
+    'export async function load(id: string) {\n  const r = await fetch(`/api/${id}`);\n  if (!r.ok) throw new Error(r.statusText);\n'
+    '  return r.json();\n}',
+    'func Sum(xs []int) int {\n\ts := 0\n\tfor _, x := range xs {\n\t\ts += x\n\t}\n\treturn s\n}',
+    "fn parse(line: &str) -> Option<(u32, &str)> {\n    let (a, b) = line.split_once(',')?;\n    Some((a.parse().ok()?, b))\n}",
+    'class Cache:\n    def __init__(self, n):\n        self.n = n\n        self.d = {}\n    def get(self, k):\n'
+    '        return self.d.get(k)',
+    'SELECT u.id, count(o.id) FROM users u LEFT JOIN orders o ON o.user_id = u.id GROUP BY u.id HAVING count(o.id) > 3;',
+    'for f in *.log; do grep -c ERROR "$f" | xargs -I{} echo "$f {}"; done',
+]
+PROSE = [
+    'Summarize the trade-offs between optimistic and pessimistic locking for a booking system.',
+    'Explain, for a new team member, why we pin dependency versions in CI but not in the library itself.',
+    'Draft a short incident note: the queue backed up for 40 minutes because a consumer deployed with the wrong env.',
+    'List the questions you would ask before migrating a service from REST to gRPC.',
+    'Write release notes for a change that makes retries idempotent and adds a dead-letter queue.',
+    'Compare two ways of storing feature flags and recommend one for a 5-person team.',
+]
+
+
+NAMES = ['atlas', 'beacon', 'cobalt', 'delta', 'ember', 'fjord', 'granite', 'harbor', 'iris', 'juniper', 'kestrel']
+
+
+def make_baseline_prompt(rng: random.Random) -> List[Message]:
+    kind = rng.random()
+    topic, lang = rng.choice(TOPICS), rng.choice(LANGS)
+    project = f'{rng.choice(NAMES)}-{rng.randint(2, 99)}'
+    if kind < 0.3:
+        content = (
+            f'In the {project} service, write {topic} in {lang}. Include a short docstring and one example call'
+            + rng.choice(
+                [
+                    '.',
+                    f'; the caller passes at most {rng.randint(3, 500)} items.',
+                    f' (target version {rng.randint(1, 4)}.{rng.randint(0, 20)}).',
+                ]
+            )
+        )
+    elif kind < 0.65:
+        lines = '\n'.join(f'{i + 1}: {rng.choice(SNIPPETS)}' for i in range(rng.randint(4, 40)))
+        ask = rng.choice(
+            [
+                'Explain what this does and list two bugs.',
+                'Which of these would you refactor first, and why?',
+                'Add error handling to the weakest function.',
+                'Write unit tests for the second block.',
+            ]
+        )
+        content = f'Here is a file:\n{lines}\n\n{ask}'
+    elif kind < 0.85:
+        content = (
+            f'You are reviewing a pull request that adds {topic} in {lang}. The diff touches '
+            f'{rng.randint(2, 12)} files and {rng.randint(20, 900)} lines. Summarize the risks in three bullet points.'
+        )
+    else:
+        content = rng.choice(PROSE) + (
+            f' Keep it under {rng.choice([80, 150, 300])} words.' if rng.random() < 0.5 else ''
+        )
+    return [{'role': 'user', 'content': content}]
+
+
+def baseline_max_tokens(rng: random.Random, cap: int) -> int:
+    """Mostly short-to-medium answers, occasionally long — the shape of agent traffic."""
+    return min(cap, rng.choice([64, 96, 128, 128, 192, 256, 256, 384, 512]))

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -50,6 +50,7 @@ class ServedRequest:
     completion: Optional[str] = None
     tokens: Optional[List[str]] = None
     token_logprobs: Optional[List[float]] = None
+    detail: str = ''  # axon status message when not ok
 
 
 @dataclass

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -29,6 +29,7 @@ over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
 import asyncio
 import hashlib
 import math
+import random
 import threading
 import time
 from pathlib import Path
@@ -38,11 +39,14 @@ import aiohttp
 import bittensor as bt
 
 from gittensor.constants import (
+    SERVING_BASELINE_PER_ROUND,
     SERVING_CHALLENGE_TIMEOUT,
+    SERVING_MAX_TOKENS,
     SERVING_PROBE_REQUESTS,
     SERVING_PROBE_TARGET_TPS,
 )
 from gittensor.serving.audit import AuditCase, AuditVerdict, Reference, reference_for, verify_response, verify_served
+from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
 from gittensor.serving.stream import consume_stream
@@ -91,8 +95,10 @@ def verify_served_round(
     for req in served:
         if req.model_id != release.model_id:
             continue
+        if not req.ok and 'budget' in req.detail.lower():  # this validator over-sent; not the miner's fault
+            continue
         if not req.ok:
-            verdict = AuditVerdict(False, 0.0, float('inf'), 'no completion')
+            verdict = AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
         else:
             try:
                 verdict = verify_served(reference, req.messages, req.completion, req.tokens, req.token_logprobs)
@@ -122,6 +128,68 @@ def verify_served_round(
             )
         )
     return credits
+
+
+async def baseline_round(
+    state: ServingState,
+    dendrite: bt.Dendrite,
+    serving: Sequence[Tuple[int, str, bt.AxonInfo]],
+    release: ServingRelease,
+    window_s: float,
+    per_miner: int = SERVING_BASELINE_PER_ROUND,
+    rng: Optional[random.Random] = None,
+) -> int:
+    """Send every serving axon ``per_miner`` baseline prompts at random moments within ``window_s``.
+
+    The requests take the same path as user traffic and are queued as served requests, so the next round verifies
+    them like anything else. Quarantined hotkeys are skipped. Returns the number of requests sent.
+    """
+    rng = rng or random.Random()
+    targets = [
+        (uid, hotkey, axon)
+        for uid, hotkey, axon in serving
+        if state.audits.quarantined_until(hotkey, release.model_id) == 0.0
+    ]
+
+    async def one(uid: int, hotkey: str, axon: bt.AxonInfo, delay_s: float) -> None:
+        await asyncio.sleep(delay_s)
+        messages = make_baseline_prompt(rng)
+        max_tokens = baseline_max_tokens(rng, min(SERVING_MAX_TOKENS, max(release.max_tokens, 512)))
+        synapse = InferenceSynapse(messages=messages, model_id=release.model_id, max_tokens=max_tokens, logprobs=True)
+        started = time.monotonic()
+        try:
+            response = await consume_stream(dendrite, axon, synapse, release.request_timeout)
+        except Exception as e:
+            response, err = None, repr(e)
+        else:
+            err = ''
+        ok = response is not None and response.completion is not None and response.served_model_id == release.model_id
+        status = getattr(getattr(response, 'dendrite', None), 'status_message', None) if response is not None else None
+        state.enqueue_served(
+            ServedRequest(
+                ts=time.time(),
+                uid=uid,
+                hotkey=hotkey,
+                model_id=release.model_id,
+                messages=messages,
+                ok=ok,
+                latency_ms=(time.monotonic() - started) * 1000.0 if ok else None,
+                completion=response.completion if response is not None else None,
+                tokens=list(response.tokens) if response is not None and response.tokens else None,
+                token_logprobs=list(response.token_logprobs)
+                if response is not None and response.token_logprobs
+                else None,
+                detail='' if ok else str(status or err or 'no response'),
+            )
+        )
+
+    jobs = [
+        one(uid, hotkey, axon, rng.uniform(0.0, max(0.0, window_s)))
+        for uid, hotkey, axon in targets
+        for _ in range(per_miner)
+    ]
+    await asyncio.gather(*jobs)
+    return len(jobs)
 
 
 async def audit_round(
@@ -208,10 +276,17 @@ async def _unlimited_session() -> aiohttp.ClientSession:
 class ServingAuditThread:
     """Runs ``audit_round`` every ``interval_s`` seconds on a private event loop in a daemon thread."""
 
-    def __init__(self, validator: 'Validator', state: ServingState, interval_s: float):
+    def __init__(
+        self,
+        validator: 'Validator',
+        state: ServingState,
+        interval_s: float,
+        baseline_per_round: int = SERVING_BASELINE_PER_ROUND,
+    ):
         self.validator = validator
         self.state = state
         self.interval_s = interval_s
+        self.baseline_per_round = baseline_per_round
         self._stop = threading.Event()
         self.thread = threading.Thread(target=self._run, name='serving-audits', daemon=True)
 
@@ -236,6 +311,7 @@ class ServingAuditThread:
         self._stop.wait(probe_phase_offset(self.validator.wallet.hotkey.ss58_address, self.interval_s))
         while not self._stop.is_set():
             started = time.monotonic()
+            serving: List[Tuple[int, str, bt.AxonInfo]] = []
             try:
                 serving = get_serving_axons(self.validator)
                 loop.run_until_complete(audit_round(self.state, dendrite, serving))
@@ -248,6 +324,19 @@ class ServingAuditThread:
                     self.state.audits.save(path)
                 except OSError as e:
                     bt.logging.warning(f'Serving: could not persist audit window to {path}: {e}')
+            # The rest of the interval carries this validator's own baseline prompts, spread at random so nothing
+            # marks the round boundary; they are verified next round alongside any user traffic.
+            remaining = max(0.0, self.interval_s - (time.monotonic() - started))
+            try:
+                release = load_serving_loadout().primary
+                sent = loop.run_until_complete(
+                    baseline_round(
+                        self.state, dendrite, serving, release, max(0.0, remaining - 5.0), self.baseline_per_round
+                    )
+                )
+                bt.logging.debug(f'Serving: sent {sent} baseline request(s)')
+            except Exception as e:
+                bt.logging.error(f'Serving: baseline traffic failed this round: {e!r}')
             self._stop.wait(max(0.0, self.interval_s - (time.monotonic() - started)))
 
 

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -2,7 +2,7 @@ import os
 
 import bittensor as bt
 
-from gittensor.constants import SERVING_API_DEFAULT_PORT
+from gittensor.constants import SERVING_API_DEFAULT_PORT, SERVING_BASELINE_PER_ROUND
 
 VALIDATOR_WAIT = 60  # 60 seconds
 VALIDATOR_STEPS_INTERVAL = int(
@@ -27,6 +27,7 @@ SERVING_API_KEYS = os.getenv('SERVING_API_KEYS', '')
 # Keys whose traffic may be routed to not-yet-READY miners (probation). The baseline-traffic client uses one of
 # these; user keys only ever reach READY miners.
 SERVING_BASELINE_API_KEYS = os.getenv('SERVING_BASELINE_API_KEYS', '')
+SERVING_BASELINE_PER_ROUND = int(os.getenv('SERVING_BASELINE_PER_ROUND', str(SERVING_BASELINE_PER_ROUND)))
 SERVING_API_HOST = os.getenv('SERVING_API_HOST', '127.0.0.1')
 SERVING_API_PORT = int(os.getenv('SERVING_API_PORT', str(SERVING_API_DEFAULT_PORT)))
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -47,6 +47,7 @@ from gittensor.validator.utils.config import (
     SERVING_API_PORT,
     SERVING_AUDIT_INTERVAL_S,
     SERVING_BASELINE_API_KEYS,
+    SERVING_BASELINE_PER_ROUND,
     SERVING_ENABLED,
     STORE_DB_RESULTS,
     WANDB_PROJECT,
@@ -115,7 +116,9 @@ class Validator(BaseValidatorNeuron):
                 )
             else:
                 bt.logging.info('Serving: SERVING_API_KEYS unset — audits only, no API')
-            self.serving_audits = ServingAuditThread(self, self.serving_state, SERVING_AUDIT_INTERVAL_S)
+            self.serving_audits = ServingAuditThread(
+                self, self.serving_state, SERVING_AUDIT_INTERVAL_S, SERVING_BASELINE_PER_ROUND
+            )
             self.serving_audits.start()
 
         # DB connection for validation result storage.

--- a/scripts/serving_baseline_traffic.py
+++ b/scripts/serving_baseline_traffic.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Baseline traffic for the serving gateway: keeps every miner audited when real traffic is quiet.
+"""External baseline traffic for the serving gateway (optional; the validator sends its own baseline in-process).
 
-Served traffic is the only audit the validator runs, so with no users a miner would coast on a stale window and a
-new miner could never earn one. This client sends realistic, varied prompts through the gateway at a steady rate
-using a key from SERVING_BASELINE_API_KEYS, which lets the gateway route to probation (not yet READY) miners too.
+Useful for load tests and for exercising the gateway path end to end from another host. Uses the same prompt corpus
+as the validator (gittensor/serving/baseline.py); a key from SERVING_BASELINE_API_KEYS lets the gateway route to
+probation (not yet READY) miners too.
 
     export KEY=<baseline key>
     python3 scripts/serving_baseline_traffic.py --base-url http://127.0.0.1:8790 --rate 12 --duration 300
@@ -20,50 +20,13 @@ import time
 import urllib.error
 import urllib.request
 
-TOPICS = [
-    'a rate limiter for an HTTP API',
-    'retry with exponential backoff',
-    'a LRU cache',
-    'parsing a CSV with quotes',
-    'a binary search over a sorted list',
-    'merging two sorted iterators',
-    'a token bucket',
-    'validating an email',
-    'a background job queue',
-    'reading a large file in chunks',
-    'a simple state machine',
-    'a debounce helper',
-]
-LANGS = ['Python', 'TypeScript', 'Go', 'Rust']
-SNIPPET = (
-    'def handle(req):\n    if not req.ok:\n        return None\n    items = [x for x in req.items if x.active]\n'
-    '    return sorted(items, key=lambda x: x.ts)\n'
-)
-
-
-def make_prompt(rng: random.Random) -> list:
-    kind = rng.random()
-    topic, lang = rng.choice(TOPICS), rng.choice(LANGS)
-    if kind < 0.35:
-        content = f'Write {topic} in {lang}. Include a short docstring and one example call.'
-    elif kind < 0.7:
-        filler = ' '.join(f'line {i}: {SNIPPET.strip()}' for i in range(rng.randint(5, 60)))
-        content = f'Here is a file:\n{filler}\n\nExplain what handle() does and list two bugs.'
-    else:
-        content = (
-            f'You are reviewing a pull request that adds {topic} in {lang}. The diff touches '
-            f'{rng.randint(2, 9)} files. Summarize the risks in three bullet points.'
-        )
-    return [{'role': 'user', 'content': content}]
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt  # noqa: E402
 
 
 def one(base: str, key: str, rng: random.Random, timeout: float) -> dict:
     body = json.dumps(
-        {
-            'messages': make_prompt(rng),
-            'max_tokens': rng.choice([64, 128, 256, 512]),
-            'stream': True,
-        }
+        {'messages': make_baseline_prompt(rng), 'max_tokens': baseline_max_tokens(rng, 1024), 'stream': True}
     ).encode()
     req = urllib.request.Request(
         base.rstrip('/') + '/v1/chat/completions',

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -699,6 +699,70 @@ def test_audit_round_verifies_served_traffic(monkeypatch):
     assert scores['hk1'] == 1.0 and [m.uid for m in state.ready_miners()] == [1]
 
 
+def test_baseline_round_spreads_prompts_and_queues_them_for_verification(monkeypatch):
+    """Each live axon gets per_miner baseline prompts at random times; dead axons queue misses; quarantined skip."""
+    import asyncio
+    import random
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    live, dead, struck = (SimpleNamespace(is_serving=True) for _ in range(3))
+    dendrite, calls = _dendrite_echoing(good, dead_axons=(dead,))
+    state = ServingState(settlement_rounds=1)
+    state.audits.strike('hk3', good.model_id)
+    serving = [(1, 'hk1', live), (2, 'hk2', dead), (3, 'hk3', struck)]
+    sent = asyncio.run(
+        fwd.baseline_round(state, dendrite, serving, good, window_s=0.05, per_miner=2, rng=random.Random(7))  # type: ignore[arg-type]
+    )
+    assert sent == 4 and calls == {id(live): 2, id(dead): 2}
+    queued = state.drain_served()
+    assert sorted(q.uid for q in queued) == [1, 1, 2, 2]
+    assert all(q.ok and q.tokens and q.messages[0]['role'] == 'user' for q in queued if q.uid == 1)
+    assert all(not q.ok and q.detail for q in queued if q.uid == 2)
+    assert len({q.messages[0]['content'] for q in queued}) == 4  # every prompt distinct
+    for q in queued:
+        state.enqueue_served(q)
+    scores = _round(state, dendrite, serving, good, monkeypatch)
+    assert scores['hk1'] == 1.0 and scores['hk2'] == 0.0 and scores['hk3'] == 0.0
+    assert state.audits.verdict('hk1', good.model_id).n_audits == 2
+    assert (
+        state.audits.verdict('hk2', good.model_id).n_audits == 2
+        and not state.audits.verdict('hk2', good.model_id).passed
+    )
+
+
+def test_budget_refusal_is_neutral_not_a_miss(monkeypatch):
+    from types import SimpleNamespace
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+    dendrite, _ = _dendrite_echoing(good)
+    state = ServingState(settlement_rounds=1)
+    state.enqueue_served(_served(1, good))
+    refused = _served(1, good, ok=False)
+    refused.detail = 'Validator audit budget spent (50000 tokens per tempo)'
+    state.enqueue_served(refused)
+    state.enqueue_served(_served(1, good, ok=False))
+    _round(state, dendrite, [(1, 'hk1', axon)], good, monkeypatch)
+    w = state.audits.verdict('hk1', good.model_id)
+    assert w.n_audits == 2 and w.mean == 0.5  # one pass, one real miss, the refusal ignored
+
+
+def test_baseline_prompts_vary_in_shape_and_length():
+    import random
+
+    from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
+
+    rng = random.Random(1)
+    prompts = [make_baseline_prompt(rng)[0]['content'] for _ in range(200)]
+    lengths = sorted(len(p) for p in prompts)
+    assert len(set(prompts)) > 190 and lengths[0] < 120 and lengths[-1] > 2000
+    assert {baseline_max_tokens(rng, 1024) for _ in range(200)} >= {64, 128, 256, 512}
+    assert baseline_max_tokens(rng, 100) <= 100
+
+
 def test_audit_round_skips_release_without_reference(monkeypatch):
     """A release whose reference is unreachable is skipped and logged; the round still completes."""
     from types import SimpleNamespace


### PR DESCRIPTION
Follow-up to #1702/#1703: a validator with no users (any validator but ours) had nothing to verify, and the only fix was a separate cron script. Now the validator generates its own baseline traffic.

- **`baseline_round`** (audit thread): after each round, every serving axon that is not quarantined gets `SERVING_BASELINE_PER_ROUND` (2, env-overridable) prompts at random moments spread over the rest of the interval — same synapse, same dendrite, same hotkey as user traffic, nothing marks the round boundary. Results are queued as served requests and verified next round like anything else. Real traffic doesn't displace them (2 × ~256 tokens/miner/round is noise, well inside the permitted-validator budget); it adds to the evidence.
- **`gittensor/serving/baseline.py`**: shared prompt corpus — 30 topics × 8 languages, 7 pasted snippets, prose shapes, project names/numbers for entropy; inputs from ~80 chars to ~5k, `max_tokens` 64–512 skewed short. `scripts/serving_baseline_traffic.py` becomes a thin external client over the same corpus (load tests / other hosts).
- **Budget refusals are neutral**: `ServedRequest.detail` carries the axon status message; a `Validator audit budget spent` refusal is skipped in verification (neither credit nor blame) so an over-sending small validator can't score honest miners 0 and lose its own vtrust.
- Setup for any validator is now: reference GPU + `SERVING_ENABLED=true`. No gateway or cron required to verify miners.

Tests: baseline round (spread, dead axon → misses, quarantined skipped, prompts distinct, verified next round), neutral budget refusal, corpus variety. 707 passed; ruff/format/pyright/vulture clean.