### PR TITLE
serving: pay = window × speed on served traffic (TTFT × load-aware decode, 0.5× floor); burst is telemetry

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -126,6 +126,7 @@ jobs:
                  single_stream_decode_tps: $speed[0].single_stream_decode_tps,
                  probe_shaped_decode_tps: $speed[0].probe_shaped_decode_tps,
                  burst_concurrency: $speed[0].burst_concurrency,
+                 decode_per_request: $speed[0].decode_per_request,
                  measured_on: ($pin + " on a rented RTX 5090, actions run " + $run)
                })' \
             gittensor/validator/weights/serving_loadout.json > /tmp/loadout.json

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -176,17 +176,13 @@ assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHA
 SERVING_SETTLEMENT_ROUNDS = 12  # 12 x 5-minute audit rounds
 SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before a probe request counts as failed
 SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
-# Capacity = saturation burst. After settling the window, every READY miner is sent the blessed concurrency of
-# salted prompts at the same instant as every other miner (fleet-wide), verified afterwards by teacher forcing.
-# Verified tokens per second of decode time (batch wall-clock minus the first TTFT) over the release's blessed
-# aggregate at that concurrency (`speed.decode_tps_target`, measured on one honest 5090 by the conformance run) is
-# the capacity, capped at 1. Below SERVING_PROBE_FLOOR_RATIO x blessed the capacity is 0: sparkinfer queues rather
-# than 429s past its concurrency (2026-08-27: 16/24/32 concurrent all ~275 tok/s aggregate, wall 3.7 s -> 7 s), so
-# two hotkeys on one card each see ~half the blessed aggregate and fall under the floor. Probe outcomes affect
-# capacity only, never the window. The constants are fallbacks for a release without speed facts.
+# Load burst (telemetry). After settling the window, every READY miner is sent the blessed concurrency of salted
+# prompts at the same instant, verified afterwards by teacher forcing; verified tokens per second of decode time over
+# the release's blessed aggregate at that concurrency (`speed.decode_tps_target`) is reported per round and persisted
+# (dashboard: does this card's aggregate look like one 5090's?). It does not enter pay: capacity is priced by speed on
+# served traffic (below). The constants are fallbacks for a release without speed facts.
 SERVING_PROBE_REQUESTS = 16
 SERVING_PROBE_TARGET_TPS = 280.0
-SERVING_PROBE_FLOOR_RATIO = 0.6
 # A probe reading can only be too low (another validator's burst, a user spike, a blip), never too high: the miner
 # had to deliver those verified tokens. A reading under SERVING_PROBE_DIP_RATIO x the miner's median of its last
 # three is re-measured once after a random SERVING_PROBE_RETRY_DELAY_S and the better reading kept; a real slowdown
@@ -203,6 +199,16 @@ SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per ro
 # case, caught by the concurrent capacity probe.
 SERVING_LATENCY_FULL_CREDIT_MS = 500.0
 SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
+# Decode speed on served traffic. Each served request with at least SERVING_DECODE_MIN_TOKENS completion tokens
+# yields a validator-observed decode rate, tokens / (total - TTFT); it is compared with what one honest card does on
+# this runtime at the number of requests THIS validator had in flight to the miner (the release's blessing-time
+# `speed.decode_per_request` curve, interpolated), so a miner busy with our own load is not penalised for it.
+# Credit = min(1, observed / expected); under SERVING_DECODE_FLOOR_RATIO it is 0 — a card shared between hotkeys or a
+# runtime that is not the blessed one is slower by integer factors under load, honest variance is +-10%. Round credit
+# is the mean over the round's served requests (misses 0), so availability, latency and speed price together.
+SERVING_DECODE_FLOOR_RATIO = 0.5
+SERVING_DECODE_MIN_TOKENS = 32
+SERVING_DECODE_PER_REQUEST_FALLBACK = ((1, 440.0), (6, 46.0), (16, 19.0))  # (concurrent requests, tok/s each)
 # Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 7498736, SPARKINFER_DETERMINISTIC=1), so an
 # honest miner reproduces the reference's greedy tokens exactly and its logprobs to float noise; every planted
 # cheater differs on every prompt (measured 2026-08-24, internal serving-experiments notes: honest max |delta| 0.0000,

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -130,6 +130,7 @@ def build_app(
         miner = state.acquire(release.model_id, probation=key in baseline)
         if miner is None:
             raise HTTPException(status_code=429, detail='no READY serving capacity')
+        inflight = state.inflight().get(miner.uid, 1)
 
         request_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())
