### PR TITLE
serving: hardware attestation (VRAM fill + seeded GEMM chain, random half-fleet cohorts) replaces the load burst

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -18,6 +18,10 @@ on:
         description: "CMAKE_CUDA_ARCHITECTURES"
         required: false
         default: "120"
+      image_tag:
+        description: "Image tag to push (default: the sparkinfer ref). Use e.g. <ref>-attest1 for a gittensor-side image change so the blessed tag is not overwritten."
+        required: false
+        default: ""
       conformance:
         description: "After the push, rent a 5090 on Lium, run the conformance checker and open the pin-bump PR on a pass"
         type: boolean
@@ -33,6 +37,7 @@ jobs:
   image:
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+      tag: ${{ steps.ref.outputs.tag }}
     # push-triggered runs (Dockerfile/workflow changed) only BUILD, to catch Dockerfile breakage in CI;
     # the image is pushed to Docker Hub only from the Run workflow button (workflow_dispatch).
     name: ${{ github.event_name == 'workflow_dispatch' && 'build and push' || 'build only (dry run)' }}
@@ -49,7 +54,8 @@ jobs:
             REF=$(jq -r '.releases[0].runtime_pin' gittensor/validator/weights/serving_loadout.json | sed 's/.*@//')
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "building sparkinfer@$REF"
+          TAG="${{ inputs.image_tag }}"; echo "tag=${TAG:-$REF}" >> "$GITHUB_OUTPUT"
+          echo "building sparkinfer@$REF as entrius/sparkinfer:${TAG:-$REF}"
 
       - name: Free disk space (CUDA devel image is large)
         run: |
@@ -76,7 +82,7 @@ jobs:
             SPARKINFER_REF=${{ steps.ref.outputs.ref }}
             CUDA_ARCHS=${{ inputs.cuda_archs || '120' }}
           tags: |
