### PR TITLE
serving miner: attest axon hooks typed AttestSynapse (attach signature assertion)

### DIFF
--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -81,9 +81,9 @@ class ServingMiner(BaseNeuron):
             verify_fn=partial(verify_inference, self),
         ).attach(
             forward_fn=partial(handle_attest, self),
-            blacklist_fn=partial(blacklist_inference, self),
-            priority_fn=partial(priority_inference, self),
-            verify_fn=partial(verify_inference, self),
+            blacklist_fn=partial(blacklist_attest, self),
+            priority_fn=partial(priority_attest, self),
+            verify_fn=partial(verify_attest, self),
         )
         self.backend_slots = asyncio.Semaphore(SERVING_BACKEND_CONCURRENCY)
         self.seen_nonces: 'OrderedDict[str, None]' = OrderedDict()
@@ -249,6 +249,27 @@ async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) ->
     if not reserve_audit_budget(miner, hotkey, int(synapse.max_tokens)):
         return True, f'Validator audit budget spent ({validator_tokens_per_tempo()} tokens per tempo)'
     return False, 'Permitted validator'
+
+
+# bt.Axon.attach asserts each hook's signature against the forward's synapse type, so the attestation hooks are
+# typed AttestSynapse and delegate to the inference gate. An attestation charges no tokens to a validator's budget.
+async def blacklist_attest(miner: ServingMiner, synapse: AttestSynapse) -> Tuple[bool, str]:
+    return await blacklist_inference(miner, _as_budget_free(synapse))
+
+
+async def priority_attest(miner: ServingMiner, synapse: AttestSynapse) -> float:
+    return await priority_inference(miner, _as_budget_free(synapse))
+
+
+async def verify_attest(miner: ServingMiner, synapse: AttestSynapse) -> None:
+    await verify_inference(miner, synapse)  # type: ignore[arg-type]
+
+
+def _as_budget_free(synapse: AttestSynapse) -> InferenceSynapse:
+    """The inference gate reads dendrite + max_tokens; an attestation is the same caller charging zero tokens."""
+    shim = InferenceSynapse(messages=[], model_id='', max_tokens=0)
+    shim.dendrite = synapse.dendrite
+    return shim
 
 
 async def priority_inference(miner: ServingMiner, synapse: InferenceSynapse) -> float:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1420,3 +1420,19 @@ def test_sidecar_url_derives_from_the_runtime_url():
     assert _sidecar_url('http://82.76.142.91:45565') == 'http://82.76.142.91:8081'
     assert _sidecar_url('http://reference:8080/') == 'http://reference:8081'
     assert _sidecar_url(None) is None
+
+
+def test_miner_axon_hooks_match_their_forward_synapse_types():
+    """bt.Axon.attach asserts blacklist/priority/verify signatures against the forward's synapse annotation."""
+    import inspect
+    from functools import partial
+
+    from neurons import serving_miner as sm
+
+    for fwd, bl, pr, vf, syn in (
+        (sm.handle_inference, sm.blacklist_inference, sm.priority_inference, sm.verify_inference, 'InferenceSynapse'),
+        (sm.handle_attest, sm.blacklist_attest, sm.priority_attest, sm.verify_attest, 'AttestSynapse'),
+    ):
+        for fn in (fwd, bl, pr, vf):
+            (param,) = inspect.signature(partial(fn, None)).parameters.values()
+            assert param.name == 'synapse' and getattr(param.annotation, '__name__', param.annotation) == syn


### PR DESCRIPTION
Soak 6 first start on #1722: both miners crashed in `ServingMiner.__init__` —

```
AssertionError: The blacklist_fn function must have the signature: blacklist( synapse: AttestSynapse ) -> tuple[bool, str]
```

`bt.Axon.attach` asserts each hook's signature against the forward's synapse annotation; the attest forward reused the `InferenceSynapse`-typed blacklist/priority/verify. Adds `blacklist_attest` / `priority_attest` / `verify_attest` typed `AttestSynapse` that delegate to the inference gate through a budget-free shim (an attestation charges no tokens to a validator's budget), and a test that every hook's parameter annotation matches its forward's synapse type.