@@ -157,6 +158,7 @@ def build_app(
                     else '',
                     source='gateway',
                     ttft_ms=finite_or_none(getattr(result, 'observed_ttft_ms', None)) if result else None,
+                    inflight=inflight,
                 )
             )
             state.record(

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -24,7 +24,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import bittensor as bt
 
@@ -52,7 +52,8 @@ class ServingRelease:
     # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator prices capacity and latency
     # against these, so the "one card" bar tracks the runtime as it gets faster. None -> the constants' defaults.
     decode_tps_target: Optional[float] = None  # aggregate decode tok/s of one honest card at burst_concurrency
-    burst_concurrency: Optional[int] = None  # requests in the saturation burst (the runtime's blessed concurrency)
+    burst_concurrency: Optional[int] = None  # requests in the load burst (the runtime's blessed concurrency)
+    decode_per_request: Optional[Dict[int, float]] = None  # concurrent requests -> per-request decode tok/s, one card
     ttft_full_ms: Optional[float] = None  # validator-observed TTFT up to which latency credit is 1.0
     ttft_zero_ms: Optional[float] = None  # ... and at which it reaches 0.0
 
@@ -73,6 +74,7 @@ class ServingRelease:
             request_timeout=float(raw.get('request_timeout', 60.0)),
             decode_tps_target=_optional_float(speed.get('decode_tps_target')),
             burst_concurrency=int(speed['burst_concurrency']) if speed.get('burst_concurrency') else None,
+            decode_per_request={int(k): float(v) for k, v in (speed.get('decode_per_request') or {}).items()} or None,
             ttft_full_ms=_optional_float(speed.get('ttft_full_ms')),
             ttft_zero_ms=_optional_float(speed.get('ttft_zero_ms')),
         )

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -54,6 +54,7 @@ class ServedRequest:
     detail: str = ''  # axon status message when not ok
     source: str = 'gateway'  # 'gateway' | 'baseline'
     ttft_ms: Optional[float] = None  # validator-observed time to first streamed event
+    inflight: int = 1  # this validator's requests in flight to the miner when this one was dispatched (incl. itself)
 
 
 @dataclass

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -16,18 +16,19 @@ wipes the window and quarantines the hotkey. Miners whose window passes are
 published READY; serving axons that are not READY (and not quarantined) are
 published as *probation* so baseline traffic can give them a window.
 
-    round score = window passes (0/1) x mean latency credit over this round's served requests x capacity
+    round score = window passes (0/1) x mean speed credit over this round's served requests
 
