### PR TITLE
serving: CI conformance on a rented 5090 after the sparkinfer image push

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -104,6 +104,8 @@ jobs:
           sudo apt-get install -y -qq jq
 
       - name: Rent, boot, check, tear down
+        env:
+          CONFORMANCE_RENT_WAIT_MIN: "20"
         run: scripts/serving_conformance_on_lium.sh "$REF" "conformance-$REF"
 
       - name: Upload the report

--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -3,8 +3,9 @@ name: sparkinfer image
 # Builds the blessed serving runtime (see the Serving Runtime Contract in the miner docs) from a pinned upstream commit and
 # publishes it as entrius/sparkinfer:<ref>. Run manually with the commit you intend to bless; the
 # resulting tag is what goes into `runtime_pin` in gittensor/validator/weights/serving_loadout.json.
-# No GPU in CI: this only proves the release builds. Conformance (scripts/check_serving_runtime.py) runs
-# on the validator reference GPU before the pin is updated.
+# No GPU in CI: the build job only proves the release builds. The `conformance` job then rents one RTX 5090
+# on Lium (scripts/serving_conformance_on_lium.sh), runs scripts/check_serving_runtime.py against the pushed
+# image, uploads the report, and on a clean pass opens the pin-bump PR. Needs the LIUM_API_KEY secret.
 
 on:
   workflow_dispatch:
@@ -17,6 +18,11 @@ on:
         description: "CMAKE_CUDA_ARCHITECTURES"
         required: false
         default: "120"
+      conformance:
+        description: "After the push, rent a 5090 on Lium, run the conformance checker and open the pin-bump PR on a pass"
+        type: boolean
+        required: false
+        default: true
   # Build-only check (never pushes) whenever the Dockerfile or this workflow changes.
   push:
     paths:
@@ -25,6 +31,8 @@ on:
 
 jobs:
   image:
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
     # push-triggered runs (Dockerfile/workflow changed) only BUILD, to catch Dockerfile breakage in CI;
     # the image is pushed to Docker Hub only from the Run workflow button (workflow_dispatch).
     name: ${{ github.event_name == 'workflow_dispatch' && 'build and push' || 'build only (dry run)' }}
