### PR TITLE
serving: bless sparkinfer 7498736 with its measured speed facts

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -204,7 +204,7 @@ SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per ro
 # case, caught by the concurrent capacity probe.
 SERVING_LATENCY_FULL_CREDIT_MS = 500.0
 SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
-# Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 12954e6, SPARKINFER_DETERMINISTIC=1), so an
+# Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 7498736, SPARKINFER_DETERMINISTIC=1), so an
 # honest miner reproduces the reference's greedy tokens exactly and its logprobs to float noise; every planted
 # cheater differs on every prompt (measured 2026-08-24, internal serving-experiments notes: honest max |delta| 0.0000,
 # cheapest cheater min mean |delta| 0.0057 / min max |delta| 0.129). Both bands must hold for an audit to pass.

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -30,7 +30,7 @@ Three references, picked per release by ``reference_for``:
 - ``positional_overlap``: fraction of positions whose token matches the
   reference, ignoring divergence (telemetry).
 
-The blessed runtime is bit-reproducible (sparkinfer 12954e6 with
+The blessed runtime is bit-reproducible (sparkinfer 7498736 with
 ``SPARKINFER_DETERMINISTIC=1``), so an honest miner reproduces the reference
 exactly and ``passed`` is decisive per audit: all tokens match and logprobs
 agree to float noise (``SERVING_AUDIT_*`` bands in constants.py, calibrated in

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -1,5 +1,8 @@
 {
-  "pricing": { "tao_usd": 228.79, "updated": "2026-08-26" },
+  "pricing": {
+    "tao_usd": 228.79,
+    "updated": "2026-08-26"
+  },
   "releases": [
     {
       "model_id": "qwen3.6-35b-a3b",
@@ -7,10 +10,17 @@
       "base_url": "http://127.0.0.1:8080",
       "max_tokens": 64,
       "request_timeout": 60,
-      "runtime_pin": "gittensor-ai-lab/sparkinfer@12954e6",
+      "runtime_pin": "gittensor-ai-lab/sparkinfer@7498736",
       "model_file": "unsloth/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
       "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
-      "audit_bank": "serving_audit_bank.json"
+      "audit_bank": "serving_audit_bank.json",
+      "speed": {
+        "decode_tps_target": 258.5,
+        "single_stream_decode_tps": 443.6,
+        "probe_shaped_decode_tps": 287.3,
+        "probe_burst": 6,
+        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27 conformance + soak 4"
+      }
     }
   ]
 }


### PR DESCRIPTION
`entrius/sparkinfer:7498736` (upstream `main` incl. sparkinfer#925: `token_id` on every logprob entry, `bytes` on `/v1/score`) passed `scripts/check_serving_runtime.py` on a rented RTX 5090 (Lium `brave-fox-20`, 2026-08-27 22:35 UTC): every MUST, D1 p05 1.000 / drift p95 0.0000, R8 max |Δ| 0.000000, R6 16-parallel 16×200 no crash. Report + `speed.json` in the private serving-experiments notes (`2026-08-27-7498736-pin/`).

Bumps `runtime_pin` and writes the release's blessing-time speed facts:

| | |
|---|---|
| single-stream decode | 443.6 tok/s |
| probe-shaped (6 concurrent) decode | 287.3 tok/s |
| `decode_tps_target` (0.9 ×) | **258.5** |

This is what #1714's capacity probe now compares a miner against (decode tok/s, TTFT excluded) — up from the 180 constant, which had one validator's RTT baked in. With this pin live, #1709's token-id verification is active end to end and the tokenization-mismatch misses from soak 3 should be gone (soak 4 is running on this image now).

Note: with the `latest`-tag / self-calibration design this file stops carrying a pin at all; until that lands this is the blessing path (#1711).