-``capacity`` comes from the round's saturation burst: every READY miner gets
+Speed credit is measured on served traffic only (TTFT and decode rate against the
+blessing's curve at the load this validator imposed; ``scoring.py``). The load
+burst is telemetry: every READY miner gets
 the release's blessed concurrency of prompts at the same instant as every other miner —
 each prompt unique to that hotkey and round (salted), verified afterwards by
 teacher forcing under the reference like any served request, so an answer can
 neither be shared between hotkeys on one card nor precomputed. Verified tokens
 per second of *decode* time (batch wall-clock minus the first observed TTFT, so
 network distance prices latency, not throughput) over the release's blessed
-``decode_tps_target`` (capped at 1, 0 under ``SERVING_PROBE_FLOOR_RATIO``) is its
-capacity — hotkeys sharing one GPU each fall under the floor. Probe outcomes
-affect capacity only, never the window. Round scores are settled
+``decode_tps_target`` (capped at 1) is reported and persisted per round so a
+shared or slow card is visible; it does not enter pay and never touches the window. Round scores are settled
 over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
 """
 
@@ -53,7 +54,6 @@ from gittensor.constants import (
     SERVING_DORMANT_RETRY_ROUNDS,
     SERVING_MAX_TOKENS,
     SERVING_PROBE_DIP_RATIO,
-    SERVING_PROBE_FLOOR_RATIO,
     SERVING_PROBE_REQUESTS,
     SERVING_PROBE_RETRY_DELAY_S,
     SERVING_PROBE_TARGET_TPS,
@@ -68,7 +68,7 @@ from gittensor.serving.store import ServingStore
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
 from gittensor.validator.serving.persist import ServingRoundStorage
-from gittensor.validator.serving.scoring import latency_credit
+from gittensor.validator.serving.scoring import request_speed_credit
 from gittensor.validator.utils.config import STORE_DB_RESULTS
 
 if TYPE_CHECKING:
@@ -227,14 +227,9 @@ def verify_served_round(
         else:
             state.audits.record(req.hotkey, release.model_id, verdict.value)
             bump('pass' if verdict.passed else 'miss')
-        # Speed is priced on time to first token (network + queue + prefill); generation length is the user's
-        # choice and throughput is priced by the capacity probe. Fall back to total latency for legacy records.
-        speed_ms = req.ttft_ms if req.ttft_ms is not None else req.latency_ms
-        credits.setdefault(req.hotkey, []).append(
-            latency_credit(speed_ms, release.ttft_full_ms, release.ttft_zero_ms)
-            if verdict.passed and speed_ms is not None
-            else 0.0
-        )
+        # Speed is priced on served traffic: time to first token and decode rate against the blessing's curve at
+        # the load this validator had in flight to the miner (gittensor/validator/serving/scoring.py).
+        credits.setdefault(req.hotkey, []).append(request_speed_credit(req, release) if verdict.passed else 0.0)
         state.record(
             RequestRecord(
                 ts=time.time(),
@@ -275,6 +270,7 @@ async def baseline_round(
         messages = make_baseline_prompt(rng)
         max_tokens = baseline_max_tokens(rng, min(SERVING_MAX_TOKENS, max(release.max_tokens, 512)))
         synapse = InferenceSynapse(messages=messages, model_id=release.model_id, max_tokens=max_tokens, logprobs=True)
+        inflight = state.inflight().get(uid, 0) + 1
         started = time.monotonic()
         try:
             response = await consume_stream(dendrite, axon, synapse, release.request_timeout)
@@ -307,6 +303,7 @@ async def baseline_round(
                 detail='' if ok else str(status or err or 'no response'),
                 source='baseline',
                 ttft_ms=getattr(response, 'observed_ttft_ms', None) if ok else None,
+                inflight=inflight,
             )
         )
 
@@ -433,14 +430,11 @@ async def audit_round(
         else:  # probe disabled: capacity is not measured
             rates = [target_tps] * len(passing)
         for (uid, hotkey, _, credit), tps in zip(passing, rates):
-            ratio = tps / target_tps
-            capacity = (
-                min(1.0, ratio) if ratio >= SERVING_PROBE_FLOOR_RATIO else 0.0
-            )  # under the floor = shared / not a card
-            score = credit * capacity
+            capacity = min(1.0, tps / target_tps)  # telemetry: this card's burst aggregate against one 5090's
+            score = credit
             bt.logging.info(
-                f'Serving: UID {uid} {release.model_id} probe {tps:.0f} tok/s capacity {capacity:.2f} '
-                f'latency credit {credit:.2f} score {score:.3f}'
+                f'Serving: UID {uid} {release.model_id} burst {tps:.0f} tok/s ({capacity:.2f}x blessed) '
+                f'speed credit {credit:.2f} score {score:.3f}'
             )
             if score > best[hotkey][0]:
                 best[hotkey] = (score, release.model_id)

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -1,24 +1,31 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-"""Serving latency credit (sub-subnet B beta).
+"""Serving speed credit (sub-subnet B beta).
 
 Correctness is decided by the rolling ``AuditWindow`` (gittensor/serving/audit.py);
-this module only prices speed. The input is the validator-observed time to
-first streamed token of a served request (network + queue + prefill): 1.0 up
-to SERVING_LATENCY_FULL_CREDIT_MS, falling linearly to 0.0 at
-SERVING_LATENCY_ZERO_CREDIT_MS. Total latency is not used — generation length
-is the user's choice, and throughput is priced by the capacity probe. A miner's
-round score is its window verdict (0/1) times the mean credit over the round's
-served requests — misses earn 0 credit, which folds availability in.
+this module only prices speed, on served traffic. Two validator-observed numbers
+per served request: time to first streamed token (network + queue + prefill) —
+1.0 up to SERVING_LATENCY_FULL_CREDIT_MS, 0.0 at SERVING_LATENCY_ZERO_CREDIT_MS —
+and decode rate, completion tokens over (total − TTFT), against what one honest
+card does on this runtime at the load this validator itself had in flight to the
+miner (the release's blessing-time curve). Credit = ttft_credit × decode_credit;
+decode under SERVING_DECODE_FLOOR_RATIO × expected is 0. A miner's round score is
+its window verdict (0/1) times the mean credit over the round's served requests —
+misses earn 0 credit, which folds availability in.
 """
 
-from typing import Optional
+from typing import Dict, Optional, Sequence, Tuple
 
 from gittensor.constants import (
+    SERVING_DECODE_FLOOR_RATIO,
+    SERVING_DECODE_MIN_TOKENS,
+    SERVING_DECODE_PER_REQUEST_FALLBACK,
     SERVING_LATENCY_FULL_CREDIT_MS,
     SERVING_LATENCY_ZERO_CREDIT_MS,
 )
+from gittensor.serving.loadout import ServingRelease
+from gittensor.serving.state import ServedRequest
 
 
 def latency_credit(elapsed_ms: float, full_ms: Optional[float] = None, zero_ms: Optional[float] = None) -> float:
@@ -30,3 +37,40 @@ def latency_credit(elapsed_ms: float, full_ms: Optional[float] = None, zero_ms: 
     if elapsed_ms >= zero:
         return 0.0
     return 1.0 - (elapsed_ms - full) / (zero - full)
+
+
+def expected_decode_tps(curve: Optional[Dict[int, float]], inflight: int) -> float:
+    """Per-request decode tok/s one honest card delivers at ``inflight`` concurrent requests (piecewise-linear)."""
+    points: Sequence[Tuple[int, float]] = sorted(curve.items()) if curve else SERVING_DECODE_PER_REQUEST_FALLBACK
+    n = max(1, int(inflight))
+    if n <= points[0][0]:
+        return points[0][1]
+    for (n0, t0), (n1, t1) in zip(points, points[1:]):
+        if n <= n1:
+            return t0 + (t1 - t0) * (n - n0) / (n1 - n0)
+    return points[-1][1]
+
+
+def decode_credit(observed_tps: float, expected_tps: float, floor_ratio: float = SERVING_DECODE_FLOOR_RATIO) -> float:
+    if expected_tps <= 0:
+        return 1.0
+    ratio = observed_tps / expected_tps
+    return 0.0 if ratio < floor_ratio else min(1.0, ratio)
+
+
+def request_speed_credit(req: ServedRequest, release: ServingRelease) -> float:
+    """Speed credit of one verified served request: TTFT band × decode band (decode only when measurable)."""
+    speed_ms = req.ttft_ms if req.ttft_ms is not None else req.latency_ms
+    if speed_ms is None:
+        return 0.0
+    credit = latency_credit(speed_ms, release.ttft_full_ms, release.ttft_zero_ms)
+    tokens = len(req.tokens or [])
+    if (
+        tokens >= SERVING_DECODE_MIN_TOKENS
+        and req.ttft_ms is not None
+        and req.latency_ms is not None
+        and req.latency_ms > req.ttft_ms
+    ):
+        observed = tokens / ((req.latency_ms - req.ttft_ms) / 1000.0)
+        credit *= decode_credit(observed, expected_decode_tps(release.decode_per_request, req.inflight))
+    return credit

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -19,7 +19,14 @@
         "single_stream_decode_tps": 443.6,
         "probe_shaped_decode_tps": 280.0,
         "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 \u2014 queues past 16, wall 3.7 s -> 7 s)",
-        "burst_concurrency": 16
+        "burst_concurrency": 16,
+        "decode_per_request": {
+          "1": 443.6,
+          "6": 46.0,
+          "16": 19.4,
+          "24": 19.4,
+          "32": 19.5
+        }
       }
     }
   ]

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -308,6 +308,7 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
         tokens, ttft, wall = _stream_once(base_url, model_id, messages, max_tokens, timeout)
         single.append((tokens / max(wall - ttft, 1e-3), ttft * 1000.0))
     aggregate = []
