### PR TITLE
serving: salted per-hotkey capacity probe + per-release blessing-time speed facts

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -116,9 +116,18 @@ jobs:
           path: conformance-${{ env.REF }}/
           if-no-files-found: warn
 
-      - name: Bump runtime_pin
+      - name: Bump runtime_pin and the release's speed facts
         run: |
-          jq --arg pin "gittensor-ai-lab/sparkinfer@$REF" '.releases[0].runtime_pin = $pin' \
+          jq --arg pin "gittensor-ai-lab/sparkinfer@$REF" --arg run "$GITHUB_RUN_ID" \
+            --slurpfile speed "conformance-$REF/speed.json" \
+            '.releases[0].runtime_pin = $pin
+             | .releases[0].speed = ((.releases[0].speed // {}) + {
+                 decode_tps_target: $speed[0].decode_tps_target,
+                 single_stream_decode_tps: $speed[0].single_stream_decode_tps,
+                 probe_shaped_decode_tps: $speed[0].probe_shaped_decode_tps,
+                 probe_burst: $speed[0].probe_burst,
+                 measured_on: ($pin + " on a rented RTX 5090, actions run " + $run)
+               })' \
             gittensor/validator/weights/serving_loadout.json > /tmp/loadout.json
           mv /tmp/loadout.json gittensor/validator/weights/serving_loadout.json
           git diff --stat
