### PR TITLE
serving: persist each audit round to the DB so compute miners can see their status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ WANDB_VALIDATOR_NAME=vali
 # GITTENSOR_MINER_PATS_FILE=/path/to/miner_pats.json
 
 # validator database settings (for gittensor validator/dashboard)
-STORE_DB_RESULTS=false
+STORE_DB_RESULTS=false  # also persists serving (compute) rounds for gittensor.io/compute when SERVING_ENABLED
 # DB_HOST=
 # DB_PORT=
 # DB_NAME=

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -243,6 +243,7 @@ BLOCKS_PER_TEMPO = 360
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)
+SERVING_DB_RETENTION_DAYS = 7  # validator: per-round serving rows older than this are pruned on each write
 SERVING_REQUEST_LOG_SIZE = 5_000  # in-memory ring of recent API/audit requests (telemetry)
 
 # =============================================================================

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -41,6 +41,7 @@ class ServingRelease:
     base_url: Optional[str] = None  # miner side: the runtime this miner serves from
     runtime_pin: Optional[str] = None
     model_sha256: Optional[str] = None  # digest of the model file; runtime_pin + model_sha256 = the release
+    model_file: Optional[str] = None  # HF path of the model file, informational (the digest is what is enforced)
     audit_bank: Optional[str] = None  # validator side: snapshot reference, filename under weights/
     reference_url: Optional[str] = (
         None  # validator side: live reference runtime (own GPU or a rented one); wins over audit_bank
@@ -56,6 +57,7 @@ class ServingRelease:
             max_tokens=int(raw.get('max_tokens', 64)),
             base_url=raw.get('base_url'),
             runtime_pin=raw.get('runtime_pin'),
+            model_file=raw.get('model_file'),
             model_sha256=raw.get('model_sha256'),
             audit_bank=raw.get('audit_bank'),
             reference_url=raw.get('reference_url'),

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -130,6 +130,11 @@ class ServingState:
                 if hk in self._history
             }
 
+    def settled_scores(self) -> Dict[str, float]:
+        """Trailing-window settled score per hotkey (missing rounds count 0)."""
+        with self._lock:
+            return {hk: sum(xs) / self.settlement_rounds for hk, xs in self._history.items()}
+
     def enqueue_served(self, served: ServedRequest) -> None:
         with self._lock:
             self._served.append(served)

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -79,6 +79,7 @@ async def forward(self: 'Validator') -> None:
         maintainer_uids_by_repo = build_maintainer_uids_by_repo(miner_evaluations, master_repositories, miner_uids)
         serving_scores = self.serving_state.scores_for(self.metagraph.hotkeys) if SERVING_ENABLED else {}
         pricing = serving_pricing(self) if SERVING_ENABLED and serving_scores else None
+        self.last_serving_pricing = pricing  # the serving audit thread stamps it on the rounds it persists
         rewards = blend_emission_pools(
             miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, serving_scores, pricing
         )

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -440,10 +440,15 @@ class ServingAuditThread:
                 except OSError as e:
                     bt.logging.warning(f'Serving: could not persist audit window to {path}: {e}')
             if self.storage is not None:
+                try:
+                    release = load_serving_loadout().primary
+                except Exception:
+                    release = None
                 self.storage.store_round(
                     validator_hotkey=self.validator.wallet.hotkey.ss58_address,
                     state=self.state,
                     pricing=getattr(self.validator, 'last_serving_pricing', None),
+                    release=release,
                 )
             # The rest of the interval carries this validator's own baseline prompts, spread at random so nothing
             # marks the round boundary; they are verified next round alongside any user traffic.

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -57,7 +57,9 @@ from gittensor.serving.loadout import ServingRelease, load_serving_loadout
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
+from gittensor.validator.serving.persist import ServingRoundStorage
 from gittensor.validator.serving.scoring import latency_credit
