### PR TITLE
validator: durable serving state (SQLite) + state/log dir on the mounted volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ PORT=8099 # neuron axon port, must be accessible by public
 
 # Options: info, debug, trace
 LOG_LEVEL=info
+LOG_FILE_MAX_MB=10  # rotating bittensor.log under ./data (validator): size per file / files kept
+LOG_FILE_BACKUPS=4
 
 # Path to bittensor wallets on host (default: ~/.bittensor/wallets)
 WALLET_PATH=~/.bittensor/wallets

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -15,7 +15,16 @@ services:
     volumes:
       # 'ro' = readonly
       - ${WALLET_PATH}:/root/.bittensor/wallets:ro
+      # state.npz, serving.db and the rotating bittensor.log live under ./data/<wallet>/<hotkey>/netuid<N>/validator
+      # (the entrypoint passes --logging.logging_dir /app/data), so they outlive the container.
       - ./data:/app/data
+    # `docker logs` buffer: 3 x 10 MB, oldest dropped. Dies with the container — the durable copy is the
+    # rotating bittensor.log under ./data (LOG_FILE_MAX_MB / LOG_FILE_BACKUPS).
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     # optional: uncomment this if you are running validator database
     # networks:
     #   - gittensor_network

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -191,20 +191,6 @@ class AuditWindow:
             window._quarantine[(str(hk), str(mid))] = float(until)
         return window
 
