### PR TITLE
serving: capacity = saturation burst at the blessed concurrency, floor under 0.6× blessed

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -125,7 +125,7 @@ jobs:
                  decode_tps_target: $speed[0].decode_tps_target,
                  single_stream_decode_tps: $speed[0].single_stream_decode_tps,
                  probe_shaped_decode_tps: $speed[0].probe_shaped_decode_tps,
-                 probe_burst: $speed[0].probe_burst,
+                 burst_concurrency: $speed[0].burst_concurrency,
                  measured_on: ($pin + " on a rented RTX 5090, actions run " + $run)
                })' \
             gittensor/validator/weights/serving_loadout.json > /tmp/loadout.json
@@ -144,7 +144,7 @@ jobs:
             `entrius/sparkinfer:${{ env.REF }}` passed `scripts/check_serving_runtime.py` on a rented RTX 5090
             (run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — report in the
             `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin` and writes the release's
-            blessing-time speed facts (`speed.decode_tps_target` = 0.9 x the probe-shaped decode tok/s of one honest
-            card on this runtime — what earns capacity 1.0). Update the sha named in the comments at
+            blessing-time speed facts (`speed.decode_tps_target` = aggregate decode tok/s of one honest card at the
+            blessed `burst_concurrency` — capacity 1.0; 0 under the floor ratio). Update the sha named in the comments at
             `gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.
           add-paths: gittensor/validator/weights/serving_loadout.json

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -176,18 +176,17 @@ assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHA
 SERVING_SETTLEMENT_ROUNDS = 12  # 12 x 5-minute audit rounds
 SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before a probe request counts as failed
 SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
-# Capacity probe: after settling the window, every READY miner is sent SERVING_PROBE_REQUESTS reference prompts at the
-# same instant as every other miner. Verified tokens delivered per wall-clock second, over
-# SERVING_PROBE_TARGET_TPS, capped at 1, is the miner's capacity. One RTX 5090 delivers a fixed throughput however many
-# hotkeys front it, so N hotkeys on one card share one card's pay; a hotkey with more than one card is capped at one
-# card's worth (register one hotkey per GPU). Target = what one honest 5090 delivers under this probe as measured by the
-# validator (RTT included). Calibrated on testnet 2026-08-25 (validator on a DO droplet, card in Romania): one miner alone
-# 183-186 tok/s; two hotkeys on the same card 104-115 tok/s each (sum 210-227) -> capacities ~1.0 vs ~0.6.
-# Probe outcomes affect capacity only, never the audit window (a slow host halves its pay; it does not flap out of READY).
-SERVING_PROBE_REQUESTS = 6
-# Fallback only: a release carries its own blessing-time `speed.decode_tps_target` (serving_loadout.json), measured on
-# that runtime by the conformance job as decode tok/s (TTFT excluded), so the bar moves with the runtime.
-SERVING_PROBE_TARGET_TPS = 180.0
+# Capacity = saturation burst. After settling the window, every READY miner is sent the blessed concurrency of
+# salted prompts at the same instant as every other miner (fleet-wide), verified afterwards by teacher forcing.
+# Verified tokens per second of decode time (batch wall-clock minus the first TTFT) over the release's blessed
+# aggregate at that concurrency (`speed.decode_tps_target`, measured on one honest 5090 by the conformance run) is
+# the capacity, capped at 1. Below SERVING_PROBE_FLOOR_RATIO x blessed the capacity is 0: sparkinfer queues rather
+# than 429s past its concurrency (2026-08-27: 16/24/32 concurrent all ~275 tok/s aggregate, wall 3.7 s -> 7 s), so
+# two hotkeys on one card each see ~half the blessed aggregate and fall under the floor. Probe outcomes affect
+# capacity only, never the window. The constants are fallbacks for a release without speed facts.
+SERVING_PROBE_REQUESTS = 16
+SERVING_PROBE_TARGET_TPS = 280.0
+SERVING_PROBE_FLOOR_RATIO = 0.6
 # A probe reading can only be too low (another validator's burst, a user spike, a blip), never too high: the miner
 # had to deliver those verified tokens. A reading under SERVING_PROBE_DIP_RATIO x the miner's median of its last
 # three is re-measured once after a random SERVING_PROBE_RETRY_DELAY_S and the better reading kept; a real slowdown

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -51,7 +51,8 @@ class ServingRelease:
     # Speed of one honest card on this exact runtime, measured at blessing time (scripts/check_serving_runtime.py
     # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator prices capacity and latency
     # against these, so the "one card" bar tracks the runtime as it gets faster. None -> the constants' defaults.
-    decode_tps_target: Optional[float] = None  # probe-shaped aggregate decode tok/s that earns capacity 1.0
+    decode_tps_target: Optional[float] = None  # aggregate decode tok/s of one honest card at burst_concurrency
+    burst_concurrency: Optional[int] = None  # requests in the saturation burst (the runtime's blessed concurrency)
     ttft_full_ms: Optional[float] = None  # validator-observed TTFT up to which latency credit is 1.0
     ttft_zero_ms: Optional[float] = None  # ... and at which it reaches 0.0
 
@@ -71,6 +72,7 @@ class ServingRelease:
             reference_api_key=raw.get('reference_api_key'),
             request_timeout=float(raw.get('request_timeout', 60.0)),
             decode_tps_target=_optional_float(speed.get('decode_tps_target')),
+            burst_concurrency=int(speed['burst_concurrency']) if speed.get('burst_concurrency') else None,
             ttft_full_ms=_optional_float(speed.get('ttft_full_ms')),
             ttft_zero_ms=_optional_float(speed.get('ttft_zero_ms')),
         )

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -18,15 +18,16 @@ published as *probation* so baseline traffic can give them a window.
 
     round score = window passes (0/1) x mean latency credit over this round's served requests x capacity
 
-``capacity`` comes from the round's load probe: every READY miner gets
-``SERVING_PROBE_REQUESTS`` prompts at the same instant as every other miner —
+``capacity`` comes from the round's saturation burst: every READY miner gets
+the release's blessed concurrency of prompts at the same instant as every other miner —
 each prompt unique to that hotkey and round (salted), verified afterwards by
 teacher forcing under the reference like any served request, so an answer can
 neither be shared between hotkeys on one card nor precomputed. Verified tokens
 per second of *decode* time (batch wall-clock minus the first observed TTFT, so
 network distance prices latency, not throughput) over the release's blessed
-``decode_tps_target`` (capped at 1) is its capacity — so hotkeys sharing one
-GPU share one GPU's pay. Probe outcomes affect capacity only, never the window. Round scores are settled
+``decode_tps_target`` (capped at 1, 0 under ``SERVING_PROBE_FLOOR_RATIO``) is its
+capacity — hotkeys sharing one GPU each fall under the floor. Probe outcomes
+affect capacity only, never the window. Round scores are settled
 over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
 """
 
@@ -52,6 +53,7 @@ from gittensor.constants import (
     SERVING_DORMANT_RETRY_ROUNDS,
     SERVING_MAX_TOKENS,
     SERVING_PROBE_DIP_RATIO,
+    SERVING_PROBE_FLOOR_RATIO,
     SERVING_PROBE_REQUESTS,
     SERVING_PROBE_RETRY_DELAY_S,
     SERVING_PROBE_TARGET_TPS,
@@ -410,7 +412,8 @@ async def audit_round(
         if not passing:
             continue
         target_tps = release.decode_tps_target or SERVING_PROBE_TARGET_TPS
-        if SERVING_PROBE_REQUESTS > 0:
+        burst = release.burst_concurrency or SERVING_PROBE_REQUESTS
+        if burst > 0:
             rates = await asyncio.gather(
                 *(
                     probe_with_retry(
@@ -421,7 +424,7 @@ async def audit_round(
                         axon,
                         release,
                         reference,
-                        probe_prompts(SERVING_PROBE_REQUESTS),
+                        probe_prompts(burst),
                         probe_retry_delay_s,
                     )
                     for uid, hotkey, axon, _ in passing
@@ -430,7 +433,10 @@ async def audit_round(
         else:  # probe disabled: capacity is not measured
             rates = [target_tps] * len(passing)
         for (uid, hotkey, _, credit), tps in zip(passing, rates):
-            capacity = min(1.0, tps / target_tps)
+            ratio = tps / target_tps
+            capacity = (
+                min(1.0, ratio) if ratio >= SERVING_PROBE_FLOOR_RATIO else 0.0
+            )  # under the floor = shared / not a card
             score = credit * capacity
             bt.logging.info(
                 f'Serving: UID {uid} {release.model_id} probe {tps:.0f} tok/s capacity {capacity:.2f} '

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -15,11 +15,11 @@
       "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
       "audit_bank": "serving_audit_bank.json",
       "speed": {
-        "decode_tps_target": 258.5,
+        "decode_tps_target": 280.0,
         "single_stream_decode_tps": 443.6,
-        "probe_shaped_decode_tps": 287.3,
-        "probe_burst": 6,
-        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27 conformance + soak 4"
+        "probe_shaped_decode_tps": 280.0,
+        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 \u2014 queues past 16, wall 3.7 s -> 7 s)",
+        "burst_concurrency": 16
       }
     }
   ]

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -325,8 +325,9 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
         'probe_burst': burst,
         'client_ttft_ms_median': round(statistics.median(t for _, t in single), 1),
         'max_tokens': max_tokens,
-        # what the release carries: 90% of one honest card leaves room for normal variance, none for a shared card
-        'decode_tps_target': round(0.9 * probe_tps, 1),
+        # what the release carries: capacity = aggregate / decode_tps_target capped at 1, 0 under the floor ratio
+        'decode_tps_target': round(probe_tps, 1),
+        'burst_concurrency': burst,
     }
 
 
@@ -348,7 +349,9 @@ def main() -> int:
         default=None,
         help='also measure the speed profile (single-stream and probe-shaped decode tok/s) and write it here',
     )
-    ap.add_argument('--speed-burst', type=int, default=6, help='concurrent requests in the probe-shaped measurement')
+    ap.add_argument(
+        '--speed-burst', type=int, default=16, help='concurrent requests in the saturation burst (blessed concurrency)'
+    )
     args = ap.parse_args()
     global API_KEY
     API_KEY = args.api_key

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1092,7 +1092,7 @@ def test_audit_round_skips_release_without_reference(monkeypatch):
 
 
 def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
-    """Two hotkeys on one card each get about half the capacity a lone card gets; a lone card gets ~1."""
+    """Two hotkeys on one card each see about half the blessed aggregate and earn nothing; a lone card gets ~1."""
     from types import SimpleNamespace
 
     from gittensor.validator.serving import forward as fwd
@@ -1125,8 +1125,8 @@ def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
     serving = [(1, 'hk1', lone), (2, 'hk2', a), (3, 'hk3', b)]
     scores = _round(state, dendrite, serving, good, monkeypatch, probes=4)
     assert scores['hk1'] == pytest.approx(1.0, abs=0.15)
-    assert scores['hk2'] == pytest.approx(0.5, abs=0.15) and scores['hk3'] == pytest.approx(0.5, abs=0.15)
-    assert scores['hk2'] + scores['hk3'] == pytest.approx(scores['hk1'], abs=0.2)
+    assert scores['hk2'] == 0.0 and scores['hk3'] == 0.0  # each sees ~half the blessed aggregate: under the floor
+    assert all(r.ok for r in state.recent(50) if r.kind == 'probe')  # the burst was answered correctly, just slowly
 
 
 def test_probe_misses_cost_capacity_not_the_window(monkeypatch):


### PR DESCRIPTION
Measured on the soak-4 5090 (`entrius/sparkinfer:7498736`, 64-token requests):

| concurrent | wall | aggregate decode | TTFT max |
|---|---|---|---|
| 6 | 1.6 s | ~255 tok/s | 0.2 s |
| **16** | 3.7 s | **280** | 2.9 s |
| 24 | 5.4 s | 268 | 3.8 s |
| 32 | 7.0 s | 275 | 6.0 s |

sparkinfer **queues** past its concurrency rather than 429ing, and aggregate throughput is flat — so two hotkeys on one card under two 16-bursts don't error, they each get ~half the blessed aggregate. That is the signature this PR keys on.

- The probe is now the **saturation burst**: `speed.burst_concurrency` (16 for this pin) salted, teacher-force-verified requests per READY miner, same instant fleet-wide, as before.
- `capacity = min(1, aggregate / speed.decode_tps_target)` where the target is the blessed aggregate at that concurrency (280, measured — no 0.9 discount), and **0 below `SERVING_PROBE_FLOOR_RATIO = 0.6`**: a shared card (≈0.5×) or something that is not a card earns nothing that round. Speed above the floor still prices continuously up to 1.0 — never more than one card.
- Checker `--speed-burst` defaults to 16 and writes `burst_concurrency`; the CI pin-bump carries it into the loadout. Loadout for 7498736 updated with the measured numbers.
- Tests: shared-GPU split now asserts both sharers score 0 while their answers were verified correct (probe outcomes never touch the window).

Open question (Alex, 8/27 late): burst scheduling — simultaneous fleet-wide (this PR, as today) vs one hotkey at a time. See the note in `13-attest-and-speed-design`.