### PR TITLE
serving: latency credit on validator-observed time to first token, not total latency

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -193,12 +193,13 @@ SERVING_PROBE_TARGET_TPS = 180.0
 SERVING_PROBE_DIP_RATIO = 0.7
 SERVING_PROBE_RETRY_DELAY_S = (15.0, 45.0)
 SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per round
-# Latency credit for a 64-token audit (release.max_tokens). An honest 5090 answers in ~165 ms on-box
-# (measured 2026-08-22/24: p95 166 ms); add validator<->miner RTT and an
-# honest miner anywhere on earth lands under ~450 ms. Credit is flat to FULL and falls linearly to 0 at
-# ZERO, so a miner proxying audits to a GPU in another region (extra RTT + a slower runtime: llama.cpp
-# measured ~600 ms) loses credit in proportion. Same-region proxying is NOT visible here; that is the
-# one-GPU-many-hotkeys case, caught by concurrent burst audits (launch plan, gap 0).
+# Latency credit on the validator-observed time to first streamed token (network + queue + prefill). An honest
+# 5090 reports TTFT ~26 ms on-box (2026-08-27 conformance) and a 64-token answer in ~165 ms (2026-08-22/24); add
+# validator<->miner RTT and an honest miner anywhere on earth lands well under FULL. Credit is flat to FULL and
+# falls linearly to 0 at ZERO, so a miner proxying to a GPU in another region or queueing requests loses credit
+# in proportion. Generation length does not enter (mini-soak 2026-08-27: total latency of 64-512-token answers
+# scored a perfect miner at 0.24). Same-region proxying is NOT visible here; that is the one-GPU-many-hotkeys
+# case, caught by the concurrent capacity probe.
 SERVING_LATENCY_FULL_CREDIT_MS = 500.0
 SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
 # Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 12954e6, SPARKINFER_DETERMINISTIC=1), so an

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -155,6 +155,7 @@ def build_app(
                     if not ok
                     else '',
                     source='gateway',
+                    ttft_ms=finite_or_none(getattr(result, 'observed_ttft_ms', None)) if result else None,
                 )
             )
             state.record(

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -52,6 +52,7 @@ class ServedRequest:
     token_logprobs: Optional[List[float]] = None
     detail: str = ''  # axon status message when not ok
     source: str = 'gateway'  # 'gateway' | 'baseline'
+    ttft_ms: Optional[float] = None  # validator-observed time to first streamed event
 
 
 @dataclass

--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -16,6 +16,7 @@ so the miner can't tell the two apart and users get tokens as they decode.
 """
 
 import json
+import time
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, Iterator, List, Optional
 
@@ -139,12 +140,18 @@ async def consume_stream(
     """Stream one inference from ``axon`` and return the filled synapse; relay each event to ``on_event`` if given."""
     parser, assembler = SSEParser(), StreamAssembler()
     final: Optional[InferenceSynapse] = None
+    started = time.monotonic()
+    observed_ttft_ms: Optional[float] = None
     async for chunk in dendrite.call_stream(target_axon=axon, synapse=synapse, timeout=timeout, deserialize=False):
         if isinstance(chunk, (bytes, bytearray)):
             for event in parser.feed(bytes(chunk)):
+                if observed_ttft_ms is None:
+                    observed_ttft_ms = (time.monotonic() - started) * 1000.0
                 assembler.feed(event)
                 if on_event is not None:
                     await on_event(event)
         else:
             final = chunk  # the dendrite yields the header-filled synapse last
-    return assembler.apply(final if final is not None else synapse)
+    result = assembler.apply(final if final is not None else synapse)
+    result.observed_ttft_ms = observed_ttft_ms
+    return result

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -63,6 +63,7 @@ class InferenceSynapse(bt.StreamingSynapse):
     token_logprobs: Optional[List[float]] = None
     finish_reason: Optional[str] = None
     usage: Optional[Dict[str, int]] = None
+    observed_ttft_ms: Optional[float] = None  # set by the validator: wall-clock to the first streamed event
 
     async def process_streaming_response(self, response):  # aiohttp ClientResponse
         async for chunk in response.content.iter_any():

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -141,8 +141,11 @@ def verify_served_round(
         else:
             state.audits.record(req.hotkey, release.model_id, verdict.value)
             bump('pass' if verdict.passed else 'miss')
+        # Speed is priced on time to first token (network + queue + prefill); generation length is the user's
+        # choice and throughput is priced by the capacity probe. Fall back to total latency for legacy records.
+        speed_ms = req.ttft_ms if req.ttft_ms is not None else req.latency_ms
         credits.setdefault(req.hotkey, []).append(
-            latency_credit(req.latency_ms) if verdict.passed and req.latency_ms is not None else 0.0
+            latency_credit(speed_ms) if verdict.passed and speed_ms is not None else 0.0
         )
         state.record(
             RequestRecord(
@@ -209,6 +212,7 @@ async def baseline_round(
                 else None,
                 detail='' if ok else str(status or err or 'no response'),
                 source='baseline',
+                ttft_ms=getattr(response, 'observed_ttft_ms', None) if ok else None,
             )
         )
 

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -4,11 +4,13 @@
 """Serving latency credit (sub-subnet B beta).
 
 Correctness is decided by the rolling ``AuditWindow`` (gittensor/serving/audit.py);
-this module only prices speed. Latency credit is 1.0 up to
-SERVING_LATENCY_FULL_CREDIT_MS and falls linearly to 0.0 at
-SERVING_LATENCY_ZERO_CREDIT_MS. A miner's round score is its window verdict
-(0/1) times the mean latency credit over the round's audits — misses earn 0
-credit, which folds availability into the same number.
+this module only prices speed. The input is the validator-observed time to
+first streamed token of a served request (network + queue + prefill): 1.0 up
+to SERVING_LATENCY_FULL_CREDIT_MS, falling linearly to 0.0 at
+SERVING_LATENCY_ZERO_CREDIT_MS. Total latency is not used — generation length
+is the user's choice, and throughput is priced by the capacity probe. A miner's
+round score is its window verdict (0/1) times the mean credit over the round's
+served requests — misses earn 0 credit, which folds availability in.
 """
 
 from gittensor.constants import (

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -839,6 +839,42 @@ def test_round_summary_is_published_for_status(monkeypatch):
     )
 
 
+def test_consume_stream_observes_time_to_first_token():
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.serving.stream import consume_stream
+    from gittensor.synapses import InferenceSynapse
+
+    good = _echo_release()
+    dendrite, _ = _dendrite_echoing(good)
+    axon = SimpleNamespace(is_serving=True)
+    syn = InferenceSynapse(messages=MSGS, model_id=good.model_id, max_tokens=4, logprobs=True)
+    out = asyncio.run(consume_stream(dendrite, axon, syn, 5.0))  # type: ignore[arg-type]
+    assert out.completion and out.observed_ttft_ms is not None and 0.0 <= out.observed_ttft_ms < 5000.0
+    dead_dendrite, _ = _dendrite_echoing(good, dead_axons=(axon,))
+    miss = asyncio.run(consume_stream(dead_dendrite, axon, syn.model_copy(), 5.0))  # type: ignore[arg-type]
+    assert miss.completion is None and miss.observed_ttft_ms is None
+
+
+def test_latency_credit_uses_time_to_first_token_not_total_latency(monkeypatch):
+    """A long answer that streamed promptly earns full credit; a slow first token does not."""
+    from types import SimpleNamespace
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+    dendrite, _ = _dendrite_echoing(good)
+    state = ServingState(settlement_rounds=1)
+    prompt = _served(1, good, latency_ms=4800.0)  # 512 tokens took ~5 s ...
+    prompt.ttft_ms = 120.0  # ... but the first token came fast
+    slow = _served(2, good, latency_ms=900.0)
+    slow.ttft_ms = 1000.0  # queued for a second before answering
+    state.enqueue_served(prompt)
+    state.enqueue_served(slow)
+    scores = _round(state, dendrite, [(1, 'hk1', axon), (2, 'hk2', axon)], good, monkeypatch)
+    assert scores['hk1'] == 1.0 and scores['hk2'] == pytest.approx(0.5)
+
+
 def test_audit_round_skips_release_without_reference(monkeypatch):
     """A release whose reference is unreachable is skipped and logged; the round still completes."""
     from types import SimpleNamespace


### PR DESCRIPTION
Found in the 2 h mini-soak (2026-08-27, first rounds): a perfect miner (window 6/6, capacity 1.00) scored **0.24** because latency credit was applied to *total* request latency, and served/baseline requests now run 64–512 output tokens (1–5 s). The 500/1500 ms band was calibrated on 64-token audits.

- `consume_stream` records the validator's own wall-clock to the first streamed event → `InferenceSynapse.observed_ttft_ms` (validator-set; the miner-reported `ttft_ms` in usage stays telemetry).
- `ServedRequest.ttft_ms` carries it from both the gateway and the baseline sender; `verify_served_round` prices speed on it (falls back to total latency for records without it).
- Generation length no longer enters the score — it's the user's choice; throughput is priced by the capacity probe. The band is unchanged: honest TTFT is ~26 ms on-box + RTT, so FULL at 500 ms leaves the same room; queueing or cross-region proxying still costs credit.

Tests: `consume_stream` observes TTFT (and None on a miss); a 5 s answer with a 120 ms first token earns 1.0, a 1 s first token earns 0.5. Full suite green; ruff/format/pyright/vulture clean.