-    def save(self, path: Path) -> None:
-        """Persist so a validator restart does not reset every miner to an empty (lenient) window."""
-        tmp = path.with_suffix(path.suffix + '.tmp')
-        tmp.write_text(json.dumps(self.to_dict()))
-        tmp.replace(path)
-
-    @classmethod
-    def load(cls, path: Path, **kwargs) -> 'AuditWindow':
-        """Load a saved window; a missing or unreadable file yields an empty one."""
-        try:
-            return cls.from_dict(json.loads(path.read_text()), **kwargs)
-        except (OSError, ValueError, TypeError):
-            return cls(**kwargs)
-
     def verdict(self, hotkey: str, model_id: str, now: Optional[float] = None) -> WindowVerdict:
         until = self.quarantined_until(hotkey, model_id, now)
         xs = self._values.get((hotkey, model_id))

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -1,0 +1,103 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Durable serving state for the validator: one SQLite file next to ``state.npz``.
+
+Everything the audit loop otherwise keeps only in RAM — audit windows and quarantines, probe readings, the
+trailing settlement history, dormancy counters — is written after every round in one transaction, and read
+back at startup. A validator restart therefore neither resets every miner to probation nor zeroes settled pay.
+SQLite (stdlib, WAL) rather than JSON so a crash mid-write cannot leave a truncated file behind.
+"""
+
+import json
+import sqlite3
+from collections import deque
+from pathlib import Path
+from typing import Optional
+
+from gittensor.serving.state import ServingState
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_values (hotkey TEXT, model_id TEXT, seq INTEGER, value REAL,
+    PRIMARY KEY (hotkey, model_id, seq));
+CREATE TABLE IF NOT EXISTS quarantine (hotkey TEXT, model_id TEXT, until REAL, PRIMARY KEY (hotkey, model_id));
+CREATE TABLE IF NOT EXISTS probe_history (hotkey TEXT, seq INTEGER, tps REAL, PRIMARY KEY (hotkey, seq));
+CREATE TABLE IF NOT EXISTS round_history (hotkey TEXT, seq INTEGER, score REAL, PRIMARY KEY (hotkey, seq));
+CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
+"""
+
+
+class ServingStore:
+    def __init__(self, path: Path):
+        self.path = path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as db:
+            db.executescript(SCHEMA)
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path, timeout=10.0)
+        db.execute('PRAGMA journal_mode=WAL')
+        return db
+
+    def save(self, state: ServingState) -> None:
+        """Snapshot the audit-thread state in one transaction (the tables are small: a few rows per hotkey)."""
+        audits = state.audits.to_dict()
+        with self._connect() as db:
+            for table in ('audit_values', 'quarantine', 'probe_history', 'round_history', 'dormant'):
+                db.execute(f'DELETE FROM {table}')
+            db.executemany(
+                'INSERT INTO audit_values VALUES (?, ?, ?, ?)',
+                [(hk, mid, i, x) for hk, mid, xs in audits['values'] for i, x in enumerate(xs)],
+            )
+            db.executemany('INSERT INTO quarantine VALUES (?, ?, ?)', audits['quarantine'])
+            db.executemany(
+                'INSERT INTO probe_history VALUES (?, ?, ?)',
+                [(hk, i, x) for hk, xs in state.probe_history.items() for i, x in enumerate(xs)],
+            )
+            db.executemany(
+                'INSERT INTO round_history VALUES (?, ?, ?)',
+                [(hk, i, x) for hk, xs in state._history.items() for i, x in enumerate(xs)],
+            )
+            db.executemany('INSERT INTO dormant VALUES (?, ?)', list(state.dormant_rounds.items()))
+
+    def load(self, state: ServingState) -> ServingState:
+        """Restore a snapshot into ``state``; an empty or unreadable store leaves it untouched."""
+        try:
+            with self._connect() as db:
+                values = db.execute('SELECT hotkey, model_id, value FROM audit_values ORDER BY hotkey, model_id, seq')
+                for hk, mid, x in values:
+                    state.audits.record(hk, mid, x)
+                for hk, mid, until in db.execute('SELECT hotkey, model_id, until FROM quarantine'):
+                    state.audits._quarantine[(hk, mid)] = float(until)
+                for hk, x in db.execute('SELECT hotkey, tps FROM probe_history ORDER BY hotkey, seq'):
+                    state.probe_history.setdefault(hk, deque(maxlen=3)).append(float(x))
+                for hk, x in db.execute('SELECT hotkey, score FROM round_history ORDER BY hotkey, seq'):
+                    state._history.setdefault(hk, deque(maxlen=state.settlement_rounds)).append(float(x))
+                for hk, rounds in db.execute('SELECT hotkey, rounds FROM dormant'):
+                    state.dormant_rounds[hk] = int(rounds)
+        except sqlite3.Error:
+            pass
+        return state
+
+    def migrate_json(self, legacy: Path) -> bool:
+        """One-time import of the pre-SQLite ``serving_audits.json`` window; the file is renamed afterwards."""
+        if not legacy.exists():
+            return False
+        try:
+            raw = json.loads(legacy.read_text())
+        except (OSError, ValueError):
+            return False
+        state = ServingState()
+        for hk, mid, xs in raw.get('values', []):
+            for x in xs:
+                state.audits.record(str(hk), str(mid), float(x))
+        for hk, mid, until in raw.get('quarantine', []):
+            state.audits._quarantine[(str(hk), str(mid))] = float(until)
+        self.save(state)
+        legacy.rename(legacy.with_suffix('.json.migrated'))
+        return True
+
+
+def serving_store_path(full_path: Optional[str]) -> Optional[Path]:
+    """Where serving state lives: next to state.npz in the neuron's state dir, or None when the neuron has none."""
+    return Path(full_path) / 'serving.db' if full_path else None

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -40,7 +40,6 @@ import threading
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 import aiohttp
@@ -63,6 +62,7 @@ from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
 from gittensor.serving.probe import make_prompts
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
+from gittensor.serving.store import ServingStore
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
 from gittensor.validator.serving.persist import ServingRoundStorage
@@ -510,9 +510,11 @@ class ServingAuditThread:
         state: ServingState,
         interval_s: float,
         baseline_per_round: int = SERVING_BASELINE_PER_ROUND,
+        store: Optional[ServingStore] = None,
     ):
         self.validator = validator
         self.state = state
+        self.store = store
         self.interval_s = interval_s
         self.baseline_per_round = baseline_per_round
         self._stop = threading.Event()
@@ -548,12 +550,11 @@ class ServingAuditThread:
             except Exception as e:  # a serving fault must never take the validator down
                 bt.logging.error(f'Serving round failed, no serving scores this round: {e!r}')
                 self.state.publish_round([], {})
-            path = audit_window_path(self.validator)
-            if path is not None:
+            if self.store is not None:
                 try:
