### PR TITLE
serving: score the miner's own token ids instead of re-tokenizing its text

### DIFF
--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -150,6 +150,7 @@ def build_app(
                     latency_ms=latency_ms,
                     completion=result.completion if result else None,
                     tokens=list(result.tokens) if result and result.tokens else None,
+                    token_ids=list(result.token_ids) if result and result.token_ids else None,
                     token_logprobs=list(result.token_logprobs) if result and result.token_logprobs else None,
                     detail=str(getattr(getattr(result, 'dendrite', None), 'status_message', None) or '')
                     if not ok

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -216,7 +216,9 @@ class AuditWindow:
 
 
 class Reference(Protocol):
-    def score_served(self, messages: List[Message], completion: str) -> dict: ...
+    def score_served(
+        self, messages: List[Message], completion: str, token_ids: Optional[Sequence[int]] = None
+    ) -> dict: ...
 
     model_id: str
 
@@ -254,7 +256,7 @@ class BankReference:
     def sample(self) -> AuditCase:
         return secrets.choice(self.cases)
 
-    def score_served(self, messages: List[Message], completion: str) -> dict:
+    def score_served(self, messages: List[Message], completion: str, token_ids: Optional[Sequence[int]] = None) -> dict:
         raise NotImplementedError('a bank reference cannot verify served traffic; run a live reference')
 
     def __len__(self) -> int:
@@ -279,7 +281,7 @@ class EchoReference:
             reference_completion=ref.completion,
         )
 
-    def score_served(self, messages: List[Message], completion: str) -> dict:
+    def score_served(self, messages: List[Message], completion: str, token_ids: Optional[Sequence[int]] = None) -> dict:
         """Teacher-forced scoring for the echo backend: the argmax is the expected token at every position."""
         tokens = completion.split(' ') if completion else []
         ref = expected_completion(messages, max(1, len(tokens)), self.model_id)
@@ -319,14 +321,23 @@ class LiveReference:
         messages = make_prompts(1, seed=secrets.randbits(64))[0]
         return self.case_for(messages)
 
-    def score(self, messages: List[Message], completion: str) -> dict:
+    def score(self, messages: List[Message], completion: str, token_ids: Optional[Sequence[int]] = None) -> dict:
         """Teacher-forced logprobs of ``completion`` under the reference (R8): verifies text the reference
-        did not generate. A trailing end-of-turn token in the miner's token list is not part of the text;
-        ``verify_served`` strips it before comparing lengths."""
-        return score(self.base_url, self.model_id, messages, completion, self.timeout, self.api_key)
+        did not generate. With ``token_ids`` the reference forces the miner's own tokens rather than
+        re-tokenizing the text. A trailing end-of-turn token in the miner's token list is not part of the
+        text; ``verify_served`` strips it before comparing lengths."""
+        return score(
+            self.base_url,
+            self.model_id,
+            messages,
+            completion,
+            self.timeout,
+            self.api_key,
+            completion_token_ids=token_ids,
+        )
 
-    def score_served(self, messages: List[Message], completion: str) -> dict:
-        return self.score(messages, completion)
+    def score_served(self, messages: List[Message], completion: str, token_ids: Optional[Sequence[int]] = None) -> dict:
+        return self.score(messages, completion, token_ids)
 
     def __len__(self) -> int:
         return 1
@@ -383,25 +394,33 @@ def verify_served(
     completion: Optional[str],
     tokens: Optional[Sequence[str]],
     token_logprobs: Optional[Sequence[float]],
+    token_ids: Optional[Sequence[int]] = None,
     end_of_turn: Sequence[str] = ('<|im_end|>', '<|endoftext|>', '</s>'),
 ) -> AuditVerdict:
     """Verify a served (greedy) completion by teacher forcing it under the reference.
 
     The reference's argmax at each position is what an honest copy would have generated, so the miner's tokens
