### PR TITLE
serving: log the reason when a READY miner misses a served request

### DIFF
--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -124,6 +124,7 @@ def verify_served_round(
     def bump(key: str) -> None:
         summary[key] = summary.get(key, 0) + 1
 
+    ready_uids = {m.uid for m in state.ready_miners()}
     credits: Dict[str, List[float]] = {}
     for req, verdict in zip(mine, verdicts):
         bump('served')
@@ -131,6 +132,11 @@ def verify_served_round(
         if verdict is None:
             bump('neutral')
             continue
+        if not verdict.passed and not verdict.hard and req.uid in ready_uids:
+            bt.logging.info(
+                f'Serving: READY UID {req.uid} missed a {req.source} request ({verdict.reason}; '
+                f'{len(req.tokens or [])} tokens, {req.latency_ms or 0:.0f} ms)'
+            )
         if verdict.hard:
             until = state.audits.strike(req.hotkey, release.model_id)
             bump('strike')

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -878,6 +878,30 @@ def test_latency_credit_uses_time_to_first_token_not_total_latency(monkeypatch):
     assert scores['hk1'] == 1.0 and scores['hk2'] == pytest.approx(0.5)
 
 
+def test_ready_miner_misses_are_logged_with_a_reason(monkeypatch):
+    from types import SimpleNamespace
+
+    import bittensor as bt
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+    dendrite, _ = _dendrite_echoing(good)
+    state = ServingState(settlement_rounds=1)
+    state.publish_round([_ready(1)], {'hk1': 1.0})
+    seen: list = []
+    monkeypatch.setattr(bt.logging, 'info', lambda msg, *a, **k: seen.append(str(msg)))
+    for _ in range(4):
+        state.enqueue_served(_served(1, good))
+    miss = _served(1, good, ok=False)
+    miss.detail = 'Request timeout after 60.0 seconds'
+    state.enqueue_served(miss)
+    state.enqueue_served(_served(2, good, ok=False))  # not READY: stays quiet
+    _round(state, dendrite, [(1, 'hk1', axon), (2, 'hk2', axon)], good, monkeypatch)
+    hits = [m for m in seen if 'READY UID 1 missed' in m]
+    assert len(hits) == 1 and 'Request timeout after 60.0 seconds' in hits[0] and 'gateway request' in hits[0]
+    assert not any('READY UID 2' in m for m in seen)
+
+
 def test_audit_round_skips_release_without_reference(monkeypatch):
     """A release whose reference is unreachable is skipped and logged; the round still completes."""
     from types import SimpleNamespace


### PR DESCRIPTION
Mini-soak 2026-08-27 left ~3% of UID 27's misses unexplained: the miner log was silent and the validator keeps miss reasons only in the 50-record status ring. Now a miss (not a strike) by a READY miner logs one INFO line with the axon status / verdict reason, source, token count and latency. Probation/dead axons stay quiet.