-                    self.state.audits.save(path)
-                except OSError as e:
-                    bt.logging.warning(f'Serving: could not persist audit window to {path}: {e}')
+                    self.store.save(self.state)
+                except Exception as e:
+                    bt.logging.warning(f'Serving: could not persist serving state to {self.store.path}: {e!r}')
             if self.storage is not None:
                 try:
                     release = load_serving_loadout().primary
@@ -584,12 +585,6 @@ class ServingAuditThread:
 def probe_phase_offset(hotkey: str, interval_s: float) -> float:
     """Deterministic start offset in [0, interval) for this validator's audit clock."""
     return (int(hashlib.sha256(hotkey.encode()).hexdigest()[:8], 16) % 1_000_000) / 1_000_000 * interval_s
-
-
-def audit_window_path(self: 'Validator') -> Optional[Path]:
-    """Where the rolling audit window is persisted: next to state.npz, or None when the neuron has no state dir."""
-    full_path = getattr(getattr(getattr(self, 'config', None), 'neuron', None), 'full_path', None)
-    return Path(full_path) / 'serving_audits.json' if full_path else None
 
 
 def get_serving_axons(self: 'Validator') -> List[Tuple[int, str, bt.AxonInfo]]:

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -16,10 +16,12 @@
 # DEALINGS IN THE SOFTWARE.
 
 import copy
+import os
 import time
 from abc import ABC, abstractmethod
 
 import bittensor as bt
+from bittensor.utils.btlogging import loggingmachine as bt_loggingmachine
 from websockets.exceptions import ConnectionClosedError
 
 from gittensor import __spec_version__ as spec_version
@@ -65,7 +67,10 @@ class BaseNeuron(ABC):
         self.config.merge(base_config)
         self.check_config(self.config)
 
-        # Set up logging with the provided configuration.
+        # --logging.record_log keeps a rotating copy of the log next to state.npz (the compose mounts that dir), so
+        # both outlive the container; bittensor hard-codes 25 MB x 10, so size it first.
+        bt_loggingmachine.DEFAULT_MAX_ROTATING_LOG_FILE_SIZE = int(os.getenv('LOG_FILE_MAX_MB', '10')) * 1024 * 1024
+        bt_loggingmachine.DEFAULT_LOG_BACKUP_COUNT = int(os.getenv('LOG_FILE_BACKUPS', '4'))
         bt.logging.set_config(config=self.config.logging)
 
         # If a gpu is required, set the device to cuda:N (e.g. cuda:0)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -27,9 +27,9 @@ import wandb
 from gittensor import __version__
 from gittensor.classes import MinerEvaluation, MinerEvaluationCache, ServingPricing
 from gittensor.serving.api import parse_api_keys, start_serving_api
-from gittensor.serving.audit import AuditWindow
 from gittensor.serving.loadout import load_serving_loadout
 from gittensor.serving.state import ServingState
