### PR TITLE
serving: dormant axons leave the report and stop receiving baseline prompts

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -231,6 +231,14 @@ SERVING_QUARANTINE_S = 3600.0
 # inside the permitted-validator budget — it just adds to the evidence. This is what lets a validator with no users
 # verify miners at all, and keeps quiet hours from being a free period.
 SERVING_BASELINE_PER_ROUND = 2
+# Most UIDs are not compute miners: OSS miners run no neuron, and validators' axons exist for PAT traffic. axon.is_serving
+# alone still nominates them, and every baseline prompt to one costs a request_timeout. A hotkey that answers no
+# request with a completion for SERVING_DORMANT_AFTER_ROUNDS consecutive rounds (timeouts, refusals, or an axon that
+# says "Success" and serves nothing) is *dormant*: it leaves the round report, is not persisted, and receives no
+# baseline prompts — except one retry every SERVING_DORMANT_RETRY_ROUNDS so a miner that comes online later is picked
+# up within the hour. A completion resets it. A serving-miner registry replaces this heuristic later.
+SERVING_DORMANT_AFTER_ROUNDS = 3
+SERVING_DORMANT_RETRY_ROUNDS = 12
 SERVING_API_DEFAULT_PORT = 8790
 # Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Set so
 # that only the reference-running validator clears it (2026-08-26: one hotkey holds >1M alpha, the next 0.27M); every

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -89,6 +89,7 @@ class ServingState:
     audits: AuditWindow = field(default_factory=AuditWindow)  # audit-loop thread only; persisted by the validator
     _history: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> last N round scores
     probe_history: Dict[str, Deque[float]] = field(default_factory=dict)  # audit thread only: hotkey -> last tps