+from gittensor.validator.utils.config import STORE_DB_RESULTS
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -99,12 +101,15 @@ def verify_served_round(
     release: ServingRelease,
     served: Sequence[ServedRequest],
     summary: Optional[Dict[str, int]] = None,
+    last_miss: Optional[Dict[str, str]] = None,
 ) -> Dict[str, List[float]]:
     """Verify every served request for ``release`` into the window; return latency credits per hotkey.
 
-    Reference calls run on a small thread pool; window updates stay on this thread.
+    Reference calls run on a small thread pool; window updates stay on this thread. ``last_miss`` (hotkey ->
+    reason) is filled with the most recent miss or strike reason so the round report can show a miner why.
     """
     summary = summary if summary is not None else {}
+    last_miss = last_miss if last_miss is not None else {}
     mine = [req for req in served if req.model_id == release.model_id]
 
     def judge(req: ServedRequest) -> Optional[AuditVerdict]:
@@ -139,6 +144,8 @@ def verify_served_round(
                 f'Serving: READY UID {req.uid} missed a {req.source} request ({verdict.reason}; '
                 f'{len(req.tokens or [])} tokens, {req.latency_ms or 0:.0f} ms)'
             )
+        if not verdict.passed:
+            last_miss[req.hotkey] = verdict.reason
         if verdict.hard:
             until = state.audits.strike(req.hotkey, release.model_id)
             bump('strike')
@@ -283,7 +290,8 @@ async def audit_round(
     best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in serving}
     probation: Dict[int, ReadyMiner] = {}
     summary: Dict[str, int] = {}
-    windows: Dict[int, dict] = {}
+    windows: Dict[int, dict] = {}  # per-UID round report; published in state.last_round and persisted to the DB
+    last_miss: Dict[str, str] = {}
 
     for release in loadout.releases:
         try:
@@ -294,13 +302,23 @@ async def audit_round(
                 'set SERVING_REFERENCE_URL to a conformant runtime'
             )
             continue
-        credits = verify_served_round(state, reference, release, served, summary)
+        credits = verify_served_round(state, reference, release, served, summary, last_miss)
         passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
         for uid, hotkey, axon in serving:
             window = state.audits.verdict(hotkey, release.model_id)
             round_credits = credits.get(hotkey)
             credit = sum(round_credits) / len(round_credits) if round_credits else 1.0
-            windows[uid] = {**window.as_dict(), 'model_id': release.model_id, 'served': len(round_credits or [])}
+            windows[uid] = {
+                **window.as_dict(),
+                'hotkey': hotkey,
+                'model_id': release.model_id,
+                'served': len(round_credits or []),
+                'credit': round(credit, 4),
+                'probe_tps': None,
+                'capacity': 0.0,
+                'score': 0.0,
+                'last_miss': last_miss.get(hotkey, ''),
+            }
             bt.logging.debug(
                 f'Serving: UID {uid} {release.model_id} window {window.as_dict()} '
                 f'served {len(round_credits or [])} credit {credit:.3f}'
@@ -332,6 +350,7 @@ async def audit_round(
             )
             if score > best[hotkey][0]:
                 best[hotkey] = (score, release.model_id)
+                windows[uid].update(probe_tps=round(tps, 1), capacity=round(capacity, 4), score=round(score, 4))
 
     scores = {hotkey: score for hotkey, (score, _) in best.items()}
     ready: List[ReadyMiner] = []
@@ -340,7 +359,9 @@ async def audit_round(
         if score > 0.0:
             ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, model_id=model_id))
             probation.pop(uid, None)
-    quarantined = sum(1 for w in windows.values() if w.get('quarantined_until', 0.0) > 0.0)
+    for uid, report in windows.items():
+        report['status'] = miner_status(report)
+    quarantined = sum(1 for w in windows.values() if w['status'] == 'quarantined')
     summary.update(ready=len(ready), probation=len(probation), quarantined=quarantined)
     state.publish_round(ready, scores, list(probation.values()), {**summary, 'windows': windows})
     bt.logging.info(
@@ -350,6 +371,15 @@ async def audit_round(
         f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined}'
     )
     return scores