+from gittensor.serving.store import ServingStore, serving_store_path
 from gittensor.validator import pat_storage
 from gittensor.validator.forward import forward
 from gittensor.validator.pat_handler import (
@@ -40,7 +40,7 @@ from gittensor.validator.pat_handler import (
     priority_pat_broadcast,
     priority_pat_check,
 )
-from gittensor.validator.serving.forward import ServingAuditThread, audit_window_path
+from gittensor.validator.serving.forward import ServingAuditThread
 from gittensor.validator.utils.config import (
     SERVING_API_HOST,
     SERVING_API_KEYS,
@@ -97,9 +97,12 @@ class Validator(BaseValidatorNeuron):
         # Serving sub-mechanism (beta): audit loop publishes READY miners here; the inference API dispatches to them.
         # The API starts only when SERVING_API_KEYS is set.
         self.serving_state = ServingState()
-        audits_path = audit_window_path(self)
-        if audits_path is not None:
-            self.serving_state.audits = AuditWindow.load(audits_path)
+        self.serving_store = None
+        store_path = serving_store_path(getattr(getattr(self.config, 'neuron', None), 'full_path', None))
+        if store_path is not None:
+            self.serving_store = ServingStore(store_path)
+            self.serving_store.migrate_json(store_path.with_name('serving_audits.json'))
+            self.serving_store.load(self.serving_state)
         self.serving_api = None
         if SERVING_ENABLED:
             api_keys = parse_api_keys(SERVING_API_KEYS)
@@ -118,7 +121,7 @@ class Validator(BaseValidatorNeuron):
             else:
                 bt.logging.info('Serving: SERVING_API_KEYS unset — audits only, no API')
             self.serving_audits = ServingAuditThread(
-                self, self.serving_state, SERVING_AUDIT_INTERVAL_S, SERVING_BASELINE_PER_ROUND
+                self, self.serving_state, SERVING_AUDIT_INTERVAL_S, SERVING_BASELINE_PER_ROUND, self.serving_store
             )
             self.serving_audits.start()
 

--- a/scripts/vali-entrypoint.sh
+++ b/scripts/vali-entrypoint.sh
@@ -14,4 +14,5 @@ exec python neurons/validator.py \
   --subtensor.network ${SUBTENSOR_NETWORK} \
   --axon.port ${PORT} \
   --logging.${LOG_LEVEL} \
+  --logging.record_log --logging.logging_dir /app/data \
   "$@"

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1,6 +1,7 @@
 """Tests for the serving beta: deterministic backend, audit verification, gateway dispatch, emission pool blending."""
 
 import json
+from collections import deque
 from typing import Dict
 
 import bittensor as bt
@@ -488,29 +489,53 @@ def test_latency_credit_matches_measured_latencies():
     assert latency_credit(600.0 + intercontinental_rtt + 2 * 150.0) < 0.4  # slow runtime behind the proxy
 
 
-def test_audit_window_persists_across_restart(tmp_path):
-    path = tmp_path / 'serving_audits.json'
-    assert AuditWindow.load(path).verdict('hk', 'm').n_audits == 0  # missing file -> empty window
-    w = AuditWindow(size=3)
+def test_serving_store_round_trips_audit_thread_state(tmp_path):
+    from gittensor.serving.store import ServingStore, serving_store_path
+
+    path = serving_store_path(str(tmp_path))
+    assert path == tmp_path / 'serving.db' and serving_store_path(None) is None
+    store = ServingStore(path)  # type: ignore[arg-type]
+    assert store.load(ServingState()).audits.verdict('hk', 'm').n_audits == 0  # empty store -> untouched state
+
+    state = ServingState(settlement_rounds=3)
+    state.audits = AuditWindow(size=3)
     for x in (0.2, 0.9, 0.8, 0.7):  # 0.2 rolls out
-        w.record('hk', 'm', x)
-    w.record('hk2', 'm', 1.0)
-    w.save(path)
-    loaded = AuditWindow.load(path, size=3)
-    assert loaded.verdict('hk', 'm').as_dict() == w.verdict('hk', 'm').as_dict()
-    assert loaded.verdict('hk2', 'm').n_audits == 1
-    path.write_text('not json')
-    assert AuditWindow.load(path).verdict('hk', 'm').n_audits == 0  # corrupt file -> empty window, no crash
+        state.audits.record('hk', 'm', x)
+    state.audits.record('hk2', 'm', 1.0)
+    state.audits.strike('hk3', 'm', now=1000.0)
+    state.probe_history['hk'] = deque([180.0, 178.0], maxlen=3)
+    state.publish_round([], {'hk': 0.9})
+    state.publish_round([], {'hk': 1.0})
+    state.dormant_rounds['dead'] = 2
+    store.save(state)
+
+    loaded = store.load(ServingState(settlement_rounds=3, audits=AuditWindow(size=3)))
+    assert loaded.audits.verdict('hk', 'm').as_dict() == state.audits.verdict('hk', 'm').as_dict()
+    assert loaded.audits.verdict('hk2', 'm').n_audits == 1
+    assert loaded.audits.quarantined_until('hk3', 'm', now=1500.0) == state.audits.quarantined_until(
+        'hk3', 'm', now=1500.0
+    )
+    assert list(loaded.probe_history['hk']) == [180.0, 178.0]
+    assert loaded.settled_scores() == state.settled_scores()
+    assert loaded.dormant_rounds == {'dead': 2}
+
+    state.audits.record('hk', 'm', 0.1)
+    store.save(state)  # a second save replaces, never appends
+    assert store.load(ServingState(audits=AuditWindow(size=3))).audits.verdict('hk', 'm').n_audits == 3
 
 
-def test_audit_window_path_follows_neuron_state_dir(tmp_path):
-    from types import SimpleNamespace
+def test_serving_store_migrates_the_legacy_json_window(tmp_path):
+    from gittensor.serving.store import ServingStore
 
-    from gittensor.validator.serving.forward import audit_window_path
-
-    vali = SimpleNamespace(config=SimpleNamespace(neuron=SimpleNamespace(full_path=str(tmp_path))))
-    assert audit_window_path(vali) == tmp_path / 'serving_audits.json'  # type: ignore[arg-type]
-    assert audit_window_path(SimpleNamespace()) is None  # type: ignore[arg-type]
+    legacy = tmp_path / 'serving_audits.json'
+    legacy.write_text(json.dumps({'values': [['hk', 'm', [1.0, 0.0, 1.0]]], 'quarantine': [['hk2', 'm', 9e12]]}))
+    store = ServingStore(tmp_path / 'serving.db')
+    assert store.migrate_json(legacy) and not legacy.exists() and (tmp_path / 'serving_audits.json.migrated').exists()
+    loaded = store.load(ServingState())
+    assert loaded.audits.verdict('hk', 'm').n_audits == 3 and loaded.audits.quarantined_until('hk2', 'm') > 0
+    assert not store.migrate_json(legacy)  # already migrated
+    (tmp_path / 'broken.json').write_text('nope')
+    assert not store.migrate_json(tmp_path / 'broken.json')
 
 
 def test_probe_score_parses_teacher_forced_response(monkeypatch):
@@ -744,9 +769,11 @@ def test_audit_window_strike_wipes_and_quarantines(tmp_path):
     w.record('hk', 'm', 1.0)
     assert not w.verdict('hk', 'm', now=1050.0).passed  # still quarantined even with a clean record
     assert w.verdict('hk', 'm', now=1101.0).passed and w.verdict('hk', 'm', now=1101.0).quarantined_until == 0.0
-    path = tmp_path / 'audits.json'
-    w.save(path)
-    again = AuditWindow.load(path, quarantine_s=100.0)
+    from gittensor.serving.store import ServingStore
+
+    store = ServingStore(tmp_path / 'serving.db')
+    store.save(ServingState(audits=w))
+    again = store.load(ServingState(audits=AuditWindow(quarantine_s=100.0))).audits
     assert again.verdict('hk', 'm', now=1050.0).quarantined_until == 1100.0
 
 


### PR DESCRIPTION
Soak 4 finding: a validator redeploy (`docker compose down` / container recreate) reset every miner's audit window — `serving_audits.json` and `state.npz` both live in the container's `~/.bittensor/miners/...`, which is not mounted. Every restart dropped the whole fleet to probation for ~3 rounds and zeroed the OSS scores' state too.

Same recipe allways uses for its validator:

- **State dir on the volume.** `vali-entrypoint.sh` passes `--logging.record_log --logging.logging_dir /app/data`; bittensor derives `neuron.full_path` from it, so `state.npz`, the serving state and the rotating `bittensor.log` all land under `./data/<wallet>/<hotkey>/netuid<N>/validator/` (already mounted). `LOG_FILE_MAX_MB` / `LOG_FILE_BACKUPS` (default 10 MB × 4) size the durable log instead of bittensor's 25 MB × 10.
- **`docker logs` buffer capped** at 3 × 10 MB in the compose.
- **Serving state in SQLite, not JSON.** New `gittensor/serving/store.py`: one `serving.db` (stdlib `sqlite3`, WAL) written in a single transaction after every round and read at startup — audit windows + quarantines (as before) **plus** probe history, the 12-round settlement history and dormancy counters, so a restart no longer zeroes settled pay either. Atomic by construction; the JSON overwrite was not. A pre-existing `serving_audits.json` is imported once and renamed `.migrated`.

Tests: store round-trip of every field, replace-not-append on resave, legacy JSON migration, strike/quarantine survives a reload.

Operator note: on an existing deployment the first start after this change begins with an empty state dir under `./data` (the old in-container files are gone with the container anyway); from then on restarts keep everything.