### PR TITLE
serving: skip actively validating UIDs (vtrust > 0), not permit holders

### DIFF
--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -425,20 +425,21 @@ def get_serving_axons(self: 'Validator') -> List[Tuple[int, str, bt.AxonInfo]]:
     """(uid, hotkey, axon) for every UID (excluding self) whose axon is serving — the candidate serving miners.
 
     Snapshot of the metagraph taken on the audit thread. Beta heuristic: axon.is_serving is the only signal.
-    Validator-permit holders are skipped (they serve axons for PAT handling, never inference); a serving-miner
+    UIDs that are actively validating (validator_trust > 0) are skipped — they serve axons for PAT handling, never
+    inference. A permit alone is not the signal: on a small subnet nearly every UID holds one. A serving-miner
     registry replaces this later.
     """
     hotkeys = list(self.metagraph.hotkeys)
     axons = list(self.metagraph.axons)
-    permits = getattr(self.metagraph, 'validator_permit', None)
+    vtrust = getattr(self.metagraph, 'validator_trust', None)
     serving: List[Tuple[int, str, bt.AxonInfo]] = []
     for uid, (hotkey, axon) in enumerate(zip(hotkeys, axons)):
         if uid == self.uid:
             continue
         try:
-            if permits is not None and bool(permits[uid]):
+            if vtrust is not None and float(vtrust[uid]) > 0.0:
                 continue
-        except (IndexError, TypeError):
+        except (IndexError, TypeError, ValueError):
             pass
         if axon is not None and axon.is_serving:
             serving.append((uid, hotkey, axon))

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -798,7 +798,9 @@ def test_probe_retries_once_on_a_dip_and_keeps_the_better_reading(monkeypatch):
     assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 170.0 and calls['n'] == 6  # type: ignore[arg-type]
 
 
-def test_get_serving_axons_skips_validator_permits():
+def test_get_serving_axons_skips_active_validators_not_permit_holders():
+    """On a small subnet nearly every UID holds a permit (testnet 422: 10 of 46, incl. the test miner); only UIDs
+    with validator_trust > 0 are actually validating."""
     from types import SimpleNamespace
 
     from gittensor.validator.serving.forward import get_serving_axons
@@ -807,12 +809,13 @@ def test_get_serving_axons_skips_validator_permits():
     vali = SimpleNamespace(
         uid=0,
         metagraph=SimpleNamespace(
-            hotkeys=['me', 'other-vali', 'miner', 'off'],
-            axons=[axon, axon, axon, SimpleNamespace(is_serving=False)],
-            validator_permit=[True, True, False, False],
+            hotkeys=['me', 'other-vali', 'miner-with-permit', 'miner', 'off'],
+            axons=[axon, axon, axon, axon, SimpleNamespace(is_serving=False)],
+            validator_permit=[True, True, True, False, False],
+            validator_trust=[1.0, 0.99, 0.0, 0.0, 0.0],
         ),
     )
-    assert [(u, h) for u, h, _ in get_serving_axons(vali)] == [(2, 'miner')]  # type: ignore[arg-type]
+    assert [(u, h) for u, h, _ in get_serving_axons(vali)] == [(2, 'miner-with-permit'), (3, 'miner')]  # type: ignore[arg-type]
 
 
 def test_round_summary_is_published_for_status(monkeypatch):


### PR DESCRIPTION
Found in the first round of the 2 h mini-soak (2026-08-27 00:17 UTC): the serving miner (UID 27) vanished from the serving list — on testnet 422, 10 of 46 UIDs hold a validator permit, including the test miner, so #1705's permit skip dropped it. Only 3 UIDs have `validator_trust > 0`.

`get_serving_axons` now skips UIDs with `validator_trust > 0` (actually validating) instead of permit holders. On mainnet that is the real validator set; on small subnets a permit means nothing.

Test updated: a miner holding a permit with vtrust 0 stays in the list.