-    must match it and the miner's logprobs must match the reference's logprob of that same token. A completion
-    that re-tokenizes to a different length is not comparable position by position and counts as a soft miss;
-    the bands failing on aligned lengths is a wrong answer (``hard``).
+    must match it and the miner's logprobs must match the reference's logprob of that same token. When the miner
+    reported ``token_ids`` the reference forces exactly that sequence; otherwise it re-tokenizes the text, and a
+    text that re-tokenizes to a different length (a greedy decode is not always the canonical tokenization of
+    its own output) is not comparable position by position and counts as a soft miss. The bands failing on
+    aligned lengths is a wrong answer (``hard``). A reference that echoes the forced tokens' bytes lets the ids
+    be bound to the text the user actually received.
     """
     if completion is None or not tokens or token_logprobs is None or len(tokens) != len(token_logprobs):
         return AuditVerdict(False, 0.0, float('inf'), 'missing or malformed logprobs')
     mine, mine_lp = list(tokens), list(token_logprobs)
+    mine_ids = list(token_ids) if token_ids and len(token_ids) == len(mine) else None
     if mine and mine[-1] in end_of_turn:
         mine, mine_lp = mine[:-1], mine_lp[:-1]
+        mine_ids = mine_ids[:-1] if mine_ids else None
     if not mine:
         return AuditVerdict(False, 0.0, float('inf'), 'empty completion')
-    ref = reference.score_served(messages, completion)
+    ref = reference.score_served(messages, completion, mine_ids)
     argmax, ref_lp = ref.get('argmax') or [], ref.get('logprobs') or []
     if len(argmax) != len(mine) or len(ref_lp) != len(mine):
         return AuditVerdict(False, 0.0, float('inf'), f'tokenization mismatch ({len(mine)} vs {len(argmax)})')
+    if mine_ids and ref.get('bytes') and b''.join(ref['bytes']).decode('utf-8', 'replace') != completion:
+        return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the completion')
     case = AuditCase(messages=list(messages), max_tokens=len(mine), reference_tokens=argmax, reference_logprobs=ref_lp)
     return verify_response(case, mine, mine_lp)

--- a/gittensor/serving/backends.py
+++ b/gittensor/serving/backends.py
@@ -37,6 +37,7 @@ class GenerationResult:
     model_id: str
     generation_ms: float
     tokens: Optional[List[str]] = None
+    token_ids: Optional[List[int]] = None
     token_logprobs: Optional[List[float]] = None
     ttft_ms: Optional[float] = None
     decode_tps: Optional[float] = None
@@ -155,11 +156,14 @@ class OpenAICompatBackend:
 
         choice = payload['choices'][0]
         tokens: Optional[List[str]] = None
+        token_ids: Optional[List[int]] = None
         token_logprobs: Optional[List[float]] = None
         content_lp = (choice.get('logprobs') or {}).get('content')
         if content_lp:
             tokens = [entry['token'] for entry in content_lp]
             token_logprobs = [float(entry['logprob']) for entry in content_lp]
+            if all(entry.get('token_id') is not None for entry in content_lp):
+                token_ids = [int(entry['token_id']) for entry in content_lp]
 
         # sparkinfer puts its timing fields inside `usage` (contract R5); accept top level too.
         usage = payload.get('usage') or {}
@@ -169,6 +173,7 @@ class OpenAICompatBackend:
             model_id=payload.get('model', self.model_id),
             generation_ms=float(timing['generation_ms'] if timing['generation_ms'] is not None else elapsed_ms),
             tokens=tokens,
+            token_ids=token_ids,
             token_logprobs=token_logprobs,
             ttft_ms=timing['ttft_ms'],
             decode_tps=timing['decode_tps'],

--- a/gittensor/serving/probe.py
+++ b/gittensor/serving/probe.py
@@ -118,8 +118,13 @@ def score(
     timeout: float,
     api_key: Optional[str] = None,
     top_logprobs: int = 1,
+    completion_token_ids: Optional[Sequence[int]] = None,
 ) -> dict:
     """Teacher-forced scoring (contract R8): per-token logprobs of ``completion`` under the model.