+    per_request = []
     for i in range(reps):
         batch = prompts[i * burst : (i + 1) * burst]
         started = time.monotonic()
@@ -317,8 +318,14 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
         tokens = sum(t for t, _, _ in results)
         first = min(ttft for _, ttft, _ in results)
         aggregate.append(tokens / max(wall - first, 1e-3))
+        per_request.extend(t / max(w - tt, 1e-3) for t, tt, w in results)
     single_tps = statistics.median(t for t, _ in single)
     probe_tps = statistics.median(aggregate)
+    curve = {1: round(single_tps, 1), burst: round(statistics.median(per_request), 1)}
+    if burst != 6:  # a mid point so the validator's interpolation follows the real curve
+        with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
+            r6 = list(pool.map(lambda m: _stream_once(base_url, model_id, m, max_tokens, timeout), prompts[:6]))
+        curve[6] = round(statistics.median(t / max(w - tt, 1e-3) for t, tt, w in r6), 1)
     return {
         'single_stream_decode_tps': round(single_tps, 1),
         'probe_shaped_decode_tps': round(probe_tps, 1),
@@ -328,6 +335,9 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
         # what the release carries: capacity = aggregate / decode_tps_target capped at 1, 0 under the floor ratio
         'decode_tps_target': round(probe_tps, 1),
         'burst_concurrency': burst,
+        # concurrent requests -> per-request decode tok/s of one honest card: the validator prices a served request
+        # against this curve at the load it had in flight to the miner
+        'decode_per_request': {str(k): v for k, v in sorted(curve.items())},
     }
 
 

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1092,7 +1092,7 @@ def test_audit_round_skips_release_without_reference(monkeypatch):
 
 
 def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
