### PR TITLE
serving: pre-soak — probe retry on dip, threaded verification, round summary, R8 conformance

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -186,6 +186,13 @@ SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round i
 # Probe outcomes affect capacity only, never the audit window (a slow host halves its pay; it does not flap out of READY).
 SERVING_PROBE_REQUESTS = 6
 SERVING_PROBE_TARGET_TPS = 180.0
+# A probe reading can only be too low (another validator's burst, a user spike, a blip), never too high: the miner
+# had to deliver those verified tokens. A reading under SERVING_PROBE_DIP_RATIO x the miner's median of its last
+# three is re-measured once after a random SERVING_PROBE_RETRY_DELAY_S and the better reading kept; a real slowdown
+# dips twice and sticks.
+SERVING_PROBE_DIP_RATIO = 0.7
+SERVING_PROBE_RETRY_DELAY_S = (15.0, 45.0)
+SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per round
 # Latency credit for a 64-token audit (release.max_tokens). An honest 5090 answers in ~165 ms on-box
 # (measured 2026-08-22/24: p95 166 ms); add validator<->miner RTT and an
 # honest miner anywhere on earth lands under ~450 ms. Credit is flat to FULL and falls linearly to 0 at

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -154,6 +154,7 @@ def build_app(
                     detail=str(getattr(getattr(result, 'dendrite', None), 'status_message', None) or '')
                     if not ok
                     else '',
+                    source='gateway',
                 )
             )
             state.record(

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -51,6 +51,7 @@ class ServedRequest:
     tokens: Optional[List[str]] = None
     token_logprobs: Optional[List[float]] = None
     detail: str = ''  # axon status message when not ok
+    source: str = 'gateway'  # 'gateway' | 'baseline'
 
 
 @dataclass
@@ -85,12 +86,18 @@ class ServingState:
     _served: Deque[ServedRequest] = field(default_factory=lambda: deque(maxlen=SERVING_REQUEST_LOG_SIZE))
     audits: AuditWindow = field(default_factory=AuditWindow)  # audit-loop thread only; persisted by the validator
     _history: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> last N round scores
+    probe_history: Dict[str, Deque[float]] = field(default_factory=dict)  # audit thread only: hotkey -> last tps
+    last_round: dict = field(default_factory=dict)  # audit thread's summary of the last round, for /v1/serving/status
     settlement_rounds: int = SERVING_SETTLEMENT_ROUNDS
     last_round_ts: float = 0.0
     ready_ttl_s: float = SERVING_READY_TTL_S
 
     def publish_round(
-        self, miners: List[ReadyMiner], scores: Dict[str, float], probation: Optional[List[ReadyMiner]] = None
+        self,
+        miners: List[ReadyMiner],
+        scores: Dict[str, float],
+        probation: Optional[List[ReadyMiner]] = None,
+        summary: Optional[dict] = None,
     ) -> None:
         """Audit thread: publish the READY and probation sets for the gateway and settle this round's scores.
 
@@ -108,6 +115,7 @@ class ServingState:
                 self._history[hotkey].append(float(scores.get(hotkey, 0.0)))
             for hotkey in [hk for hk, xs in self._history.items() if not any(xs)]:
                 del self._history[hotkey]
+            self.last_round = dict(summary or {})
             self.last_round_ts = time.time()
 
     def scores_for(self, hotkeys: Sequence[str]) -> Dict[int, float]:
@@ -191,6 +199,7 @@ class ServingState:
                 'pending_verification': len(self._served),
                 'inflight': dict(self._inflight),
                 'last_round_ts': self.last_round_ts,
+                'last_round': dict(self.last_round),
                 'requests_logged': len(log),
                 'gateway_requests': sum(1 for r in log if r.kind == 'gateway'),
                 'gateway_ok': sum(1 for r in log if r.kind == 'gateway' and r.ok),

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -30,8 +30,11 @@ import asyncio
 import hashlib
 import math
 import random
+import statistics
 import threading
 import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
@@ -42,8 +45,11 @@ from gittensor.constants import (
     SERVING_BASELINE_PER_ROUND,
     SERVING_CHALLENGE_TIMEOUT,
     SERVING_MAX_TOKENS,
+    SERVING_PROBE_DIP_RATIO,
     SERVING_PROBE_REQUESTS,
+    SERVING_PROBE_RETRY_DELAY_S,
     SERVING_PROBE_TARGET_TPS,
+    SERVING_VERIFY_WORKERS,
 )
 from gittensor.serving.audit import AuditCase, AuditVerdict, Reference, reference_for, verify_response, verify_served
 from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
@@ -88,31 +94,53 @@ async def probe_axon(
 
 
 def verify_served_round(
-    state: ServingState, reference: Reference, release: ServingRelease, served: Sequence[ServedRequest]
+    state: ServingState,
+    reference: Reference,
+    release: ServingRelease,
+    served: Sequence[ServedRequest],
+    summary: Optional[Dict[str, int]] = None,
 ) -> Dict[str, List[float]]:
-    """Verify every served request for ``release`` into the window; return latency credits per hotkey."""
-    credits: Dict[str, List[float]] = {}
-    for req in served:
-        if req.model_id != release.model_id:
-            continue
+    """Verify every served request for ``release`` into the window; return latency credits per hotkey.
+
+    Reference calls run on a small thread pool; window updates stay on this thread.
+    """
+    summary = summary if summary is not None else {}
+    mine = [req for req in served if req.model_id == release.model_id]
+
+    def judge(req: ServedRequest) -> Optional[AuditVerdict]:
         if not req.ok and 'budget' in req.detail.lower():  # this validator over-sent; not the miner's fault
-            continue
+            return None
         if not req.ok:
-            verdict = AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
-        else:
-            try:
-                verdict = verify_served(reference, req.messages, req.completion, req.tokens, req.token_logprobs)
-            except Exception as e:  # reference hiccup: neither credit nor blame
-                bt.logging.warning(f'Serving: could not verify a request served by UID {req.uid}: {e!r}')
-                continue
+            return AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
+        try:
+            return verify_served(reference, req.messages, req.completion, req.tokens, req.token_logprobs)
+        except Exception as e:  # reference hiccup: neither credit nor blame
+            bt.logging.warning(f'Serving: could not verify a request served by UID {req.uid}: {e!r}')
+            return None
+
+    with ThreadPoolExecutor(max_workers=SERVING_VERIFY_WORKERS) as pool:
+        verdicts = list(pool.map(judge, mine))
+
+    def bump(key: str) -> None:
+        summary[key] = summary.get(key, 0) + 1
+
+    credits: Dict[str, List[float]] = {}
+    for req, verdict in zip(mine, verdicts):
+        bump('served')
+        bump(req.source)
+        if verdict is None:
+            bump('neutral')
+            continue
         if verdict.hard:
             until = state.audits.strike(req.hotkey, release.model_id)
+            bump('strike')
             bt.logging.warning(
                 f'Serving: UID {req.uid} served a WRONG answer ({verdict.reason}); window wiped, '
                 f'quarantined until {time.strftime("%H:%M:%S", time.gmtime(until))} UTC'
             )
         else:
             state.audits.record(req.hotkey, release.model_id, verdict.value)
+            bump('pass' if verdict.passed else 'miss')
         credits.setdefault(req.hotkey, []).append(
             latency_credit(req.latency_ms) if verdict.passed and req.latency_ms is not None else 0.0
         )
@@ -180,6 +208,7 @@ async def baseline_round(
                 if response is not None and response.token_logprobs
                 else None,
                 detail='' if ok else str(status or err or 'no response'),
+                source='baseline',
             )
         )
 
@@ -192,11 +221,43 @@ async def baseline_round(
     return len(jobs)
 
 
+def probe_dipped(state: ServingState, hotkey: str, tps: float, ratio: float = SERVING_PROBE_DIP_RATIO) -> bool:
+    """True when ``tps`` is well under this miner's recent form (median of its last three readings)."""
+    recent = state.probe_history.get(hotkey)
+    return bool(recent) and len(recent) >= 2 and tps < ratio * statistics.median(recent)
+
+
+async def probe_with_retry(
+    state: ServingState,
+    dendrite: bt.Dendrite,
+    uid: int,
+    hotkey: str,
+    axon: bt.AxonInfo,
+    release: ServingRelease,
+    reference: Reference,
+    cases: Sequence[AuditCase],
+    retry_delay_s: Optional[float] = None,
+) -> float:
+    """Probe once; if the reading dipped against the miner's recent form, re-measure once later and keep the better."""
+    tps = await probe_axon(state, dendrite, uid, hotkey, axon, release, cases)
+    if probe_dipped(state, hotkey, tps):
+        delay = random.uniform(*SERVING_PROBE_RETRY_DELAY_S) if retry_delay_s is None else retry_delay_s
+        bt.logging.info(
+            f'Serving: UID {uid} probe {tps:.0f} tok/s is a dip against recent form; re-measuring in {delay:.0f}s'
+        )
+        await asyncio.sleep(delay)
+        again = await probe_axon(state, dendrite, uid, hotkey, axon, release, [reference.sample() for _ in cases])
+        tps = max(tps, again)
+    state.probe_history.setdefault(hotkey, deque(maxlen=3)).append(tps)
+    return tps
+
+
 async def audit_round(
     state: ServingState,
     dendrite: bt.Dendrite,
     serving: Sequence[Tuple[int, str, bt.AxonInfo]],
     loadout=None,
+    probe_retry_delay_s: Optional[float] = None,
 ) -> Dict[str, float]:
     """Verify served traffic, settle windows, probe READY miners; publish READY/probation; return hotkey -> score."""
     loadout = loadout or load_serving_loadout()
@@ -208,6 +269,8 @@ async def audit_round(
 
     best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in serving}
     probation: Dict[int, ReadyMiner] = {}
+    summary: Dict[str, int] = {}
+    windows: Dict[int, dict] = {}
 
     for release in loadout.releases:
         try:
@@ -218,12 +281,13 @@ async def audit_round(
                 'set SERVING_REFERENCE_URL to a conformant runtime'
             )
             continue
-        credits = verify_served_round(state, reference, release, served)
+        credits = verify_served_round(state, reference, release, served, summary)
         passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
         for uid, hotkey, axon in serving:
             window = state.audits.verdict(hotkey, release.model_id)
             round_credits = credits.get(hotkey)
             credit = sum(round_credits) / len(round_credits) if round_credits else 1.0
+            windows[uid] = {**window.as_dict(), 'model_id': release.model_id, 'served': len(round_credits or [])}
             bt.logging.debug(
                 f'Serving: UID {uid} {release.model_id} window {window.as_dict()} '
                 f'served {len(round_credits or [])} credit {credit:.3f}'
@@ -238,7 +302,9 @@ async def audit_round(
         if probe_cases:
             rates = await asyncio.gather(
                 *(
-                    probe_axon(state, dendrite, uid, hotkey, axon, release, probe_cases)
+                    probe_with_retry(
+                        state, dendrite, uid, hotkey, axon, release, reference, probe_cases, probe_retry_delay_s
+                    )
                     for uid, hotkey, axon, _ in passing
                 )
             )
@@ -261,10 +327,14 @@ async def audit_round(
         if score > 0.0:
             ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, model_id=model_id))
             probation.pop(uid, None)
-    state.publish_round(ready, scores, list(probation.values()))
+    quarantined = sum(1 for w in windows.values() if w.get('quarantined_until', 0.0) > 0.0)
+    summary.update(ready=len(ready), probation=len(probation), quarantined=quarantined)
+    state.publish_round(ready, scores, list(probation.values()), {**summary, 'windows': windows})
     bt.logging.info(
-        f'Serving: verified {len(served)} served request(s); {len(ready)} READY miner(s) published to gateway: '
-        f'{[m.uid for m in ready]}; {len(probation)} on probation'
+        f'Serving round: served {summary.get("served", 0)} (gateway {summary.get("gateway", 0)} / baseline '
+        f'{summary.get("baseline", 0)}) · pass {summary.get("pass", 0)} · miss {summary.get("miss", 0)} · '
+        f'strike {summary.get("strike", 0)} · neutral {summary.get("neutral", 0)} · READY {len(ready)} '
+        f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined}'
     )
     return scores
 
@@ -355,15 +425,21 @@ def get_serving_axons(self: 'Validator') -> List[Tuple[int, str, bt.AxonInfo]]:
     """(uid, hotkey, axon) for every UID (excluding self) whose axon is serving — the candidate serving miners.
 
     Snapshot of the metagraph taken on the audit thread. Beta heuristic: axon.is_serving is the only signal.
-    Validators also serve axons (for PAT handling), so they appear here and score zero on the first prompt;
-    a serving-miner registry replaces this later.
+    Validator-permit holders are skipped (they serve axons for PAT handling, never inference); a serving-miner
+    registry replaces this later.
     """
     hotkeys = list(self.metagraph.hotkeys)
     axons = list(self.metagraph.axons)
+    permits = getattr(self.metagraph, 'validator_permit', None)
     serving: List[Tuple[int, str, bt.AxonInfo]] = []
     for uid, (hotkey, axon) in enumerate(zip(hotkeys, axons)):
         if uid == self.uid:
             continue
+        try:
+            if permits is not None and bool(permits[uid]):
+                continue
+        except (IndexError, TypeError):
+            pass
         if axon is not None and axon.is_serving:
             serving.append((uid, hotkey, axon))
     return serving

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -15,6 +15,7 @@ maintainers run this before claiming conformance; miners run it before registeri
 
 import argparse
 import concurrent.futures
+import random
 import statistics
 import sys
 import time
@@ -22,6 +23,9 @@ from typing import Dict, List, Optional, Tuple
 
 import requests
 
+from gittensor.serving.audit import LiveReference, verify_served
+from gittensor.serving.baseline import make_baseline_prompt
+from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.probe import auth_headers, greedy, make_prompts, percentile, score, stability
 
 MUST, SHOULD = 'MUST', 'SHOULD'
@@ -189,9 +193,34 @@ def check_score(rep: Report, base_url: str, model_id: str, max_tokens: int, time
     if same_tok:
         diff = max(abs(a - b) for a, b in zip(sc['logprobs'], gen['reference_logprobs']))
         rep.add('R8 scored logprobs == generated logprobs', MUST, diff <= 1e-4, f'max |delta| {diff:.6f}')
-    if sc.get('argmax'):
-        agree = sum(1 for a, b in zip(sc['argmax'], gen['reference_tokens']) if a == b) / len(gen['reference_tokens'])
-        rep.add('R8 top_logprobs argmax == greedy token', SHOULD, agree >= 0.99, f'{agree:.3f}')
+    argmax = sc.get('argmax') or []
+    rep.add(
+        'R8 /v1/score returns top_logprobs argmax', MUST, len(argmax) == len(sc['tokens']), f'{len(argmax)} entries'
+    )
+    if argmax:
+        agree = sum(1 for a, b in zip(argmax, gen['reference_tokens']) if a == b) / len(gen['reference_tokens'])
+        rep.add('R8 top_logprobs argmax == greedy token', MUST, agree >= 0.99, f'{agree:.3f}')
+    # What the validator actually runs on served traffic: teacher-force the greedy output and demand a pass.
+    release = ServingRelease(
+        model_id=model_id,
+        backend='openai-compat',
+        max_tokens=max_tokens,
+        reference_url=base_url,
+        reference_api_key=API_KEY,
+        request_timeout=timeout,
+    )
+    ref = LiveReference(release)
+    verdict = verify_served(
+        ref, messages, gen['reference_completion'], gen['reference_tokens'], gen['reference_logprobs']
+    )
+    rep.add("R8 verify_served passes the model's own greedy output", MUST, verdict.passed, verdict.reason)
+    for i in range(3):  # and on longer, traffic-shaped prompts
+        msgs = make_baseline_prompt(random.Random(100 + i))
+        g = greedy(base_url, model_id, msgs, 256, timeout, API_KEY)
+        v = verify_served(ref, msgs, g['reference_completion'], g['reference_tokens'], g['reference_logprobs'])
+        rep.add(
+            f'R8 verify_served on baseline prompt #{i + 1} ({len(g["reference_tokens"])} tok)', MUST, v.passed, v.reason
+        )
 
 
 def check_overload(rep: Report, base_url: str, model_id: str, parallel: int, max_tokens: int, timeout: float) -> None:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -763,6 +763,82 @@ def test_baseline_prompts_vary_in_shape_and_length():
     assert baseline_max_tokens(rng, 100) <= 100
 
 
+def test_probe_retries_once_on_a_dip_and_keeps_the_better_reading(monkeypatch):
+    """A reading well under the miner's recent form is re-measured; a persistent dip sticks; no history, no retry."""
+    import asyncio
+    from collections import deque
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    readings: list = []
+    calls = {'n': 0}
+
+    async def fake_probe(state, dendrite, uid, hotkey, axon, release, cases):
+        calls['n'] += 1
+        return readings.pop(0)
+
+    monkeypatch.setattr(fwd, 'probe_axon', fake_probe)
+    ref = EchoReference(good)
+    args = (None, 1, 'hk1', SimpleNamespace(), good, ref, [ref.sample()] * 2)
+
+    state = ServingState()
+    readings[:] = [50.0]  # no history yet: accepted as is, no retry
+    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 50.0 and calls['n'] == 1  # type: ignore[arg-type]
+
+    state.probe_history['hk1'] = deque([180.0, 178.0], maxlen=3)
+    readings[:] = [50.0, 181.0]  # collision on the first burst, clean on the second
+    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 181.0 and calls['n'] == 3  # type: ignore[arg-type]
+    assert list(state.probe_history['hk1']) == [180.0, 178.0, 181.0]
+
+    readings[:] = [50.0, 48.0]  # a real slowdown dips twice
+    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 50.0 and calls['n'] == 5  # type: ignore[arg-type]
+    readings[:] = [170.0]  # within form: single probe
+    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 170.0 and calls['n'] == 6  # type: ignore[arg-type]
+
+
+def test_get_serving_axons_skips_validator_permits():
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving.forward import get_serving_axons
+
+    axon = SimpleNamespace(is_serving=True)
+    vali = SimpleNamespace(
+        uid=0,
+        metagraph=SimpleNamespace(
+            hotkeys=['me', 'other-vali', 'miner', 'off'],
+            axons=[axon, axon, axon, SimpleNamespace(is_serving=False)],
+            validator_permit=[True, True, False, False],
+        ),
+    )
+    assert [(u, h) for u, h, _ in get_serving_axons(vali)] == [(2, 'miner')]  # type: ignore[arg-type]
+
+
+def test_round_summary_is_published_for_status(monkeypatch):
+    from types import SimpleNamespace
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+    dendrite, _ = _dendrite_echoing(good)
+    state = ServingState(settlement_rounds=1)
+    for _ in range(2):
+        state.enqueue_served(_served(1, good))
+        base = _served(1, good)
+        base.source = 'baseline'
+        state.enqueue_served(base)
+    state.enqueue_served(_served(1, good, ok=False))
+    _round(state, dendrite, [(1, 'hk1', axon), (2, 'hk2', axon)], good, monkeypatch)
+    last = state.snapshot()['last_round']
+    assert last['served'] == 5 and last['gateway'] == 3 and last['baseline'] == 2
+    assert last['pass'] == 4 and last['miss'] == 1 and last['ready'] == 1 and last['probation'] == 1
+    assert (
+        last['windows'][1]['n_audits'] == 5
+        and last['windows'][1]['served'] == 5
+        and last['windows'][2]['n_audits'] == 0
+    )
+
+
 def test_audit_round_skips_release_without_reference(monkeypatch):
     """A release whose reference is unreachable is skipped and logged; the round still completes."""
     from types import SimpleNamespace


### PR DESCRIPTION
What the 12 h soak of the traffic-verified head needs in place first.

- **R8 conformance hardened** (`scripts/check_serving_runtime.py`): `/v1/score` must return `top_logprobs` argmax for every position (was a silent skip), argmax must equal the greedy token (SHOULD → MUST), and the exact validator path — `verify_served` through a `LiveReference` — must pass on the model's own greedy output and on three long baseline-shaped prompts. If re-tokenization or argmax were off, every honest request would be a soft miss and the soak would show nothing; run this against the pod before starting.
- **Probe retry on dip**: a reading under 0.7× the miner's median of its last three is re-measured once after a random 15–45 s and the better reading kept (`probe_with_retry`; history in `ServingState.probe_history`). A real slowdown dips twice and sticks. Removes probe collisions from the capacity numbers.
- **Threaded verification**: `/v1/score` calls run on an 8-worker pool (`SERVING_VERIFY_WORKERS`); window updates stay on the audit thread.
- **Validator-permit UIDs skipped** in `get_serving_axons` — they never serve inference and were only producing timeouts, misses and baseline waste.
- **Round summary**: one INFO line per round — `served N (gateway/baseline) · pass · miss · strike · neutral · READY [...] · probation · quarantined` — and the same plus per-UID windows under `last_round` in `/v1/serving/status`. `ServedRequest.source` tags gateway vs baseline.

Tests: retry-on-dip (no history / collision / persistent dip / in-form), permit skip, summary + windows in status. Full suite green; ruff/format/pyright/vulture clean.