@@ -134,6 +143,8 @@ jobs:
           body: |
             `entrius/sparkinfer:${{ env.REF }}` passed `scripts/check_serving_runtime.py` on a rented RTX 5090
             (run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — report in the
-            `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin`; update the sha named in the
-            comments at `gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.
+            `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin` and writes the release's
+            blessing-time speed facts (`speed.decode_tps_target` = 0.9 x the probe-shaped decode tok/s of one honest
+            card on this runtime — what earns capacity 1.0). Update the sha named in the comments at
+            `gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.
           add-paths: gittensor/validator/weights/serving_loadout.json

--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -104,6 +104,8 @@ jobs:
           sudo apt-get install -y -qq jq
 
       - name: Rent, boot, check, tear down
+        env:
+          CONFORMANCE_RENT_WAIT_MIN: "20"
         run: scripts/serving_conformance_on_lium.sh "$REF" "conformance-$REF"
 
       - name: Upload the report

--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -3,8 +3,9 @@ name: sparkinfer image
 # Builds the blessed serving runtime (see the Serving Runtime Contract in the miner docs) from a pinned upstream commit and
 # publishes it as entrius/sparkinfer:<ref>. Run manually with the commit you intend to bless; the
 # resulting tag is what goes into `runtime_pin` in gittensor/validator/weights/serving_loadout.json.
-# No GPU in CI: this only proves the release builds. Conformance (scripts/check_serving_runtime.py) runs
-# on the validator reference GPU before the pin is updated.
+# No GPU in CI: the build job only proves the release builds. The `conformance` job then rents one RTX 5090
+# on Lium (scripts/serving_conformance_on_lium.sh), runs scripts/check_serving_runtime.py against the pushed
+# image, uploads the report, and on a clean pass opens the pin-bump PR. Needs the LIUM_API_KEY secret.
 
 on:
   workflow_dispatch:
@@ -17,6 +18,11 @@ on:
         description: "CMAKE_CUDA_ARCHITECTURES"
         required: false
         default: "120"
+      conformance:
+        description: "After the push, rent a 5090 on Lium, run the conformance checker and open the pin-bump PR on a pass"
+        type: boolean
+        required: false
+        default: true
   # Build-only check (never pushes) whenever the Dockerfile or this workflow changes.
   push:
     paths:
@@ -25,6 +31,8 @@ on:
 
 jobs:
   image:
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
     # push-triggered runs (Dockerfile/workflow changed) only BUILD, to catch Dockerfile breakage in CI;
     # the image is pushed to Docker Hub only from the Run workflow button (workflow_dispatch).
     name: ${{ github.event_name == 'workflow_dispatch' && 'build and push' || 'build only (dry run)' }}
@@ -71,3 +79,59 @@ jobs:
             entrius/sparkinfer:${{ steps.ref.outputs.ref }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  conformance:
+    name: conformance on a rented 5090
+    needs: image
+    if: github.event_name == 'workflow_dispatch' && inputs.conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    env:
+      LIUM_API_KEY: ${{ secrets.LIUM_API_KEY }}
+      REF: ${{ needs.image.outputs.ref }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python + deps + lium
+        run: |
+          uv python install 3.12
+          uv sync --extra dev
+          uv tool install lium.io
+          sudo apt-get install -y -qq jq
+
+      - name: Rent, boot, check, tear down
+        run: scripts/serving_conformance_on_lium.sh "$REF" "conformance-$REF"
+
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: serving-conformance-${{ env.REF }}
+          path: conformance-${{ env.REF }}/
+          if-no-files-found: warn
+
+      - name: Bump runtime_pin
+        run: |
+          jq --arg pin "gittensor-ai-lab/sparkinfer@$REF" '.releases[0].runtime_pin = $pin' \
+            gittensor/validator/weights/serving_loadout.json > /tmp/loadout.json
+          mv /tmp/loadout.json gittensor/validator/weights/serving_loadout.json
+          git diff --stat
+
+      - name: Open the pin-bump PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          base: test
+          branch: serving/pin-${{ env.REF }}
+          commit-message: "serving: bless sparkinfer ${{ env.REF }}"
+          title: "serving: bless sparkinfer ${{ env.REF }}"
+          body: |
+            `entrius/sparkinfer:${{ env.REF }}` passed `scripts/check_serving_runtime.py` on a rented RTX 5090
+            (run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — report in the
+            `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin`; update the sha named in the
+            comments at `gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.
+          add-paths: gittensor/validator/weights/serving_loadout.json

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -152,7 +152,7 @@ RECYCLE_UID = 0
 
 # Combined scoring pool distributed by repository emission_share, then by per-repo PR/issue split.
 # Pools (OSS + SERVING) must sum to 1.0; anything unallocated within them recycles to RECYCLE_UID.
-OSS_EMISSION_SHARE = 0.93  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 37% of total)
+OSS_EMISSION_SHARE = 0.965  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 37% of total)
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
 MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
@@ -164,10 +164,10 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # (capacity-weighted, so N hotkeys on one card sum to one card) earns SERVING_GPU_HOUR_USD, converted to an emission
 # share through the on-chain alpha/TAO price and the TAO/USD rate published in serving_loadout.json (`pricing`).
 # The share is capped at SERVING_EMISSION_SHARE_CAP; what the fleet does not earn recycles to RECYCLE_UID, never to
-# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~10 cards inside the 7% cap. With no
+# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~5 cards inside the 3.5% cap. With no
 # price data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
 SERVING_GPU_HOUR_USD = 0.70
-SERVING_EMISSION_SHARE_CAP = 0.07
+SERVING_EMISSION_SHARE_CAP = 0.035
 assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -185,6 +185,8 @@ SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round i
 # 183-186 tok/s; two hotkeys on the same card 104-115 tok/s each (sum 210-227) -> capacities ~1.0 vs ~0.6.
 # Probe outcomes affect capacity only, never the audit window (a slow host halves its pay; it does not flap out of READY).
 SERVING_PROBE_REQUESTS = 6
+# Fallback only: a release carries its own blessing-time `speed.decode_tps_target` (serving_loadout.json), measured on
+# that runtime by the conformance job as decode tok/s (TTFT excluded), so the bar moves with the runtime.
 SERVING_PROBE_TARGET_TPS = 180.0
 # A probe reading can only be too low (another validator's burst, a user spike, a blip), never too high: the miner
 # had to deliver those verified tokens. A reading under SERVING_PROBE_DIP_RATIO x the miner's median of its last

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -47,9 +47,16 @@ class ServingRelease:
     )
     reference_api_key: Optional[str] = None  # bearer for a remote reference (sparkinfer --api-key)
     request_timeout: float = 60.0
+    # Speed of one honest card on this exact runtime, measured at blessing time (scripts/check_serving_runtime.py
+    # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator prices capacity and latency
+    # against these, so the "one card" bar tracks the runtime as it gets faster. None -> the constants' defaults.
+    decode_tps_target: Optional[float] = None  # probe-shaped aggregate decode tok/s that earns capacity 1.0
+    ttft_full_ms: Optional[float] = None  # validator-observed TTFT up to which latency credit is 1.0
+    ttft_zero_ms: Optional[float] = None  # ... and at which it reaches 0.0
 
     @classmethod
     def from_dict(cls, raw: dict) -> 'ServingRelease':
+        speed = raw.get('speed') or {}
         return cls(
             model_id=raw['model_id'],
             backend=raw['backend'],
@@ -61,7 +68,14 @@ class ServingRelease:
             reference_url=raw.get('reference_url'),
             reference_api_key=raw.get('reference_api_key'),
             request_timeout=float(raw.get('request_timeout', 60.0)),
+            decode_tps_target=_optional_float(speed.get('decode_tps_target')),
+            ttft_full_ms=_optional_float(speed.get('ttft_full_ms')),
+            ttft_zero_ms=_optional_float(speed.get('ttft_zero_ms')),
         )
+
+
+def _optional_float(value) -> Optional[float]:
+    return float(value) if value is not None else None
 
 
 @dataclass

--- a/gittensor/serving/probe.py
+++ b/gittensor/serving/probe.py
@@ -55,11 +55,15 @@ TEMPLATES = [
 SYSTEMS = [None, 'You are a concise assistant.', 'Answer in plain English.', 'Be precise and brief.']
 
 
-def make_prompts(count: int, seed: int) -> List[List[Dict[str, str]]]:
+def make_prompts(count: int, seed: int, salt: Optional[str] = None) -> List[List[Dict[str, str]]]:
+    """Probe prompts. ``salt`` is appended to every user message so two prompts are never identical across
+    hotkeys or rounds: an answer cannot be shared between hotkeys on one card or precomputed from the templates."""
     rng = random.Random(seed)
     prompts = []
     for _ in range(count):
         content = rng.choice(TEMPLATES).format(s=rng.choice(SUBJECTS))
+        if salt:
+            content = f'{content} (ref {salt})'
         system = rng.choice(SYSTEMS)
         msgs = [{'role': 'system', 'content': system}] if system else []
         msgs.append({'role': 'user', 'content': content})

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -19,10 +19,14 @@ published as *probation* so baseline traffic can give them a window.
     round score = window passes (0/1) x mean latency credit over this round's served requests x capacity
 
 ``capacity`` comes from the round's load probe: every READY miner gets
-``SERVING_PROBE_REQUESTS`` reference prompts at the same instant as every other
-miner, and verified tokens per wall-clock second over ``SERVING_PROBE_TARGET_TPS``
-(capped at 1) is its capacity — so hotkeys sharing one GPU share one GPU's pay.
-Probe outcomes affect capacity only, never the window. Round scores are settled
+``SERVING_PROBE_REQUESTS`` prompts at the same instant as every other miner —
+each prompt unique to that hotkey and round (salted), verified afterwards by
+teacher forcing under the reference like any served request, so an answer can
+neither be shared between hotkeys on one card nor precomputed. Verified tokens
+per second of *decode* time (batch wall-clock minus the first observed TTFT, so
+network distance prices latency, not throughput) over the release's blessed
+``decode_tps_target`` (capped at 1) is its capacity — so hotkeys sharing one
+GPU share one GPU's pay. Probe outcomes affect capacity only, never the window. Round scores are settled
 over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
 """
 
@@ -30,6 +34,7 @@ import asyncio
 import hashlib
 import math
 import random
+import secrets
 import statistics
 import threading
 import time
@@ -51,9 +56,10 @@ from gittensor.constants import (
     SERVING_PROBE_TARGET_TPS,
     SERVING_VERIFY_WORKERS,
 )
-from gittensor.serving.audit import AuditCase, AuditVerdict, Reference, reference_for, verify_response, verify_served
+from gittensor.serving.audit import AuditVerdict, Reference, reference_for, verify_served
 from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
+from gittensor.serving.probe import make_prompts
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
@@ -70,27 +76,82 @@ async def probe_axon(
     hotkey: str,
     axon: bt.AxonInfo,
     release: ServingRelease,
-    cases: Sequence[AuditCase],
+    reference: Reference,
+    prompts: Sequence[List[Dict[str, str]]],
 ) -> float:
-    """Fire all ``cases`` at once; return verified tokens per wall-clock second (0 when nothing verified)."""
+    """Fire all ``prompts`` at once; return verified tokens per second of decode time (0 when nothing verified)."""
 
-    async def one(case: AuditCase) -> Tuple[AuditVerdict, float, RequestRecord, int]:
+    async def one(messages: List[Dict[str, str]]) -> Tuple[AuditVerdict, RequestRecord, int, Optional[float]]:
         synapse = InferenceSynapse(
-            messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens, logprobs=True
+            messages=messages, model_id=release.model_id, max_tokens=release.max_tokens, logprobs=True
         )
         response = await consume_stream(dendrite, axon, synapse, SERVING_CHALLENGE_TIMEOUT)
-        verdict, elapsed_ms, record = score_response(uid, response, case, release)
-        return verdict, elapsed_ms, record, len(getattr(response, 'tokens', None) or [])
+        verdict, record = probe_verdict(uid, response, release, reference)
+        return verdict, record, len(getattr(response, 'tokens', None) or []), response.observed_ttft_ms
 
     started = time.monotonic()
-    results = await asyncio.gather(*(one(case) for case in cases))
-    wall_s = max(time.monotonic() - started, 1e-3)
+    results = await asyncio.gather(*(one(messages) for messages in prompts))
+    wall_s = time.monotonic() - started
     tokens = 0
-    for verdict, _, record, n_tokens in results:
+    ttfts: List[float] = []
+    for verdict, record, n_tokens, ttft_ms in results:
         state.record(record)
         if verdict.passed:
             tokens += n_tokens
-    return tokens / wall_s
+            if ttft_ms is not None and math.isfinite(ttft_ms):
+                ttfts.append(ttft_ms)
+    decode_s = max(wall_s - (min(ttfts) / 1000.0 if ttfts else 0.0), 1e-3)
+    return tokens / decode_s
+
+
+def probe_prompts(count: int) -> List[List[Dict[str, str]]]:
+    """``count`` prompts no other hotkey or round has seen: template + subject + a random salt each."""
+    return [make_prompts(1, seed=secrets.randbits(64), salt=secrets.token_hex(8))[0] for _ in range(count)]
+
+
+def probe_verdict(
+    uid: int, response: InferenceSynapse, release: ServingRelease, reference: Reference
+) -> Tuple[AuditVerdict, RequestRecord]:
+    """Judge one probe response by teacher forcing it under the reference: (verdict, telemetry record).
+
+    A missing response or a wrong model is a failed probe request.
+    """
+    process_time = getattr(getattr(response, 'dendrite', None), 'process_time', None)
+    elapsed_ms = float(process_time) * 1000.0 if process_time is not None else None
+
+    def rec(ok: bool, detail: str) -> RequestRecord:
+        return RequestRecord(
+            ts=time.time(),
+            kind='probe',
+            uid=uid,
+            ok=ok,
+            latency_ms=elapsed_ms,
+            completion_tokens=len(getattr(response, 'tokens', None) or []),
+            ttft_ms=getattr(response, 'ttft_ms', None),
+            decode_tps=getattr(response, 'decode_tps', None),
+            detail=detail,
+        )
+
+    if getattr(response, 'completion', None) is None:
+        dendrite = getattr(response, 'dendrite', None)
+        reason = f'no response ({getattr(dendrite, "status_code", None)} {getattr(dendrite, "status_message", None)})'
+        return AuditVerdict(False, 0.0, float('inf'), reason), rec(False, reason)
+    served = getattr(response, 'served_model_id', None)
+    if served != release.model_id:
+        reason = f'wrong model {served!r}'
+        return AuditVerdict(False, 0.0, float('inf'), reason), rec(False, reason)
+    try:
+        verdict = verify_served(
+            reference,
+            list(response.messages),
+            response.completion,
+            response.tokens,
+            response.token_logprobs,
+            token_ids=response.token_ids,
+        )
+    except Exception as e:  # reference hiccup: an unverified probe request earns no tokens, costs no window
+        verdict = AuditVerdict(False, 0.0, float('inf'), f'could not verify: {e!r}')
+    return verdict, rec(verdict.passed, verdict.reason)
 
 
 def verify_served_round(
@@ -153,7 +214,9 @@ def verify_served_round(
         # choice and throughput is priced by the capacity probe. Fall back to total latency for legacy records.
         speed_ms = req.ttft_ms if req.ttft_ms is not None else req.latency_ms
         credits.setdefault(req.hotkey, []).append(
-            latency_credit(speed_ms) if verdict.passed and speed_ms is not None else 0.0
+            latency_credit(speed_ms, release.ttft_full_ms, release.ttft_zero_ms)
+            if verdict.passed and speed_ms is not None
+            else 0.0
         )
         state.record(
             RequestRecord(
@@ -248,18 +311,18 @@ async def probe_with_retry(
     axon: bt.AxonInfo,
     release: ServingRelease,
     reference: Reference,
-    cases: Sequence[AuditCase],
+    prompts: Sequence[List[Dict[str, str]]],
     retry_delay_s: Optional[float] = None,
 ) -> float:
     """Probe once; if the reading dipped against the miner's recent form, re-measure once later and keep the better."""
-    tps = await probe_axon(state, dendrite, uid, hotkey, axon, release, cases)
+    tps = await probe_axon(state, dendrite, uid, hotkey, axon, release, reference, prompts)
     if probe_dipped(state, hotkey, tps):
         delay = random.uniform(*SERVING_PROBE_RETRY_DELAY_S) if retry_delay_s is None else retry_delay_s
         bt.logging.info(
             f'Serving: UID {uid} probe {tps:.0f} tok/s is a dip against recent form; re-measuring in {delay:.0f}s'
         )
         await asyncio.sleep(delay)
-        again = await probe_axon(state, dendrite, uid, hotkey, axon, release, [reference.sample() for _ in cases])
+        again = await probe_axon(state, dendrite, uid, hotkey, axon, release, reference, probe_prompts(len(prompts)))
         tps = max(tps, again)
     state.probe_history.setdefault(hotkey, deque(maxlen=3)).append(tps)
     return tps
@@ -311,20 +374,28 @@ async def audit_round(
                 probation[uid] = ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=0.0, model_id=release.model_id)
         if not passing:
             continue
-        probe_cases = [reference.sample() for _ in range(SERVING_PROBE_REQUESTS)]
-        if probe_cases:
+        target_tps = release.decode_tps_target or SERVING_PROBE_TARGET_TPS
+        if SERVING_PROBE_REQUESTS > 0:
             rates = await asyncio.gather(
                 *(
                     probe_with_retry(
-                        state, dendrite, uid, hotkey, axon, release, reference, probe_cases, probe_retry_delay_s
+                        state,
+                        dendrite,
+                        uid,
+                        hotkey,
+                        axon,
+                        release,
+                        reference,
+                        probe_prompts(SERVING_PROBE_REQUESTS),
+                        probe_retry_delay_s,
                     )
                     for uid, hotkey, axon, _ in passing
                 )
             )
         else:  # probe disabled: capacity is not measured
-            rates = [SERVING_PROBE_TARGET_TPS] * len(passing)
+            rates = [target_tps] * len(passing)
         for (uid, hotkey, _, credit), tps in zip(passing, rates):
-            capacity = min(1.0, tps / SERVING_PROBE_TARGET_TPS)
+            capacity = min(1.0, tps / target_tps)
             score = credit * capacity
             bt.logging.info(
                 f'Serving: UID {uid} {release.model_id} probe {tps:.0f} tok/s capacity {capacity:.2f} '
@@ -457,39 +528,3 @@ def get_serving_axons(self: 'Validator') -> List[Tuple[int, str, bt.AxonInfo]]:
         if axon is not None and axon.is_serving:
             serving.append((uid, hotkey, axon))
     return serving
-
-
-def score_response(
-    uid: int, response: InferenceSynapse, case: AuditCase, release: ServingRelease
-) -> Tuple[AuditVerdict, float, RequestRecord]:
-    """Measure one probe response: (verdict, elapsed ms, telemetry record).
-
-    A missing response or a wrong model is a failed probe request with infinite latency.
-    """
-    process_time = getattr(getattr(response, 'dendrite', None), 'process_time', None)
-    elapsed_ms = float(process_time) * 1000.0 if process_time is not None else float('inf')
-
-    def rec(ok: bool, detail: str) -> RequestRecord:
-        return RequestRecord(
-            ts=time.time(),
-            kind='probe',
-            uid=uid,
-            ok=ok,
-            latency_ms=elapsed_ms if math.isfinite(elapsed_ms) else None,
-            completion_tokens=len(getattr(response, 'tokens', None) or []),
-            ttft_ms=getattr(response, 'ttft_ms', None),
-            decode_tps=getattr(response, 'decode_tps', None),
-            detail=detail,
-        )
-
-    if getattr(response, 'completion', None) is None:
-        dendrite = getattr(response, 'dendrite', None)
-        reason = f'no response ({getattr(dendrite, "status_code", None)} {getattr(dendrite, "status_message", None)})'
-        return AuditVerdict(False, 0.0, float('inf'), reason), float('inf'), rec(False, reason)
-    served = getattr(response, 'served_model_id', None)
-    if served != release.model_id:
-        reason = f'wrong model {served!r}'
-        return AuditVerdict(False, 0.0, float('inf'), reason), float('inf'), rec(False, reason)
-
-    verdict = verify_response(case, getattr(response, 'tokens', None), getattr(response, 'token_logprobs', None))
-    return verdict, elapsed_ms, rec(verdict.passed, verdict.reason)

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -13,16 +13,20 @@ round score is its window verdict (0/1) times the mean credit over the round's
 served requests — misses earn 0 credit, which folds availability in.
 """
 
+from typing import Optional
+
 from gittensor.constants import (
     SERVING_LATENCY_FULL_CREDIT_MS,
     SERVING_LATENCY_ZERO_CREDIT_MS,
 )
 
 
-def latency_credit(elapsed_ms: float) -> float:
-    if elapsed_ms <= SERVING_LATENCY_FULL_CREDIT_MS:
+def latency_credit(elapsed_ms: float, full_ms: Optional[float] = None, zero_ms: Optional[float] = None) -> float:
+    """``full_ms`` / ``zero_ms`` are the release's blessed bands; None falls back to the constants."""
+    full = full_ms if full_ms is not None else SERVING_LATENCY_FULL_CREDIT_MS
+    zero = zero_ms if zero_ms is not None else SERVING_LATENCY_ZERO_CREDIT_MS
+    if elapsed_ms <= full:
         return 1.0
-    if elapsed_ms >= SERVING_LATENCY_ZERO_CREDIT_MS:
+    if elapsed_ms >= zero:
         return 0.0
-    span = SERVING_LATENCY_ZERO_CREDIT_MS - SERVING_LATENCY_FULL_CREDIT_MS
-    return 1.0 - (elapsed_ms - SERVING_LATENCY_FULL_CREDIT_MS) / span
+    return 1.0 - (elapsed_ms - full) / (zero - full)

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -15,6 +15,7 @@ maintainers run this before claiming conformance; miners run it before registeri
 
 import argparse
 import concurrent.futures
+import json
 import random
 import statistics
 import sys
@@ -263,6 +264,72 @@ def check_overload(rep: Report, base_url: str, model_id: str, parallel: int, max
         )
 
 
+def _stream_once(base_url: str, model_id: str, messages, max_tokens: int, timeout: float) -> Tuple[int, float, float]:
+    """One streamed greedy request: (completion tokens, client-observed TTFT s, total wall s)."""
+    from gittensor.serving.stream import SSEParser
+
+    body = {
+        'model': model_id,
+        'messages': messages,
+        'max_tokens': max_tokens,
+        'temperature': 0,
+        'stream': True,
+        'stream_options': {'include_usage': True},
+    }
+    parser = SSEParser()
+    started = time.monotonic()
+    ttft = None
+    tokens = 0
+    with requests.post(
+        f'{base_url}/v1/chat/completions', headers=auth_headers(API_KEY), json=body, stream=True, timeout=timeout
+    ) as r:
+        r.raise_for_status()
+        for chunk in r.iter_content(chunk_size=None):
+            if ttft is None:
+                ttft = time.monotonic() - started
+            for event in parser.feed(chunk):
+                if event and isinstance(event.get('usage'), dict):
+                    tokens = int(event['usage'].get('completion_tokens') or tokens)
+    return tokens, ttft if ttft is not None else float('inf'), time.monotonic() - started
+
+
+def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float, burst: int, reps: int = 3) -> Dict:
+    """Blessing-time speed facts for one honest card on this runtime, measured the way the validator measures.
+
+    ``single_stream``: one request at a time. ``probe_shaped``: ``burst`` concurrent requests, aggregate verified
+    tokens per second of decode time (batch wall-clock minus the first TTFT) — the number the capacity probe
+    compares a miner against. Client TTFT includes this client's RTT, so decode rates are RTT-free; the TTFT rows
+    are informational unless the client is on-box.
+    """
+    prompts = make_prompts(burst * reps, seed=23)
+    single = []
+    for messages in prompts[:reps]:
+        _stream_once(base_url, model_id, messages, 8, timeout)  # warm
+        tokens, ttft, wall = _stream_once(base_url, model_id, messages, max_tokens, timeout)
+        single.append((tokens / max(wall - ttft, 1e-3), ttft * 1000.0))
+    aggregate = []
+    for i in range(reps):
+        batch = prompts[i * burst : (i + 1) * burst]
+        started = time.monotonic()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=burst) as pool:
+            results = list(pool.map(lambda m: _stream_once(base_url, model_id, m, max_tokens, timeout), batch))
+        wall = time.monotonic() - started
+        tokens = sum(t for t, _, _ in results)
+        first = min(ttft for _, ttft, _ in results)
+        aggregate.append(tokens / max(wall - first, 1e-3))
+    single_tps = statistics.median(t for t, _ in single)
+    probe_tps = statistics.median(aggregate)
+    return {
+        'single_stream_decode_tps': round(single_tps, 1),
+        'probe_shaped_decode_tps': round(probe_tps, 1),
+        'probe_burst': burst,
+        'client_ttft_ms_median': round(statistics.median(t for _, t in single), 1),
+        'max_tokens': max_tokens,
+        # what the release carries: 90% of one honest card leaves room for normal variance, none for a shared card
+        'decode_tps_target': round(0.9 * probe_tps, 1),
+    }
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--base-url', default='http://127.0.0.1:8080')
@@ -276,6 +343,12 @@ def main() -> int:
     )
     ap.add_argument('--overload-max-tokens', type=int, default=512)
     ap.add_argument('--api-key', default=None, help='bearer for a remote runtime (sparkinfer --api-key)')
+    ap.add_argument(
+        '--speed-json',
+        default=None,
+        help='also measure the speed profile (single-stream and probe-shaped decode tok/s) and write it here',
+    )
+    ap.add_argument('--speed-burst', type=int, default=6, help='concurrent requests in the probe-shaped measurement')
     args = ap.parse_args()
     global API_KEY
     API_KEY = args.api_key
@@ -293,6 +366,12 @@ def main() -> int:
         )
     if args.parallel > 0:
         check_overload(rep, base_url, args.model_id, args.parallel, args.overload_max_tokens, args.timeout)
+
+    if args.speed_json:
+        profile = speed_profile(base_url, args.model_id, args.max_tokens, args.timeout, args.speed_burst)
+        with open(args.speed_json, 'w') as f:
+            json.dump(profile, f, indent=2)
+        print(f'\nSpeed profile ({args.speed_json}): {profile}')
 
     failures = rep.must_failures
     print(

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -5,7 +5,7 @@
 #
 # Rents one 1x5090 executor, boots entrius/sparkinfer:<ref> with the loadout's MODEL_SHA256, waits for the
 # model download, runs scripts/check_serving_runtime.py against the pod's public 8080 and writes the report
-# to <out dir>/conformance.txt. Exit code is the checker's (1 = a MUST failed). The pod is removed on every
+# to <out dir>/conformance.txt and the blessing-time speed profile to <out dir>/speed.json. Exit code is the checker's (1 = a MUST failed). The pod is removed on every
 # exit path; --ttl is the backstop if this process dies.
 set -euo pipefail
 
@@ -59,7 +59,7 @@ curl -s "$BASE/v1/models" | tee "$OUT/models.json"; echo
 
 set +e
 uv run python scripts/check_serving_runtime.py --base-url "$BASE" --model-id "$MODEL_ID" \
-  --determinism-count 30 --repeat 3 --parallel 16 2>&1 | tee "$OUT/conformance.txt"
+  --determinism-count 30 --repeat 3 --parallel 16 --speed-json "$OUT/speed.json" 2>&1 | tee "$OUT/conformance.txt"
 RC=${PIPESTATUS[0]}
 set -e
 echo "checker exit $RC (report: $OUT/conformance.txt)"

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Conformance-check a built serving runtime image on a rented RTX 5090 (Lium), then tear the pod down.
+#
+#   LIUM_API_KEY=... scripts/serving_conformance_on_lium.sh <sparkinfer ref> [out dir]
+#
+# Rents one 1x5090 executor, boots entrius/sparkinfer:<ref> with the loadout's MODEL_SHA256, waits for the
+# model download, runs scripts/check_serving_runtime.py against the pod's public 8080 and writes the report
+# to <out dir>/conformance.txt. Exit code is the checker's (1 = a MUST failed). The pod is removed on every
+# exit path; --ttl is the backstop if this process dies.
+set -euo pipefail
+
+REF="${1:?sparkinfer ref (image tag)}"
+OUT="${2:-serving-conformance-$REF}"
+LOADOUT="$(dirname "$0")/../gittensor/validator/weights/serving_loadout.json"
+MODEL_ID=$(jq -r '.releases[0].model_id' "$LOADOUT")
+MODEL_SHA=$(jq -r '.releases[0].model_sha256' "$LOADOUT")
+POD="conf-${REF:0:7}-$RANDOM"
+GPU="${CONFORMANCE_GPU:-5090}"
+RENT_WAIT_MIN="${CONFORMANCE_RENT_WAIT_MIN:-60}"
+BOOT_WAIT_MIN="${CONFORMANCE_BOOT_WAIT_MIN:-45}"
+mkdir -p "$OUT"
+
+cleanup() { lium rm "$POD" -y >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "renting 1x$GPU for entrius/sparkinfer:$REF (waiting up to ${RENT_WAIT_MIN} min for a free card)"
+for ((i = 0; i < RENT_WAIT_MIN; i++)); do
+  NODE=$(lium ls --gpu "$GPU" --format json 2>/dev/null | jq -r '[.[] | select(.gpu_count == 1 and .download_mbps >= 150)] | sort_by(.price_per_hour) | .[0].id // empty')
+  [ -n "$NODE" ] && break
+  sleep 60
+done
+[ -n "${NODE:-}" ] || { echo "no 1x$GPU executor became available in ${RENT_WAIT_MIN} min"; exit 2; }
+lium up "$NODE" --name "$POD" --image "entrius/sparkinfer:$REF" --internal-ports 22,8080 \
+  -e "MODEL_SHA256=$MODEL_SHA" -e SPARKINFER_DETERMINISTIC=1 --ttl 3h -y --no-ssh
+
+echo "waiting for the pod's public 8080 and the model download (up to ${BOOT_WAIT_MIN} min)"
+BASE=""
+for ((i = 0; i < BOOT_WAIT_MIN * 6; i++)); do
+  if [ -z "$BASE" ]; then
+    BASE=$(lium ps --format json 2>/dev/null | python3 -c '
+import json, sys
+name = sys.argv[1]
+for p in json.load(sys.stdin):
+    if p.get("name") != name or p.get("status") != "RUNNING":
+        continue
+    ports = p.get("ports") or {}
+    items = ports.items() if isinstance(ports, dict) else [(x.get("internal") or x.get("internal_port"), x.get("external") or x.get("external_port")) for x in ports]
+    for internal, external in items:
+        if str(internal) == "8080" and external:
+            print(f"http://{p.get(\"ssh_ip\") or p.get(\"ip\")}:{external}")
+' "$POD" || true)
+  fi
+  if [ -n "$BASE" ] && curl -sf --max-time 5 "$BASE/v1/models" >/dev/null 2>&1; then break; fi
+  sleep 10
+done
+[ -n "$BASE" ] && curl -sf --max-time 5 "$BASE/v1/models" >/dev/null || { echo "runtime never answered on $BASE"; lium ps; exit 2; }
+echo "runtime up at $BASE"
+curl -s "$BASE/v1/models" | tee "$OUT/models.json"; echo
+
+set +e
+uv run python scripts/check_serving_runtime.py --base-url "$BASE" --model-id "$MODEL_ID" \
+  --determinism-count 30 --repeat 3 --parallel 16 2>&1 | tee "$OUT/conformance.txt"
+RC=${PIPESTATUS[0]}
+set -e
+echo "checker exit $RC (report: $OUT/conformance.txt)"
+exit "$RC"

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -389,15 +389,16 @@ def test_audit_window_tolerates_one_miss_per_round():
     assert window_threshold(1, SERVING_AUDIT_WINDOW_THRESHOLDS) == window_threshold(SERVING_AUDIT_WINDOW)
 
 
-def test_score_response_feeds_window_metrics():
+def test_probe_verdict_teacher_forces_the_response():
     from gittensor.synapses import InferenceSynapse
-    from gittensor.validator.serving.forward import score_response
+    from gittensor.validator.serving.forward import probe_verdict
 
     release = _echo_release()
-    case = EchoReference(release).sample()
+    ref = EchoReference(release)
+    case = ref.sample()
     miss = InferenceSynapse(messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens)
-    verdict, ms, rec = score_response(3, miss, case, release)
-    assert verdict.positional_overlap == 0.0 and ms == float('inf') and not rec.ok
+    verdict, rec = probe_verdict(3, miss, release, ref)
+    assert not verdict.passed and not rec.ok
     assert rec.latency_ms is None  # inf is not JSON; /v1/serving/status must serialize the record
 
     honest = InferenceSynapse(
@@ -409,12 +410,72 @@ def test_score_response_feeds_window_metrics():
         tokens=list(case.reference_tokens),
         token_logprobs=list(case.reference_logprobs),
     )
-    verdict, _, rec = score_response(3, honest, case, release)
-    assert verdict.positional_overlap == 1.0 and verdict.passed and rec.ok
+    verdict, rec = probe_verdict(3, honest, release, ref)
+    assert verdict.passed and rec.ok
 
     wrong = honest.model_copy(update={'served_model_id': 'other'})
-    verdict, _, rec = score_response(3, wrong, case, release)
-    assert verdict.positional_overlap == 0.0 and rec.detail.startswith('wrong model')
+    verdict, rec = probe_verdict(3, wrong, release, ref)
+    assert not verdict.passed and rec.detail.startswith('wrong model')
+
+    tokens = list(case.reference_tokens)
+    tokens[len(tokens) // 2] = 'xxxxxxxx'
+    lie = honest.model_copy(update={'tokens': tokens, 'completion': ' '.join(tokens)})
+    verdict, rec = probe_verdict(3, lie, release, ref)
+    assert not verdict.passed and verdict.hard
+
+
+def test_probe_prompts_are_unique_per_hotkey_and_salted(monkeypatch):
+    """Two hotkeys probed in one round never see the same prompt, so one card cannot answer for both."""
+    from types import SimpleNamespace
+
+    from gittensor.serving.probe import make_prompts
+
+    good = _echo_release()
+    seen: Dict[int, list] = {}
+    dendrite, _ = _dendrite_echoing(good)
+    inner = dendrite.call_stream
+
+    async def call_stream(target_axon, synapse, timeout, deserialize):
+        seen.setdefault(id(target_axon), []).append(synapse.messages[-1]['content'])
+        async for chunk in inner(target_axon, synapse, timeout, deserialize):
+            yield chunk
+
+    dendrite.call_stream = call_stream
+    a, b = SimpleNamespace(is_serving=True), SimpleNamespace(is_serving=True)
+    state = ServingState(settlement_rounds=1)
+    for uid in (1, 2):
+        state.enqueue_served(_served(uid, good))
+    scores = _round(state, dendrite, [(1, 'hk1', a), (2, 'hk2', b)], good, monkeypatch, probes=3)
+    assert scores['hk1'] > 0 and scores['hk2'] > 0
+    probes_a = [c for c in seen[id(a)] if '(ref ' in c]
+    probes_b = [c for c in seen[id(b)] if '(ref ' in c]
+    assert len(probes_a) == 3 and len(probes_b) == 3
+    assert not set(probes_a) & set(probes_b) and len(set(probes_a)) == 3
+    plain = make_prompts(1, seed=1)[0][-1]['content']
+    assert make_prompts(1, seed=1, salt='abcd')[0][-1]['content'] == f'{plain} (ref abcd)'
+
+
+def test_release_speed_facts_price_capacity_and_latency(tmp_path):
+    from gittensor.serving.loadout import load_serving_loadout
+
+    raw = {
+        'releases': [
+            {
+                'model_id': 'm',
+                'backend': 'echo',
+                'speed': {'decode_tps_target': 900.0, 'ttft_full_ms': 300.0, 'ttft_zero_ms': 900.0},
+            }
+        ]
+    }
+    path = tmp_path / 'loadout.json'
+    path.write_text(json.dumps(raw))
+    release = load_serving_loadout(path).primary
+    assert (release.decode_tps_target, release.ttft_full_ms, release.ttft_zero_ms) == (900.0, 300.0, 900.0)
+    assert latency_credit(300.0, release.ttft_full_ms, release.ttft_zero_ms) == 1.0
+    assert latency_credit(600.0, release.ttft_full_ms, release.ttft_zero_ms) == pytest.approx(0.5)
+    assert latency_credit(400.0) == 1.0 and latency_credit(600.0) == pytest.approx(0.9)  # constants' defaults
+    bare = load_serving_loadout(ECHO_LOADOUT_PATH).primary
+    assert bare.decode_tps_target is None and bare.ttft_full_ms is None
 
 
 def test_latency_credit_matches_measured_latencies():
@@ -591,7 +652,7 @@ def _dendrite_echoing(good: ServingRelease, dead_axons=(), gpu_of=None, token_s:
     import asyncio
     from types import SimpleNamespace
 
-    from gittensor.serving.stream import result_to_sse
+    from gittensor.serving.stream import result_to_sse, sse_event
 
     calls: Dict[int, int] = {}  # id(axon) -> requests sent
     inflight: Dict[object, int] = {}
@@ -602,6 +663,7 @@ def _dendrite_echoing(good: ServingRelease, dead_axons=(), gpu_of=None, token_s:
         if not any(target_axon is d for d in dead_axons):
             gpu = (gpu_of or {}).get(id(target_axon))
             if gpu is not None:
+                yield sse_event({'choices': [{'index': 0, 'delta': {'role': 'assistant'}, 'finish_reason': None}]})
                 inflight[gpu] = inflight.get(gpu, 0) + 1
                 await asyncio.sleep(0)  # let the other concurrent requests register before we measure load
                 await asyncio.sleep(token_s * synapse.max_tokens * inflight[gpu])
@@ -848,7 +910,7 @@ def test_probe_retries_once_on_a_dip_and_keeps_the_better_reading(monkeypatch):
     readings: list = []
     calls = {'n': 0}
 
-    async def fake_probe(state, dendrite, uid, hotkey, axon, release, cases):
+    async def fake_probe(state, dendrite, uid, hotkey, axon, release, reference, prompts):
         calls['n'] += 1
         return readings.pop(0)
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -26,6 +26,8 @@ resync_metagraph
 required_hash_fields
 # bt.Dendrite's lazily-created aiohttp session, preset by the audit thread with an uncapped connector
 _session
+# Reference.sample: reference-case generator kept on the protocol for the conformance checker, bank tooling and tests
+sample
 # bt.StreamingSynapse hooks called by the dendrite
 process_streaming_response
 extract_response_json


### PR DESCRIPTION
Stacked on #1711 (includes its commits; merge that first and this diff shrinks to the serving change).

## The hole

The capacity probe sent the **same 6 prompts to every READY hotkey at the same instant**. N hotkeys on one card could compute each answer once and stream it from all N — each measures ~1 card, one card is paid N times. The 832-combination template space was also precomputable. Capacity is the only thing binding pay to hardware, so this was a pay exploit, not a fairness wobble.

## The fix

- **Salted, per-hotkey probe prompts.** Every probe request gets its own `make_prompts(salt=…)` (template + subject + random salt), never shared across hotkeys or rounds. Verified after the fact by **teacher forcing under the reference** (`verify_served`, same path as served traffic, token ids from #1709) instead of pre-generating a shared reference answer — so unique prompts cost one prefill each on the reference, not 6×N generations.
- **Decode-only throughput.** Capacity = verified tokens ÷ (batch wall-clock − first observed TTFT). Network distance no longer leaks into throughput; it is priced by the TTFT credit where it belongs. One validator's RTT is no longer baked into the yardstick.
- **Speed is a per-release, blessing-time fact.** `serving_loadout.json` releases gain `speed.{decode_tps_target, ttft_full_ms, ttft_zero_ms}`; the validator prices capacity and latency against the release, constants are fallbacks only. `check_serving_runtime.py --speed-json` measures single-stream and probe-shaped (6-concurrent) decode tok/s on the conformance GPU; the CI pin-bump PR writes them, with `decode_tps_target = 0.9 ×` the probe-shaped rate of one honest card. The "one card" bar now moves with sparkinfer as it gets faster — which is also what keeps the multi-hotkey game losing.

`score_response` is replaced by `probe_verdict`. Tests: unique-per-hotkey + salted prompts, teacher-forced probe verdicts (a wrong token is hard), release speed facts pricing capacity/latency, shared-GPU split still ~0.5/0.5 with decode-only measurement.

Not yet: the loadout on `test` carries no `speed` block until the next blessing run writes one, so behaviour on the current pin is unchanged (target 180, bands 500/1500).