+
+
+def miner_status(report: dict) -> str:
+    """'ready' | 'quarantined' | 'probation' for one UID's round report."""
+    if report.get('score', 0.0) > 0.0:
+        return 'ready'
+    if report.get('quarantined_until', 0.0) > 0.0:
+        return 'quarantined'
+    return 'probation'
 
 
 async def _unlimited_session() -> aiohttp.ClientSession:
@@ -372,6 +402,8 @@ class ServingAuditThread:
         self.baseline_per_round = baseline_per_round
         self._stop = threading.Event()
         self.thread = threading.Thread(target=self._run, name='serving-audits', daemon=True)
+        # Own connection: psycopg connections are not shared across threads, and the OSS round holds the other one.
+        self.storage: Optional[ServingRoundStorage] = ServingRoundStorage() if STORE_DB_RESULTS else None
 
     def start(self) -> None:
         self.thread.start()
@@ -407,6 +439,12 @@ class ServingAuditThread:
                     self.state.audits.save(path)
                 except OSError as e:
                     bt.logging.warning(f'Serving: could not persist audit window to {path}: {e}')
+            if self.storage is not None:
+                self.storage.store_round(
+                    validator_hotkey=self.validator.wallet.hotkey.ss58_address,
+                    state=self.state,
+                    pricing=getattr(self.validator, 'last_serving_pricing', None),
+                )
             # The rest of the interval carries this validator's own baseline prompts, spread at random so nothing
             # marks the round boundary; they are verified next round alongside any user traffic.
             remaining = max(0.0, self.interval_s - (time.monotonic() - started))

--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -17,7 +17,8 @@ from typing import Any, Dict, Optional
 import bittensor as bt
 
 from gittensor.classes import ServingPricing
-from gittensor.constants import SERVING_DB_RETENTION_DAYS
+from gittensor.constants import SERVING_DB_RETENTION_DAYS, SERVING_EMISSION_SHARE_CAP, SERVING_GPU_HOUR_USD
+from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.state import ServingState
 from gittensor.validator.emission_allocation import serving_share
 from gittensor.validator.storage.database import create_database_connection
@@ -35,11 +36,13 @@ def round_rows(
     last_round: Dict[str, Any],
     settled: Dict[str, float],
     pricing: Optional[ServingPricing],
+    release: Optional[ServingRelease] = None,
 ) -> tuple[tuple, list[tuple]]:
     """(serving_rounds row, serving_miner_rounds rows) for one audit round.
 
     ``card_equivalents`` and ``pool_share`` are what the next OSS round will pay on: settled scores summed, priced
-    through ``serving_share`` exactly as ``blend_emission_pools`` does.
+    through ``serving_share`` exactly as ``blend_emission_pools`` does. The economics ($/GPU-hour, cap) and the
+    enforced release (pin, digest) ride along so readers never hard-code them.
     """
     windows: Dict[int, dict] = last_round.get('windows', {})
     card_equiv = sum(settled.values())
@@ -61,6 +64,12 @@ def round_rows(
         share,
         pricing.alpha_per_hour_to_miners if pricing and pricing.usable else None,
         pricing.alpha_usd if pricing and pricing.usable else None,
+        SERVING_GPU_HOUR_USD,
+        SERVING_EMISSION_SHARE_CAP,
+        release.model_id if release else None,
+        release.runtime_pin if release else None,
+        release.model_sha256 if release else None,
+        release.model_file if release else None,
     )
     miners = []
     for uid, w in windows.items():
@@ -106,13 +115,14 @@ class ServingRoundStorage:
         validator_hotkey: str,
         state: ServingState,
         pricing: Optional[ServingPricing],