-            entrius/sparkinfer:${{ steps.ref.outputs.ref }}
+            entrius/sparkinfer:${{ steps.ref.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -89,6 +95,7 @@ jobs:
     env:
       LIUM_API_KEY: ${{ secrets.LIUM_API_KEY }}
       REF: ${{ needs.image.outputs.ref }}
+      TAG: ${{ needs.image.outputs.tag }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -106,7 +113,7 @@ jobs:
       - name: Rent, boot, check, tear down
         env:
           CONFORMANCE_RENT_WAIT_MIN: "20"
-        run: scripts/serving_conformance_on_lium.sh "$REF" "conformance-$REF"
+        run: scripts/serving_conformance_on_lium.sh "$TAG" "conformance-$REF"
 
       - name: Upload the report
         if: always()
@@ -122,12 +129,14 @@ jobs:
             --slurpfile speed "conformance-$REF/speed.json" \
             '.releases[0].runtime_pin = $pin
              | .releases[0].speed = ((.releases[0].speed // {}) + {
-                 decode_tps_target: $speed[0].decode_tps_target,
                  single_stream_decode_tps: $speed[0].single_stream_decode_tps,
-                 probe_shaped_decode_tps: $speed[0].probe_shaped_decode_tps,
-                 burst_concurrency: $speed[0].burst_concurrency,
                  decode_per_request: $speed[0].decode_per_request,
                  measured_on: ($pin + " on a rented RTX 5090, actions run " + $run)
+               })
+             | .releases[0].attest = ((.releases[0].attest // {}) + {
+                 iters: ($speed[0].attest.attest_iters // 3),
+                 vram_model_reserved_bytes: ($speed[0].attest.vram_model_reserved_bytes // 24000000000),
+                 reference_wall_ms: $speed[0].attest.attest_ref_wall_ms
                })' \
             gittensor/validator/weights/serving_loadout.json > /tmp/loadout.json
           mv /tmp/loadout.json gittensor/validator/weights/serving_loadout.json
@@ -145,7 +154,7 @@ jobs:
             `entrius/sparkinfer:${{ env.REF }}` passed `scripts/check_serving_runtime.py` on a rented RTX 5090
             (run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — report in the
             `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin` and writes the release's
-            blessing-time speed facts (`speed.decode_tps_target` = aggregate decode tok/s of one honest card at the
-            blessed `burst_concurrency` — capacity 1.0; 0 under the floor ratio). Update the sha named in the comments at
+            blessing-time speed facts (`speed.decode_per_request`, the per-request decode curve served traffic is
+            priced against) and attestation facts (`attest.*`). Update the sha named in the comments at
             `gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.
           add-paths: gittensor/validator/weights/serving_loadout.json

--- a/docker/attest/attest_server.py
+++ b/docker/attest/attest_server.py
@@ -27,7 +27,11 @@ def run(args, timeout=120.0):
         queued_ms = (time.monotonic() - started) * 1000.0
         proc = subprocess.run([BIN, *args], capture_output=True, text=True, timeout=timeout)
     if proc.returncode != 0:
-        return 500, {'error': (proc.stdout or proc.stderr).strip()[:500], 'exit': proc.returncode, 'queued_ms': queued_ms}
+        return 500, {
+            'error': (proc.stdout or proc.stderr).strip()[:500],
+            'exit': proc.returncode,
+            'queued_ms': queued_ms,
+        }
     out = json.loads(proc.stdout)
     out['queued_ms'] = round(queued_ms, 1)
     return 200, out
@@ -51,7 +55,9 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path != '/v1/attest/info' or not self._auth():
             return self._send(404, {'error': 'not found'})
-        self._send(*run(['--seed', '1', '--iters', '1', '--dim', '256', '--matrices', '2', '--device', 'all'], timeout=30.0))
+        self._send(
+            *run(['--seed', '1', '--iters', '1', '--dim', '256', '--matrices', '2', '--device', 'all'], timeout=30.0)
+        )
 
     def do_POST(self):
         if self.path != '/v1/attest' or not self._auth():

--- a/docker/attest/attest_server.py
+++ b/docker/attest/attest_server.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Attestation sidecar for the serving runtime image: runs gt_attest on request (stdlib only).
+
+POST /v1/attest  {"seed": <u64>, "iters": <n>, "fill": true}  -> gt_attest's JSON plus "queued_ms"
+GET  /v1/attest/info                                          -> devices without running a challenge (iters 1, no fill,
+                                                                 small working set)
+Challenges run one at a time; concurrent requests queue and report their own wall including the wait, which is what
+lets a validator see two hotkeys sharing one card. Optional bearer via ATTEST_API_KEY.
+"""
+
+import json
+import os
+import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+BIN = os.environ.get('GT_ATTEST_BIN', '/opt/sparkinfer/bin/gt_attest')
+PORT = int(os.environ.get('ATTEST_PORT', '8081'))
+API_KEY = os.environ.get('ATTEST_API_KEY')
+LOCK = threading.Lock()
+
+
+def run(args, timeout=120.0):
+    started = time.monotonic()
+    with LOCK:
+        queued_ms = (time.monotonic() - started) * 1000.0
+        proc = subprocess.run([BIN, *args], capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        return 500, {'error': (proc.stdout or proc.stderr).strip()[:500], 'exit': proc.returncode, 'queued_ms': queued_ms}
+    out = json.loads(proc.stdout)
+    out['queued_ms'] = round(queued_ms, 1)
+    return 200, out
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, status, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _auth(self):
+        if API_KEY and self.headers.get('Authorization') != f'Bearer {API_KEY}':
+            self._send(401, {'error': 'unauthorized'})
+            return False
+        return True
+
+    def do_GET(self):
+        if self.path != '/v1/attest/info' or not self._auth():
+            return self._send(404, {'error': 'not found'})
+        self._send(*run(['--seed', '1', '--iters', '1', '--dim', '256', '--matrices', '2', '--device', 'all'], timeout=30.0))
+
+    def do_POST(self):
+        if self.path != '/v1/attest' or not self._auth():
+            return self._send(404, {'error': 'not found'})
+        try:
+            body = json.loads(self.rfile.read(int(self.headers.get('Content-Length', '0')) or b'{}'))
+            seed, iters = int(body['seed']), int(body.get('iters', 3))
+        except (ValueError, KeyError, TypeError):
+            return self._send(400, {'error': 'seed (u64) required; iters optional'})
+        args = ['--seed', str(seed), '--iters', str(max(1, min(iters, 20))), '--device', 'all']
+        if body.get('fill', True):
+            args.append('--fill')
+        self._send(*run(args))
+
+    def log_message(self, fmt, *args):  # quiet
+        pass
+
+
+if __name__ == '__main__':
+    ThreadingHTTPServer(('0.0.0.0', PORT), Handler).serve_forever()

--- a/docker/attest/entrypoint.sh
+++ b/docker/attest/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Start the attestation sidecar beside sparkinfer_server, then hand over to the runtime's own entrypoint.
+python3 /opt/sparkinfer/bin/attest_server.py &
+exec bash server/run.sh --download "$@"

--- a/docker/attest/gt_attest.cu
+++ b/docker/attest/gt_attest.cu
@@ -1,0 +1,132 @@
+// gt_attest — hardware attestation challenge for serving miners (Gittensor compute).
+//
+// Fills the GPU's free VRAM with a seeded stream, then runs a seeded chain of fp32 matrix products through tanh over a
+// working set carved from that fill, hashing the first 64 KiB of every matrix after each iteration into one SHA-256
+// digest. Deterministic for a given seed on any sm_120 card (hand-written tiled GEMM, no atomics, no reductions, no
+// TF32, no fast-math), so a validator's reference 5090 recomputes the same digest. One pass (--iters 3) is sized to
+// ~1.5 s on an idle 5090; two hotkeys sharing a card cannot both fill the free VRAM, and their chains run ~2x slower.
+//
+//   gt_attest --seed <u64> [--iters 3] [--fill] [--device <i>|all] [--dim 1024] [--matrices 512]
+// prints one JSON object (or {"devices":[...]} for all) and exits 0; exit 2 = bad args, 3 = allocation failure.
+#include <cuda_runtime.h>
+#include <nvml.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <chrono>
+#include <string>
+#include <vector>
+
+#define CHECK(x) do { cudaError_t e_ = (x); if (e_ != cudaSuccess) { std::fprintf(stderr, "{\"error\":\"%s at %s:%d\"}\n", cudaGetErrorString(e_), __FILE__, __LINE__); std::exit(3); } } while (0)
+
+// ---------------------------------------------------------------- SHA-256 (host) --------------------------------
+struct Sha256 {
+    uint32_t h[8]; uint64_t len = 0; uint8_t buf[64]; size_t n = 0;
+    static uint32_t rotr(uint32_t x, int k) { return (x >> k) | (x << (32 - k)); }
+    Sha256() { const uint32_t iv[8] = {0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19}; std::memcpy(h, iv, 32); }
+    void block(const uint8_t* p) {
+        static const uint32_t K[64] = {0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2};
+        uint32_t w[64];
+        for (int i = 0; i < 16; i++) w[i] = (uint32_t)p[4*i] << 24 | (uint32_t)p[4*i+1] << 16 | (uint32_t)p[4*i+2] << 8 | p[4*i+3];
+        for (int i = 16; i < 64; i++) { uint32_t s0 = rotr(w[i-15],7) ^ rotr(w[i-15],18) ^ (w[i-15] >> 3); uint32_t s1 = rotr(w[i-2],17) ^ rotr(w[i-2],19) ^ (w[i-2] >> 10); w[i] = w[i-16] + s0 + w[i-7] + s1; }
+        uint32_t a=h[0],b=h[1],c=h[2],d=h[3],e=h[4],f=h[5],g=h[6],hh=h[7];
+        for (int i = 0; i < 64; i++) { uint32_t S1 = rotr(e,6)^rotr(e,11)^rotr(e,25); uint32_t ch = (e&f)^(~e&g); uint32_t t1 = hh+S1+ch+K[i]+w[i]; uint32_t S0 = rotr(a,2)^rotr(a,13)^rotr(a,22); uint32_t mj = (a&b)^(a&c)^(b&c); uint32_t t2 = S0+mj; hh=g; g=f; f=e; e=d+t1; d=c; c=b; b=a; a=t1+t2; }
+        h[0]+=a; h[1]+=b; h[2]+=c; h[3]+=d; h[4]+=e; h[5]+=f; h[6]+=g; h[7]+=hh;
+    }
+    void update(const uint8_t* p, size_t k) { len += k; while (k) { size_t t = 64 - n; if (t > k) t = k; std::memcpy(buf + n, p, t); n += t; p += t; k -= t; if (n == 64) { block(buf); n = 0; } } }
+    std::string hex() { uint64_t bits = len * 8; uint8_t pad = 0x80; update(&pad, 1); uint8_t z = 0; while (n != 56) update(&z, 1); uint8_t l[8]; for (int i = 0; i < 8; i++) l[i] = (uint8_t)(bits >> (56 - 8*i)); update(l, 8); char out[65]; for (int i = 0; i < 8; i++) std::snprintf(out + 8*i, 9, "%08x", h[i]); return std::string(out, 64); }
+};
+
+// ---------------------------------------------------------------- kernels ---------------------------------------
+__device__ __forceinline__ uint64_t splitmix(uint64_t x) { x += 0x9e3779b97f4a7c15ULL; x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL; x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL; return x ^ (x >> 31); }
+
+// Seeded fill: every element depends only on (seed, index) — deterministic and embarrassingly parallel.
+__global__ void fill_kernel(float* p, size_t n, uint64_t seed) {
+    size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x; size_t stride = (size_t)gridDim.x * blockDim.x;
+    for (; i < n; i += stride) { uint64_t r = splitmix(seed ^ (i * 0x2545F4914F6CDD1DULL)); p[i] = ((r >> 40) & 0xFFFFFF) / 16777216.0f - 0.5f; }
+}
+
+// C = tanh(A * B) for square d x d fp32 matrices; 32x32 tiles, fixed summation order per element, no FMA contraction
+// (compiled with -fmad=false) so the result is bit-identical on every card of the architecture.
+#define TILE 32
+__global__ void gemm_tanh_kernel(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C, int d) {
+    __shared__ float As[TILE][TILE]; __shared__ float Bs[TILE][TILE];
+    int row = blockIdx.y * TILE + threadIdx.y, col = blockIdx.x * TILE + threadIdx.x; float acc = 0.0f;
+    for (int t = 0; t < d; t += TILE) {
+        As[threadIdx.y][threadIdx.x] = A[(size_t)row * d + t + threadIdx.x];
+        Bs[threadIdx.y][threadIdx.x] = B[(size_t)(t + threadIdx.y) * d + col];
+        __syncthreads();
+        #pragma unroll
+        for (int k = 0; k < TILE; k++) acc = acc + As[threadIdx.y][k] * Bs[k][threadIdx.x];
+        __syncthreads();
+    }
+    C[(size_t)row * d + col] = tanhf(acc * (1.0f / 64.0f));
+}
+
+// ---------------------------------------------------------------- one device ------------------------------------
+static std::string device_uuid(int dev) {
+    char pci[32]; if (cudaDeviceGetPCIBusId(pci, sizeof pci, dev) == cudaSuccess) {
+        nvmlDevice_t h; char uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE];
+        if (nvmlDeviceGetHandleByPciBusId_v2(pci, &h) == NVML_SUCCESS && nvmlDeviceGetUUID(h, uuid, sizeof uuid) == NVML_SUCCESS) return uuid;
+    }
+    cudaDeviceProp p; cudaGetDeviceProperties(&p, dev); char out[64]; std::snprintf(out, sizeof out, "GPU-");
+    for (int i = 0; i < 16; i++) std::snprintf(out + 4 + 2*i, 3, "%02x", (unsigned char)p.uuid.bytes[i]);
+    return out;
+}
+
+static void run_device(int dev, uint64_t seed, int iters, bool fill, int d, int matrices, bool last) {
+    auto t0 = std::chrono::steady_clock::now();
+    CHECK(cudaSetDevice(dev));
+    cudaDeviceProp prop; CHECK(cudaGetDeviceProperties(&prop, dev));
+    size_t free_b = 0, total_b = 0; CHECK(cudaMemGetInfo(&free_b, &total_b));
+    size_t mat_bytes = (size_t)d * d * sizeof(float), work_bytes = mat_bytes * (size_t)(matrices + 1);
+    if (free_b < work_bytes + (256u << 20)) { std::printf("{\"device\":%d,\"error\":\"not enough free VRAM: %zu\"}\n", dev, free_b); std::exit(3); }
+    // fill: everything free minus headroom, in large chunks (the working set is the first chunk)
+    std::vector<void*> chunks; size_t filled = 0;
+    size_t want = fill ? free_b - (256u << 20) : work_bytes;
+    while (filled < want) {
+        size_t chunk = want - filled; if (chunk > (2ull << 30)) chunk = 2ull << 30; if (chunks.empty() && chunk < work_bytes) chunk = work_bytes;
+        void* p = nullptr; if (cudaMalloc(&p, chunk) != cudaSuccess) { if (chunks.empty()) { std::printf("{\"device\":%d,\"error\":\"fill\"}\n", dev); std::exit(3); } break; }
+        fill_kernel<<<4096, 256>>>((float*)p, chunk / sizeof(float), seed ^ (uint64_t)chunks.size());
+        chunks.push_back(p); filled += chunk;
+    }
+    CHECK(cudaDeviceSynchronize());
+    float* M = (float*)chunks[0]; float* scratch = M + (size_t)matrices * d * d;
+    dim3 grid(d / TILE, d / TILE), block(TILE, TILE);
+    Sha256 sha; std::vector<uint8_t> head(64 * 1024);
+    for (int it = 0; it < iters; it++) {
+        for (int i = 0; i < matrices; i++) {
+            const float* A = M + (size_t)i * d * d; const float* B = M + (size_t)((i + 1) % matrices) * d * d;
+            gemm_tanh_kernel<<<grid, block>>>(A, B, scratch, d);
+            CHECK(cudaMemcpyAsync((void*)A, scratch, mat_bytes, cudaMemcpyDeviceToDevice));
+        }
+        CHECK(cudaDeviceSynchronize());
+        for (int i = 0; i < matrices; i++) { CHECK(cudaMemcpy(head.data(), M + (size_t)i * d * d, head.size(), cudaMemcpyDeviceToHost)); sha.update(head.data(), head.size()); }
+    }
+    for (void* p : chunks) cudaFree(p);
+    double ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+    std::printf("{\"device\":%d,\"uuid\":\"%s\",\"name\":\"%s\",\"sm_count\":%d,\"vram_total\":%zu,\"vram_free_before\":%zu,\"filled_bytes\":%zu,\"dim\":%d,\"matrices\":%d,\"iters\":%d,\"digest\":\"%s\",\"wall_ms\":%.1f}%s\n",
+        dev, device_uuid(dev).c_str(), prop.name, prop.multiProcessorCount, total_b, free_b, filled, d, matrices, iters, sha.hex().c_str(), ms, last ? "" : ",");
+}
+
+int main(int argc, char** argv) {
+    uint64_t seed = 0; int iters = 3, d = 1024, matrices = 512; bool fill = false, have_seed = false; std::string device = "0";
+    for (int i = 1; i < argc; i++) {
+        std::string a = argv[i]; auto next = [&](void) -> const char* { if (i + 1 >= argc) { std::fprintf(stderr, "missing value for %s\n", a.c_str()); std::exit(2); } return argv[++i]; };
+        if (a == "--seed") { seed = std::strtoull(next(), nullptr, 10); have_seed = true; }
+        else if (a == "--iters") iters = std::atoi(next());
+        else if (a == "--dim") d = std::atoi(next());
+        else if (a == "--matrices") matrices = std::atoi(next());
+        else if (a == "--device") device = next();
+        else if (a == "--fill") fill = true;
+        else { std::fprintf(stderr, "unknown arg %s\n", a.c_str()); return 2; }
+    }
+    if (!have_seed || iters < 1 || d % TILE != 0 || d < TILE || matrices < 2) { std::fprintf(stderr, "usage: gt_attest --seed <u64> [--iters n] [--fill] [--device i|all] [--dim d] [--matrices m]\n"); return 2; }
+    nvmlInit_v2();
+    int count = 0; CHECK(cudaGetDeviceCount(&count));
+    if (device == "all") { std::printf("{\"devices\":["); for (int i = 0; i < count; i++) run_device(i, seed, iters, fill, d, matrices, i == count - 1); std::printf("]}\n"); }
+    else { int dev = std::atoi(device.c_str()); if (dev < 0 || dev >= count) { std::fprintf(stderr, "no device %d\n", dev); return 2; } run_device(dev, seed, iters, fill, d, matrices, true); }
+    nvmlShutdown();
+    return 0;
+}

--- a/docker/sparkinfer.Dockerfile
+++ b/docker/sparkinfer.Dockerfile
@@ -38,6 +38,11 @@ RUN git clone ${SPARKINFER_REPO} sparkinfer \
 RUN cmake -S sparkinfer -B sparkinfer/build -G Ninja \
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SERVER=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS} \
     && cmake --build sparkinfer/build
+# Hardware attestation challenge (docker/attest): deterministic fp32 GEMM chain + VRAM fill. -fmad=false so the
+# summation is bit-identical on every card of the architecture (the validator's reference recomputes the digest).
+COPY docker/attest/gt_attest.cu /src/attest/gt_attest.cu
+RUN nvcc -O3 -fmad=false -gencode arch=compute_${CUDA_ARCHS},code=sm_${CUDA_ARCHS} \
+        -o /src/attest/gt_attest /src/attest/gt_attest.cu -lnvidia-ml
 
 # ---------- runtime ----------
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
@@ -55,6 +60,9 @@ COPY --from=build /src/sparkinfer/build/runtime       build/runtime
 COPY --from=build /src/sparkinfer/build/moe           build/moe
 COPY --from=build /src/sparkinfer/build/server        build/server
 COPY --from=build /src/SPARKINFER_COMMIT              SPARKINFER_COMMIT
+COPY --from=build /src/attest/gt_attest               bin/gt_attest
+COPY docker/attest/attest_server.py                   bin/attest_server.py
+COPY docker/attest/entrypoint.sh                      bin/entrypoint.sh
 # sparkinfer_server links libsparkinfer_runtime.so + libsparkinfer_moe.so (ldd-verified on 1b8b962, 9e43bfa).
 ENV LD_LIBRARY_PATH=/opt/sparkinfer/build/runtime:/opt/sparkinfer/build/moe:${LD_LIBRARY_PATH}
 
@@ -73,7 +81,8 @@ ENV SPARKINFER_REF=${SPARKINFER_REF} \
     HOST=0.0.0.0 \
     PORT=8080
 VOLUME ["/opt/sparkinfer/models"]
-EXPOSE 8080
+# 8080 inference, 8081 attestation sidecar (docker/attest/attest_server.py)
+EXPOSE 8080 8081
 LABEL org.opencontainers.image.source="https://github.com/gittensor-ai-lab/sparkinfer" \
       io.gittensor.serving.runtime="sparkinfer" \
       io.gittensor.serving.runtime_ref="${SPARKINFER_REF}"
@@ -81,6 +90,6 @@ LABEL org.opencontainers.image.source="https://github.com/gittensor-ai-lab/spark
 HEALTHCHECK --interval=30s --timeout=5s --start-period=600s --retries=5 \
     CMD curl -fsS http://127.0.0.1:8080/v1/models || exit 1
 
-# run.sh downloads the blessed model + tokenizer into MODELS_DIR on first start (--download), then execs
-# the prebuilt server binary (it only rebuilds if the binary is missing, which it is not).
-ENTRYPOINT ["bash", "server/run.sh", "--download"]
+# bin/entrypoint.sh starts the attestation sidecar (:8081), then run.sh downloads the blessed model + tokenizer into
+# MODELS_DIR on first start (--download) and execs the prebuilt server binary.
+ENTRYPOINT ["bash", "bin/entrypoint.sh"]

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -174,21 +174,21 @@ assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHA
 # Settlement is over the trailing hour: a miner's serving score is the mean of its last SERVING_SETTLEMENT_ROUNDS
 # round scores (missing rounds count 0), so a card verified for 45 of the last 60 minutes earns 75% of the price.
 SERVING_SETTLEMENT_ROUNDS = 12  # 12 x 5-minute audit rounds
-SERVING_CHALLENGE_TIMEOUT = 30.0  # seconds before a probe request counts as failed
 SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
-# Load burst (telemetry). After settling the window, every READY miner is sent the blessed concurrency of salted
-# prompts at the same instant, verified afterwards by teacher forcing; verified tokens per second of decode time over
-# the release's blessed aggregate at that concurrency (`speed.decode_tps_target`) is reported per round and persisted
-# (dashboard: does this card's aggregate look like one 5090's?). It does not enter pay: capacity is priced by speed on
-# served traffic (below). The constants are fallbacks for a release without speed facts.
-SERVING_PROBE_REQUESTS = 16
-SERVING_PROBE_TARGET_TPS = 280.0
-# A probe reading can only be too low (another validator's burst, a user spike, a blip), never too high: the miner
-# had to deliver those verified tokens. A reading under SERVING_PROBE_DIP_RATIO x the miner's median of its last
-# three is re-measured once after a random SERVING_PROBE_RETRY_DELAY_S and the better reading kept; a real slowdown
-# dips twice and sticks.
-SERVING_PROBE_DIP_RATIO = 0.7
-SERVING_PROBE_RETRY_DELAY_S = (15.0, 45.0)
+# Hardware attestation (gittensor/validator/serving/attest.py, docker/attest). Each round a random
+# SERVING_ATTEST_COHORT_FRACTION of the READY miners (plus never-passed and last-round failures) is sent one fresh
+# seed at the same instant; the runtime image's gt_attest fills the card's free VRAM and runs a deterministic GEMM
+# chain. Expected digest and wall time come from the validator's own reference (same image). PASS needs the digest,
+# wall <= SERVING_ATTEST_BUDGET_RATIO x reference, and >= SERVING_ATTEST_MIN_FILL_RATIO of the free VRAM filled
+# (free = total - SERVING_VRAM_MODEL_RESERVED_BYTES; the release may override). Two hotkeys on one card cannot both
+# fill it at once (P(caught) = fraction^2 per round). Never a strike: capacity 0 that round, re-challenged next.
+SERVING_ATTEST_COHORT_FRACTION = 0.5
+SERVING_ATTEST_ITERS = 3
+SERVING_ATTEST_BUDGET_RATIO = 1.6
+SERVING_ATTEST_MIN_FILL_RATIO = 0.6
+SERVING_ATTEST_TIMEOUT = 45.0  # seconds: fill + chain on a 5090 is ~1.5 s; queued challenges show up as slow
+SERVING_ATTEST_UUID_MEMORY_ROUNDS = 12
+SERVING_VRAM_MODEL_RESERVED_BYTES = 24e9  # what sparkinfer holds with the model loaded (7498736 on a 5090: 23.7 GB)
 SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per round
 # Latency credit on the validator-observed time to first streamed token (network + queue + prefill). An honest
 # 5090 reports TTFT ~26 ms on-box (2026-08-27 conformance) and a 64-token answer in ~165 ms (2026-08-22/24); add
@@ -207,6 +207,8 @@ SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
 # runtime that is not the blessed one is slower by integer factors under load, honest variance is +-10%. Round credit
 # is the mean over the round's served requests (misses 0), so availability, latency and speed price together.
 SERVING_DECODE_FLOOR_RATIO = 0.5
+SERVING_DECODE_TOLERANCE_RATIO = 0.8  # full credit down to this fraction of expected: the curve is measured on-box, the
+# validator observes stream delivery over the WAN (soak 5: honest cards read 0.75-0.96x); credit = min(1, ratio / this)
 SERVING_DECODE_MIN_TOKENS = 32
 SERVING_DECODE_PER_REQUEST_FALLBACK = ((1, 440.0), (6, 46.0), (16, 19.0))  # (concurrent requests, tok/s each)
 # Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 7498736, SPARKINFER_DETERMINISTIC=1), so an

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -51,15 +51,20 @@ class ServingRelease:
     # Speed of one honest card on this exact runtime, measured at blessing time (scripts/check_serving_runtime.py
     # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator prices capacity and latency
     # against these, so the "one card" bar tracks the runtime as it gets faster. None -> the constants' defaults.
-    decode_tps_target: Optional[float] = None  # aggregate decode tok/s of one honest card at burst_concurrency
-    burst_concurrency: Optional[int] = None  # requests in the load burst (the runtime's blessed concurrency)
     decode_per_request: Optional[Dict[int, float]] = None  # concurrent requests -> per-request decode tok/s, one card
+    # Attestation (docker/attest). Miner side: attest_url = the runtime's sidecar (default: base_url host, port 8081).
+    # Validator side: attest_reference_url = the reference's sidecar (default: reference_url host, port 8081).
+    attest_url: Optional[str] = None
+    attest_reference_url: Optional[str] = None
+    attest_iters: Optional[int] = None
+    vram_model_reserved_bytes: Optional[float] = None
     ttft_full_ms: Optional[float] = None  # validator-observed TTFT up to which latency credit is 1.0
     ttft_zero_ms: Optional[float] = None  # ... and at which it reaches 0.0
 
     @classmethod
     def from_dict(cls, raw: dict) -> 'ServingRelease':
         speed = raw.get('speed') or {}
+        attest = raw.get('attest') or {}
         return cls(
             model_id=raw['model_id'],
             backend=raw['backend'],
@@ -72,9 +77,11 @@ class ServingRelease:
             reference_url=raw.get('reference_url'),
             reference_api_key=raw.get('reference_api_key'),
             request_timeout=float(raw.get('request_timeout', 60.0)),
-            decode_tps_target=_optional_float(speed.get('decode_tps_target')),
-            burst_concurrency=int(speed['burst_concurrency']) if speed.get('burst_concurrency') else None,
             decode_per_request={int(k): float(v) for k, v in (speed.get('decode_per_request') or {}).items()} or None,
+            attest_url=attest.get('url') or _sidecar_url(raw.get('base_url')),
+            attest_reference_url=attest.get('reference_url') or _sidecar_url(raw.get('reference_url')),
+            attest_iters=int(attest['iters']) if attest.get('iters') else None,
+            vram_model_reserved_bytes=_optional_float(attest.get('vram_model_reserved_bytes')),
             ttft_full_ms=_optional_float(speed.get('ttft_full_ms')),
             ttft_zero_ms=_optional_float(speed.get('ttft_zero_ms')),
         )
@@ -82,6 +89,19 @@ class ServingRelease:
 
 def _optional_float(value) -> Optional[float]:
     return float(value) if value is not None else None
+
+
+def _sidecar_url(base: Optional[str], port: int = 8081) -> Optional[str]:
+    """The attestation sidecar next to a runtime URL: same scheme and host, port 8081."""
+    if not base:
+        return None
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(base)
+    host = parts.hostname or ''
+    if ':' in host:
+        host = f'[{host}]'
+    return urlunsplit((parts.scheme or 'http', f'{host}:{port}', '', '', ''))
 
 
 @dataclass
@@ -128,6 +148,9 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
     reference_override = os.getenv('SERVING_REFERENCE_URL')
     if reference_override:
         loadout.primary.reference_url = reference_override
+        loadout.primary.attest_reference_url = os.getenv('SERVING_ATTEST_REFERENCE_URL') or _sidecar_url(
+            reference_override
+        )
     key_override = os.getenv('SERVING_REFERENCE_API_KEY')
     if key_override:
         loadout.primary.reference_api_key = key_override

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -91,6 +91,8 @@ class ServingState:
     _history: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> last N round scores
     probe_history: Dict[str, Deque[float]] = field(default_factory=dict)  # audit thread only: hotkey -> last tps
     dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
+    attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
+    attest_round: int = 0
     last_round: dict = field(default_factory=dict)  # audit thread's summary of the last round, for /v1/serving/status
     settlement_rounds: int = SERVING_SETTLEMENT_ROUNDS
     last_round_ts: float = 0.0

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS quarantine (hotkey TEXT, model_id TEXT, until REAL, P
 CREATE TABLE IF NOT EXISTS probe_history (hotkey TEXT, seq INTEGER, tps REAL, PRIMARY KEY (hotkey, seq));
 CREATE TABLE IF NOT EXISTS round_history (hotkey TEXT, seq INTEGER, score REAL, PRIMARY KEY (hotkey, seq));
 CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
+CREATE TABLE IF NOT EXISTS attest (hotkey TEXT PRIMARY KEY, status TEXT);
 """
 
 
@@ -43,7 +44,7 @@ class ServingStore:
         """Snapshot the audit-thread state in one transaction (the tables are small: a few rows per hotkey)."""
         audits = state.audits.to_dict()
         with self._connect() as db:
-            for table in ('audit_values', 'quarantine', 'probe_history', 'round_history', 'dormant'):
+            for table in ('audit_values', 'quarantine', 'probe_history', 'round_history', 'dormant', 'attest'):
                 db.execute(f'DELETE FROM {table}')
             db.executemany(
                 'INSERT INTO audit_values VALUES (?, ?, ?, ?)',
@@ -59,6 +60,9 @@ class ServingStore:
                 [(hk, i, x) for hk, xs in state._history.items() for i, x in enumerate(xs)],
             )
             db.executemany('INSERT INTO dormant VALUES (?, ?)', list(state.dormant_rounds.items()))
+            db.executemany(
+                'INSERT INTO attest VALUES (?, ?)', [(hk, json.dumps(st)) for hk, st in state.attest_status.items()]
+            )
 
     def load(self, state: ServingState) -> ServingState:
         """Restore a snapshot into ``state``; an empty or unreadable store leaves it untouched."""
@@ -75,6 +79,8 @@ class ServingStore:
                     state._history.setdefault(hk, deque(maxlen=state.settlement_rounds)).append(float(x))
                 for hk, rounds in db.execute('SELECT hotkey, rounds FROM dormant'):
                     state.dormant_rounds[hk] = int(rounds)
+                for hk, st in db.execute('SELECT hotkey, status FROM attest'):
+                    state.attest_status[hk] = json.loads(st)
         except sqlite3.Error:
             pass
         return state

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -1,5 +1,5 @@
 # Entrius 2025
-from typing import ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 import bittensor as bt
 from pydantic import Field
@@ -101,3 +101,21 @@ class PatCheckSynapse(bt.Synapse):
     has_pat: Optional[bool] = None
     pat_valid: Optional[bool] = None
     rejection_reason: Optional[str] = None
+
+
+class AttestSynapse(bt.Synapse):
+    """Hardware attestation challenge (gittensor/validator/serving/attest.py). The miner answers with its runtime's
+    gt_attest result: per-device GPU UUID, bytes of free VRAM filled, the digest of a seeded GEMM chain and wall time."""
+
+    required_hash_fields: ClassVar[tuple[str, ...]] = ('seed', 'iters', 'fill')
+
+    # Request
+    seed: int
+    iters: int = 3
+    fill: bool = True
+
+    # Response
+    devices: Optional[List[Dict[str, Any]]] = None
+    wall_ms: Optional[float] = None
+    queued_ms: Optional[float] = None
+    error: Optional[str] = None

--- a/gittensor/validator/serving/attest.py
+++ b/gittensor/validator/serving/attest.py
@@ -1,0 +1,211 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Hardware attestation of serving miners (sub-subnet B beta).
+
+Each round a random half of the READY miners (plus every miner that has never passed and every miner that failed
+last round) is sent one fresh ``AttestSynapse`` — same seed, same instant. The miner's runtime image answers with
+``gt_attest`` (docker/attest): it fills the card's free VRAM with a seeded stream and runs a deterministic fp32
+GEMM chain, returning the GPU's UUID, bytes filled, a SHA-256 digest and wall time. The validator asks its own
+reference runtime (same image) for the same seed first, so the expected digest and reference wall time come from
+an honest 5090 — no GPU code runs in the validator process.
+
+PASS = digest matches, wall within ``SERVING_ATTEST_BUDGET_RATIO`` x the reference's, and most of the free VRAM was
+filled. Overlap is the mechanism: two hotkeys fronting one card cannot both fill its free VRAM at the same instant
+and their chains run ~2x slower, so a sharing pair is caught within a few rounds (P = fraction^2 per round). Two
+hotkeys reporting the same GPU UUID within ``SERVING_ATTEST_UUID_MEMORY_ROUNDS`` rounds both fail. A failure is
+never a strike: capacity 0 for the round, re-challenged next round. Miners not in the cohort keep their last
+verdict; a miner with no verdict yet is not READY (admission).
+"""
+
+import asyncio
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, cast
+
+import bittensor as bt
+import requests
+
+from gittensor.constants import (
+    SERVING_ATTEST_BUDGET_RATIO,
+    SERVING_ATTEST_COHORT_FRACTION,
+    SERVING_ATTEST_ITERS,
+    SERVING_ATTEST_MIN_FILL_RATIO,
+    SERVING_ATTEST_TIMEOUT,
+    SERVING_ATTEST_UUID_MEMORY_ROUNDS,
+    SERVING_VRAM_MODEL_RESERVED_BYTES,
+)
+from gittensor.serving.loadout import ServingRelease
+from gittensor.serving.state import ServingState
+from gittensor.synapses import AttestSynapse
+
+
+@dataclass
+class AttestVerdict:
+    passed: bool
+    reason: str
+    uuid: str = ''
+    wall_ms: Optional[float] = None
+    filled_bytes: int = 0
+
+    def as_status(self, now: float, round_no: int) -> dict:
+        return {
+            'passed': self.passed,
+            'reason': self.reason,
+            'uuid': self.uuid,
+            'wall_ms': self.wall_ms,
+            'filled_bytes': self.filled_bytes,
+            'ts': now,
+            'round': round_no,
+        }
+
+
+def choose_cohort(
+    hotkeys: Sequence[str], status: Dict[str, dict], fraction: float = SERVING_ATTEST_COHORT_FRACTION, rng=None
+) -> List[str]:
+    """A random ``fraction`` of ``hotkeys`` (fresh every round), plus never-attested and last-round failures."""
+    rng = rng or secrets.SystemRandom()
+    pool = list(hotkeys)
+    n = min(len(pool), max(1, -(-len(pool) * fraction // 1).__int__())) if pool else 0
+    chosen = set(rng.sample(pool, n)) if n else set()
+    for hk in pool:
+        st = status.get(hk)
+        if st is None or not st.get('passed'):
+            chosen.add(hk)
+    return sorted(chosen)
+
+
+def reference_challenge(release: ServingRelease, seed: int, iters: int, timeout: float) -> Tuple[str, float]:
+    """(expected digest, reference wall ms) from the validator's own reference runtime for ``seed``."""
+    if not release.attest_reference_url:
+        raise RuntimeError('no attest_reference_url on the release')
+    r = requests.post(
+        f'{release.attest_reference_url.rstrip("/")}/v1/attest',
+        json={'seed': seed, 'iters': iters, 'fill': False},
+        timeout=timeout,
+    )
+    r.raise_for_status()
+    payload = r.json()
+    devices = payload.get('devices') or [payload]
+    first = devices[0]
+    if 'digest' not in first:
+        raise RuntimeError(f'reference attest returned no digest: {payload}')
+    return str(first['digest']), float(first.get('wall_ms') or 0.0)
+
+
+def judge(
+    response: Optional[AttestSynapse],
+    expected_digest: str,
+    ref_wall_ms: float,
+    release: ServingRelease,
+    budget_ratio: float = SERVING_ATTEST_BUDGET_RATIO,
+    min_fill_ratio: float = SERVING_ATTEST_MIN_FILL_RATIO,
+) -> AttestVerdict:
+    if response is None or response.devices is None:
+        detail = getattr(response, 'error', None) or getattr(
+            getattr(response, 'dendrite', None), 'status_message', None
+        )
+        return AttestVerdict(False, f'no attestation ({detail or "timeout"})')
+    if not response.devices:
+        return AttestVerdict(False, 'no devices')
+    dev = response.devices[0]
+    if dev.get('error'):
+        return AttestVerdict(False, f'challenge error: {dev["error"]}')
+    uuid = str(dev.get('uuid') or '')
+    wall = float(dev.get('wall_ms') or 0.0) + float(response.queued_ms or 0.0)
+    filled = int(dev.get('filled_bytes') or 0)
+    if str(dev.get('digest')) != expected_digest:
+        return AttestVerdict(False, 'digest mismatch', uuid, wall, filled)
+    budget = budget_ratio * ref_wall_ms if ref_wall_ms > 0 else float('inf')
+    if wall > budget:
+        return AttestVerdict(False, f'too slow: {wall:.0f} ms > {budget:.0f} ms budget', uuid, wall, filled)
+    reserved = release.vram_model_reserved_bytes or SERVING_VRAM_MODEL_RESERVED_BYTES
+    expected_free = max(0.0, float(dev.get('vram_total') or 0.0) - reserved)
+    if expected_free > 0 and filled < min_fill_ratio * expected_free:
+        return AttestVerdict(
+            False, f'under-filled: {filled / 1e9:.1f} GB of {expected_free / 1e9:.1f} GB free', uuid, wall, filled
+        )
+    return AttestVerdict(True, 'ok', uuid, wall, filled)
+
+
+async def send_challenges(
+    dendrite: bt.Dendrite,
+    targets: Sequence[Tuple[int, str, bt.AxonInfo]],
+    seed: int,
+    iters: int,
+    timeout: float = SERVING_ATTEST_TIMEOUT,
+) -> Dict[str, Optional[AttestSynapse]]:
+    """Fire the same challenge at every target at once; None where the call failed."""
+
+    async def one(axon: bt.AxonInfo) -> Optional[AttestSynapse]:
+        try:
+            result = await dendrite.call(
+                target_axon=axon,
+                synapse=AttestSynapse(seed=seed, iters=iters, fill=True),
+                timeout=timeout,
+                deserialize=False,
+            )
+            return cast(AttestSynapse, result)
+        except Exception as e:  # network / axon fault: judged as no attestation
+            bt.logging.debug(f'Serving: attest call failed: {e!r}')
+            return None
+
+    results = await asyncio.gather(*(one(axon) for _, _, axon in targets))
+    return {hotkey: resp for (_, hotkey, _), resp in zip(targets, results)}
+
+
+def dedupe_uuids(
+    state: ServingState, round_no: int, memory_rounds: int = SERVING_ATTEST_UUID_MEMORY_ROUNDS
+) -> List[str]:
+    """Hotkeys whose passing attestation reports a GPU UUID another hotkey reported within ``memory_rounds``."""
+    by_uuid: Dict[str, List[str]] = {}
+    for hk, st in state.attest_status.items():
+        if st.get('uuid') and st.get('passed') and round_no - int(st.get('round', 0)) <= memory_rounds:
+            by_uuid.setdefault(st['uuid'], []).append(hk)
+    return sorted(hk for hks in by_uuid.values() if len(hks) > 1 for hk in hks)
+
+
+async def attest_round(
+    state: ServingState,
+    dendrite: bt.Dendrite,
+    candidates: Sequence[Tuple[int, str, bt.AxonInfo]],
+    release: ServingRelease,
+    rng=None,
+    timeout: float = SERVING_ATTEST_TIMEOUT,
+) -> Dict[str, bool]:
+    """Challenge this round's cohort, update ``state.attest_status``; return hotkey -> attested for every candidate.
+
+    Without an ``attest_reference_url`` (localnet / echo) attestation is off and every candidate counts as attested.
+    If the reference itself fails, nothing changes this round (neutral).
+    """
+    round_no = state.attest_round = getattr(state, 'attest_round', 0) + 1
+    if not release.attest_reference_url:
+        return {hk: True for _, hk, _ in candidates}
+    hotkeys = [hk for _, hk, _ in candidates]
+    cohort = set(choose_cohort(hotkeys, state.attest_status, rng=rng))
+    seed = secrets.randbits(63)
+    iters = release.attest_iters or SERVING_ATTEST_ITERS
+    try:
+        expected, ref_wall = await asyncio.to_thread(reference_challenge, release, seed, iters, timeout)
+    except Exception as e:
+        bt.logging.error(f'Serving: reference attestation failed, attest neutral this round: {e!r}')
+        return {hk: bool(state.attest_status.get(hk, {}).get('passed')) for hk in hotkeys}
+    targets = [(uid, hk, axon) for uid, hk, axon in candidates if hk in cohort]
+    responses = await send_challenges(dendrite, targets, seed, iters, timeout)
+    now = time.time()
+    for uid, hk, _ in targets:
+        verdict = judge(responses.get(hk), expected, ref_wall, release)
+        state.attest_status[hk] = verdict.as_status(now, round_no)
+        bt.logging.info(
+            f'Serving: UID {uid} attest {"PASS" if verdict.passed else "FAIL"} '
+            f'{verdict.wall_ms or 0:.0f} ms (ref {ref_wall:.0f}) fill {verdict.filled_bytes / 1e9:.1f} GB '
+            f'uuid {verdict.uuid or "-"}{"" if verdict.passed else " — " + verdict.reason}'
+        )
+    for hk in dedupe_uuids(state, round_no):
+        st = state.attest_status.get(hk, {})
+        if st.get('passed'):
+            uid = next((u for u, h, _ in candidates if h == hk), '?')
+            bt.logging.warning(f'Serving: UID {uid} attest FAIL — duplicate GPU {st.get("uuid")} across hotkeys')
+            state.attest_status[hk] = {**st, 'passed': False, 'reason': f'duplicate GPU {st.get("uuid")}'}
+    return {hk: bool(state.attest_status.get(hk, {}).get('passed')) for hk in hotkeys}

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -16,31 +16,21 @@ wipes the window and quarantines the hotkey. Miners whose window passes are
 published READY; serving axons that are not READY (and not quarantined) are
 published as *probation* so baseline traffic can give them a window.
 
-    round score = window passes (0/1) x mean speed credit over this round's served requests
+    round score = window passes (0/1) x mean speed credit over this round's served requests x attested (0/1)
 
 Speed credit is measured on served traffic only (TTFT and decode rate against the
-blessing's curve at the load this validator imposed; ``scoring.py``). The load
-burst is telemetry: every READY miner gets
-the release's blessed concurrency of prompts at the same instant as every other miner —
-each prompt unique to that hotkey and round (salted), verified afterwards by
-teacher forcing under the reference like any served request, so an answer can
-neither be shared between hotkeys on one card nor precomputed. Verified tokens
-per second of *decode* time (batch wall-clock minus the first observed TTFT, so
-network distance prices latency, not throughput) over the release's blessed
-``decode_tps_target`` (capped at 1) is reported and persisted per round so a
-shared or slow card is visible; it does not enter pay and never touches the window. Round scores are settled
-over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
+blessing's curve at the load this validator imposed; ``scoring.py``). ``attested``
+is the miner's last hardware attestation verdict (``attest.py``: a random half of
+the READY miners is challenged every round; a miner with no verdict yet stays on
+probation). Round scores are settled over the trailing ``SERVING_SETTLEMENT_ROUNDS``
+rounds by ``ServingState``.
 """
 
 import asyncio
 import hashlib
-import math
 import random
-import secrets
-import statistics
 import threading
 import time
-from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
@@ -49,121 +39,25 @@ import bittensor as bt
 
 from gittensor.constants import (
     SERVING_BASELINE_PER_ROUND,
-    SERVING_CHALLENGE_TIMEOUT,
     SERVING_DORMANT_AFTER_ROUNDS,
     SERVING_DORMANT_RETRY_ROUNDS,
     SERVING_MAX_TOKENS,
-    SERVING_PROBE_DIP_RATIO,
-    SERVING_PROBE_REQUESTS,
-    SERVING_PROBE_RETRY_DELAY_S,
-    SERVING_PROBE_TARGET_TPS,
     SERVING_VERIFY_WORKERS,
 )
 from gittensor.serving.audit import AuditVerdict, Reference, reference_for, verify_served
 from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
-from gittensor.serving.probe import make_prompts
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
 from gittensor.serving.store import ServingStore
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
+from gittensor.validator.serving.attest import attest_round
 from gittensor.validator.serving.persist import ServingRoundStorage
 from gittensor.validator.serving.scoring import request_speed_credit
 from gittensor.validator.utils.config import STORE_DB_RESULTS
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
-
-
-async def probe_axon(
-    state: ServingState,
-    dendrite: bt.Dendrite,
-    uid: int,
-    hotkey: str,
-    axon: bt.AxonInfo,
-    release: ServingRelease,
-    reference: Reference,
-    prompts: Sequence[List[Dict[str, str]]],
-) -> float:
-    """Fire all ``prompts`` at once; return verified tokens per second of decode time (0 when nothing verified).
-
-    The clock covers the streams only. Verification (teacher forcing on the reference, a blocking HTTP call) runs
-    afterwards on a worker thread so it neither stalls the event loop mid-burst nor counts against the miner.
-    """
-
-    async def one(messages: List[Dict[str, str]]) -> InferenceSynapse:
-        synapse = InferenceSynapse(
-            messages=messages, model_id=release.model_id, max_tokens=release.max_tokens, logprobs=True
-        )
-        return await consume_stream(dendrite, axon, synapse, SERVING_CHALLENGE_TIMEOUT)
-
-    started = time.monotonic()
-    responses = await asyncio.gather(*(one(messages) for messages in prompts))
-    wall_s = time.monotonic() - started
-    verdicts = await asyncio.gather(
-        *(asyncio.to_thread(probe_verdict, uid, response, release, reference) for response in responses)
-    )
-    tokens = 0
-    ttfts: List[float] = []
-    for response, (verdict, record) in zip(responses, verdicts):
-        state.record(record)
-        if verdict.passed:
-            tokens += len(getattr(response, 'tokens', None) or [])
-            ttft_ms = response.observed_ttft_ms
-            if ttft_ms is not None and math.isfinite(ttft_ms):
-                ttfts.append(ttft_ms)
-    decode_s = max(wall_s - (min(ttfts) / 1000.0 if ttfts else 0.0), 1e-3)
-    return tokens / decode_s
-
-
-def probe_prompts(count: int) -> List[List[Dict[str, str]]]:
-    """``count`` prompts no other hotkey or round has seen: template + subject + a random salt each."""
-    return [make_prompts(1, seed=secrets.randbits(64), salt=secrets.token_hex(8))[0] for _ in range(count)]
-
-
-def probe_verdict(
-    uid: int, response: InferenceSynapse, release: ServingRelease, reference: Reference
-) -> Tuple[AuditVerdict, RequestRecord]:
-    """Judge one probe response by teacher forcing it under the reference: (verdict, telemetry record).
-
-    A missing response or a wrong model is a failed probe request.
-    """
-    process_time = getattr(getattr(response, 'dendrite', None), 'process_time', None)
-    elapsed_ms = float(process_time) * 1000.0 if process_time is not None else None
-
-    def rec(ok: bool, detail: str) -> RequestRecord:
-        return RequestRecord(
-            ts=time.time(),
-            kind='probe',
-            uid=uid,
-            ok=ok,
-            latency_ms=elapsed_ms,
-            completion_tokens=len(getattr(response, 'tokens', None) or []),
-            ttft_ms=getattr(response, 'ttft_ms', None),
-            decode_tps=getattr(response, 'decode_tps', None),
-            detail=detail,
-        )
-
-    if getattr(response, 'completion', None) is None:
-        dendrite = getattr(response, 'dendrite', None)
-        reason = f'no response ({getattr(dendrite, "status_code", None)} {getattr(dendrite, "status_message", None)})'
-        return AuditVerdict(False, 0.0, float('inf'), reason), rec(False, reason)
-    served = getattr(response, 'served_model_id', None)
-    if served != release.model_id:
-        reason = f'wrong model {served!r}'
-        return AuditVerdict(False, 0.0, float('inf'), reason), rec(False, reason)
-    try:
-        verdict = verify_served(
-            reference,
-            list(response.messages),
-            response.completion,
-            response.tokens,
-            response.token_logprobs,
-            token_ids=response.token_ids,
-        )
-    except Exception as e:  # reference hiccup: an unverified probe request earns no tokens, costs no window
-        verdict = AuditVerdict(False, 0.0, float('inf'), f'could not verify: {e!r}')
-    return verdict, rec(verdict.passed, verdict.reason)
 
 
 def verify_served_round(
@@ -316,45 +210,14 @@ async def baseline_round(
     return len(jobs)
 
 
-def probe_dipped(state: ServingState, hotkey: str, tps: float, ratio: float = SERVING_PROBE_DIP_RATIO) -> bool:
-    """True when ``tps`` is well under this miner's recent form (median of its last three readings)."""
-    recent = state.probe_history.get(hotkey)
-    return bool(recent) and len(recent) >= 2 and tps < ratio * statistics.median(recent)
-
-
-async def probe_with_retry(
-    state: ServingState,
-    dendrite: bt.Dendrite,
-    uid: int,
-    hotkey: str,
-    axon: bt.AxonInfo,
-    release: ServingRelease,
-    reference: Reference,
-    prompts: Sequence[List[Dict[str, str]]],
-    retry_delay_s: Optional[float] = None,
-) -> float:
-    """Probe once; if the reading dipped against the miner's recent form, re-measure once later and keep the better."""
-    tps = await probe_axon(state, dendrite, uid, hotkey, axon, release, reference, prompts)
-    if probe_dipped(state, hotkey, tps):
-        delay = random.uniform(*SERVING_PROBE_RETRY_DELAY_S) if retry_delay_s is None else retry_delay_s
-        bt.logging.info(
-            f'Serving: UID {uid} probe {tps:.0f} tok/s is a dip against recent form; re-measuring in {delay:.0f}s'
-        )
-        await asyncio.sleep(delay)
-        again = await probe_axon(state, dendrite, uid, hotkey, axon, release, reference, probe_prompts(len(prompts)))
-        tps = max(tps, again)
-    state.probe_history.setdefault(hotkey, deque(maxlen=3)).append(tps)
-    return tps
-
-
 async def audit_round(
     state: ServingState,
     dendrite: bt.Dendrite,
     serving: Sequence[Tuple[int, str, bt.AxonInfo]],
     loadout=None,
-    probe_retry_delay_s: Optional[float] = None,
+    attest_rng=None,
 ) -> Dict[str, float]:
-    """Verify served traffic, settle windows, probe READY miners; publish READY/probation; return hotkey -> score."""
+    """Verify served traffic, settle windows, attest READY miners; publish READY/probation; return hotkey -> score."""
     loadout = loadout or load_serving_loadout()
     served = state.drain_served()
     if not serving:
@@ -367,6 +230,7 @@ async def audit_round(
     dormant = len(serving) - len(active)
 
     best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in active}
+    axon_of = {uid: axon for uid, _, axon in serving}
     probation: Dict[int, ReadyMiner] = {}
     summary: Dict[str, int] = {}
     windows: Dict[int, dict] = {}  # per-UID round report; published in state.last_round and persisted to the DB
@@ -408,37 +272,31 @@ async def audit_round(
                 probation[uid] = ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=0.0, model_id=release.model_id)
         if not passing:
             continue
-        target_tps = release.decode_tps_target or SERVING_PROBE_TARGET_TPS
-        burst = release.burst_concurrency or SERVING_PROBE_REQUESTS
-        if burst > 0:
-            rates = await asyncio.gather(
-                *(
-                    probe_with_retry(
-                        state,
-                        dendrite,
-                        uid,
-                        hotkey,
-                        axon,
-                        release,
-                        reference,
-                        probe_prompts(burst),
-                        probe_retry_delay_s,
-                    )
-                    for uid, hotkey, axon, _ in passing
-                )
-            )
-        else:  # probe disabled: capacity is not measured
-            rates = [target_tps] * len(passing)
-        for (uid, hotkey, _, credit), tps in zip(passing, rates):
-            capacity = min(1.0, tps / target_tps)  # telemetry: this card's burst aggregate against one 5090's
-            score = credit
+        attested = await attest_round(
+            state, dendrite, [(uid, hotkey, axon) for uid, hotkey, axon, _ in passing], release, rng=attest_rng
+        )
+        for uid, hotkey, _, credit in passing:
+            ok = attested.get(hotkey, False)
+            score = credit if ok else 0.0
+            st = state.attest_status.get(hotkey, {})
             bt.logging.info(
-                f'Serving: UID {uid} {release.model_id} burst {tps:.0f} tok/s ({capacity:.2f}x blessed) '
-                f'speed credit {credit:.2f} score {score:.3f}'
+                f'Serving: UID {uid} {release.model_id} attested {"yes" if ok else "no"} speed credit {credit:.2f} '
+                f'score {score:.3f}'
             )
+            windows[uid].update(
+                attested=ok,
+                gpu_uuid=st.get('uuid', ''),
+                attest_ms=st.get('wall_ms'),
+                attest_reason=st.get('reason', 'not attested yet'),
+                capacity=1.0 if ok else 0.0,
+                score=round(score, 4),
+            )
+            if not ok and uid not in probation:  # admission / failed attest: not READY, keep receiving baseline
+                probation[uid] = ReadyMiner(
+                    uid=uid, hotkey=hotkey, axon=axon_of[uid], score=0.0, model_id=release.model_id
+                )
             if score > best[hotkey][0]:
                 best[hotkey] = (score, release.model_id)
-                windows[uid].update(probe_tps=round(tps, 1), capacity=round(capacity, 4), score=round(score, 4))
 
     scores = {hotkey: score for hotkey, (score, _) in best.items()}
     ready: List[ReadyMiner] = []
@@ -534,11 +392,11 @@ class ServingAuditThread:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         dendrite = bt.Dendrite(wallet=self.validator.wallet)
-        # The probe streams from every READY miner at once (fleet x SERVING_PROBE_REQUESTS); aiohttp's default
+        # Baseline traffic and attestation go to every serving miner at once; aiohttp's default
         # connector caps a session at 100 connections, which would queue late miners on the validator and skew
         # their measured throughput. Uncapped connector for the audit dendrite only.
         dendrite._session = loop.run_until_complete(_unlimited_session())
-        # Validators probe on the same interval; a per-hotkey phase offset keeps their bursts from landing on a
+        # Validators audit on the same interval; a per-hotkey phase offset keeps their attest cohorts from landing on a
         # miner at the same instant and each reading half a card.
         self._stop.wait(probe_phase_offset(self.validator.wallet.hotkey.ss58_address, self.interval_s))
         while not self._stop.is_set():

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -21,6 +21,7 @@ from gittensor.constants import (
     SERVING_DECODE_FLOOR_RATIO,
     SERVING_DECODE_MIN_TOKENS,
     SERVING_DECODE_PER_REQUEST_FALLBACK,
+    SERVING_DECODE_TOLERANCE_RATIO,
     SERVING_LATENCY_FULL_CREDIT_MS,
     SERVING_LATENCY_ZERO_CREDIT_MS,
 )
@@ -51,11 +52,17 @@ def expected_decode_tps(curve: Optional[Dict[int, float]], inflight: int) -> flo
     return points[-1][1]
 
 
-def decode_credit(observed_tps: float, expected_tps: float, floor_ratio: float = SERVING_DECODE_FLOOR_RATIO) -> float:
+def decode_credit(
+    observed_tps: float,
+    expected_tps: float,
+    floor_ratio: float = SERVING_DECODE_FLOOR_RATIO,
+    tolerance_ratio: float = SERVING_DECODE_TOLERANCE_RATIO,
+) -> float:
+    """1.0 down to ``tolerance_ratio`` x expected, then linear, 0 under ``floor_ratio`` x expected."""
     if expected_tps <= 0:
         return 1.0
     ratio = observed_tps / expected_tps
-    return 0.0 if ratio < floor_ratio else min(1.0, ratio)
+    return 0.0 if ratio < floor_ratio else min(1.0, ratio / tolerance_ratio)
 
 
 def request_speed_credit(req: ServedRequest, release: ServingRelease) -> float:

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -15,11 +15,8 @@
       "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
       "audit_bank": "serving_audit_bank.json",
       "speed": {
-        "decode_tps_target": 280.0,
         "single_stream_decode_tps": 443.6,
-        "probe_shaped_decode_tps": 280.0,
         "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 \u2014 queues past 16, wall 3.7 s -> 7 s)",
-        "burst_concurrency": 16,
         "decode_per_request": {
           "1": 443.6,
           "6": 46.0,
@@ -27,6 +24,10 @@
           "24": 19.4,
           "32": 19.5
         }
+      },
+      "attest": {
+        "iters": 3,
+        "vram_model_reserved_bytes": 24000000000
       }
     }
   ]

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -39,6 +39,7 @@ from functools import partial
 from typing import Dict, Optional, Tuple
 
 import bittensor as bt
+import requests
 from bittensor.core.stream import StreamingSynapse
 from bittensor.utils.axon_utils import allowed_nonce_window_ns, calculate_diff_seconds
 from bittensor_wallet import Keypair
@@ -53,7 +54,7 @@ from gittensor.constants import (
 )
 from gittensor.serving.backends import InferenceBackend, load_backend
 from gittensor.serving.loadout import load_serving_loadout
-from gittensor.synapses import InferenceSynapse
+from gittensor.synapses import AttestSynapse, InferenceSynapse
 from neurons.base.neuron import BaseNeuron
 
 BTStreamingResponse = StreamingSynapse.BTStreamingResponse
@@ -75,6 +76,11 @@ class ServingMiner(BaseNeuron):
         self.axon = bt.Axon(wallet=self.wallet, config=self.config)
         self.axon.attach(
             forward_fn=partial(handle_inference, self),
+            blacklist_fn=partial(blacklist_inference, self),
+            priority_fn=partial(priority_inference, self),
+            verify_fn=partial(verify_inference, self),
+        ).attach(
+            forward_fn=partial(handle_attest, self),
             blacklist_fn=partial(blacklist_inference, self),
             priority_fn=partial(priority_inference, self),
             verify_fn=partial(verify_inference, self),
@@ -138,6 +144,34 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BT
             await producer
 
     return synapse.create_streaming_response(token_streamer)
+
+
+async def handle_attest(miner: ServingMiner, synapse: AttestSynapse) -> AttestSynapse:
+    """Run the validator's hardware challenge on this miner's runtime (attest sidecar, docker/attest)."""
+    url = miner.release.attest_url
+    if not url:
+        synapse.error = 'no attest_url on the release'
+        return synapse
+
+    def call() -> dict:
+        r = requests.post(
+            f'{url.rstrip("/")}/v1/attest',
+            json={'seed': int(synapse.seed), 'iters': int(synapse.iters), 'fill': bool(synapse.fill)},
+            timeout=max(5.0, float(synapse.timeout or 45.0) - 2.0),
+        )
+        r.raise_for_status()
+        return r.json()
+
+    try:
+        payload = await asyncio.get_running_loop().run_in_executor(None, call)
+    except Exception as e:
+        synapse.error = f'attest sidecar: {e!r}'[:300]
+        return synapse
+    devices = payload.get('devices') or [payload]
+    synapse.devices = [dict(d) for d in devices]
+    synapse.wall_ms = float(devices[0].get('wall_ms') or 0.0) if devices else None
+    synapse.queued_ms = float(payload.get('queued_ms') or 0.0)
+    return synapse
 
 
 async def verify_inference(miner: ServingMiner, synapse: InferenceSynapse) -> None:

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -341,6 +341,54 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
     }
 
 
+def check_attest(rep: Report, base_url: str, timeout: float) -> Dict:
+    """A1: the runtime image's attestation sidecar (:8081) answers a seeded challenge with a digest inside 3 s idle,
+    and two simultaneous challenges each take >= 1.6x a single one (the property the cohort check rests on)."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(base_url)
+    host = parts.hostname or ''
+    attest_url = urlunsplit((parts.scheme or 'http', f'{host}:8081', '', '', ''))
+    facts: Dict = {}
+    try:
+        single = requests.post(
+            f'{attest_url}/v1/attest', json={'seed': 12345, 'iters': 3, 'fill': True}, timeout=timeout
+        )
+        single.raise_for_status()
+        dev = (single.json().get('devices') or [single.json()])[0]
+    except Exception as e:
+        rep.add('A1 POST :8081/v1/attest', MUST, False, repr(e)[:120])
+        return facts
+    wall = float(dev.get('wall_ms') or 0.0)
+    rep.add('A1 POST :8081/v1/attest', MUST, bool(dev.get('digest')), f'{wall:.0f} ms, uuid {dev.get("uuid")}')
+    rep.add('A1 attest wall <= 3000 ms idle', MUST, 0 < wall <= 3000.0, f'{wall:.0f} ms')
+    again = requests.post(f'{attest_url}/v1/attest', json={'seed': 12345, 'iters': 3, 'fill': True}, timeout=timeout)
+    same = again.ok and (again.json().get('devices') or [again.json()])[0].get('digest') == dev.get('digest')
+    rep.add('A1 digest deterministic for a seed', MUST, bool(same))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        pair = list(
+            pool.map(
+                lambda _: requests.post(
+                    f'{attest_url}/v1/attest', json={'seed': 777, 'iters': 3, 'fill': True}, timeout=timeout
+                ).json(),
+                range(2),
+            )
+        )
+    walls = [float((r.get('devices') or [r])[0].get('wall_ms') or 0.0) + float(r.get('queued_ms') or 0.0) for r in pair]
+    rep.add(
+        'A1 two simultaneous challenges each >= 1.6x one',
+        MUST,
+        min(walls) >= 1.6 * wall,
+        f'{walls[0]:.0f} / {walls[1]:.0f} ms vs {wall:.0f}',
+    )
+    facts.update(
+        attest_ref_wall_ms=round(wall, 1),
+        attest_iters=3,
+        vram_model_reserved_bytes=int(dev.get('vram_total') or 0) - int(dev.get('vram_free_before') or 0),
+    )
+    return facts
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--base-url', default='http://127.0.0.1:8080')
@@ -380,8 +428,10 @@ def main() -> int:
     if args.parallel > 0:
         check_overload(rep, base_url, args.model_id, args.parallel, args.overload_max_tokens, args.timeout)
 
+    attest_facts = check_attest(rep, base_url, args.timeout)
     if args.speed_json:
         profile = speed_profile(base_url, args.model_id, args.max_tokens, args.timeout, args.speed_burst)
+        profile['attest'] = attest_facts
         with open(args.speed_json, 'w') as f:
             json.dump(profile, f, indent=2)
         print(f'\nSpeed profile ({args.speed_json}): {profile}')

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -391,72 +391,6 @@ def test_audit_window_tolerates_one_miss_per_round():
     assert window_threshold(1, SERVING_AUDIT_WINDOW_THRESHOLDS) == window_threshold(SERVING_AUDIT_WINDOW)
 
 
-def test_probe_verdict_teacher_forces_the_response():
-    from gittensor.synapses import InferenceSynapse
-    from gittensor.validator.serving.forward import probe_verdict
-
-    release = _echo_release()
-    ref = EchoReference(release)
-    case = ref.sample()
-    miss = InferenceSynapse(messages=case.messages, model_id=release.model_id, max_tokens=case.max_tokens)
-    verdict, rec = probe_verdict(3, miss, release, ref)
-    assert not verdict.passed and not rec.ok
-    assert rec.latency_ms is None  # inf is not JSON; /v1/serving/status must serialize the record
-
-    honest = InferenceSynapse(
-        messages=case.messages,
-        model_id=release.model_id,
-        max_tokens=case.max_tokens,
-        completion=case.reference_completion,
-        served_model_id=release.model_id,
-        tokens=list(case.reference_tokens),
-        token_logprobs=list(case.reference_logprobs),
-    )
-    verdict, rec = probe_verdict(3, honest, release, ref)
-    assert verdict.passed and rec.ok
-
-    wrong = honest.model_copy(update={'served_model_id': 'other'})
-    verdict, rec = probe_verdict(3, wrong, release, ref)
-    assert not verdict.passed and rec.detail.startswith('wrong model')
-
-    tokens = list(case.reference_tokens)
-    tokens[len(tokens) // 2] = 'xxxxxxxx'
-    lie = honest.model_copy(update={'tokens': tokens, 'completion': ' '.join(tokens)})
-    verdict, rec = probe_verdict(3, lie, release, ref)
-    assert not verdict.passed and verdict.hard
-
-
-def test_probe_prompts_are_unique_per_hotkey_and_salted(monkeypatch):
-    """Two hotkeys probed in one round never see the same prompt, so one card cannot answer for both."""
-    from types import SimpleNamespace
-
-    from gittensor.serving.probe import make_prompts
-
-    good = _echo_release()
-    seen: Dict[int, list] = {}
-    dendrite, _ = _dendrite_echoing(good)
-    inner = dendrite.call_stream
-
-    async def call_stream(target_axon, synapse, timeout, deserialize):
-        seen.setdefault(id(target_axon), []).append(synapse.messages[-1]['content'])
-        async for chunk in inner(target_axon, synapse, timeout, deserialize):
-            yield chunk
-
-    dendrite.call_stream = call_stream
-    a, b = SimpleNamespace(is_serving=True), SimpleNamespace(is_serving=True)
-    state = ServingState(settlement_rounds=1)
-    for uid in (1, 2):
-        state.enqueue_served(_served(uid, good))
-    scores = _round(state, dendrite, [(1, 'hk1', a), (2, 'hk2', b)], good, monkeypatch, probes=3)
-    assert scores['hk1'] > 0 and scores['hk2'] > 0
-    probes_a = [c for c in seen[id(a)] if '(ref ' in c]
-    probes_b = [c for c in seen[id(b)] if '(ref ' in c]
-    assert len(probes_a) == 3 and len(probes_b) == 3
-    assert not set(probes_a) & set(probes_b) and len(set(probes_a)) == 3
-    plain = make_prompts(1, seed=1)[0][-1]['content']
-    assert make_prompts(1, seed=1, salt='abcd')[0][-1]['content'] == f'{plain} (ref abcd)'
-
-
 def test_release_speed_facts_price_capacity_and_latency(tmp_path):
     from gittensor.serving.loadout import load_serving_loadout
 
@@ -465,19 +399,19 @@ def test_release_speed_facts_price_capacity_and_latency(tmp_path):
             {
                 'model_id': 'm',
                 'backend': 'echo',
-                'speed': {'decode_tps_target': 900.0, 'ttft_full_ms': 300.0, 'ttft_zero_ms': 900.0},
+                'speed': {'ttft_full_ms': 300.0, 'ttft_zero_ms': 900.0},
             }
         ]
     }
     path = tmp_path / 'loadout.json'
     path.write_text(json.dumps(raw))
     release = load_serving_loadout(path).primary
-    assert (release.decode_tps_target, release.ttft_full_ms, release.ttft_zero_ms) == (900.0, 300.0, 900.0)
+    assert (release.ttft_full_ms, release.ttft_zero_ms) == (300.0, 900.0)
     assert latency_credit(300.0, release.ttft_full_ms, release.ttft_zero_ms) == 1.0
     assert latency_credit(600.0, release.ttft_full_ms, release.ttft_zero_ms) == pytest.approx(0.5)
     assert latency_credit(400.0) == 1.0 and latency_credit(600.0) == pytest.approx(0.9)  # constants' defaults
     bare = load_serving_loadout(ECHO_LOADOUT_PATH).primary
-    assert bare.decode_tps_target is None and bare.ttft_full_ms is None
+    assert bare.ttft_full_ms is None and bare.attest_reference_url is None
 
 
 def test_latency_credit_matches_measured_latencies():
@@ -733,7 +667,6 @@ def _round(state, dendrite, serving, release, monkeypatch, probes: int = 0):
 
     from gittensor.validator.serving import forward as fwd
 
-    monkeypatch.setattr(fwd, 'SERVING_PROBE_REQUESTS', probes)
     return asyncio.run(fwd.audit_round(state, dendrite, serving, ServingLoadout(releases=[release])))  # type: ignore[arg-type]
 
 
@@ -926,41 +859,6 @@ def test_baseline_prompts_vary_in_shape_and_length():
     assert baseline_max_tokens(rng, 100) <= 100
 
 
-def test_probe_retries_once_on_a_dip_and_keeps_the_better_reading(monkeypatch):
-    """A reading well under the miner's recent form is re-measured; a persistent dip sticks; no history, no retry."""
-    import asyncio
-    from collections import deque
-    from types import SimpleNamespace
-
-    from gittensor.validator.serving import forward as fwd
-
-    good = _echo_release()
-    readings: list = []
-    calls = {'n': 0}
-
-    async def fake_probe(state, dendrite, uid, hotkey, axon, release, reference, prompts):
-        calls['n'] += 1
-        return readings.pop(0)
-
-    monkeypatch.setattr(fwd, 'probe_axon', fake_probe)
-    ref = EchoReference(good)
-    args = (None, 1, 'hk1', SimpleNamespace(), good, ref, [ref.sample()] * 2)
-
-    state = ServingState()
-    readings[:] = [50.0]  # no history yet: accepted as is, no retry
-    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 50.0 and calls['n'] == 1  # type: ignore[arg-type]
-
-    state.probe_history['hk1'] = deque([180.0, 178.0], maxlen=3)
-    readings[:] = [50.0, 181.0]  # collision on the first burst, clean on the second
-    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 181.0 and calls['n'] == 3  # type: ignore[arg-type]
-    assert list(state.probe_history['hk1']) == [180.0, 178.0, 181.0]
-
-    readings[:] = [50.0, 48.0]  # a real slowdown dips twice
-    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 50.0 and calls['n'] == 5  # type: ignore[arg-type]
-    readings[:] = [170.0]  # within form: single probe
-    assert asyncio.run(fwd.probe_with_retry(state, *args, retry_delay_s=0.0)) == 170.0 and calls['n'] == 6  # type: ignore[arg-type]
-
-
 def test_get_serving_axons_skips_active_validators_not_permit_holders():
     """On a small subnet nearly every UID holds a permit (testnet 422: 10 of 46, incl. the test miner); only UIDs
     with validator_trust > 0 are actually validating."""
@@ -1077,7 +975,6 @@ def test_audit_round_skips_release_without_reference(monkeypatch):
     axon = SimpleNamespace(is_serving=True)
     state = ServingState(settlement_rounds=1)
     state.enqueue_served(_served(1, good))
-    monkeypatch.setattr('gittensor.validator.serving.forward.SERVING_PROBE_REQUESTS', 0)
     import asyncio
 
     from gittensor.validator.serving import forward as fwd
@@ -1091,64 +988,6 @@ def test_audit_round_skips_release_without_reference(monkeypatch):
     assert state.scores_for(['v', 'other']) == {}  # UID 1's hotkey changed since the round: nothing carries over
 
 
-def test_capacity_probe_splits_a_shared_gpu(monkeypatch):
-    """Two hotkeys on one card each report about half the blessed burst aggregate (telemetry); a lone card ~1."""
-    from types import SimpleNamespace
-
-    from gittensor.validator.serving import forward as fwd
-
-    good = _echo_release()
-    lone, a, b = (SimpleNamespace(is_serving=True) for _ in range(3))
-    gpu_of = {id(lone): 'gpu-1', id(a): 'gpu-2', id(b): 'gpu-2'}
-    dendrite, _ = _dendrite_echoing(good, gpu_of=gpu_of, token_s=0.0005)
-    rates = []
-    real_probe = fwd.probe_axon
-
-    async def spy(*args, **kwargs):
-        rate = await real_probe(*args, **kwargs)
-        rates.append(rate)
-        return rate
-
-    monkeypatch.setattr(fwd, 'probe_axon', spy)
-    monkeypatch.setattr(fwd, 'SERVING_PROBE_TARGET_TPS', 1e-9)
-    state = ServingState(settlement_rounds=1)
-    state.enqueue_served(_served(1, good))
-    _round(state, dendrite, [(1, 'hk1', lone)], good, monkeypatch, probes=4)
-    probe = [r for r in state.recent(50) if r.kind == 'probe']
-    assert len(probe) == 4 and all(r.ok for r in probe)
-    lone_tps = rates[0]
-
-    monkeypatch.setattr(fwd, 'SERVING_PROBE_TARGET_TPS', lone_tps)
-    state = ServingState(settlement_rounds=1)
-    for uid in (1, 2, 3):
-        state.enqueue_served(_served(uid, good))
-    serving = [(1, 'hk1', lone), (2, 'hk2', a), (3, 'hk3', b)]
-    scores = _round(state, dendrite, serving, good, monkeypatch, probes=4)
-    assert scores == {'hk1': 1.0, 'hk2': 1.0, 'hk3': 1.0}  # the burst is telemetry: pay comes from served speed
-    tele = state.last_round['windows']
-    assert tele[1]['capacity'] == pytest.approx(1.0, abs=0.15)
-    assert tele[2]['capacity'] == pytest.approx(0.5, abs=0.15) and tele[3]['capacity'] == pytest.approx(0.5, abs=0.15)
-    assert all(r.ok for r in state.recent(50) if r.kind == 'probe')  # answered correctly, just slowly
-
-
-def test_probe_misses_are_telemetry_not_the_window(monkeypatch):
-    """A miner that serves traffic honestly but chokes on the burst keeps its window and pay; the burst is re-sent."""
-    from types import SimpleNamespace
-
-    good = _echo_release()
-    axon = SimpleNamespace(is_serving=True)
-    dendrite, calls = _dendrite_echoing(good, dead_axons=(axon,))  # every probe request dropped
-    state = ServingState(settlement_rounds=1)
-    for _ in range(2):
-        state.enqueue_served(_served(1, good))
-        scores = _round(state, dendrite, [(1, 'hk1', axon)], good, monkeypatch, probes=6)
-        assert scores == {'hk1': 1.0} and state.last_round['windows'][1]['capacity'] == 0.0
-    assert calls == {id(axon): 12}
-    window = state.audits.verdict('hk1', good.model_id)
-    assert window.passed and window.n_audits == 2 and window.mean == 1.0
-    assert sum(1 for r in state.recent(50) if r.kind == 'probe' and not r.ok) == 12
-
-
 def test_decode_speed_prices_served_requests_against_the_blessing_curve():
     from gittensor.validator.serving.scoring import decode_credit, expected_decode_tps, request_speed_credit
 
@@ -1158,7 +997,8 @@ def test_decode_speed_prices_served_requests_against_the_blessing_curve():
     assert expected_decode_tps(curve, 11) == pytest.approx(32.5)  # linear between 6 and 16
     assert expected_decode_tps(None, 6) == 46.0  # constants' fallback curve
     assert decode_credit(440.0, 440.0) == 1.0 and decode_credit(600.0, 440.0) == 1.0  # never more than one card
-    assert decode_credit(330.0, 440.0) == pytest.approx(0.75)
+    assert decode_credit(352.0, 440.0) == 1.0  # 0.8x: inside the tolerance for WAN-observed decode
+    assert decode_credit(264.0, 440.0) == pytest.approx(0.75)  # 0.6x -> 0.6 / 0.8
     assert decode_credit(200.0, 440.0) == 0.0  # under the floor: shared card / not the blessed runtime
 
     release = _echo_release()
@@ -1186,7 +1026,7 @@ def test_decode_speed_prices_served_requests_against_the_blessing_curve():
     assert request_speed_credit(busy, release) == pytest.approx(1.0)
     shared = req(64, 100.0, 100.0 + 64 / 19.0 * 1000.0, inflight=1)  # 19 tok/s while we sent it one request
     assert request_speed_credit(shared, release) == 0.0
-    slowish = req(64, 100.0, 100.0 + 64 / 330.0 * 1000.0)
+    slowish = req(64, 100.0, 100.0 + 64 / 264.0 * 1000.0)
     assert request_speed_credit(slowish, release) == pytest.approx(0.75)
     short = req(8, 100.0, 5_000.0)  # too few tokens to measure decode: TTFT band only
     assert request_speed_credit(short, release) == 1.0
@@ -1449,3 +1289,134 @@ def test_axon_that_answers_without_a_completion_gets_a_real_reason(monkeypatch):
     asyncio.run(fwd.baseline_round(state, dendrite, serving, good, window_s=0.01, per_miner=1, rng=random.Random(1)))
     (q,) = state.drain_served()
     assert not q.ok and q.detail.startswith('no completion: axon answered "Success"') and good.model_id in q.detail
+
+
+def _attest_release(reference: str = 'http://ref:8081') -> ServingRelease:
+    release = _echo_release()
+    release.attest_reference_url = reference
+    release.vram_model_reserved_bytes = 24e9
+    return release
+
+
+def _attest_reply(
+    digest: str = 'd', wall_ms: float = 1500.0, filled: int = 8_000_000_000, uuid: str = 'GPU-a', queued_ms=0.0
+):
+    from gittensor.synapses import AttestSynapse
+
+    return AttestSynapse(
+        seed=1,
+        devices=[{'uuid': uuid, 'digest': digest, 'wall_ms': wall_ms, 'filled_bytes': filled, 'vram_total': 34e9}],
+        wall_ms=wall_ms,
+        queued_ms=queued_ms,
+    )
+
+
+def test_attest_verdicts():
+    from gittensor.validator.serving.attest import judge
+
+    release = _attest_release()
+    assert judge(_attest_reply(), 'd', 1400.0, release).passed
+    assert judge(None, 'd', 1400.0, release).reason.startswith('no attestation')
+    assert judge(_attest_reply(digest='x'), 'd', 1400.0, release).reason == 'digest mismatch'
+    slow = judge(_attest_reply(wall_ms=1500.0, queued_ms=1500.0), 'd', 1400.0, release)  # queued behind another
+    assert not slow.passed and slow.reason.startswith('too slow')
+    assert judge(_attest_reply(filled=2_000_000_000), 'd', 1400.0, release).reason.startswith('under-filled')
+    from gittensor.synapses import AttestSynapse
+
+    assert judge(AttestSynapse(seed=1, error='sidecar down'), 'd', 1400.0, release).reason.startswith('no attestation')
+
+
+def test_attest_cohort_is_random_half_plus_unproven_and_failed():
+    import random
+
+    from gittensor.validator.serving.attest import choose_cohort
+
+    hotkeys = [f'hk{i}' for i in range(20)]
+    status = {hk: {'passed': True} for hk in hotkeys}
+    status['hk3'] = {'passed': False}
+    del status['hk7']  # never attested
+    rng = random.Random(1)
+    cohort = choose_cohort(hotkeys, status, rng=rng)
+    assert 'hk3' in cohort and 'hk7' in cohort and 10 <= len(cohort) <= 12
+    together = sum(1 for _ in range(400) if {'hk1', 'hk2'} <= set(choose_cohort(hotkeys, status, rng=rng)))
+    assert 60 <= together <= 140  # P = 0.25 per round for a sharing pair
+
+
+def test_attest_round_gates_pay_and_persists(monkeypatch, tmp_path):
+    import asyncio
+
+    """No verdict -> probation; a failing cohort member scores 0; a passing one keeps its speed credit; non-cohort
+    members keep their last verdict; duplicate GPU UUIDs fail both; status survives the store."""
+    import random
+    from types import SimpleNamespace
+
+    from gittensor.serving.store import ServingStore
+    from gittensor.validator.serving import attest as att
+
+    release = _attest_release()
+    monkeypatch.setattr(att, 'reference_challenge', lambda rel, seed, iters, timeout: ('d', 1400.0))
+    replies = {}
+
+    async def call(target_axon, synapse, timeout, deserialize):
+        return replies[id(target_axon)]
+
+    axons = {hk: SimpleNamespace(is_serving=True) for hk in ('hk1', 'hk2', 'hk3')}
+    replies[id(axons['hk1'])] = _attest_reply(uuid='GPU-1')
+    replies[id(axons['hk2'])] = _attest_reply(uuid='GPU-2', digest='wrong')
+    replies[id(axons['hk3'])] = _attest_reply(uuid='GPU-1')  # same card as hk1
+    dendrite = SimpleNamespace(call=call)
+    state = ServingState()
+    candidates = [(1, 'hk1', axons['hk1']), (2, 'hk2', axons['hk2']), (3, 'hk3', axons['hk3'])]
+    out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
+    assert out == {'hk1': False, 'hk2': False, 'hk3': False}  # hk2 wrong digest; hk1/hk3 share GPU-1
+    assert state.attest_status['hk2']['reason'] == 'digest mismatch'
+    assert 'duplicate GPU' in state.attest_status['hk1']['reason']
+
+    replies[id(axons['hk3'])] = _attest_reply(uuid='GPU-3')
+    out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
+    assert out['hk1'] and out['hk3'] and not out['hk2']  # all three were re-challenged (none had passed)
+    store = ServingStore(tmp_path / 'serving.db')
+    store.save(state)
+    again = store.load(ServingState())
+    assert again.attest_status['hk1']['uuid'] == 'GPU-1' and again.attest_status['hk2']['passed'] is False
+
+    monkeypatch.setattr(att, 'reference_challenge', lambda *a, **k: (_ for _ in ()).throw(RuntimeError('ref down')))
+    neutral = asyncio.run(att.attest_round(state, dendrite, candidates, release))  # type: ignore[arg-type]
+    assert neutral == {'hk1': True, 'hk2': False, 'hk3': True}  # reference down: nothing changes
+
+
+def test_audit_round_requires_attestation_when_a_reference_is_configured(monkeypatch):
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving import attest as att
+
+    release = _attest_release()
+    monkeypatch.setattr(att, 'reference_challenge', lambda rel, seed, iters, timeout: ('d', 1400.0))
+    good, bad = SimpleNamespace(is_serving=True), SimpleNamespace(is_serving=True)
+    replies = {id(good): _attest_reply(uuid='GPU-g'), id(bad): _attest_reply(uuid='GPU-b', wall_ms=9_000.0)}
+    dendrite, _ = _dendrite_echoing(release)
+
+    async def call(target_axon, synapse, timeout, deserialize):
+        return replies[id(target_axon)]
+
+    dendrite.call = call
+    state = ServingState(settlement_rounds=1)
+    for uid in (1, 2):
+        state.enqueue_served(_served(uid, release))
+    scores = _round(state, dendrite, [(1, 'hk1', good), (2, 'hk2', bad)], release, monkeypatch)
+    assert scores == {'hk1': 1.0, 'hk2': 0.0}
+    snap = state.snapshot()
+    assert snap['ready_uids'] == [1] and snap['probation_uids'] == [2]  # failed attest: not READY, not struck
+    w = state.audits.verdict('hk2', release.model_id)
+    assert w.passed and w.quarantined_until == 0.0
+    tele = state.last_round['windows']
+    assert tele[1]['attested'] and tele[1]['gpu_uuid'] == 'GPU-g' and not tele[2]['attested']
+    assert tele[2]['attest_reason'].startswith('too slow')
+
+
+def test_sidecar_url_derives_from_the_runtime_url():
+    from gittensor.serving.loadout import _sidecar_url
+
+    assert _sidecar_url('http://82.76.142.91:45565') == 'http://82.76.142.91:8081'
+    assert _sidecar_url('http://reference:8080/') == 'http://reference:8081'
+    assert _sidecar_url(None) is None


### PR DESCRIPTION
Implements `~/vlabs/gittensor/compute/15-attest-implementation-spec-2026-08-28.md` (decided with Alex 01:00 8/28). No synthetic traffic is left in the pay path: **the 16-request load burst is deleted**, including its telemetry. Speed stays on served traffic (#1721), now with a tolerance band (§ below).

```
round score = window(0/1) × mean speed credit over served requests × attested(0/1)
```

**Image (`docker/attest`, built into `entrius/sparkinfer:<tag>` by the existing workflow — new `image_tag` input so a gittensor-side image change does not overwrite the blessed sha tag):**
- `gt_attest.cu` — our own challenge, compiled in the build stage with `-fmad=false` for sm_120: fills all free VRAM with a seeded stream, runs a seeded fp32 tiled-GEMM + tanh chain over a 2 GB working set (512 × 1024²), SHA-256 over the head of every matrix per iteration → one digest; reports GPU UUID (NVML), VRAM, bytes filled, wall ms. Hand-written GEMM with fixed summation order, no atomics/reductions/TF32, so every card of the architecture produces the same bits. GraVal is not used (closed OpenCL `.so`, does not initialise on sm_120 — tested 8/27).
- `attest_server.py` — stdlib sidecar on **:8081**: `POST /v1/attest {seed, iters, fill}` runs the binary; challenges are serialised, and a queued one reports its wait, which is what makes two hotkeys on one card visible. `entrypoint.sh` starts it beside `sparkinfer_server`.

**Validator (`gittensor/validator/serving/attest.py`):** each round a random **half** of the READY miners (plus never-attested and last-round failures), one fresh seed, fired at the same instant. The expected digest and reference wall time come from the validator's **own reference** (same image, `attest_reference_url` = reference host :8081) — no GPU code in the validator. PASS = digest matches ∧ wall (incl. queue) ≤ 1.6× reference ∧ ≥ 60 % of free VRAM filled (free = total − `attest.vram_model_reserved_bytes`, 24 GB for this pin). Two hotkeys reporting the same GPU UUID within 12 rounds both fail. **Never a strike**: a failure is capacity 0 for the round and re-challenge next round; a miner with no verdict yet is not READY (admission). Reference failure → neutral round. Non-cohort miners keep their last verdict; verdicts persist in `serving.db`. Without an `attest_reference_url` (localnet/echo) attestation is off.

**Miner:** `AttestSynapse` handler in `serving_miner.py` proxies to its runtime's sidecar (`attest.url` in the loadout, default `base_url` host :8081). Same caller gate / verify as inference.

**Decode credit tolerance:** soak 5 showed honest miners at 0.61–0.96 because the blessing curve is measured on-box and the validator observes stream delivery over the WAN; credit is now 1.0 down to 0.8× expected (`SERVING_DECODE_TOLERANCE_RATIO`), linear below, floor 0.5×. Proper fix (validator-vantage curve at blessing) still listed in the spec.

**Blessing:** `check_serving_runtime.py` gains A1 (attest answers, ≤ 3 s idle, deterministic per seed, two simultaneous challenges each ≥ 1.6× one) and writes `attest.*` facts; the CI pin-bump writes `attest.{iters, vram_model_reserved_bytes, reference_wall_ms}`. Loadout carries `attest` and `decode_per_request`; `decode_tps_target`/`burst_concurrency` are gone.

**Not yet done / needs a GPU:** the CUDA binary has only been compiled by CI (build-only dry run on this push; a real image `7498736-attest1` is dispatched from this branch). Sizing (`--iters`) and the ≥1.6× overlap property must be measured on a 5090; the test plan is spec §3 (fresh pods with `--internal-ports 22,8080,8081`, a deliberate third hotkey on one card). `serving_miner_rounds` still writes `capacity` = attested and `probe_tps` = null; a gittensor-db migration for `attested / gpu_uuid / attest_ms` is a follow-up. README serving sections still describe the burst.

Known limits (spec §4): same-arch bigger cards can pass for more than one hotkey; a forked image can fake digest/UUID; a non-serving job on the card fails that round's attest (capacity 0, not a strike).