+    dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
     last_round: dict = field(default_factory=dict)  # audit thread's summary of the last round, for /v1/serving/status
     settlement_rounds: int = SERVING_SETTLEMENT_ROUNDS
     last_round_ts: float = 0.0

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -49,6 +49,8 @@ import bittensor as bt
 from gittensor.constants import (
     SERVING_BASELINE_PER_ROUND,
     SERVING_CHALLENGE_TIMEOUT,
+    SERVING_DORMANT_AFTER_ROUNDS,
+    SERVING_DORMANT_RETRY_ROUNDS,
     SERVING_MAX_TOKENS,
     SERVING_PROBE_DIP_RATIO,
     SERVING_PROBE_REQUESTS,
@@ -251,13 +253,13 @@ async def baseline_round(
     """Send every serving axon ``per_miner`` baseline prompts at random moments within ``window_s``.
 
     The requests take the same path as user traffic and are queued as served requests, so the next round verifies
-    them like anything else. Quarantined hotkeys are skipped. Returns the number of requests sent.
+    them like anything else. Quarantined and dormant hotkeys are skipped. Returns the number of requests sent.
     """
     rng = rng or random.Random()
     targets = [
         (uid, hotkey, axon)
         for uid, hotkey, axon in serving
-        if state.audits.quarantined_until(hotkey, release.model_id) == 0.0
+        if state.audits.quarantined_until(hotkey, release.model_id) == 0.0 and not skip_baseline(state, hotkey)
     ]
 
     async def one(uid: int, hotkey: str, axon: bt.AxonInfo, delay_s: float) -> None:
@@ -274,6 +276,11 @@ async def baseline_round(
             err = ''
         ok = response is not None and response.completion is not None and response.served_model_id == release.model_id
         status = getattr(getattr(response, 'dendrite', None), 'status_message', None) if response is not None else None
+        if (
+            response is not None and not ok
+        ):  # the axon answered but served nothing: not a compute miner (or a broken one)
+            served_as = getattr(response, 'served_model_id', None) or 'nothing'
+            status = f'no completion: axon answered "{status or "OK"}" serving {served_as}, not {release.model_id}'
         state.enqueue_served(
             ServedRequest(
                 ts=time.time(),
@@ -350,7 +357,11 @@ async def audit_round(
         state.publish_round([], {})
         return {}
 
-    best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in serving}
+    update_dormancy(state, serving, served)
+    active = [(uid, hotkey, axon) for uid, hotkey, axon in serving if not is_dormant(state, hotkey)]
+    dormant = len(serving) - len(active)
+
+    best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in active}
     probation: Dict[int, ReadyMiner] = {}
     summary: Dict[str, int] = {}
     windows: Dict[int, dict] = {}  # per-UID round report; published in state.last_round and persisted to the DB
@@ -367,7 +378,7 @@ async def audit_round(
             continue
         credits = verify_served_round(state, reference, release, served, summary, last_miss)
         passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
-        for uid, hotkey, axon in serving:
+        for uid, hotkey, axon in active:
             window = state.audits.verdict(hotkey, release.model_id)
             round_credits = credits.get(hotkey)
             credit = sum(round_credits) / len(round_credits) if round_credits else 1.0
@@ -425,7 +436,7 @@ async def audit_round(
 
     scores = {hotkey: score for hotkey, (score, _) in best.items()}
     ready: List[ReadyMiner] = []
-    for uid, hotkey, axon in serving:
+    for uid, hotkey, axon in active:
         score, model_id = best[hotkey]
         if score > 0.0:
             ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, model_id=model_id))
@@ -433,15 +444,42 @@ async def audit_round(
     for uid, report in windows.items():
         report['status'] = miner_status(report)
     quarantined = sum(1 for w in windows.values() if w['status'] == 'quarantined')
-    summary.update(ready=len(ready), probation=len(probation), quarantined=quarantined)
+    summary.update(ready=len(ready), probation=len(probation), quarantined=quarantined, dormant=dormant)
     state.publish_round(ready, scores, list(probation.values()), {**summary, 'windows': windows})
     bt.logging.info(
         f'Serving round: served {summary.get("served", 0)} (gateway {summary.get("gateway", 0)} / baseline '
         f'{summary.get("baseline", 0)}) · pass {summary.get("pass", 0)} · miss {summary.get("miss", 0)} · '
         f'strike {summary.get("strike", 0)} · neutral {summary.get("neutral", 0)} · READY {len(ready)} '
-        f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined}'
+        f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined} · dormant {dormant}'
     )
     return scores
+
+
+def update_dormancy(
+    state: ServingState, serving: Sequence[Tuple[int, str, bt.AxonInfo]], served: Sequence[ServedRequest]
+) -> None:
+    """A completion resets a hotkey's dormancy count; a round of requests with none bumps it. Unasked = unchanged."""
+    asked = {req.hotkey for req in served}
+    answered = {req.hotkey for req in served if req.completion}
+    for _, hotkey, _ in serving:
+        if hotkey in answered:
+            state.dormant_rounds[hotkey] = 0
+        elif hotkey in asked:
+            state.dormant_rounds[hotkey] = state.dormant_rounds.get(hotkey, 0) + 1
+
+
+def is_dormant(state: ServingState, hotkey: str) -> bool:
+    return state.dormant_rounds.get(hotkey, 0) >= SERVING_DORMANT_AFTER_ROUNDS
+
+
+def skip_baseline(state: ServingState, hotkey: str) -> bool:
+    """Dormant hotkeys get no baseline prompts except one retry every SERVING_DORMANT_RETRY_ROUNDS; a skipped
+    round still counts so the retry clock keeps moving."""
+    n = state.dormant_rounds.get(hotkey, 0)
+    if n < SERVING_DORMANT_AFTER_ROUNDS or n % SERVING_DORMANT_RETRY_ROUNDS == 0:
+        return False
+    state.dormant_rounds[hotkey] = n + 1
+    return True
 
 
 def miner_status(report: dict) -> str:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -3,6 +3,7 @@
 import json
 from typing import Dict
 
+import bittensor as bt
 import pytest
 from fastapi.testclient import TestClient
 
@@ -1290,3 +1291,67 @@ def test_probe_phase_offset_is_deterministic_and_spread():
 
     a, b = probe_phase_offset('5Gjr7VuY', 300.0), probe_phase_offset('5E2LP6En', 300.0)
     assert a == probe_phase_offset('5Gjr7VuY', 300.0) and 0.0 <= a < 300.0 and 0.0 <= b < 300.0 and a != b
+
+
+def test_dead_axons_go_dormant_and_stop_receiving_baseline_prompts(monkeypatch):
+    """A hotkey that never returns a completion drops out of the report after N rounds and is only retried hourly."""
+    import asyncio
+    import random
+    from types import SimpleNamespace
+
+    from gittensor.constants import SERVING_DORMANT_AFTER_ROUNDS, SERVING_DORMANT_RETRY_ROUNDS
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    live, dead = (SimpleNamespace(is_serving=True) for _ in range(2))
+    dendrite, calls = _dendrite_echoing(good, dead_axons=(dead,))
+    state = ServingState(settlement_rounds=1)
+    serving = [(1, 'hk1', live), (2, 'hk2', dead)]
+
+    def cycle() -> int:
+        sent = asyncio.run(
+            fwd.baseline_round(state, dendrite, serving, good, window_s=0.01, per_miner=1, rng=random.Random(1))  # type: ignore[arg-type]
+        )
+        for q in state.drain_served():
+            state.enqueue_served(q)
+        _round(state, dendrite, serving, good, monkeypatch)
+        return sent
+
+    for _ in range(SERVING_DORMANT_AFTER_ROUNDS - 1):
+        assert cycle() == 2  # still asked while it earns its dormancy
+        assert 2 in state.last_round['windows'] and state.snapshot()['probation_uids'] == [2]
+    assert cycle() == 2  # asked once more; the audit that follows tips it over
+    assert state.last_round['dormant'] == 1 and 2 not in state.last_round['windows']
+    assert state.snapshot()['probation_uids'] == []
+    dead_calls = calls[id(dead)]
+    quiet = 0
+    while cycle() == 1:  # dormant: only the live axon is asked...
+        quiet += 1
+        assert quiet < 3 * SERVING_DORMANT_RETRY_ROUNDS
+    assert quiet == SERVING_DORMANT_RETRY_ROUNDS - SERVING_DORMANT_AFTER_ROUNDS  # ...until the hourly retry
+    assert calls[id(dead)] == dead_calls + 1
+    assert state.last_round['dormant'] == 1  # still dormant after an unanswered retry
+
+
+def test_axon_that_answers_without_a_completion_gets_a_real_reason(monkeypatch):
+    """An OSS/validator axon says "Success" and serves nothing; the miss reason must say so, not "Success"."""
+    import asyncio
+    import random
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import forward as fwd
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+
+    async def consume(_dendrite, _axon, synapse, _timeout):
+        synapse.dendrite = bt.TerminalInfo(status_message='Success')
+        return synapse  # unfilled: no completion, no served_model_id
+
+    monkeypatch.setattr(fwd, 'consume_stream', consume)
+    state = ServingState(settlement_rounds=1)
+    asyncio.run(
+        fwd.baseline_round(state, object(), [(1, 'hk1', axon)], good, window_s=0.01, per_miner=1, rng=random.Random(1))
+    )  # type: ignore[arg-type]
+    (q,) = state.drain_served()
+    assert not q.ok and q.detail.startswith('no completion: axon answered "Success"') and good.model_id in q.detail

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1338,6 +1338,7 @@ def test_axon_that_answers_without_a_completion_gets_a_real_reason(monkeypatch):
     import asyncio
     import random
     from types import SimpleNamespace
+    from typing import Any
 
     from gittensor.validator.serving import forward as fwd
 
@@ -1350,8 +1351,8 @@ def test_axon_that_answers_without_a_completion_gets_a_real_reason(monkeypatch):
 
     monkeypatch.setattr(fwd, 'consume_stream', consume)
     state = ServingState(settlement_rounds=1)
-    asyncio.run(
-        fwd.baseline_round(state, object(), [(1, 'hk1', axon)], good, window_s=0.01, per_miner=1, rng=random.Random(1))
-    )  # type: ignore[arg-type]
+    serving: list = [(1, 'hk1', axon)]
+    dendrite: Any = object()
+    asyncio.run(fwd.baseline_round(state, dendrite, serving, good, window_s=0.01, per_miner=1, rng=random.Random(1)))
     (q,) = state.drain_served()
     assert not q.ok and q.detail.startswith('no completion: axon answered "Success"') and good.model_id in q.detail


### PR DESCRIPTION
First real rounds on test showed the gap: the validator treats every UID with `axon.is_serving` as a compute candidate, so gittensor.io/compute listed 20 "probation" miners that are dead testnet axons and validators, each costing a 60 s baseline timeout per prompt per round. On mainnet that would be ~every UID.

**Dormancy.** A hotkey that answers no request with a completion for `SERVING_DORMANT_AFTER_ROUNDS = 3` consecutive rounds (timeouts, refusals, or an axon that says "Success" and serves nothing) is *dormant*:
- excluded from the round report (`windows`), so not persisted and not shown on `/compute`; counted as `dormant` in the round summary/log line;
- skipped by `baseline_round`, except one retry every `SERVING_DORMANT_RETRY_ROUNDS = 12` (~1 h) so a miner that comes online later is picked up within the hour;
- any completion resets the counter.

Not touched: `get_serving_axons` (still the candidate source), READY/probation logic for responsive miners, the gateway. A serving-miner registry is still the real fix; this removes ~all of the noise until then.

**Reason strings.** An axon that answered with status "Success" but no completion (OSS/validator axons echo the synapse back unfilled) was recorded with reason `Success` — which the UI then showed in red. The reason is now `no completion: axon answered "Success" serving nothing, not qwen3.6-35b-a3b`.

Tests: dormancy lifecycle (asked → dormant → quiet for exactly `RETRY − AFTER` rounds → hourly retry → still dormant), and the reason string. 728 passed, ruff + vulture clean.

https://claude.ai/code/session_01P5CYyMbujwmNVM27o3PQCd