+
+    With ``completion_token_ids`` the runtime forces exactly those tokens instead of re-tokenizing the text, so a
+    miner's own greedy token sequence is scored position by position even where a fresh tokenization of the same
+    text would pick different boundaries.
 
     Returns ``tokens``, ``logprobs`` and, when ``top_logprobs`` > 0, ``argmax`` (the model's own
     top token at each position) so a verifier can compare any miner output position by position.
@@ -127,7 +132,16 @@ def score(
     r = requests.post(
         f'{base_url.rstrip("/")}/v1/score',
         headers=auth_headers(api_key),
-        json={'model': model_id, 'messages': messages, 'completion': completion, 'top_logprobs': top_logprobs},
+        json={
+            'model': model_id,
+            'messages': messages,
+            'top_logprobs': top_logprobs,
+            **(
+                {'completion_token_ids': list(completion_token_ids)}
+                if completion_token_ids
+                else {'completion': completion}
+            ),
+        },
         timeout=timeout,
     )
     r.raise_for_status()
@@ -137,6 +151,10 @@ def score(
         'logprobs': [float(x) for x in payload['logprobs']],
         'usage': payload.get('usage') or {},
     }
+    if payload.get('token_ids'):
+        out['token_ids'] = [int(x) for x in payload['token_ids']]
+    if payload.get('bytes'):
+        out['bytes'] = [bytes(b) for b in payload['bytes']]
     if top_logprobs > 0 and payload.get('top_logprobs'):
         out['argmax'] = [(alts[0]['token'] if alts else None) for alts in payload['top_logprobs']]
     return out

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -49,6 +49,7 @@ class ServedRequest:
     latency_ms: Optional[float]
     completion: Optional[str] = None
     tokens: Optional[List[str]] = None
+    token_ids: Optional[List[int]] = None
     token_logprobs: Optional[List[float]] = None
     detail: str = ''  # axon status message when not ok
     source: str = 'gateway'  # 'gateway' | 'baseline'

--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -64,6 +64,7 @@ class StreamAssembler:
 
     content: str = ''
     tokens: List[str] = field(default_factory=list)
+    token_ids: List[int] = field(default_factory=list)
     token_logprobs: List[float] = field(default_factory=list)
     model_id: Optional[str] = None
     finish_reason: Optional[str] = None
@@ -86,6 +87,8 @@ class StreamAssembler:
             for entry in (choice.get('logprobs') or {}).get('content') or []:
                 self.tokens.append(entry['token'])
                 self.token_logprobs.append(float(entry['logprob']))
+                if entry.get('token_id') is not None:
+                    self.token_ids.append(int(entry['token_id']))
             if choice.get('finish_reason'):
                 self.finish_reason = choice['finish_reason']
         usage = event.get('usage')
@@ -102,6 +105,7 @@ class StreamAssembler:
         synapse.completion = self.content
         synapse.served_model_id = self.model_id
         synapse.tokens = self.tokens or None
+        synapse.token_ids = self.token_ids if self.token_ids and len(self.token_ids) == len(self.tokens) else None
         synapse.token_logprobs = self.token_logprobs or None
         synapse.finish_reason = self.finish_reason
         synapse.usage = self.usage
@@ -116,8 +120,12 @@ def result_to_sse(result: GenerationResult, request_id: str, created: int, logpr
     base = {'id': request_id, 'object': 'chat.completion.chunk', 'created': created, 'model': result.model_id}
     delta: dict = {'index': 0, 'delta': {'role': 'assistant', 'content': result.completion}, 'finish_reason': None}
     if logprobs and result.tokens and result.token_logprobs:
+        ids = result.token_ids if result.token_ids and len(result.token_ids) == len(result.tokens) else None
         delta['logprobs'] = {
-            'content': [{'token': t, 'logprob': lp} for t, lp in zip(result.tokens, result.token_logprobs)]
+            'content': [
+                {'token': t, 'logprob': lp, **({'token_id': ids[i]} if ids else {})}
+                for i, (t, lp) in enumerate(zip(result.tokens, result.token_logprobs))
+            ]
         }
     yield sse_event({**base, 'choices': [delta]})
     yield sse_event({**base, 'choices': [{'index': 0, 'delta': {}, 'finish_reason': result.finish_reason or 'stop'}]})

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -60,6 +60,7 @@ class InferenceSynapse(bt.StreamingSynapse):
     ttft_ms: Optional[float] = None
     decode_tps: Optional[float] = None
     tokens: Optional[List[str]] = None
+    token_ids: Optional[List[int]] = None
     token_logprobs: Optional[List[float]] = None
     finish_reason: Optional[str] = None
     usage: Optional[Dict[str, int]] = None

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -113,7 +113,9 @@ def verify_served_round(
         if not req.ok:
             return AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
         try:
-            return verify_served(reference, req.messages, req.completion, req.tokens, req.token_logprobs)
+            return verify_served(
+                reference, req.messages, req.completion, req.tokens, req.token_logprobs, token_ids=req.token_ids
+            )
         except Exception as e:  # reference hiccup: neither credit nor blame
             bt.logging.warning(f'Serving: could not verify a request served by UID {req.uid}: {e!r}')
             return None
@@ -213,6 +215,7 @@ async def baseline_round(
                 latency_ms=(time.monotonic() - started) * 1000.0 if ok else None,
                 completion=response.completion if response is not None else None,
                 tokens=list(response.tokens) if response is not None and response.tokens else None,
+                token_ids=list(response.token_ids) if response is not None and response.token_ids else None,
                 token_logprobs=list(response.token_logprobs)
                 if response is not None and response.token_logprobs
                 else None,

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -234,6 +234,7 @@ class _FakeResponse:
         self.completion = result.completion
         self.served_model_id = model_id
         self.tokens = result.tokens
+        self.token_ids = result.token_ids
         self.token_logprobs = result.token_logprobs
         self.ttft_ms = 12.0
         self.decode_tps = 99.0
@@ -480,7 +481,79 @@ def test_probe_score_parses_teacher_forced_response(monkeypatch):
     assert seen['url'] == 'http://ref:8080/v1/score' and seen['headers'] == {'Authorization': 'Bearer k'}
     assert seen['body']['completion'] == 'Paris' and seen['body']['top_logprobs'] == 1
     assert out['tokens'] == ['Par', 'is'] and out['logprobs'] == [-0.1, -0.02] and out['argmax'] == ['Par', 'is']
-    assert out['usage']['ttft_ms'] == 3.0
+    assert out['usage']['ttft_ms'] == 3.0 and out['token_ids'] == [1, 2]
+    forced = probe.score(
+        'http://ref:8080/', 'm', [{'role': 'user', 'content': 'q'}], 'Paris', 5.0, completion_token_ids=[1, 2]
+    )
+    assert seen['body']['completion_token_ids'] == [1, 2] and 'completion' not in seen['body']
+    assert forced['token_ids'] == [1, 2]
+
+
+def test_verify_served_forces_miner_token_ids():
+    """With miner token ids the reference scores that exact sequence: no re-tokenization, no length mismatch."""
+    from gittensor.serving.audit import verify_served
+
+    release = _echo_release()
+    good = _served(1, release)
+    tokens, logprobs = list(good.tokens or []), list(good.token_logprobs or [])
+    ids = list(range(100, 100 + len(tokens)))
+    calls = []
+
+    class ForcingReference:
+        model_id = release.model_id
+
+        def score_served(self, messages, completion, token_ids=None):
+            calls.append(list(token_ids) if token_ids else None)
+            if token_ids:
+                return {'tokens': tokens, 'logprobs': logprobs, 'argmax': tokens, 'usage': {}}
+            retok = tokens + ['x']  # a fresh tokenization of the text disagrees on length
+            return {'tokens': retok, 'logprobs': logprobs + [0.0], 'argmax': retok, 'usage': {}}
+
+        def sample(self):
+            raise NotImplementedError
+
+        def __len__(self):
+            return 1
+
+    ref = ForcingReference()
+    assert verify_served(ref, good.messages, good.completion, tokens, logprobs, token_ids=ids).passed
+    assert calls[-1] == ids
+    eos = verify_served(
+        ref, good.messages, good.completion, tokens + ['<|im_end|>'], logprobs + [0.0], token_ids=ids + [7]
+    )
+    assert eos.passed and calls[-1] == ids
+    fallback = verify_served(ref, good.messages, good.completion, tokens, logprobs)
+    assert calls[-1] is None and 'tokenization mismatch' in fallback.reason
+    short = verify_served(ref, good.messages, good.completion, tokens, logprobs, token_ids=ids[:-1])
+    assert calls[-1] is None and not short.passed  # a malformed id list falls back to the text path
+
+    class BindingReference(ForcingReference):
+        def score_served(self, messages, completion, token_ids=None):
+            out = super().score_served(messages, completion, token_ids)
+            out['bytes'] = [b'not the completion'] + [b''] * (len(out['tokens']) - 1)
+            return out
+
+    lie = verify_served(BindingReference(), good.messages, good.completion, tokens, logprobs, token_ids=ids)
+    assert not lie.passed and not lie.hard and 'do not spell' in lie.reason
+
+
+def test_stream_assembler_collects_token_ids():
+    from gittensor.serving.stream import SSEParser, StreamAssembler, result_to_sse
+    from gittensor.synapses import InferenceSynapse
+
+    release = _echo_release()
+    result = expected_completion(MSGS, 3, release.model_id)
+    result.token_ids = [11, 12, 13]
+    a = StreamAssembler()
+    for event in SSEParser().feed(b''.join(result_to_sse(result, 'id', 0, True))):
+        a.feed(event)
+    syn = a.apply(InferenceSynapse(messages=MSGS, model_id=release.model_id))
+    assert syn.token_ids == [11, 12, 13] and syn.tokens == result.tokens
+    plain = StreamAssembler()
+    result.token_ids = None
+    for event in SSEParser().feed(b''.join(result_to_sse(result, 'id', 0, True))):
+        plain.feed(event)
+    assert plain.apply(InferenceSynapse(messages=MSGS, model_id=release.model_id)).token_ids is None
 
 
 def test_emission_pools_sum_to_one():


### PR DESCRIPTION
## Why

Soak 3 (2026-08-27, two miners, 5.6 h) showed 12 of 15 READY-miner misses were `tokenization mismatch (N vs N+1..4)`: `verify_served` sends the miner's decoded **text** to `/v1/score`, the reference re-tokenizes it, and a greedy decode is not always the canonical tokenization of its own output (`"\n","\n"` vs `"\n\n"`, digit merges). Same text, different boundaries, so we bailed on length before comparing anything. Every one of those was an honest answer; each cost a window slot and UID 16 touched the 0.8 threshold five times. Deterministic, not noise.

## What

- Miner logprob entries may carry `token_id`; the stream assembler / `OpenAICompatBackend.generate` collect them into `InferenceSynapse.token_ids` → `ServedRequest.token_ids`.
- `verify_served` passes them to `/v1/score` as `completion_token_ids` (contract R8 already supports it), so the reference forces the miner's exact sequence. Text path is unchanged as the fallback for miners that don't report ids.
- If the reference echoes the forced tokens' `bytes`, the ids are bound to the completion text the user received (soft miss on disagreement) — closes the "correct ids, garbage text" hole once the runtime returns bytes.

## Needs

sparkinfer emits `bytes` but not `token_id` per chat logprob entry; miners proxy the SSE untouched, so a one-line runtime change (+ `bytes` on the `/v1/score` response) and a pin bump makes this live with no miner code change: gittensor-ai-lab/sparkinfer PR linked below. Until then behaviour is identical to today.