-    """Two hotkeys on one card each see about half the blessed aggregate and earn nothing; a lone card gets ~1."""
+    """Two hotkeys on one card each report about half the blessed burst aggregate (telemetry); a lone card ~1."""
     from types import SimpleNamespace
 
     from gittensor.validator.serving import forward as fwd
@@ -1124,13 +1124,15 @@ def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
         state.enqueue_served(_served(uid, good))
     serving = [(1, 'hk1', lone), (2, 'hk2', a), (3, 'hk3', b)]
     scores = _round(state, dendrite, serving, good, monkeypatch, probes=4)
-    assert scores['hk1'] == pytest.approx(1.0, abs=0.15)
-    assert scores['hk2'] == 0.0 and scores['hk3'] == 0.0  # each sees ~half the blessed aggregate: under the floor
-    assert all(r.ok for r in state.recent(50) if r.kind == 'probe')  # the burst was answered correctly, just slowly
+    assert scores == {'hk1': 1.0, 'hk2': 1.0, 'hk3': 1.0}  # the burst is telemetry: pay comes from served speed
+    tele = state.last_round['windows']
+    assert tele[1]['capacity'] == pytest.approx(1.0, abs=0.15)
+    assert tele[2]['capacity'] == pytest.approx(0.5, abs=0.15) and tele[3]['capacity'] == pytest.approx(0.5, abs=0.15)
+    assert all(r.ok for r in state.recent(50) if r.kind == 'probe')  # answered correctly, just slowly
 
 
-def test_probe_misses_cost_capacity_not_the_window(monkeypatch):
-    """A miner that serves traffic honestly but chokes on the burst keeps its window and is probed again."""
+def test_probe_misses_are_telemetry_not_the_window(monkeypatch):
+    """A miner that serves traffic honestly but chokes on the burst keeps its window and pay; the burst is re-sent."""
     from types import SimpleNamespace
 
     good = _echo_release()