+        release: Optional[ServingRelease] = None,
         now: Optional[dt.datetime] = None,
     ) -> bool:
         last_round = dict(state.last_round)
         if not last_round or not state.last_round_ts:
             return False
         round_ts = now or dt.datetime.fromtimestamp(state.last_round_ts, dt.timezone.utc)
-        summary, miners = round_rows(validator_hotkey, round_ts, last_round, state.settled_scores(), pricing)
+        summary, miners = round_rows(validator_hotkey, round_ts, last_round, state.settled_scores(), pricing, release)
         conn = self._connection()
         if conn is None:
             return False

--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -1,0 +1,147 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Persist each serving audit round so compute miners can see what this validator saw.
+
+The serving loop is otherwise RAM-only: a miner has no way to learn that it is on probation, why its last request
+missed, or what its settled score is worth. ``ServingRoundStorage`` writes the round report ``audit_round`` already
+builds (``state.last_round``) plus the settled scores into two tables that the das API reads for gittensor.io.
+
+Runs on the audit thread with its own connection (psycopg connections are single-threaded). Any failure is logged
+and dropped — persistence must never stall or fail a round.
+"""
+
+import datetime as dt
+from typing import Any, Dict, Optional
+
+import bittensor as bt
+
+from gittensor.classes import ServingPricing
+from gittensor.constants import SERVING_DB_RETENTION_DAYS
+from gittensor.serving.state import ServingState
+from gittensor.validator.emission_allocation import serving_share
+from gittensor.validator.storage.database import create_database_connection
+from gittensor.validator.storage.queries import (
+    BULK_INSERT_SERVING_MINER_ROUNDS,
+    INSERT_SERVING_ROUND,
+    PRUNE_SERVING_MINER_ROUNDS,
+    PRUNE_SERVING_ROUNDS,
+)
+
+
+def round_rows(
+    validator_hotkey: str,
+    round_ts: dt.datetime,
+    last_round: Dict[str, Any],
+    settled: Dict[str, float],
+    pricing: Optional[ServingPricing],
+) -> tuple[tuple, list[tuple]]:
+    """(serving_rounds row, serving_miner_rounds rows) for one audit round.
+
+    ``card_equivalents`` and ``pool_share`` are what the next OSS round will pay on: settled scores summed, priced
+    through ``serving_share`` exactly as ``blend_emission_pools`` does.
+    """
+    windows: Dict[int, dict] = last_round.get('windows', {})
+    card_equiv = sum(settled.values())
+    share = serving_share(card_equiv, pricing)
+    summary = (
+        validator_hotkey,
+        round_ts,
+        int(last_round.get('served', 0)),
+        int(last_round.get('gateway', 0)),
+        int(last_round.get('baseline', 0)),
+        int(last_round.get('pass', 0)),
+        int(last_round.get('miss', 0)),
+        int(last_round.get('strike', 0)),
+        int(last_round.get('neutral', 0)),
+        int(last_round.get('ready', 0)),
+        int(last_round.get('probation', 0)),
+        int(last_round.get('quarantined', 0)),
+        card_equiv,
+        share,
+        pricing.alpha_per_hour_to_miners if pricing and pricing.usable else None,
+        pricing.alpha_usd if pricing and pricing.usable else None,
+    )
+    miners = []
+    for uid, w in windows.items():
+        until = float(w.get('quarantined_until', 0.0) or 0.0)
+        miners.append(
+            (
+                validator_hotkey,
+                round_ts,
+                int(uid),
+                str(w.get('hotkey', '')),
+                str(w.get('model_id', '')),
+                str(w.get('status', 'probation')),
+                float(w.get('mean', 0.0)),
+                int(w.get('n_audits', 0)),
+                bool(w.get('passed', False)),
+                dt.datetime.fromtimestamp(until, dt.timezone.utc) if until > 0 else None,
+                int(w.get('served', 0)),
+                float(w.get('credit', 0.0)),
+                w.get('probe_tps'),
+                float(w.get('capacity', 0.0)),
+                float(w.get('score', 0.0)),
+                float(settled.get(str(w.get('hotkey', '')), 0.0)),
+                (str(w.get('last_miss', '') or '')[:500]) or None,
+            )
+        )
+    return summary, miners
+
+
+class ServingRoundStorage:
+    """Writes one audit round per call; reconnects lazily after a failure."""
+
+    def __init__(self, retention_days: int = SERVING_DB_RETENTION_DAYS):
+        self.retention_days = retention_days
+        self._conn: Optional[Any] = None
+
+    def _connection(self) -> Optional[Any]:
+        if self._conn is None or getattr(self._conn, 'closed', False):
+            self._conn = create_database_connection()
+        return self._conn
+
+    def store_round(
+        self,
+        validator_hotkey: str,
+        state: ServingState,
+        pricing: Optional[ServingPricing],
+        now: Optional[dt.datetime] = None,
+    ) -> bool:
+        last_round = dict(state.last_round)
+        if not last_round or not state.last_round_ts:
+            return False
+        round_ts = now or dt.datetime.fromtimestamp(state.last_round_ts, dt.timezone.utc)
+        summary, miners = round_rows(validator_hotkey, round_ts, last_round, state.settled_scores(), pricing)
+        conn = self._connection()
+        if conn is None:
+            return False
+        try:
+            with conn.cursor() as cur:
+                cur.execute(INSERT_SERVING_ROUND, summary)
+                if miners:
+                    cur.executemany(BULK_INSERT_SERVING_MINER_ROUNDS, miners)
+                cur.execute(PRUNE_SERVING_ROUNDS, (validator_hotkey, self.retention_days))
+                cur.execute(PRUNE_SERVING_MINER_ROUNDS, (validator_hotkey, self.retention_days))
+            conn.commit()
+            bt.logging.debug(f'Serving: persisted round {round_ts:%H:%M:%S} ({len(miners)} miner rows)')
+            return True
+        except Exception as e:  # never let persistence fail a round
+            bt.logging.warning(f'Serving: could not persist round to the database: {e!r}')
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            try:
+                conn.close()
+            except Exception:
+                pass
+            self._conn = None
+            return False
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            finally:
+                self._conn = None

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -193,3 +193,30 @@ DO UPDATE SET
     total_open_issues = EXCLUDED.total_open_issues,
     updated_at = NOW()
 """