@@ -71,3 +79,59 @@ jobs:
             entrius/sparkinfer:${{ steps.ref.outputs.ref }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  conformance:
+    name: conformance on a rented 5090
+    needs: image
+    if: github.event_name == 'workflow_dispatch' && inputs.conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    env:
+      LIUM_API_KEY: ${{ secrets.LIUM_API_KEY }}
+      REF: ${{ needs.image.outputs.ref }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python + deps + lium
+        run: |
+          uv python install 3.12
+          uv sync --extra dev
+          uv tool install lium.io
+          sudo apt-get install -y -qq jq
+
+      - name: Rent, boot, check, tear down
+        run: scripts/serving_conformance_on_lium.sh "$REF" "conformance-$REF"
+
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: serving-conformance-${{ env.REF }}
+          path: conformance-${{ env.REF }}/
+          if-no-files-found: warn
+
+      - name: Bump runtime_pin
+        run: |
+          jq --arg pin "gittensor-ai-lab/sparkinfer@$REF" '.releases[0].runtime_pin = $pin' \
+            gittensor/validator/weights/serving_loadout.json > /tmp/loadout.json
+          mv /tmp/loadout.json gittensor/validator/weights/serving_loadout.json
+          git diff --stat
+
+      - name: Open the pin-bump PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          base: test
+          branch: serving/pin-${{ env.REF }}
+          commit-message: "serving: bless sparkinfer ${{ env.REF }}"
+          title: "serving: bless sparkinfer ${{ env.REF }}"
+          body: |
+            `entrius/sparkinfer:${{ env.REF }}` passed `scripts/check_serving_runtime.py` on a rented RTX 5090
+            (run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — report in the
+            `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin`; update the sha named in the
+            comments at `gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.
+          add-paths: gittensor/validator/weights/serving_loadout.json

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -152,7 +152,7 @@ RECYCLE_UID = 0
 
 # Combined scoring pool distributed by repository emission_share, then by per-repo PR/issue split.
 # Pools (OSS + SERVING) must sum to 1.0; anything unallocated within them recycles to RECYCLE_UID.
-OSS_EMISSION_SHARE = 0.93  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 37% of total)
+OSS_EMISSION_SHARE = 0.965  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 37% of total)
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
 MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
@@ -164,10 +164,10 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # (capacity-weighted, so N hotkeys on one card sum to one card) earns SERVING_GPU_HOUR_USD, converted to an emission
 # share through the on-chain alpha/TAO price and the TAO/USD rate published in serving_loadout.json (`pricing`).
 # The share is capped at SERVING_EMISSION_SHARE_CAP; what the fleet does not earn recycles to RECYCLE_UID, never to
-# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~10 cards inside the 7% cap. With no
+# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~5 cards inside the 3.5% cap. With no
 # price data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
 SERVING_GPU_HOUR_USD = 0.70
-SERVING_EMISSION_SHARE_CAP = 0.07
+SERVING_EMISSION_SHARE_CAP = 0.035
 assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Conformance-check a built serving runtime image on a rented RTX 5090 (Lium), then tear the pod down.
+#
+#   LIUM_API_KEY=... scripts/serving_conformance_on_lium.sh <sparkinfer ref> [out dir]
+#
+# Rents one 1x5090 executor, boots entrius/sparkinfer:<ref> with the loadout's MODEL_SHA256, waits for the
+# model download, runs scripts/check_serving_runtime.py against the pod's public 8080 and writes the report
+# to <out dir>/conformance.txt. Exit code is the checker's (1 = a MUST failed). The pod is removed on every
+# exit path; --ttl is the backstop if this process dies.
+set -euo pipefail
+
+REF="${1:?sparkinfer ref (image tag)}"
+OUT="${2:-serving-conformance-$REF}"
+LOADOUT="$(dirname "$0")/../gittensor/validator/weights/serving_loadout.json"
+MODEL_ID=$(jq -r '.releases[0].model_id' "$LOADOUT")
+MODEL_SHA=$(jq -r '.releases[0].model_sha256' "$LOADOUT")
+POD="conf-${REF:0:7}-$RANDOM"
+GPU="${CONFORMANCE_GPU:-5090}"
+RENT_WAIT_MIN="${CONFORMANCE_RENT_WAIT_MIN:-60}"
+BOOT_WAIT_MIN="${CONFORMANCE_BOOT_WAIT_MIN:-45}"
+mkdir -p "$OUT"
+
+cleanup() { lium rm "$POD" -y >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "renting 1x$GPU for entrius/sparkinfer:$REF (waiting up to ${RENT_WAIT_MIN} min for a free card)"
+for ((i = 0; i < RENT_WAIT_MIN; i++)); do
+  NODE=$(lium ls --gpu "$GPU" --format json 2>/dev/null | jq -r '[.[] | select(.gpu_count == 1 and .download_mbps >= 150)] | sort_by(.price_per_hour) | .[0].id // empty')
+  [ -n "$NODE" ] && break
+  sleep 60
+done
+[ -n "${NODE:-}" ] || { echo "no 1x$GPU executor became available in ${RENT_WAIT_MIN} min"; exit 2; }
+lium up "$NODE" --name "$POD" --image "entrius/sparkinfer:$REF" --internal-ports 22,8080 \
+  -e "MODEL_SHA256=$MODEL_SHA" -e SPARKINFER_DETERMINISTIC=1 --ttl 3h -y --no-ssh
+
+echo "waiting for the pod's public 8080 and the model download (up to ${BOOT_WAIT_MIN} min)"
+BASE=""
+for ((i = 0; i < BOOT_WAIT_MIN * 6; i++)); do
+  if [ -z "$BASE" ]; then
+    BASE=$(lium ps --format json 2>/dev/null | python3 -c '
+import json, sys
+name = sys.argv[1]
+for p in json.load(sys.stdin):
+    if p.get("name") != name or p.get("status") != "RUNNING":
+        continue
+    ports = p.get("ports") or {}
+    items = ports.items() if isinstance(ports, dict) else [(x.get("internal") or x.get("internal_port"), x.get("external") or x.get("external_port")) for x in ports]
+    for internal, external in items:
+        if str(internal) == "8080" and external:
+            print(f"http://{p.get(\"ssh_ip\") or p.get(\"ip\")}:{external}")
+' "$POD" || true)
+  fi
+  if [ -n "$BASE" ] && curl -sf --max-time 5 "$BASE/v1/models" >/dev/null 2>&1; then break; fi
+  sleep 10
+done
+[ -n "$BASE" ] && curl -sf --max-time 5 "$BASE/v1/models" >/dev/null || { echo "runtime never answered on $BASE"; lium ps; exit 2; }
+echo "runtime up at $BASE"
+curl -s "$BASE/v1/models" | tee "$OUT/models.json"; echo
+
+set +e
+uv run python scripts/check_serving_runtime.py --base-url "$BASE" --model-id "$MODEL_ID" \
+  --determinism-count 30 --repeat 3 --parallel 16 2>&1 | tee "$OUT/conformance.txt"
+RC=${PIPESTATUS[0]}
+set -e
+echo "checker exit $RC (report: $OUT/conformance.txt)"
+exit "$RC"


### PR DESCRIPTION
The image workflow proved the build; blessing still meant renting a card by hand and running the checker. This adds a `conformance` job (workflow_dispatch, on by default) after the push:

- `scripts/serving_conformance_on_lium.sh <ref>` — rents the cheapest free 1×5090 on Lium (waits up to 20 min for one in CI; 60 by default when run by hand), boots `entrius/sparkinfer:<ref>` with the loadout's `MODEL_SHA256` + `SPARKINFER_DETERMINISTIC=1`, waits for the model download, runs `scripts/check_serving_runtime.py` (30×3 D1, 16-parallel R6) against the pod's public 8080, removes the pod on every exit path (`--ttl 3h` backstop). Exit code is the checker's. Same script works locally for a manual blessing.
- On a pass: bumps `runtime_pin` in `serving_loadout.json` and opens `serving/pin-<ref>` → `test` via `peter-evans/create-pull-request` with a link to the run + report artifact. A MUST failure fails the job, no PR.

Needs the `LIUM_API_KEY` repo secret (the test-budget key). ~$0.70 per run at 5090 prices; the model download (~20–30 min) dominates wall-clock.