@@ -1140,11 +1142,75 @@ def test_probe_misses_cost_capacity_not_the_window(monkeypatch):
     for _ in range(2):
         state.enqueue_served(_served(1, good))
         scores = _round(state, dendrite, [(1, 'hk1', axon)], good, monkeypatch, probes=6)
-        assert scores == {'hk1': 0.0}
+        assert scores == {'hk1': 1.0} and state.last_round['windows'][1]['capacity'] == 0.0
     assert calls == {id(axon): 12}
     window = state.audits.verdict('hk1', good.model_id)
     assert window.passed and window.n_audits == 2 and window.mean == 1.0
     assert sum(1 for r in state.recent(50) if r.kind == 'probe' and not r.ok) == 12
+
+
+def test_decode_speed_prices_served_requests_against_the_blessing_curve():
+    from gittensor.validator.serving.scoring import decode_credit, expected_decode_tps, request_speed_credit
+
+    curve = {1: 440.0, 6: 46.0, 16: 19.0}
+    assert expected_decode_tps(curve, 1) == 440.0 and expected_decode_tps(curve, 0) == 440.0
+    assert expected_decode_tps(curve, 16) == 19.0 and expected_decode_tps(curve, 40) == 19.0
+    assert expected_decode_tps(curve, 11) == pytest.approx(32.5)  # linear between 6 and 16
+    assert expected_decode_tps(None, 6) == 46.0  # constants' fallback curve
+    assert decode_credit(440.0, 440.0) == 1.0 and decode_credit(600.0, 440.0) == 1.0  # never more than one card
+    assert decode_credit(330.0, 440.0) == pytest.approx(0.75)
+    assert decode_credit(200.0, 440.0) == 0.0  # under the floor: shared card / not the blessed runtime
+
+    release = _echo_release()
+    release.decode_per_request = curve
+
+    def req(tokens: int, ttft_ms: float, latency_ms: float, inflight: int = 1) -> ServedRequest:
+        return ServedRequest(
+            ts=0.0,
+            uid=1,
+            hotkey='hk1',
+            model_id=release.model_id,
+            messages=MSGS,
+            ok=True,
+            latency_ms=latency_ms,
+            completion='x',
+            tokens=['t'] * tokens,
+            token_logprobs=[0.0] * tokens,
+            ttft_ms=ttft_ms,
+            inflight=inflight,
+        )
+
+    honest = req(64, 100.0, 100.0 + 64 / 440.0 * 1000.0)  # 440 tok/s after a 100 ms TTFT
+    assert request_speed_credit(honest, release) == pytest.approx(1.0)
+    busy = req(64, 100.0, 100.0 + 64 / 19.0 * 1000.0, inflight=16)  # 19 tok/s is what one card does at 16 in flight
+    assert request_speed_credit(busy, release) == pytest.approx(1.0)
+    shared = req(64, 100.0, 100.0 + 64 / 19.0 * 1000.0, inflight=1)  # 19 tok/s while we sent it one request
+    assert request_speed_credit(shared, release) == 0.0
+    slowish = req(64, 100.0, 100.0 + 64 / 330.0 * 1000.0)
+    assert request_speed_credit(slowish, release) == pytest.approx(0.75)
+    short = req(8, 100.0, 5_000.0)  # too few tokens to measure decode: TTFT band only
+    assert request_speed_credit(short, release) == 1.0
+    slow_ttft = req(64, 1_000.0, 1_000.0 + 64 / 440.0 * 1000.0)
+    assert request_speed_credit(slow_ttft, release) == pytest.approx(0.5)
+
+
+def test_gateway_and_baseline_record_inflight_at_dispatch(monkeypatch):
+    state = ServingState()
+    state.publish_round([_ready(7)], {})
+    client = _gateway_client(state, monkeypatch)
+    h = {'Authorization': 'Bearer k1'}
+    assert client.post('/v1/chat/completions', json={'messages': MSGS}, headers=h).status_code == 200
+    (served,) = state.drain_served()
+    assert served.inflight == 1  # the only request in flight when it was dispatched
+
+
+def test_release_speed_curve_parses(tmp_path):
+    from gittensor.serving.loadout import load_serving_loadout
+
+    raw = {'releases': [{'model_id': 'm', 'backend': 'echo', 'speed': {'decode_per_request': {'1': 440, '16': 19.5}}}]}
+    path = tmp_path / 'loadout.json'
+    path.write_text(json.dumps(raw))
+    assert load_serving_loadout(path).primary.decode_per_request == {1: 440.0, 16: 19.5}
 
 
 def test_serving_share_prices_gpu_hours_inside_the_cap(monkeypatch):