+
+# Serving (compute) rounds — one summary row per validator per audit round, one row per serving UID per round.
+# Rows carry the writing validator's hotkey: every validator sees its own traffic, so the UI shows one
+# validator's snapshot, never a consensus.
+INSERT_SERVING_ROUND = """
+INSERT INTO serving_rounds (
+    validator_hotkey, round_ts, served, gateway, baseline, passes, misses, strikes, neutral,
+    ready, probation, quarantined, card_equivalents, pool_share, alpha_per_hour, alpha_usd
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+ON CONFLICT (validator_hotkey, round_ts) DO NOTHING
+"""
+
+BULK_INSERT_SERVING_MINER_ROUNDS = """
+INSERT INTO serving_miner_rounds (
+    validator_hotkey, round_ts, uid, hotkey, model_id, status, window_mean, window_n, window_passed,
+    quarantined_until, served, credit, probe_tps, capacity, round_score, settled_score, last_miss_reason
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+ON CONFLICT (validator_hotkey, round_ts, uid, hotkey) DO NOTHING
+"""
+
+PRUNE_SERVING_ROUNDS = """
+DELETE FROM serving_rounds WHERE validator_hotkey = %s AND round_ts < NOW() - (%s * INTERVAL '1 day')
+"""
+
+PRUNE_SERVING_MINER_ROUNDS = """
+DELETE FROM serving_miner_rounds WHERE validator_hotkey = %s AND round_ts < NOW() - (%s * INTERVAL '1 day')
+"""

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -200,8 +200,9 @@ DO UPDATE SET
 INSERT_SERVING_ROUND = """
 INSERT INTO serving_rounds (
     validator_hotkey, round_ts, served, gateway, baseline, passes, misses, strikes, neutral,
-    ready, probation, quarantined, card_equivalents, pool_share, alpha_per_hour, alpha_usd
-) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    ready, probation, quarantined, card_equivalents, pool_share, alpha_per_hour, alpha_usd,
+    gpu_hour_usd, pool_cap, model_id, runtime_pin, model_sha256, model_file
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT (validator_hotkey, round_ts) DO NOTHING
 """
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -19,13 +19,13 @@
 import os
 import time
 from functools import partial
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 import bittensor as bt
 import wandb
 
 from gittensor import __version__
