### PR TITLE
serving: soak 4 small fixes (cap log, loadout log spam, Lium 5090 filter)

### DIFF
--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -128,9 +128,16 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
     if key_override:
         loadout.primary.reference_api_key = key_override
 
-    for release in loadout.releases:
-        bt.logging.info(
-            f'Serving release: model={release.model_id} backend={release.backend} pin={release.runtime_pin} '
-            f'reference={"live " + release.reference_url if release.reference_url else (release.audit_bank or "echo")}'
-        )
+    lines = [
+        f'Serving release: model={release.model_id} backend={release.backend} pin={release.runtime_pin} '
+        f'reference={"live " + release.reference_url if release.reference_url else (release.audit_bank or "echo")}'
+        for release in loadout.releases
+    ]
+    if lines != _last_logged:  # the loadout is re-read several times a round; announce it when it changes
+        _last_logged[:] = lines
+        for line in lines:
+            bt.logging.info(line)
     return loadout
+
+
+_last_logged: List[str] = []

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -72,7 +72,7 @@ def blend_emission_pools(
         recycle_share += serving_unallocated + (SERVING_EMISSION_SHARE_CAP - share)
         bt.logging.info(
             f'Serving pool: {card_equiv:.2f} card-equivalents x ${SERVING_GPU_HOUR_USD:.2f}/h = '
-            f'{share * 100:.2f}% of emissions (cap {SERVING_EMISSION_SHARE_CAP * 100:.0f}%) across '
+            f'{share * 100:.2f}% of emissions (cap {SERVING_EMISSION_SHARE_CAP * 100:g}%) across '
             f'{sum(1 for r in serving_rewards.values() if r > 0)} serving miners'
         )
 

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -25,7 +25,8 @@ trap cleanup EXIT
 
 echo "renting 1x$GPU for entrius/sparkinfer:$REF (waiting up to ${RENT_WAIT_MIN} min for a free card)"
 for ((i = 0; i < RENT_WAIT_MIN; i++)); do
-  NODE=$(lium ls --gpu "$GPU" --format json 2>/dev/null | jq -r '[.[] | select(.gpu_count == 1 and .download_mbps >= 150)] | sort_by(.price_per_hour) | .[0].id // empty')
+  # `lium ls --gpu X --format json` returns [] even when cards are listed; filter the full listing instead.
+  NODE=$(lium ls --format json 2>/dev/null | jq -r --arg gpu "RTX$GPU" '[.[] | select(.gpu_type == $gpu and .gpu_count == 1 and .vram_gb >= 30 and .download_mbps >= 150)] | sort_by(.price_per_hour) | .[0].id // empty')
   [ -n "$NODE" ] && break
   sleep 60
 done


### PR DESCRIPTION
Three things soak 4 surfaced, none behaviour-changing:

- `Serving pool: … (cap 4%)` — the 3.5 % cap was formatted `.0f`. Now `:g` → `cap 3.5%`.
- `Serving release: …` logged ~4× per round (the loadout is re-read by the audit round, the persist step and pricing). Logged only when the lines change.
- `scripts/serving_conformance_on_lium.sh` used `lium ls --gpu 5090 --format json`, which returns `[]` even while 5090s are listed (the CLI's `--gpu` filter does not match `RTX5090` in JSON mode) — the CI conformance job would have waited its 20 min and failed every time. Filters the full listing on `gpu_type == "RTX5090"`, and requires `vram_gb >= 30` so the 48 GB "RTX6000" (Ada, sm_89) nodes can never be picked for an arch-120 image.