### PR TITLE
serving: bind token ids to streamed bytes; tolerate split multibyte chars; retry verify on connection blips

### DIFF
--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -152,6 +152,7 @@ def build_app(
                     completion=result.completion if result else None,
                     tokens=list(result.tokens) if result and result.tokens else None,
                     token_ids=list(result.token_ids) if result and result.token_ids else None,
+                    token_bytes=list(result.token_bytes) if result and result.token_bytes else None,
                     token_logprobs=list(result.token_logprobs) if result and result.token_logprobs else None,
                     detail=str(getattr(getattr(result, 'dendrite', None), 'status_message', None) or '')
                     if not ok

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -382,6 +382,7 @@ def verify_served(
     token_logprobs: Optional[Sequence[float]],
     token_ids: Optional[Sequence[int]] = None,
     end_of_turn: Sequence[str] = ('<|im_end|>', '<|endoftext|>', '</s>'),
+    token_bytes: Optional[Sequence[Sequence[int]]] = None,
 ) -> AuditVerdict:
     """Verify a served (greedy) completion by teacher forcing it under the reference.
 
@@ -397,16 +398,28 @@ def verify_served(
         return AuditVerdict(False, 0.0, float('inf'), 'missing or malformed logprobs')
     mine, mine_lp = list(tokens), list(token_logprobs)
     mine_ids = list(token_ids) if token_ids and len(token_ids) == len(mine) else None
+    mine_bytes = [bytes(b) for b in token_bytes] if token_bytes and len(token_bytes) == len(mine) else None
     if mine and mine[-1] in end_of_turn:
         mine, mine_lp = mine[:-1], mine_lp[:-1]
         mine_ids = mine_ids[:-1] if mine_ids else None
+        mine_bytes = mine_bytes[:-1] if mine_bytes else None
     if not mine:
         return AuditVerdict(False, 0.0, float('inf'), 'empty completion')
     ref = reference.score_served(messages, completion, mine_ids)
     argmax, ref_lp = ref.get('argmax') or [], ref.get('logprobs') or []
     if len(argmax) != len(mine) or len(ref_lp) != len(mine):
         return AuditVerdict(False, 0.0, float('inf'), f'tokenization mismatch ({len(mine)} vs {len(argmax)})')
-    if mine_ids and ref.get('bytes') and b''.join(ref['bytes']).decode('utf-8', 'replace') != completion:
-        return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the completion')
+    if mine_ids and ref.get('bytes'):
+        # Bind the forced ids to what the user received. Exact on bytes when the miner reported them; the decoded
+        # text is only compared when it decodes cleanly (a multibyte character split across streamed tokens shows
+        # up as replacement characters in the stream's text and is not the miner's doing).
+        ref_bytes = b''.join(ref['bytes'])
+        if mine_bytes is not None:
+            if b''.join(mine_bytes) != ref_bytes:
+                return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the streamed bytes')
+        else:
+            text = ref_bytes.decode('utf-8', 'replace')
+            if '\ufffd' not in text and '\ufffd' not in completion and text != completion:
+                return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the completion')
     case = AuditCase(messages=list(messages), max_tokens=len(mine), reference_tokens=argmax, reference_logprobs=ref_lp)
     return verify_response(case, mine, mine_lp)

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -50,6 +50,7 @@ class ServedRequest:
     completion: Optional[str] = None
     tokens: Optional[List[str]] = None
     token_ids: Optional[List[int]] = None
+    token_bytes: Optional[List[List[int]]] = None
     token_logprobs: Optional[List[float]] = None
     detail: str = ''  # axon status message when not ok
     source: str = 'gateway'  # 'gateway' | 'baseline'

--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -65,6 +65,7 @@ class StreamAssembler:
     content: str = ''
     tokens: List[str] = field(default_factory=list)
     token_ids: List[int] = field(default_factory=list)
+    token_bytes: List[List[int]] = field(default_factory=list)
     token_logprobs: List[float] = field(default_factory=list)
     model_id: Optional[str] = None
     finish_reason: Optional[str] = None
@@ -89,6 +90,8 @@ class StreamAssembler:
                 self.token_logprobs.append(float(entry['logprob']))
                 if entry.get('token_id') is not None:
                     self.token_ids.append(int(entry['token_id']))
+                if isinstance(entry.get('bytes'), list):
+                    self.token_bytes.append([int(b) for b in entry['bytes']])
             if choice.get('finish_reason'):
                 self.finish_reason = choice['finish_reason']
         usage = event.get('usage')
@@ -106,6 +109,9 @@ class StreamAssembler:
         synapse.served_model_id = self.model_id
         synapse.tokens = self.tokens or None
         synapse.token_ids = self.token_ids if self.token_ids and len(self.token_ids) == len(self.tokens) else None
+        synapse.token_bytes = (
+            self.token_bytes if self.token_bytes and len(self.token_bytes) == len(self.tokens) else None
+        )
         synapse.token_logprobs = self.token_logprobs or None
         synapse.finish_reason = self.finish_reason
         synapse.usage = self.usage

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -61,6 +61,7 @@ class InferenceSynapse(bt.StreamingSynapse):
     decode_tps: Optional[float] = None
     tokens: Optional[List[str]] = None
     token_ids: Optional[List[int]] = None
+    token_bytes: Optional[List[List[int]]] = None  # raw UTF-8 bytes of each token, as the runtime reports them
     token_logprobs: Optional[List[float]] = None
     finish_reason: Optional[str] = None
     usage: Optional[Dict[str, int]] = None

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -82,13 +82,24 @@ def verify_served_round(
             return None
         if not req.ok:
             return AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
-        try:
-            return verify_served(
-                reference, req.messages, req.completion, req.tokens, req.token_logprobs, token_ids=req.token_ids
-            )
-        except Exception as e:  # reference hiccup: neither credit nor blame
-            bt.logging.warning(f'Serving: could not verify a request served by UID {req.uid}: {e!r}')
-            return None
+        for attempt in range(2):  # a connection blip to the reference is retried once before going neutral
+            try:
+                return verify_served(
+                    reference,
+                    req.messages,
+                    req.completion,
+                    req.tokens,
+                    req.token_logprobs,
+                    token_ids=req.token_ids,
+                    token_bytes=req.token_bytes,
+                )
+            except Exception as e:  # reference hiccup: neither credit nor blame
+                if attempt == 0 and isinstance(e, (ConnectionError, OSError)) or 'Connect' in type(e).__name__:
+                    time.sleep(1.0)
+                    continue
+                bt.logging.warning(f'Serving: could not verify a request served by UID {req.uid}: {e!r}')
+                return None
+        return None
 
     with ThreadPoolExecutor(max_workers=SERVING_VERIFY_WORKERS) as pool:
         verdicts = list(pool.map(judge, mine))
@@ -191,6 +202,7 @@ async def baseline_round(
                 completion=response.completion if response is not None else None,
                 tokens=list(response.tokens) if response is not None and response.tokens else None,
                 token_ids=list(response.token_ids) if response is not None and response.token_ids else None,
+                token_bytes=list(response.token_bytes) if response is not None and response.token_bytes else None,
                 token_logprobs=list(response.token_logprobs)
                 if response is not None and response.token_logprobs
                 else None,

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -576,6 +576,7 @@ def test_verify_served_forces_miner_token_ids():
         ).reason
     )
     # a multibyte character split across streamed tokens: the stream's text carries U+FFFD, the bytes are fine
+    assert good.completion is not None
     split_text = '\ufffd' + good.completion[1:]
     assert verify_served(ExactReference(), good.messages, split_text, tokens, logprobs, token_ids=ids).passed
 

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -237,6 +237,7 @@ class _FakeResponse:
         self.served_model_id = model_id
         self.tokens = result.tokens
         self.token_ids = result.token_ids
+        self.token_bytes = None
         self.token_logprobs = result.token_logprobs
         self.ttft_ms = 12.0
         self.decode_tps = 99.0
@@ -556,6 +557,27 @@ def test_verify_served_forces_miner_token_ids():
 
     lie = verify_served(BindingReference(), good.messages, good.completion, tokens, logprobs, token_ids=ids)
     assert not lie.passed and not lie.hard and 'do not spell' in lie.reason
+
+    class ExactReference(ForcingReference):
+        def score_served(self, messages, completion, token_ids=None):
+            out = super().score_served(messages, completion, token_ids)
+            out['bytes'] = [t.encode() for t in tokens]  # what the forced ids spell
+            return out
+
+    mine_bytes = [list(t.encode()) for t in tokens]
+    assert verify_served(
+        ExactReference(), good.messages, good.completion, tokens, logprobs, token_ids=ids, token_bytes=mine_bytes
+    ).passed
+    forged = [list(b'x')] + mine_bytes[1:]
+    assert (
+        'streamed bytes'
+        in verify_served(
+            ExactReference(), good.messages, good.completion, tokens, logprobs, token_ids=ids, token_bytes=forged
+        ).reason
+    )
+    # a multibyte character split across streamed tokens: the stream's text carries U+FFFD, the bytes are fine
+    split_text = '\ufffd' + good.completion[1:]
+    assert verify_served(ExactReference(), good.messages, split_text, tokens, logprobs, token_ids=ids).passed
 
 
 def test_stream_assembler_collects_token_ids():


### PR DESCRIPTION
Soak 6 (first run on the `7498736` image, which returns `bytes` on `/v1/score`) surfaced two things in one round:

- `READY UID 16 missed a gateway request (token ids do not spell the completion; 128 tokens)` — a **false miss on an honest miner**. Not reproducible in 26 direct runs; the pattern fits a multibyte character split across two streamed tokens: the stream's `content` carries U+FFFD for each partial token while the reference's joined bytes decode to the real character. The binding check (#1709) compared decoded text and tripped.
  Fix: the stream assembler now collects each token's `bytes` (sparkinfer reports them per logprob entry) into `InferenceSynapse.token_bytes` → `ServedRequest.token_bytes`, and `verify_served` binds the forced ids to the **miner's bytes exactly** (`b''.join(mine) == b''.join(reference)`). The decoded-text comparison remains only as a fallback for miners that report no bytes, and is skipped when either side contains a replacement character.
- `neutral 7` — seven `ConnectTimeout`s to the reference's `/v1/score` under 8 parallel verify calls (the pod's port forward drops connection bursts). Verification now retries once after 1 s on connection errors before going neutral.

Tests: exact-bytes pass, forged-bytes miss, split-character text tolerated.