-from gittensor.classes import MinerEvaluation, MinerEvaluationCache
+from gittensor.classes import MinerEvaluation, MinerEvaluationCache, ServingPricing
 from gittensor.serving.api import parse_api_keys, start_serving_api
 from gittensor.serving.audit import AuditWindow
 from gittensor.serving.loadout import load_serving_loadout
@@ -66,6 +66,7 @@ class Validator(BaseValidatorNeuron):
     """
 
     db_storage: DatabaseStorage = None
+    last_serving_pricing: Optional[ServingPricing] = None  # set each OSS round; read by the serving audit thread
     evaluation_cache: MinerEvaluationCache = None
 
     def __init__(self, config=None):

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -1,0 +1,132 @@
+"""Serving round persistence: the round report is turned into DB rows and never fails a round."""
+
+import datetime as dt
+from collections import deque
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+persist = pytest.importorskip('gittensor.validator.serving.persist')
+forward = pytest.importorskip('gittensor.validator.serving.forward')
+state_module = pytest.importorskip('gittensor.serving.state')
+classes = pytest.importorskip('gittensor.classes')
+
+ROUND = {
+    'served': 4,
+    'gateway': 1,
+    'baseline': 3,
+    'pass': 3,
+    'miss': 1,
+    'strike': 0,
+    'neutral': 0,
+    'ready': 1,
+    'probation': 1,
+    'quarantined': 0,
+    'windows': {
+        16: {
+            'passed': True,
+            'n_audits': 10,
+            'mean': 0.9,
+            'threshold': 0.8,
+            'quarantined_until': 0.0,
+            'hotkey': 'hk16',
+            'model_id': 'qwen',
+            'served': 3,
+            'credit': 1.0,
+            'probe_tps': 190.0,
+            'capacity': 1.0,
+            'score': 1.0,
+            'last_miss': '',
+            'status': 'ready',
+        },
+        27: {
+            'passed': False,
+            'n_audits': 2,
+            'mean': 0.5,
+            'threshold': 0.8,
+            'quarantined_until': 1_800_000_000.0,
+            'hotkey': 'hk27',
+            'model_id': 'qwen',
+            'served': 1,
+            'credit': 0.0,
+            'probe_tps': None,
+            'capacity': 0.0,
+            'score': 0.0,
+            'last_miss': 'tokenization mismatch (3 vs 4)',
+            'status': 'quarantined',
+        },
+    },
+}
+
+
+def _state() -> 'state_module.ServingState':
+    st = state_module.ServingState()
+    st.last_round = dict(ROUND)
+    st.last_round_ts = 1_700_000_000.0
+    st._history = {'hk16': deque([1.0] * 6, maxlen=12), 'hk27': deque([0.5] * 2, maxlen=12)}
+    return st
+
+
+def test_round_rows_shape_and_pricing():
+    pricing = classes.ServingPricing(alpha_per_hour_to_miners=100.0, alpha_usd=1.0)
+    ts = dt.datetime(2026, 8, 27, tzinfo=dt.timezone.utc)
+    summary, miners = persist.round_rows('vali', ts, ROUND, {'hk16': 0.5, 'hk27': 1 / 12}, pricing)
+    assert summary[:3] == ('vali', ts, 4)
+    assert summary[12] == pytest.approx(0.5 + 1 / 12)  # card equivalents = settled sum
+    assert 0 < summary[13] <= 0.035  # priced share inside the cap
+    assert summary[14:] == (100.0, 1.0)
+    assert len(miners) == 2
+    ready = next(m for m in miners if m[2] == 16)
+    assert ready[5] == 'ready' and ready[12] == 190.0 and ready[15] == 0.5 and ready[16] is None
+    quarantined = next(m for m in miners if m[2] == 27)
+    assert quarantined[5] == 'quarantined'
+    assert quarantined[9] == dt.datetime.fromtimestamp(1_800_000_000.0, dt.timezone.utc)
+    assert quarantined[16].startswith('tokenization mismatch')
+
+
+def test_round_rows_without_pricing_pays_cap_pro_rata():
+    summary, _ = persist.round_rows('vali', dt.datetime.now(dt.timezone.utc), ROUND, {'hk16': 1.0}, None)
+    assert summary[13] == 0.035 and summary[14] is None and summary[15] is None
+
+
+def test_store_round_writes_and_prunes():
+    conn = MagicMock()
+    conn.closed = False
+    cur = conn.cursor.return_value.__enter__.return_value
+    with patch.object(persist, 'create_database_connection', return_value=conn):
+        storage = persist.ServingRoundStorage()
+        assert storage.store_round('vali', _state(), None) is True
+    assert cur.execute.call_count == 3  # summary insert + 2 prunes
+    assert cur.executemany.call_count == 1 and len(cur.executemany.call_args.args[1]) == 2
+    assert cur.execute.call_args_list[1].args[1] == ('vali', 7)
+    conn.commit.assert_called_once()
+
+
+def test_store_round_failure_is_swallowed_and_reconnects():
+    conn = MagicMock()
+    conn.closed = False
+    conn.cursor.return_value.__enter__.return_value.execute.side_effect = RuntimeError('db down')
+    with patch.object(persist, 'create_database_connection', return_value=conn) as factory:
+        storage = persist.ServingRoundStorage()
+        assert storage.store_round('vali', _state(), None) is False
+        conn.rollback.assert_called_once()
+        conn.close.assert_called_once()
+        assert storage._conn is None
+        storage.store_round('vali', _state(), None)
+        assert factory.call_count == 2
+
+
+def test_store_round_skips_before_first_round():
+    with patch.object(persist, 'create_database_connection') as factory:
+        assert persist.ServingRoundStorage().store_round('vali', state_module.ServingState(), None) is False
+        factory.assert_not_called()
+
+
+def test_miner_status():
+    assert forward.miner_status({'score': 0.9}) == 'ready'
+    assert forward.miner_status({'score': 0.0, 'quarantined_until': 5.0}) == 'quarantined'
+    assert forward.miner_status({'score': 0.0, 'quarantined_until': 0.0}) == 'probation'
+
+
+def test_settled_scores():
+    assert _state().settled_scores() == {'hk16': pytest.approx(0.5), 'hk27': pytest.approx(1 / 12)}

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -60,7 +60,7 @@ ROUND = {
 }
 
 
-def _state() -> 'state_module.ServingState':
+def _state():
     st = state_module.ServingState()
     st.last_round = dict(ROUND)
     st.last_round_ts = 1_700_000_000.0

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -10,6 +10,7 @@ persist = pytest.importorskip('gittensor.validator.serving.persist')
 forward = pytest.importorskip('gittensor.validator.serving.forward')
 state_module = pytest.importorskip('gittensor.serving.state')
 classes = pytest.importorskip('gittensor.classes')
+loadout = pytest.importorskip('gittensor.serving.loadout')
 
 ROUND = {
     'served': 4,
@@ -74,7 +75,9 @@ def test_round_rows_shape_and_pricing():
     assert summary[:3] == ('vali', ts, 4)
     assert summary[12] == pytest.approx(0.5 + 1 / 12)  # card equivalents = settled sum
     assert 0 < summary[13] <= 0.035  # priced share inside the cap
-    assert summary[14:] == (100.0, 1.0)
+    assert summary[14:16] == (100.0, 1.0)
+    assert summary[16:18] == (0.70, 0.035)  # economics ride along so das never hard-codes them
+    assert summary[18:] == (None, None, None, None)
     assert len(miners) == 2
     ready = next(m for m in miners if m[2] == 16)
     assert ready[5] == 'ready' and ready[12] == 190.0 and ready[15] == 0.5 and ready[16] is None
@@ -82,6 +85,24 @@ def test_round_rows_shape_and_pricing():
     assert quarantined[5] == 'quarantined'
     assert quarantined[9] == dt.datetime.fromtimestamp(1_800_000_000.0, dt.timezone.utc)
     assert quarantined[16].startswith('tokenization mismatch')
+
+
+def test_round_rows_carry_the_enforced_release():
+    release = loadout.ServingRelease.from_dict(
+        {
+            'model_id': 'qwen',
+            'backend': 'openai-compat',
+            'runtime_pin': 'org/sparkinfer@abc',
+            'model_sha256': 'ff',
+            'model_file': 'org/model.gguf',
+        }
+    )
+    summary, _ = persist.round_rows('vali', dt.datetime.now(dt.timezone.utc), ROUND, {}, None, release)
+    assert summary[18:] == ('qwen', 'org/sparkinfer@abc', 'ff', 'org/model.gguf')
+
+
+def test_default_loadout_keeps_model_file():
+    assert loadout.load_serving_loadout().primary.model_file.endswith('.gguf')
 
 
 def test_round_rows_without_pricing_pays_cap_pro_rata():


### PR DESCRIPTION
Layer 1 of 4 for compute-miner visibility on gittensor.io (validator → gittensor-db → das → ui).

The serving loop is RAM-only today: a miner can't tell it is on probation, why its last request missed, or what its settled score is worth. This PR has the audit thread persist the round report `audit_round` already builds:

- `serving_miner_rounds` — per (validator, round, uid): `status` ready/probation/quarantined, window mean/n/passed, `quarantined_until`, served count, TTFT credit, probe tok/s, capacity, round score, trailing settled score, `last_miss_reason`.
- `serving_rounds` — per (validator, round): served/gateway/baseline/pass/miss/strike/neutral counts, ready/probation/quarantined counts, `card_equivalents` (settled sum), `pool_share` (via `serving_share`, same as `blend_emission_pools`), and the pricing inputs (`alpha_per_hour`, `alpha_usd`; NULL when unpriced). The OSS round caches its `ServingPricing` on the validator for this.

Rows carry the writing validator's hotkey — every validator sees only its own traffic, so the UI will show one validator's snapshot with a footnote, never a consensus.

Mechanics: own psycopg connection on the `serving-audits` thread (connections are single-threaded and the OSS round holds the other one), lazy reconnect after a failure, 7-day prune (`SERVING_DB_RETENTION_DAYS`) on every write, and a write failure is logged and dropped — never fails a round. Gated by `STORE_DB_RESULTS` like the OSS evaluations. `verify_served_round` now also records the last miss/strike reason per hotkey, and `audit_round` enriches the published `windows` report (hotkey, credit, probe_tps, capacity, score, status) — visible in `/v1/serving/status` too.

Schema lives in gittensor-db (`serving_rounds.sql`, `serving_miner_rounds.sql`); merge that first on test.

Tests: `tests/validator/test_serving_persist.py` (row shaping with/without pricing, write+prune, failure swallow+reconnect, pre-first-round skip, status derivation, settled scores). Full suite 722 passed; ruff + vulture clean.

https://claude.ai/code/session_01P5CYyMbujwmNVM27o3PQCd
