### PR TITLE
serving: attest cohort = least recently challenged first (ties at random)

### DIFF
--- a/gittensor/validator/serving/attest.py
+++ b/gittensor/validator/serving/attest.py
@@ -64,11 +64,18 @@ class AttestVerdict:
 def choose_cohort(
     hotkeys: Sequence[str], status: Dict[str, dict], fraction: float = SERVING_ATTEST_COHORT_FRACTION, rng=None
 ) -> List[str]:
-    """A random ``fraction`` of ``hotkeys`` (fresh every round), plus never-attested and last-round failures."""
+    """``fraction`` of ``hotkeys`` per round: the least recently challenged first (ties broken at random, so the
+    membership is still unpredictable), plus every never-attested hotkey and every last-round failure.
+
+    Pure random sampling let one hotkey go unchallenged for many rounds (soak 6: the other of two was drawn three
+    rounds running); with recency first, every hotkey is challenged at least every ``1/fraction`` rounds while a
+    sharing pair still lands together within a few rounds.
+    """
     rng = rng or secrets.SystemRandom()
     pool = list(hotkeys)
     n = min(len(pool), max(1, -(-len(pool) * fraction // 1).__int__())) if pool else 0
-    chosen = set(rng.sample(pool, n)) if n else set()
+    order = sorted(pool, key=lambda hk: (int((status.get(hk) or {}).get('round', -1)), rng.random()))
+    chosen = set(order[:n])
     for hk in pool:
         st = status.get(hk)
         if st is None or not st.get('passed'):

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1338,8 +1338,16 @@ def test_attest_cohort_is_random_half_plus_unproven_and_failed():
     rng = random.Random(1)
     cohort = choose_cohort(hotkeys, status, rng=rng)
     assert 'hk3' in cohort and 'hk7' in cohort and 10 <= len(cohort) <= 12
-    together = sum(1 for _ in range(400) if {'hk1', 'hk2'} <= set(choose_cohort(hotkeys, status, rng=rng)))
-    assert 60 <= together <= 140  # P = 0.25 per round for a sharing pair
+    # least recently challenged first: simulate rounds, every hotkey is challenged at least every 2 rounds
+    last = {hk: 0 for hk in hotkeys}
+    for rnd in range(1, 21):
+        for hk in choose_cohort(hotkeys, {hk: {'passed': True, 'round': last[hk]} for hk in hotkeys}, rng=rng):
+            last[hk] = rnd
+        assert all(rnd - r <= 2 for r in last.values())
+    # a hotkey that was just challenged is not drawn again while others wait (ties broken at random)
+    fresh = {hk: {'passed': True, 'round': 5} for hk in hotkeys}
+    fresh['hk0']['round'] = 9
+    assert 'hk0' not in choose_cohort(hotkeys, fresh, rng=rng)
 
 
 def test_attest_round_gates_pay_and_persists(monkeypatch, tmp_path):


### PR DESCRIPTION
Soak 6 with a two-miner fleet: pure random sampling drew the same hotkey three rounds running while the sharer (deliberately pointed at the other's card) sat unchallenged on a stale PASS. Overlap still caught it once drawn, but "every hotkey challenged at least every `1/fraction` rounds" is the guarantee we want.

`choose_cohort` now orders hotkeys by last challenged round (ascending) with random tie-breaks, takes the first `fraction`, and still adds every never-attested and last-round-failed hotkey. Membership stays unpredictable (ties at random, failures re-drawn), sharing pairs still land together within a few rounds, and no hotkey can go more than two rounds without a challenge at `fraction = 1/2`. Test simulates 20 rounds over 20 hotkeys.