### PR DESCRIPTION
Decided with Alex 8/27 late: no synthetic traffic in the pay path. Capacity is priced by how fast a hotkey actually serves under the load it actually gets; a card shared between hotkeys (or a runtime that is not the blessed one) is slower by integer factors under load and falls under a floor.

```
round score = window(0/1) × mean over the round's served requests of  ttft_credit × decode_credit
  ttft_credit   as before (blessed bands, default 500 / 1500 ms)
  decode_credit = min(1, observed / expected);  0 below SERVING_DECODE_FLOOR_RATIO (0.5)
  observed      = completion tokens ÷ (total − TTFT), validator-observed, requests with ≥ 32 tokens
  expected      = one honest card's per-request decode at the number of requests THIS validator had in flight
                  to the miner (release `speed.decode_per_request`, piecewise-linear; measured for 7498736 on a
                  5090: 1→443.6, 6→46, 16→19.4, 24→19.4, 32→19.5 tok/s)
```
Never more than one card per hotkey; a busy honest miner is priced against what a 5090 does at that load, not against idle speed. Misses still earn 0 credit (availability), wrong answers still strike (correctness). Nothing else changes about READY.

- `ServedRequest.inflight` — recorded at dispatch by the gateway (`state.inflight()` after `acquire`) and by baseline traffic.
- `scoring.py`: `expected_decode_tps`, `decode_credit`, `request_speed_credit`.
- The load burst (#1720) no longer enters pay: it is logged (`burst N tok/s (x.xx× blessed)`) and persisted (`probe_tps`, `capacity`) as telemetry so a shared card is visible on gittensor.io.
- Checker `--speed-json` now writes the `decode_per_request` curve (1 / 6 / burst); the CI pin-bump carries it. Loadout for 7498736 filled from tonight's measurements.

Accepted, documented gap: N hotkeys on one idle card are indistinguishable until traffic arrives (bounded by the pool cap and registration cost; ends with load). UUID dedupe needs the runtime to report GPUs (`/v1/info`) — follow-up with sparkinfer.

Tests: curve interpolation and floor, honest/busy/shared/short/slow-TTFT requests, in-flight recorded at dispatch, loadout curve parsing, burst-as-telemetry.