### PR TITLE
serving: attest image split from the runtime; per-card attestation pays N cards per hotkey; sampled audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,5 +60,9 @@ SERVING_ENABLED=false
 # Overrides the primary release's reference_url. Unset = reference_url from the loadout, else its audit_bank snapshot.
 # SERVING_REFERENCE_URL=http://reference:8080
 # SERVING_REFERENCE_API_KEY=<bearer for a remote reference>
+# The attest container beside the reference (compose service `attest`, image entrius/gt-attest:GT_ATTEST_TAG).
+# Default: the reference host on port 8081 — set it when the sidecar is a separate service or host.
+# SERVING_ATTEST_REFERENCE_URL=http://attest:8081
+# GT_ATTEST_TAG=v1
 # SPARKINFER_TAG=<commit>   # image tag for the reference sidecar = runtime_pin commit in the loadout
 # SPARKINFER_MODEL_SHA256=<model_sha256 from the loadout release>

--- a/.github/workflows/attest-image.yml
+++ b/.github/workflows/attest-image.yml
@@ -1,0 +1,74 @@
+name: attest image
+
+# Builds the attestation sidecar (docker/attest) and publishes it as entrius/gt-attest:<tag>. One image for every
+# blessed release: miners run it beside their runtime container, validators beside their reference. Bump the tag
+# (v1, v2, ...) when docker/attest changes and point `attest.image` in serving_loadout.json at it. No GPU in CI: the
+# build proves it compiles; the sparkinfer conformance job exercises it on a rented 5090.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Tag to push (e.g. v1). Empty = the tag in attest.image of serving_loadout.json."
+        required: false
+        default: ""
+      cuda_archs:
+        description: "CMAKE_CUDA_ARCHITECTURES"
+        required: false
+        default: "120"
+  push:
+    paths:
+      - docker/attest/**
+      - .github/workflows/attest-image.yml
+
+jobs:
+  image:
+    name: ${{ github.event_name == 'workflow_dispatch' && 'build and push' || 'build only (dry run)' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Resolve the tag (input, else attest.image in serving_loadout.json)
+        id: tag
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          if [ -z "$TAG" ]; then
+            TAG=$(jq -r '.releases[0].attest.image // "entrius/gt-attest:dev"' gittensor/validator/weights/serving_loadout.json | sed 's/.*://')
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "building docker/attest as entrius/gt-attest:$TAG"
+
+      - name: Free disk space (CUDA devel image is large)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          docker system prune -af
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/attest/Dockerfile
+          push: ${{ github.event_name == 'workflow_dispatch' }}
+          build-args: |
+            CUDA_ARCHS=${{ inputs.cuda_archs || '120' }}
+            GT_ATTEST_VERSION=${{ steps.tag.outputs.tag }}
+          tags: |
+            entrius/gt-attest:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Digest
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "entrius/gt-attest:${{ steps.tag.outputs.tag }}@${{ steps.build.outputs.digest }}"

--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -38,6 +38,7 @@ jobs:
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
       tag: ${{ steps.ref.outputs.tag }}
+      digest: ${{ steps.build.outputs.digest }}
     # push-triggered runs (Dockerfile/workflow changed) only BUILD, to catch Dockerfile breakage in CI;
     # the image is pushed to Docker Hub only from the Run workflow button (workflow_dispatch).
     name: ${{ github.event_name == 'workflow_dispatch' && 'build and push' || 'build only (dry run)' }}
@@ -73,6 +74,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -96,6 +98,7 @@ jobs:
       LIUM_API_KEY: ${{ secrets.LIUM_API_KEY }}
       REF: ${{ needs.image.outputs.ref }}
       TAG: ${{ needs.image.outputs.tag }}
+      DIGEST: ${{ needs.image.outputs.digest }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -123,11 +126,12 @@ jobs:
           path: conformance-${{ env.REF }}/
           if-no-files-found: warn
 
-      - name: Bump runtime_pin and the release's speed facts
+      - name: Bump runtime_pin, runtime_image and the release's speed facts
         run: |
-          jq --arg pin "gittensor-ai-lab/sparkinfer@$REF" --arg run "$GITHUB_RUN_ID" \
+          jq --arg pin "gittensor-ai-lab/sparkinfer@$REF" --arg image "entrius/sparkinfer:$TAG@$DIGEST" --arg run "$GITHUB_RUN_ID" \
             --slurpfile speed "conformance-$REF/speed.json" \
             '.releases[0].runtime_pin = $pin
+             | .releases[0].runtime_image = $image
              | .releases[0].speed = ((.releases[0].speed // {}) + {
                  single_stream_decode_tps: $speed[0].single_stream_decode_tps,
                  decode_per_request: $speed[0].decode_per_request,
@@ -153,7 +157,8 @@ jobs:
           body: |
             `entrius/sparkinfer:${{ env.REF }}` passed `scripts/check_serving_runtime.py` on a rented RTX 5090
             (run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — report in the
-            `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin` and writes the release's
+            `serving-conformance-${{ env.REF }}` artifact). This bumps `runtime_pin`, pins `runtime_image` to the pushed
+            image's digest, and writes the release's
             blessing-time speed facts (`speed.decode_per_request`, the per-request decode curve served traffic is
             priced against) and attestation facts (`attest.*`). Update the sha named in the comments at
             `gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -35,7 +35,8 @@ services:
   # sparkinfer_server image miners run (built by us from a pinned upstream commit, docker/sparkinfer.Dockerfile),
   # on the validator's own GPU, so audits compare against a live honest copy instead of a bank snapshot.
   #   SPARKINFER_TAG=<runtime_pin commit> docker compose -f docker-compose.vali.yml --profile reference up -d
-  # then set SERVING_REFERENCE_URL=http://reference:8080 in .env. See the Serving Runtime Contract in the miner docs.
+  # then set SERVING_REFERENCE_URL=http://reference:8080 and SERVING_ATTEST_REFERENCE_URL=http://attest:8081 in .env.
+  # See the Serving Runtime Contract in the miner docs.
   reference:
     image: entrius/sparkinfer:${SPARKINFER_TAG:-latest}
     container_name: gt-vali-reference
@@ -55,6 +56,21 @@ services:
               capabilities: [gpu]
     volumes:
       - ./data/models:/opt/sparkinfer/models
+
+  # Attestation sidecar beside the reference (profile "reference"): the validator asks it for the expected digest
+  # and reference wall time of each round's challenge. Same image every miner box runs (attest.image in the loadout).
+  attest:
+    image: entrius/gt-attest:${GT_ATTEST_TAG:-v1}
+    container_name: gt-vali-attest
+    restart: unless-stopped
+    profiles: ["reference"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 
   watchtower:
     image: nickfedor/watchtower

--- a/docker/attest/Dockerfile
+++ b/docker/attest/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+# Gittensor attestation sidecar: one long-running container per miner box (and beside a validator's reference), on
+# every GPU the box has. Answers the validator's hardware challenge (gt_attest: seeded VRAM fill + deterministic
+# GEMM chain, docker/attest/gt_attest.cu) and a self-report (GET /info). Runtime-agnostic — the same image serves
+# every blessed release, so blessing a new runtime never touches it. Pinned by `attest.image` in the serving loadout.
+#
+#   docker build -f docker/attest/Dockerfile -t entrius/gt-attest:<tag> .
+#   docker run -d --name gt-attest --gpus all -p 8081:8081 entrius/gt-attest:<tag>
+
+ARG CUDA_VERSION=12.8.1
+ARG UBUNTU_VERSION=24.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS build
+# sm_120 = RTX 5090. The digest is only comparable across cards of one architecture; add more only if the fleet
+# blesses other hardware.
+ARG CUDA_ARCHS=120
+COPY docker/attest/gt_attest.cu /src/gt_attest.cu
+# -fmad=false: the summation is bit-identical on every card of the architecture (the validator's reference recomputes
+# the digest).
+RUN nvcc -O3 -fmad=false -gencode arch=compute_${CUDA_ARCHS},code=sm_${CUDA_ARCHS} \
+        -o /src/gt_attest /src/gt_attest.cu -lnvidia-ml
+
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends python3 curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/gt-attest
+COPY --from=build /src/gt_attest          bin/gt_attest
+COPY docker/attest/attest_server.py       bin/attest_server.py
+ARG GT_ATTEST_VERSION=dev
+ENV GT_ATTEST_BIN=/opt/gt-attest/bin/gt_attest \
+    GT_ATTEST_VERSION=${GT_ATTEST_VERSION} \
+    ATTEST_PORT=8081
+EXPOSE 8081
+LABEL io.gittensor.serving.attest="gt-attest" \
+      io.gittensor.serving.attest_version="${GT_ATTEST_VERSION}"
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8081/info || exit 1
+ENTRYPOINT ["python3", "bin/attest_server.py"]

--- a/docker/attest/attest_server.py
+++ b/docker/attest/attest_server.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""Attestation sidecar for the serving runtime image: runs gt_attest on request (stdlib only).
+"""Attestation sidecar (image entrius/gt-attest, docker/attest/Dockerfile): runs gt_attest on request (stdlib only).
 
 POST /v1/attest  {"seed": <u64>, "iters": <n>, "fill": true}  -> gt_attest's JSON plus "queued_ms"
 GET  /v1/attest/info                                          -> devices without running a challenge (iters 1, no fill,
                                                                  small working set)
+GET  /info                                                    -> self-report: GPUs as nvidia-smi sees them, driver,
+                                                                 host CPU/RAM, sidecar version. Telemetry for the
+                                                                 operator and the /compute page — a host can say
+                                                                 anything here, so nothing is paid on it; the
+                                                                 challenge above is the proof.
 Challenges run one at a time; concurrent requests queue and report their own wall including the wait, which is what
 lets a validator see two hotkeys sharing one card. Optional bearer via ATTEST_API_KEY.
 """
@@ -15,7 +20,8 @@ import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-BIN = os.environ.get('GT_ATTEST_BIN', '/opt/sparkinfer/bin/gt_attest')
+BIN = os.environ.get('GT_ATTEST_BIN', '/opt/gt-attest/bin/gt_attest')
+VERSION = os.environ.get('GT_ATTEST_VERSION', 'dev')
 PORT = int(os.environ.get('ATTEST_PORT', '8081'))
 API_KEY = os.environ.get('ATTEST_API_KEY')
 LOCK = threading.Lock()
@@ -37,6 +43,55 @@ def run(args, timeout=120.0):
     return 200, out
 
 
+def self_report() -> dict:
+    query = 'uuid,name,driver_version,memory.total,memory.used,pci.bus_id,temperature.gpu,utilization.gpu'
+    gpus, error = [], None
+    try:
+        out = subprocess.run(
+            ['nvidia-smi', f'--query-gpu={query}', '--format=csv,noheader,nounits'],
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+        )
+        if out.returncode != 0:
+            error = (out.stderr or out.stdout).strip()[:300]
+        for line in out.stdout.splitlines():
+            cols = [c.strip() for c in line.split(',')]
+            if len(cols) == 8:
+                gpus.append(
+                    {
+                        'uuid': cols[0],
+                        'name': cols[1],
+                        'driver': cols[2],
+                        'memory_total_mib': int(cols[3]),
+                        'memory_used_mib': int(cols[4]),
+                        'pci_bus_id': cols[5],
+                        'temperature_c': int(cols[6]),
+                        'utilization_pct': int(cols[7]),
+                    }
+                )
+    except Exception as e:  # no nvidia-smi in the container, or a hung driver
+        error = repr(e)[:300]
+    mem_total_kib = None
+    try:
+        with open('/proc/meminfo') as f:
+            for line in f:
+                if line.startswith('MemTotal:'):
+                    mem_total_kib = int(line.split()[1])
+                    break
+    except OSError:
+        pass
+    return {
+        'version': VERSION,
+        'hostname': os.uname().nodename,
+        'cpus': os.cpu_count(),
+        'mem_total_gib': round(mem_total_kib / 1048576, 1) if mem_total_kib else None,
+        'gpus': gpus,
+        'error': error,
+        'ts': time.time(),
+    }
+
+
 class Handler(BaseHTTPRequestHandler):
     def _send(self, status, payload):
         body = json.dumps(payload).encode()
@@ -53,7 +108,11 @@ class Handler(BaseHTTPRequestHandler):
         return True
 
     def do_GET(self):
-        if self.path != '/v1/attest/info' or not self._auth():
+        if not self._auth():
+            return
+        if self.path == '/info':
+            return self._send(200, self_report())
+        if self.path != '/v1/attest/info':
             return self._send(404, {'error': 'not found'})
         self._send(
             *run(['--seed', '1', '--iters', '1', '--dim', '256', '--matrices', '2', '--device', 'all'], timeout=30.0)

--- a/docker/attest/entrypoint.sh
+++ b/docker/attest/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Start the attestation sidecar beside sparkinfer_server, then hand over to the runtime's own entrypoint.
-python3 /opt/sparkinfer/bin/attest_server.py &
-exec bash server/run.sh --download "$@"

--- a/docker/sparkinfer.Dockerfile
+++ b/docker/sparkinfer.Dockerfile
@@ -9,6 +9,7 @@
 #
 #   docker build -f docker/sparkinfer.Dockerfile --build-arg SPARKINFER_REF=<commit> -t entrius/sparkinfer:<commit> .
 #   docker run --gpus all -p 8080:8080 -v $PWD/data/models:/opt/sparkinfer/models entrius/sparkinfer:<commit>
+# A miner box also runs the attestation container (docker/attest, entrius/gt-attest) beside it.
 
 ARG CUDA_VERSION=12.8.1
 ARG UBUNTU_VERSION=24.04
@@ -38,11 +39,6 @@ RUN git clone ${SPARKINFER_REPO} sparkinfer \
 RUN cmake -S sparkinfer -B sparkinfer/build -G Ninja \
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SERVER=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS} \
     && cmake --build sparkinfer/build
-# Hardware attestation challenge (docker/attest): deterministic fp32 GEMM chain + VRAM fill. -fmad=false so the
-# summation is bit-identical on every card of the architecture (the validator's reference recomputes the digest).
-COPY docker/attest/gt_attest.cu /src/attest/gt_attest.cu
-RUN nvcc -O3 -fmad=false -gencode arch=compute_${CUDA_ARCHS},code=sm_${CUDA_ARCHS} \
-        -o /src/attest/gt_attest /src/attest/gt_attest.cu -lnvidia-ml
 
 # ---------- runtime ----------
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
@@ -60,9 +56,6 @@ COPY --from=build /src/sparkinfer/build/runtime       build/runtime
 COPY --from=build /src/sparkinfer/build/moe           build/moe
 COPY --from=build /src/sparkinfer/build/server        build/server
 COPY --from=build /src/SPARKINFER_COMMIT              SPARKINFER_COMMIT
-COPY --from=build /src/attest/gt_attest               bin/gt_attest
-COPY docker/attest/attest_server.py                   bin/attest_server.py
-COPY docker/attest/entrypoint.sh                      bin/entrypoint.sh
 # sparkinfer_server links libsparkinfer_runtime.so + libsparkinfer_moe.so (ldd-verified on 1b8b962, 9e43bfa).
 ENV LD_LIBRARY_PATH=/opt/sparkinfer/build/runtime:/opt/sparkinfer/build/moe:${LD_LIBRARY_PATH}
 
@@ -81,8 +74,8 @@ ENV SPARKINFER_REF=${SPARKINFER_REF} \
     HOST=0.0.0.0 \
     PORT=8080
 VOLUME ["/opt/sparkinfer/models"]
-# 8080 inference, 8081 attestation sidecar (docker/attest/attest_server.py)
-EXPOSE 8080 8081
+# 8080 inference. Hardware attestation is the separate entrius/gt-attest container (docker/attest), not this image.
+EXPOSE 8080
 LABEL org.opencontainers.image.source="https://github.com/gittensor-ai-lab/sparkinfer" \
       io.gittensor.serving.runtime="sparkinfer" \
       io.gittensor.serving.runtime_ref="${SPARKINFER_REF}"
@@ -90,6 +83,6 @@ LABEL org.opencontainers.image.source="https://github.com/gittensor-ai-lab/spark
 HEALTHCHECK --interval=30s --timeout=5s --start-period=600s --retries=5 \
     CMD curl -fsS http://127.0.0.1:8080/v1/models || exit 1
 
-# bin/entrypoint.sh starts the attestation sidecar (:8081), then run.sh downloads the blessed model + tokenizer into
-# MODELS_DIR on first start (--download) and execs the prebuilt server binary.
-ENTRYPOINT ["bash", "bin/entrypoint.sh"]
+# run.sh downloads the blessed model + tokenizer into MODELS_DIR on first start (--download) and execs the prebuilt
+# server binary.
+ENTRYPOINT ["bash", "server/run.sh", "--download"]

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -188,6 +188,10 @@ SERVING_ATTEST_BUDGET_RATIO = 1.6
 SERVING_ATTEST_MIN_FILL_RATIO = 0.6
 SERVING_ATTEST_TIMEOUT = 45.0  # seconds: fill + chain on a 5090 is ~1.5 s; queued challenges show up as slow
 SERVING_ATTEST_UUID_MEMORY_ROUNDS = 12
+# A card counts only with the model resident: free VRAM before the fill must be at most total minus this fraction of
+# the reservation (a bare 5090 shows ~32 GB free, one holding the model ~8 GB). Every passing card is a card-hour, so
+# a multi-GPU hotkey earns per card it actually serves from — a second card with nothing loaded earns nothing.
+SERVING_ATTEST_MODEL_RESIDENT_RATIO = 0.8
 SERVING_VRAM_MODEL_RESERVED_BYTES = 24e9  # what sparkinfer holds with the model loaded (7498736 on a 5090: 23.7 GB)
 SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per round
 # Latency credit on the validator-observed time to first streamed token (network + queue + prefill). An honest
@@ -231,6 +235,12 @@ SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF = 0.10  # largest single-position |logprob de
 #   python scripts/serving_cheat_experiment.py analyze --honest <honest rows> --cheaters <cheater rows>
 SERVING_AUDIT_WINDOW = 10
 SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.8),)
+# Verification is one reference prefill per request, so it is sampled: per (hotkey, round) every baseline prompt and
+# every failed request is judged, and of the completed gateway requests a random max(SAMPLE_MIN, SAMPLE_FRACTION x n)
+# — the floor fills a window in one round, the fraction bounds reference load under real traffic. Nothing on the
+# wire says which requests were drawn.
+SERVING_AUDIT_SAMPLE_FRACTION = 0.2
+SERVING_AUDIT_SAMPLE_MIN = 10
 SERVING_QUARANTINE_S = 3600.0
 # Baseline traffic: every round the validator sends each serving axon this many baseline prompts of its own, at
 # random moments spread over the round (so they do not mark the round boundary), over the same path as user

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -40,6 +40,7 @@ class ServingRelease:
     max_tokens: int = 64
     base_url: Optional[str] = None  # miner side: the runtime this miner serves from
     runtime_pin: Optional[str] = None
+    runtime_image: Optional[str] = None  # the blessed image by digest (entrius/sparkinfer:<tag>@sha256:...)
     model_sha256: Optional[str] = None  # digest of the model file; runtime_pin + model_sha256 = the release
     model_file: Optional[str] = None  # HF path of the model file, informational (the digest is what is enforced)
     audit_bank: Optional[str] = None  # validator side: snapshot reference, filename under weights/
@@ -52,8 +53,10 @@ class ServingRelease:
     # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator prices capacity and latency
     # against these, so the "one card" bar tracks the runtime as it gets faster. None -> the constants' defaults.
     decode_per_request: Optional[Dict[int, float]] = None  # concurrent requests -> per-request decode tok/s, one card
-    # Attestation (docker/attest). Miner side: attest_url = the runtime's sidecar (default: base_url host, port 8081).
-    # Validator side: attest_reference_url = the reference's sidecar (default: reference_url host, port 8081).
+    # Attestation (docker/attest, image entrius/gt-attest — one container per box, beside the runtime). Miner side:
+    # attest_url = that container (default: base_url host, port 8081). Validator side: attest_reference_url = the one
+    # beside the reference (default: reference_url host, port 8081).
+    attest_image: Optional[str] = None  # the attest container every box runs (entrius/gt-attest:<tag>)
     attest_url: Optional[str] = None
     attest_reference_url: Optional[str] = None
     attest_iters: Optional[int] = None
@@ -71,6 +74,7 @@ class ServingRelease:
             max_tokens=int(raw.get('max_tokens', 64)),
             base_url=raw.get('base_url'),
             runtime_pin=raw.get('runtime_pin'),
+            runtime_image=raw.get('runtime_image'),
             model_file=raw.get('model_file'),
             model_sha256=raw.get('model_sha256'),
             audit_bank=raw.get('audit_bank'),
@@ -78,6 +82,7 @@ class ServingRelease:
             reference_api_key=raw.get('reference_api_key'),
             request_timeout=float(raw.get('request_timeout', 60.0)),
             decode_per_request={int(k): float(v) for k, v in (speed.get('decode_per_request') or {}).items()} or None,
+            attest_image=attest.get('image'),
             attest_url=attest.get('url') or _sidecar_url(raw.get('base_url')),
             attest_reference_url=attest.get('reference_url') or _sidecar_url(raw.get('reference_url')),
             attest_iters=int(attest['iters']) if attest.get('iters') else None,

--- a/gittensor/validator/serving/attest.py
+++ b/gittensor/validator/serving/attest.py
@@ -4,24 +4,27 @@
 """Hardware attestation of serving miners (sub-subnet B beta).
 
 Each round a random half of the READY miners (plus every miner that has never passed and every miner that failed
-last round) is sent one fresh ``AttestSynapse`` — same seed, same instant. The miner's runtime image answers with
-``gt_attest`` (docker/attest): it fills the card's free VRAM with a seeded stream and runs a deterministic fp32
-GEMM chain, returning the GPU's UUID, bytes filled, a SHA-256 digest and wall time. The validator asks its own
-reference runtime (same image) for the same seed first, so the expected digest and reference wall time come from
-an honest 5090 — no GPU code runs in the validator process.
+last round) is sent one fresh ``AttestSynapse`` — same seed, same instant. The miner's attest sidecar (docker/attest,
+image ``entrius/gt-attest``) answers with ``gt_attest`` on every GPU it can see: it fills the card's free VRAM with a
+seeded stream and runs a deterministic fp32 GEMM chain, returning the GPU's UUID, bytes filled, a SHA-256 digest and
+wall time. The validator asks its own reference sidecar (same image) for the same seed first, so the expected digest
+and reference wall time come from an honest 5090 — no GPU code runs in the validator process.
 
-PASS = digest matches, wall within ``SERVING_ATTEST_BUDGET_RATIO`` x the reference's, and most of the free VRAM was
-filled. Overlap is the mechanism: two hotkeys fronting one card cannot both fill its free VRAM at the same instant
-and their chains run ~2x slower, so a sharing pair is caught within a few rounds (P = fraction^2 per round). Two
-hotkeys reporting the same GPU UUID within ``SERVING_ATTEST_UUID_MEMORY_ROUNDS`` rounds both fail. A failure is
-never a strike: capacity 0 for the round, re-challenged next round. Miners not in the cohort keep their last
-verdict; a miner with no verdict yet is not READY (admission).
+A card PASSES when its digest matches, its wall is within ``SERVING_ATTEST_BUDGET_RATIO`` x the reference's, most of
+its free VRAM was filled, and the model was resident before the fill (free VRAM at most total minus
+``SERVING_ATTEST_MODEL_RESIDENT_RATIO`` x the reservation). A hotkey's ``capacity`` is its number of passing cards —
+one hotkey, N cards, N card-hours — and it is attested while at least one passes. Overlap is the mechanism: two
+hotkeys fronting one card cannot both fill its free VRAM at the same instant and their chains run ~2x slower, so a
+sharing pair is caught within a few rounds (P = fraction^2 per round). Two hotkeys reporting the same GPU UUID within
+``SERVING_ATTEST_UUID_MEMORY_ROUNDS`` rounds both fail. A failure is never a strike: capacity 0 for the round,
+re-challenged next round. Miners not in the cohort keep their last verdict; a miner with no verdict yet is not READY
+(admission).
 """
 
 import asyncio
 import secrets
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple, cast
 
 import bittensor as bt
@@ -32,6 +35,7 @@ from gittensor.constants import (
     SERVING_ATTEST_COHORT_FRACTION,
     SERVING_ATTEST_ITERS,
     SERVING_ATTEST_MIN_FILL_RATIO,
+    SERVING_ATTEST_MODEL_RESIDENT_RATIO,
     SERVING_ATTEST_TIMEOUT,
     SERVING_ATTEST_UUID_MEMORY_ROUNDS,
     SERVING_VRAM_MODEL_RESERVED_BYTES,
@@ -42,23 +46,60 @@ from gittensor.synapses import AttestSynapse
 
 
 @dataclass
-class AttestVerdict:
+class CardVerdict:
     passed: bool
     reason: str
     uuid: str = ''
     wall_ms: Optional[float] = None
     filled_bytes: int = 0
 
-    def as_status(self, now: float, round_no: int) -> dict:
+    def as_dict(self) -> dict:
         return {
             'passed': self.passed,
             'reason': self.reason,
             'uuid': self.uuid,
             'wall_ms': self.wall_ms,
             'filled_bytes': self.filled_bytes,
+        }
+
+
+@dataclass
+class AttestVerdict:
+    passed: bool
+    reason: str
+    uuid: str = ''  # first passing card (telemetry)
+    wall_ms: Optional[float] = None
+    filled_bytes: int = 0
+    cards: List[CardVerdict] = field(default_factory=list)
+
+    @property
+    def capacity(self) -> int:
+        return sum(1 for c in self.cards if c.passed)
+
+    @property
+    def uuids(self) -> List[str]:
+        return [c.uuid for c in self.cards if c.passed and c.uuid]
+
+    def as_status(self, now: float, round_no: int) -> dict:
+        return {
+            'passed': self.passed,
+            'reason': self.reason,
+            'uuid': self.uuid,
+            'uuids': self.uuids,
+            'capacity': self.capacity,
+            'cards': [c.as_dict() for c in self.cards],
+            'wall_ms': self.wall_ms,
+            'filled_bytes': self.filled_bytes,
             'ts': now,
             'round': round_no,
         }
+
+
+def status_capacity(status: Optional[dict]) -> int:
+    """Cards a stored attest status pays for (statuses persisted before ``capacity`` existed count one card)."""
+    if not status or not status.get('passed'):
+        return 0
+    return int(status.get('capacity', 1))
 
 
 def choose_cohort(
@@ -84,7 +125,7 @@ def choose_cohort(
 
 
 def reference_challenge(release: ServingRelease, seed: int, iters: int, timeout: float) -> Tuple[str, float]:
-    """(expected digest, reference wall ms) from the validator's own reference runtime for ``seed``."""
+    """(expected digest, reference wall ms) from the validator's own reference sidecar for ``seed``."""
     if not release.attest_reference_url:
         raise RuntimeError('no attest_reference_url on the release')
     r = requests.post(
@@ -101,6 +142,45 @@ def reference_challenge(release: ServingRelease, seed: int, iters: int, timeout:
     return str(first['digest']), float(first.get('wall_ms') or 0.0)
 
 
+def judge_card(
+    dev: dict,
+    queued_ms: float,
+    expected_digest: str,
+    ref_wall_ms: float,
+    release: ServingRelease,
+    budget_ratio: float,
+    min_fill_ratio: float,
+    resident_ratio: float,
+) -> CardVerdict:
+    if dev.get('error'):
+        return CardVerdict(False, f'challenge error: {dev["error"]}')
+    uuid = str(dev.get('uuid') or '')
+    wall = float(dev.get('wall_ms') or 0.0) + queued_ms
+    filled = int(dev.get('filled_bytes') or 0)
+    if str(dev.get('digest')) != expected_digest:
+        return CardVerdict(False, 'digest mismatch', uuid, wall, filled)
+    budget = budget_ratio * ref_wall_ms if ref_wall_ms > 0 else float('inf')
+    if wall > budget:
+        return CardVerdict(False, f'too slow: {wall:.0f} ms > {budget:.0f} ms budget', uuid, wall, filled)
+    reserved = release.vram_model_reserved_bytes or SERVING_VRAM_MODEL_RESERVED_BYTES
+    total = float(dev.get('vram_total') or 0.0)
+    expected_free = max(0.0, total - reserved)
+    if expected_free > 0 and filled < min_fill_ratio * expected_free:
+        return CardVerdict(
+            False, f'under-filled: {filled / 1e9:.1f} GB of {expected_free / 1e9:.1f} GB free', uuid, wall, filled
+        )
+    free_before = dev.get('vram_free_before')
+    if total > 0 and free_before is not None and float(free_before) > total - resident_ratio * reserved:
+        return CardVerdict(
+            False,
+            f'model not resident: {float(free_before) / 1e9:.1f} GB free of {total / 1e9:.1f}',
+            uuid,
+            wall,
+            filled,
+        )
+    return CardVerdict(True, 'ok', uuid, wall, filled)
+
+
 def judge(
     response: Optional[AttestSynapse],
     expected_digest: str,
@@ -108,7 +188,10 @@ def judge(
     release: ServingRelease,
     budget_ratio: float = SERVING_ATTEST_BUDGET_RATIO,
     min_fill_ratio: float = SERVING_ATTEST_MIN_FILL_RATIO,
+    resident_ratio: float = SERVING_ATTEST_MODEL_RESIDENT_RATIO,
 ) -> AttestVerdict:
+    """Every card the sidecar reported is judged on its own; the hotkey passes with any passing card and its
+    capacity is the count. The reason names the first failing card when one fails."""
     if response is None or response.devices is None:
         detail = getattr(response, 'error', None) or getattr(
             getattr(response, 'dendrite', None), 'status_message', None
@@ -116,24 +199,21 @@ def judge(
         return AttestVerdict(False, f'no attestation ({detail or "timeout"})')
     if not response.devices:
         return AttestVerdict(False, 'no devices')
-    dev = response.devices[0]
-    if dev.get('error'):
-        return AttestVerdict(False, f'challenge error: {dev["error"]}')
-    uuid = str(dev.get('uuid') or '')
-    wall = float(dev.get('wall_ms') or 0.0) + float(response.queued_ms or 0.0)
-    filled = int(dev.get('filled_bytes') or 0)
-    if str(dev.get('digest')) != expected_digest:
-        return AttestVerdict(False, 'digest mismatch', uuid, wall, filled)
-    budget = budget_ratio * ref_wall_ms if ref_wall_ms > 0 else float('inf')
-    if wall > budget:
-        return AttestVerdict(False, f'too slow: {wall:.0f} ms > {budget:.0f} ms budget', uuid, wall, filled)
-    reserved = release.vram_model_reserved_bytes or SERVING_VRAM_MODEL_RESERVED_BYTES
-    expected_free = max(0.0, float(dev.get('vram_total') or 0.0) - reserved)
-    if expected_free > 0 and filled < min_fill_ratio * expected_free:
-        return AttestVerdict(
-            False, f'under-filled: {filled / 1e9:.1f} GB of {expected_free / 1e9:.1f} GB free', uuid, wall, filled
-        )
-    return AttestVerdict(True, 'ok', uuid, wall, filled)
+    queued = float(response.queued_ms or 0.0)
+    cards = [
+        judge_card(dev, queued, expected_digest, ref_wall_ms, release, budget_ratio, min_fill_ratio, resident_ratio)
+        for dev in response.devices
+    ]
+    passing = [c for c in cards if c.passed]
+    failing = [c for c in cards if not c.passed]
+    lead = passing[0] if passing else cards[0]
+    if not passing:
+        reason = failing[0].reason
+    elif failing:
+        reason = f'{len(passing)}/{len(cards)} cards ok ({failing[0].reason})'
+    else:
+        reason = 'ok' if len(cards) == 1 else f'ok ({len(cards)} cards)'
+    return AttestVerdict(bool(passing), reason, lead.uuid, lead.wall_ms, lead.filled_bytes, cards)
 
 
 async def send_challenges(
@@ -162,15 +242,29 @@ async def send_challenges(
     return {hotkey: resp for (_, hotkey, _), resp in zip(targets, results)}
 
 
+def _status_uuids(st: dict) -> List[str]:
+    uuids = st.get('uuids')
+    if uuids is None:
+        uuids = [st['uuid']] if st.get('uuid') else []
+    return [u for u in uuids if u]
+
+
 def dedupe_uuids(
     state: ServingState, round_no: int, memory_rounds: int = SERVING_ATTEST_UUID_MEMORY_ROUNDS
-) -> List[str]:
-    """Hotkeys whose passing attestation reports a GPU UUID another hotkey reported within ``memory_rounds``."""
+) -> Dict[str, str]:
+    """hotkey -> shared GPU UUID, for every passing hotkey whose card another hotkey also reported within
+    ``memory_rounds``."""
     by_uuid: Dict[str, List[str]] = {}
     for hk, st in state.attest_status.items():
-        if st.get('uuid') and st.get('passed') and round_no - int(st.get('round', 0)) <= memory_rounds:
-            by_uuid.setdefault(st['uuid'], []).append(hk)
-    return sorted(hk for hks in by_uuid.values() if len(hks) > 1 for hk in hks)
+        if st.get('passed') and round_no - int(st.get('round', 0)) <= memory_rounds:
+            for uuid in _status_uuids(st):
+                by_uuid.setdefault(uuid, []).append(hk)
+    shared: Dict[str, str] = {}
+    for uuid, hks in sorted(by_uuid.items()):
+        if len(hks) > 1:
+            for hk in hks:
+                shared.setdefault(hk, uuid)
+    return shared
 
 
 async def attest_round(
@@ -180,15 +274,16 @@ async def attest_round(
     release: ServingRelease,
     rng=None,
     timeout: float = SERVING_ATTEST_TIMEOUT,
-) -> Dict[str, bool]:
-    """Challenge this round's cohort, update ``state.attest_status``; return hotkey -> attested for every candidate.
+) -> Dict[str, int]:
+    """Challenge this round's cohort, update ``state.attest_status``; return hotkey -> attested cards (0 = not
+    attested) for every candidate.
 
-    Without an ``attest_reference_url`` (localnet / echo) attestation is off and every candidate counts as attested.
+    Without an ``attest_reference_url`` (localnet / echo) attestation is off and every candidate counts as one card.
     If the reference itself fails, nothing changes this round (neutral).
     """
     round_no = state.attest_round = getattr(state, 'attest_round', 0) + 1
     if not release.attest_reference_url:
-        return {hk: True for _, hk, _ in candidates}
+        return {hk: 1 for _, hk, _ in candidates}
     hotkeys = [hk for _, hk, _ in candidates]
     cohort = set(choose_cohort(hotkeys, state.attest_status, rng=rng))
     seed = secrets.randbits(63)
@@ -197,7 +292,7 @@ async def attest_round(
         expected, ref_wall = await asyncio.to_thread(reference_challenge, release, seed, iters, timeout)
     except Exception as e:
         bt.logging.error(f'Serving: reference attestation failed, attest neutral this round: {e!r}')
-        return {hk: bool(state.attest_status.get(hk, {}).get('passed')) for hk in hotkeys}
+        return {hk: status_capacity(state.attest_status.get(hk)) for hk in hotkeys}
     targets = [(uid, hk, axon) for uid, hk, axon in candidates if hk in cohort]
     responses = await send_challenges(dendrite, targets, seed, iters, timeout)
     now = time.time()
@@ -207,12 +302,12 @@ async def attest_round(
         bt.logging.info(
             f'Serving: UID {uid} attest {"PASS" if verdict.passed else "FAIL"} '
             f'{verdict.wall_ms or 0:.0f} ms (ref {ref_wall:.0f}) fill {verdict.filled_bytes / 1e9:.1f} GB '
-            f'uuid {verdict.uuid or "-"}{"" if verdict.passed else " — " + verdict.reason}'
+            f'cards {verdict.capacity}/{len(verdict.cards)} uuid {verdict.uuid or "-"}'
+            f'{"" if verdict.reason.startswith("ok") else " — " + verdict.reason}'
         )
-    for hk in dedupe_uuids(state, round_no):
+    for hk, uuid in dedupe_uuids(state, round_no).items():
         st = state.attest_status.get(hk, {})
-        if st.get('passed'):
-            uid = next((u for u, h, _ in candidates if h == hk), '?')
-            bt.logging.warning(f'Serving: UID {uid} attest FAIL — duplicate GPU {st.get("uuid")} across hotkeys')
-            state.attest_status[hk] = {**st, 'passed': False, 'reason': f'duplicate GPU {st.get("uuid")}'}
-    return {hk: bool(state.attest_status.get(hk, {}).get('passed')) for hk in hotkeys}
+        uid = next((u for u, h, _ in candidates if h == hk), '?')
+        bt.logging.warning(f'Serving: UID {uid} attest FAIL — duplicate GPU {uuid} across hotkeys')
+        state.attest_status[hk] = {**st, 'passed': False, 'capacity': 0, 'reason': f'duplicate GPU {uuid}'}
+    return {hk: status_capacity(state.attest_status.get(hk)) for hk in hotkeys}

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -28,7 +28,9 @@ rounds by ``ServingState``.
 
 import asyncio
 import hashlib
+import math
 import random
+import secrets
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -39,6 +41,8 @@ import bittensor as bt
 
 from gittensor.classes import RequestSpeed
 from gittensor.constants import (
+    SERVING_AUDIT_SAMPLE_FRACTION,
+    SERVING_AUDIT_SAMPLE_MIN,
     SERVING_BASELINE_PER_ROUND,
     SERVING_DORMANT_AFTER_ROUNDS,
     SERVING_DORMANT_RETRY_ROUNDS,
@@ -61,6 +65,28 @@ if TYPE_CHECKING:
     from neurons.validator import Validator
 
 
+def sample_for_audit(
+    served: Sequence[ServedRequest],
+    fraction: float = SERVING_AUDIT_SAMPLE_FRACTION,
+    minimum: int = SERVING_AUDIT_SAMPLE_MIN,
+    rng=None,
+) -> Tuple[List[ServedRequest], List[ServedRequest]]:
+    """(to verify, skipped): per hotkey every baseline prompt and every failed request, plus a random
+    max(minimum, fraction x n) of the completed gateway requests. Order of the input is kept."""
+    rng = rng or secrets.SystemRandom()
+    by_hotkey: Dict[str, List[int]] = {}
+    for i, req in enumerate(served):
+        if req.ok and req.source == 'gateway':
+            by_hotkey.setdefault(req.hotkey, []).append(i)
+    keep = set(range(len(served)))
+    for idxs in by_hotkey.values():
+        n = len(idxs)
+        k = max(minimum, math.ceil(fraction * n))
+        if k < n:
+            keep.difference_update(set(idxs) - set(rng.sample(idxs, k)))
+    return [r for i, r in enumerate(served) if i in keep], [r for i, r in enumerate(served) if i not in keep]
+
+
 def verify_served_round(
     state: ServingState,
     reference: Reference,
@@ -68,15 +94,21 @@ def verify_served_round(
     served: Sequence[ServedRequest],
     summary: Optional[Dict[str, int]] = None,
     last_miss: Optional[Dict[str, str]] = None,
+    rng=None,
 ) -> Dict[str, List[RequestSpeed]]:
-    """Verify every served request for ``release`` into the window; return per-request speed per hotkey.
+    """Verify this round's audit sample of the requests served for ``release`` into the window; return per-request
+    speed per hotkey.
 
     Reference calls run on a small thread pool; window updates stay on this thread. ``last_miss`` (hotkey ->
     reason) is filled with the most recent miss or strike reason so the round report can show a miner why.
     """
     summary = summary if summary is not None else {}
     last_miss = last_miss if last_miss is not None else {}
-    mine = [req for req in served if req.model_id == release.model_id]
+    mine, skipped = sample_for_audit([req for req in served if req.model_id == release.model_id], rng=rng)
+    for req in skipped:
+        summary['served'] = summary.get('served', 0) + 1
+        summary[req.source] = summary.get(req.source, 0) + 1
+        summary['unsampled'] = summary.get('unsampled', 0) + 1
 
     def judge(req: ServedRequest) -> Optional[AuditVerdict]:
         if not req.ok and 'budget' in req.detail.lower():  # this validator over-sent; not the miner's fault
@@ -296,19 +328,21 @@ async def audit_round(
             state, dendrite, [(uid, hotkey, axon) for uid, hotkey, axon, _ in passing], release, rng=attest_rng
         )
         for uid, hotkey, _, credit in passing:
-            ok = attested.get(hotkey, False)
-            score = credit if ok else 0.0
+            cards = int(attested.get(hotkey, 0))
+            ok = cards > 0
+            score = credit * cards  # one card-hour per attested card at this speed
             st = state.attest_status.get(hotkey, {})
             bt.logging.info(
-                f'Serving: UID {uid} {release.model_id} attested {"yes" if ok else "no"} speed credit {credit:.2f} '
-                f'score {score:.3f}'
+                f'Serving: UID {uid} {release.model_id} attested {"yes" if ok else "no"} cards {cards} '
+                f'speed credit {credit:.2f} score {score:.3f}'
             )
             windows[uid].update(
                 attested=ok,
                 gpu_uuid=st.get('uuid', ''),
+                gpu_uuids=st.get('uuids', [st['uuid']] if st.get('uuid') else []),
                 attest_ms=st.get('wall_ms'),
                 attest_reason=st.get('reason', 'not attested yet'),
-                capacity=1.0 if ok else 0.0,
+                capacity=float(cards),
                 score=round(score, 4),
             )
             if not ok and not windows[uid]['last_miss']:

--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -70,6 +70,8 @@ def round_rows(
         release.runtime_pin if release else None,
         release.model_sha256 if release else None,
         release.model_file if release else None,
+        release.runtime_image if release else None,
+        release.attest_image if release else None,
     )
     miners = []
     for uid, w in windows.items():

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -201,8 +201,8 @@ INSERT_SERVING_ROUND = """
 INSERT INTO serving_rounds (
     validator_hotkey, round_ts, served, gateway, baseline, passes, misses, strikes, neutral,
     ready, probation, quarantined, card_equivalents, pool_share, alpha_per_hour, alpha_usd,
-    gpu_hour_usd, pool_cap, model_id, runtime_pin, model_sha256, model_file
-) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    gpu_hour_usd, pool_cap, model_id, runtime_pin, model_sha256, model_file, runtime_image, attest_image
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT (validator_hotkey, round_ts) DO NOTHING
 """
 

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -11,6 +11,7 @@
       "max_tokens": 64,
       "request_timeout": 60,
       "runtime_pin": "gittensor-ai-lab/sparkinfer@7498736",
+      "runtime_image": "entrius/sparkinfer:7498736",
       "model_file": "unsloth/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
       "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
       "audit_bank": "serving_audit_bank.json",
@@ -26,6 +27,7 @@
         }
       },
       "attest": {
+        "image": "entrius/gt-attest:v1",
         "iters": 3,
         "vram_model_reserved_bytes": 24000000000
       }

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -85,7 +85,10 @@ class ServingMiner(BaseNeuron):
             priority_fn=partial(priority_attest, self),
             verify_fn=partial(verify_attest, self),
         )
-        self.backend_slots = asyncio.Semaphore(SERVING_BACKEND_CONCURRENCY)
+        # One card's worth by default; a multi-GPU box fronting N instances sets SERVING_BACKEND_CONCURRENCY=N x 16.
+        self.backend_slots = asyncio.Semaphore(
+            int(os.getenv('SERVING_BACKEND_CONCURRENCY', SERVING_BACKEND_CONCURRENCY))
+        )
         self.seen_nonces: 'OrderedDict[str, None]' = OrderedDict()
         self.audit_budget: Dict[str, Tuple[int, int]] = {}  # validator hotkey -> (tempo, completion tokens used)
         bt.logging.info(f'ServingMiner axon: {self.axon}')

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -341,14 +341,15 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
     }
 
 
-def check_attest(rep: Report, base_url: str, timeout: float) -> Dict:
-    """A1: the runtime image's attestation sidecar (:8081) answers a seeded challenge with a digest inside 3 s idle,
-    and two simultaneous challenges each take >= 1.6x a single one (the property the cohort check rests on)."""
+def check_attest(rep: Report, base_url: str, timeout: float, attest_url: Optional[str] = None) -> Dict:
+    """A1: the attest container beside the runtime (entrius/gt-attest, :8081 on the runtime's host unless
+    ``attest_url`` says otherwise) answers a seeded challenge with a digest inside 3 s idle, and two simultaneous
+    challenges each take >= 1.6x a single one (the property the cohort check rests on)."""
     from urllib.parse import urlsplit, urlunsplit
 
     parts = urlsplit(base_url)
     host = parts.hostname or ''
-    attest_url = urlunsplit((parts.scheme or 'http', f'{host}:8081', '', '', ''))
+    attest_url = (attest_url or urlunsplit((parts.scheme or 'http', f'{host}:8081', '', '', ''))).rstrip('/')
     facts: Dict = {}
     try:
         single = requests.post(
@@ -402,6 +403,7 @@ def main() -> int:
     )
     ap.add_argument('--overload-max-tokens', type=int, default=512)
     ap.add_argument('--api-key', default=None, help='bearer for a remote runtime (sparkinfer --api-key)')
+    ap.add_argument('--attest-url', default=None, help='the attest container (default: the runtime host, port 8081)')
     ap.add_argument(
         '--speed-json',
         default=None,
@@ -428,7 +430,7 @@ def main() -> int:
     if args.parallel > 0:
         check_overload(rep, base_url, args.model_id, args.parallel, args.overload_max_tokens, args.timeout)
 
-    attest_facts = check_attest(rep, base_url, args.timeout)
+    attest_facts = check_attest(rep, base_url, args.timeout, args.attest_url)
     if args.speed_json:
         profile = speed_profile(base_url, args.model_id, args.max_tokens, args.timeout, args.speed_burst)
         profile['attest'] = attest_facts

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -3,10 +3,12 @@
 #
 #   LIUM_API_KEY=... scripts/serving_conformance_on_lium.sh <sparkinfer ref> [out dir]
 #
-# Rents one 1x5090 executor, boots entrius/sparkinfer:<ref> with the loadout's MODEL_SHA256, waits for the
-# model download, runs scripts/check_serving_runtime.py against the pod's public 8080 and writes the report
-# to <out dir>/conformance.txt and the blessing-time speed profile to <out dir>/speed.json. Exit code is the checker's (1 = a MUST failed). The pod is removed on every
-# exit path; --ttl is the backstop if this process dies.
+# Rents two 1x5090 executors: one boots entrius/sparkinfer:<ref> with the loadout's MODEL_SHA256, the other the
+# attest container (attest.image in the loadout — a Lium pod runs one image, so the sidecar gets its own card).
+# Waits for the model download, runs scripts/check_serving_runtime.py against the runtime pod's public 8080 with
+# --attest-url at the attest pod's 8081, and writes the report to <out dir>/conformance.txt and the blessing-time
+# speed profile to <out dir>/speed.json. Exit code is the checker's (1 = a MUST failed). Both pods are removed on
+# every exit path; --ttl is the backstop if this process dies.
 set -euo pipefail
 
 REF="${1:?sparkinfer ref (image tag)}"
@@ -14,52 +16,69 @@ OUT="${2:-serving-conformance-$REF}"
 LOADOUT="$(dirname "$0")/../gittensor/validator/weights/serving_loadout.json"
 MODEL_ID=$(jq -r '.releases[0].model_id' "$LOADOUT")
 MODEL_SHA=$(jq -r '.releases[0].model_sha256' "$LOADOUT")
+ATTEST_IMAGE="${CONFORMANCE_ATTEST_IMAGE:-$(jq -r '.releases[0].attest.image' "$LOADOUT")}"
 POD="conf-${REF:0:7}-$RANDOM"
+ATTEST_POD="$POD-attest"
 GPU="${CONFORMANCE_GPU:-5090}"
 RENT_WAIT_MIN="${CONFORMANCE_RENT_WAIT_MIN:-60}"
 BOOT_WAIT_MIN="${CONFORMANCE_BOOT_WAIT_MIN:-45}"
 mkdir -p "$OUT"
 
-cleanup() { lium rm "$POD" -y >/dev/null 2>&1 || true; }
+cleanup() { lium rm "$POD" -y >/dev/null 2>&1 || true; lium rm "$ATTEST_POD" -y >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
-echo "renting 1x$GPU for entrius/sparkinfer:$REF (waiting up to ${RENT_WAIT_MIN} min for a free card)"
+# `lium ls --gpu X --format json` returns [] even when cards are listed; filter the full listing instead.
+# Prints the cheapest free 1x$GPU executor id not in $1 (space-separated ids already taken).
+free_node() {
+  lium ls --format json 2>/dev/null | jq -r --arg gpu "RTX$GPU" --arg taken " $1 " \
+    '[.[] | select(.gpu_type == $gpu and .gpu_count == 1 and .vram_gb >= 30 and .download_mbps >= 150 and ($taken | contains(" " + .id + " ") | not))] | sort_by(.price_per_hour) | .[0].id // empty'
+}
+
+echo "renting 2x 1x$GPU: entrius/sparkinfer:$REF + $ATTEST_IMAGE (waiting up to ${RENT_WAIT_MIN} min for free cards)"
 for ((i = 0; i < RENT_WAIT_MIN; i++)); do
-  # `lium ls --gpu X --format json` returns [] even when cards are listed; filter the full listing instead.
-  NODE=$(lium ls --format json 2>/dev/null | jq -r --arg gpu "RTX$GPU" '[.[] | select(.gpu_type == $gpu and .gpu_count == 1 and .vram_gb >= 30 and .download_mbps >= 150)] | sort_by(.price_per_hour) | .[0].id // empty')
-  [ -n "$NODE" ] && break
+  NODE=$(free_node "")
+  ATTEST_NODE=$([ -n "$NODE" ] && free_node "$NODE" || true)
+  [ -n "$NODE" ] && [ -n "$ATTEST_NODE" ] && break
   sleep 60
 done
-[ -n "${NODE:-}" ] || { echo "no 1x$GPU executor became available in ${RENT_WAIT_MIN} min"; exit 2; }
+[ -n "${NODE:-}" ] && [ -n "${ATTEST_NODE:-}" ] || { echo "two 1x$GPU executors did not become available in ${RENT_WAIT_MIN} min"; exit 2; }
 lium up "$NODE" --name "$POD" --image "entrius/sparkinfer:$REF" --internal-ports 22,8080 \
   -e "MODEL_SHA256=$MODEL_SHA" -e SPARKINFER_DETERMINISTIC=1 --ttl 3h -y --no-ssh
+lium up "$ATTEST_NODE" --name "$ATTEST_POD" --image "$ATTEST_IMAGE" --internal-ports 22,8081 --ttl 3h -y --no-ssh
 
-echo "waiting for the pod's public 8080 and the model download (up to ${BOOT_WAIT_MIN} min)"
-BASE=""
-for ((i = 0; i < BOOT_WAIT_MIN * 6; i++)); do
-  if [ -z "$BASE" ]; then
-    BASE=$(lium ps --format json 2>/dev/null | python3 -c '
+# public URL of a pod's internal port, empty until the pod is RUNNING with the port mapped
+pod_url() {
+  lium ps --format json 2>/dev/null | python3 -c '
 import json, sys
-name = sys.argv[1]
+name, port = sys.argv[1], sys.argv[2]
 for p in json.load(sys.stdin):
     if p.get("name") != name or p.get("status") != "RUNNING":
         continue
     ports = p.get("ports") or {}
     items = ports.items() if isinstance(ports, dict) else [(x.get("internal") or x.get("internal_port"), x.get("external") or x.get("external_port")) for x in ports]
     for internal, external in items:
-        if str(internal) == "8080" and external:
+        if str(internal) == port and external:
             print(f"http://{p.get(\"ssh_ip\") or p.get(\"ip\")}:{external}")
-' "$POD" || true)
-  fi
-  if [ -n "$BASE" ] && curl -sf --max-time 5 "$BASE/v1/models" >/dev/null 2>&1; then break; fi
+' "$1" "$2" || true
+}
+
+echo "waiting for the pods' public ports and the model download (up to ${BOOT_WAIT_MIN} min)"
+BASE=""; ATTEST=""
+for ((i = 0; i < BOOT_WAIT_MIN * 6; i++)); do
+  [ -z "$BASE" ] && BASE=$(pod_url "$POD" 8080)
+  [ -z "$ATTEST" ] && ATTEST=$(pod_url "$ATTEST_POD" 8081)
+  if [ -n "$BASE" ] && [ -n "$ATTEST" ] && curl -sf --max-time 5 "$BASE/v1/models" >/dev/null 2>&1 \
+     && curl -sf --max-time 5 "$ATTEST/info" >/dev/null 2>&1; then break; fi
   sleep 10
 done
 [ -n "$BASE" ] && curl -sf --max-time 5 "$BASE/v1/models" >/dev/null || { echo "runtime never answered on $BASE"; lium ps; exit 2; }
-echo "runtime up at $BASE"
+[ -n "$ATTEST" ] && curl -sf --max-time 5 "$ATTEST/info" >/dev/null || { echo "attest container never answered on $ATTEST"; lium ps; exit 2; }
+echo "runtime up at $BASE, attest at $ATTEST"
+curl -s "$ATTEST/info" | tee "$OUT/attest-info.json"; echo
 curl -s "$BASE/v1/models" | tee "$OUT/models.json"; echo
 
 set +e
-uv run python scripts/check_serving_runtime.py --base-url "$BASE" --model-id "$MODEL_ID" \
+uv run python scripts/check_serving_runtime.py --base-url "$BASE" --model-id "$MODEL_ID" --attest-url "$ATTEST" \
   --determinism-count 30 --repeat 3 --parallel 16 --speed-json "$OUT/speed.json" 2>&1 | tee "$OUT/conformance.txt"
 RC=${PIPESTATUS[0]}
 set -e

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1469,3 +1469,127 @@ def test_miner_axon_hooks_match_their_forward_synapse_types():
         for fn in (fwd, bl, pr, vf):
             (param,) = inspect.signature(partial(fn, None)).parameters.values()
             assert param.name == 'synapse' and getattr(param.annotation, '__name__', param.annotation) == syn
+
+
+def _card(uuid: str, digest: str = 'd', wall_ms: float = 1500.0, filled: int = 8_000_000_000, free_before=None):
+    dev = {'uuid': uuid, 'digest': digest, 'wall_ms': wall_ms, 'filled_bytes': filled, 'vram_total': 34e9}
+    if free_before is not None:
+        dev['vram_free_before'] = free_before
+    return dev
+
+
+def test_attest_judges_every_card_and_counts_capacity():
+    """One hotkey, N cards: each card is judged alone; capacity = passing cards; the reason names the first failure;
+    a card without the model resident earns nothing."""
+    from gittensor.synapses import AttestSynapse
+    from gittensor.validator.serving.attest import judge
+
+    release = _attest_release()
+    two = judge(AttestSynapse(seed=1, devices=[_card('GPU-a'), _card('GPU-b')]), 'd', 1400.0, release)
+    assert two.passed and two.capacity == 2 and two.uuids == ['GPU-a', 'GPU-b'] and two.reason == 'ok (2 cards)'
+    one_bad = judge(
+        AttestSynapse(seed=1, devices=[_card('GPU-a'), _card('GPU-b', wall_ms=9_000.0)]), 'd', 1400.0, release
+    )
+    assert one_bad.passed and one_bad.capacity == 1 and one_bad.uuids == ['GPU-a']
+    assert one_bad.reason.startswith('1/2 cards ok (too slow')
+    none = judge(
+        AttestSynapse(seed=1, devices=[_card('GPU-a', digest='x'), _card('GPU-b', digest='x')]), 'd', 1400.0, release
+    )
+    assert not none.passed and none.capacity == 0 and none.reason == 'digest mismatch'
+    loaded = judge(AttestSynapse(seed=1, devices=[_card('GPU-a', free_before=9e9)]), 'd', 1400.0, release)
+    assert loaded.passed
+    bare = judge(AttestSynapse(seed=1, devices=[_card('GPU-a', free_before=33e9)]), 'd', 1400.0, release)
+    assert not bare.passed and bare.reason.startswith('model not resident')
+    status = two.as_status(0.0, 1)
+    assert status['capacity'] == 2 and status['uuids'] == ['GPU-a', 'GPU-b'] and len(status['cards']) == 2
+
+
+def test_attest_round_pays_per_card_and_dedupes_across_cards(monkeypatch):
+    """A two-card hotkey scores credit x 2; a second hotkey reporting one of those cards fails both."""
+    import asyncio
+    import random
+    from types import SimpleNamespace
+
+    from gittensor.synapses import AttestSynapse
+    from gittensor.validator.serving import attest as att
+    from gittensor.validator.serving import forward as fwd
+
+    release = _attest_release()
+    monkeypatch.setattr(att, 'reference_challenge', lambda rel, seed, iters, timeout: ('d', 1400.0))
+    replies = {}
+
+    async def call(target_axon, synapse, timeout, deserialize):
+        return replies[id(target_axon)]
+
+    axons = {hk: SimpleNamespace(is_serving=True) for hk in ('hk1', 'hk2')}
+    replies[id(axons['hk1'])] = AttestSynapse(seed=1, devices=[_card('GPU-a'), _card('GPU-b')])
+    replies[id(axons['hk2'])] = AttestSynapse(seed=1, devices=[_card('GPU-c')])
+    dendrite = SimpleNamespace(call=call)
+    state = ServingState()
+    candidates = [(1, 'hk1', axons['hk1']), (2, 'hk2', axons['hk2'])]
+    out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
+    assert out == {'hk1': 2, 'hk2': 1}
+    assert att.status_capacity(state.attest_status['hk1']) == 2
+    assert att.status_capacity({'passed': True, 'uuid': 'GPU-old'}) == 1  # status persisted before capacity existed
+
+    replies[id(axons['hk2'])] = AttestSynapse(seed=1, devices=[_card('GPU-b')])  # hk1's second card
+    state.attest_status = {}
+    out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
+    assert out == {'hk1': 0, 'hk2': 0}
+    assert state.attest_status['hk1']['reason'] == 'duplicate GPU GPU-b'
+
+    # the audit round multiplies the speed credit by the attested cards
+    good = _echo_release()
+    good.attest_reference_url = 'http://ref:8081'
+    good.vram_model_reserved_bytes = 24e9
+    state = ServingState(settlement_rounds=1)
+    for _ in range(3):
+        state.enqueue_served(_served(1, good))
+        state.enqueue_served(_served(2, good))
+    replies[id(axons['hk1'])] = AttestSynapse(seed=1, devices=[_card('GPU-a'), _card('GPU-b')])
+    replies[id(axons['hk2'])] = AttestSynapse(seed=1, devices=[_card('GPU-c')])
+    echo_dendrite, _ = _dendrite_echoing(good)
+    echo_dendrite.call = call  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        fwd, 'reference_for', lambda rel: __import__('gittensor.serving.audit', fromlist=['x']).reference_for(rel)
+    )
+    scores = asyncio.run(
+        fwd.audit_round(
+            state,
+            echo_dendrite,  # type: ignore[arg-type]
+            [(1, 'hk1', axons['hk1']), (2, 'hk2', axons['hk2'])],  # type: ignore[arg-type]
+            loadout=SimpleNamespace(releases=[good]),
+            attest_rng=random.Random(0),
+        )
+    )
+    assert scores['hk1'] == pytest.approx(2.0) and scores['hk2'] == pytest.approx(1.0)
+    tele = state.snapshot()['last_round']['windows']
+    assert tele[1]['capacity'] == 2.0 and tele[1]['gpu_uuids'] == ['GPU-a', 'GPU-b'] and tele[2]['capacity'] == 1.0
+
+
+def test_sample_for_audit_keeps_baseline_and_failures_and_draws_the_rest():
+    """Per hotkey: baseline prompts and failed requests are always verified; completed gateway requests are drawn at
+    max(minimum, fraction x n); a low-traffic miner is verified in full."""
+    import random
+
+    from gittensor.validator.serving.forward import sample_for_audit
+
+    def req(hk, source='gateway', ok=True):
+        return ServedRequest(ts=0.0, uid=1, hotkey=hk, model_id='m', messages=[], ok=ok, latency_ms=1.0, source=source)
+
+    served = (
+        [req('busy') for _ in range(100)]
+        + [req('busy', source='baseline') for _ in range(2)]
+        + [req('busy', ok=False) for _ in range(3)]
+        + [req('quiet') for _ in range(7)]
+    )
+    keep, skipped = sample_for_audit(served, fraction=0.2, minimum=10, rng=random.Random(0))
+    busy = [r for r in keep if r.hotkey == 'busy']
+    assert sum(1 for r in busy if r.source == 'gateway' and r.ok) == 20
+    assert sum(1 for r in busy if r.source == 'baseline') == 2 and sum(1 for r in busy if not r.ok) == 3
+    assert sum(1 for r in keep if r.hotkey == 'quiet') == 7
+    assert len(skipped) == 80 and all(r.hotkey == 'busy' and r.ok and r.source == 'gateway' for r in skipped)
+    kept = {id(r) for r in keep}
+    assert [id(r) for r in keep] == [id(r) for r in served if id(r) in kept]  # input order kept
+    tiny = [req('busy') for _ in range(50)]
+    assert len(sample_for_audit(tiny, fraction=0.2, minimum=10, rng=random.Random(1))[0]) == 10

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -79,7 +79,7 @@ def test_round_rows_shape_and_pricing():
     assert 0 < summary[13] <= 0.035  # priced share inside the cap
     assert summary[14:16] == (100.0, 1.0)
     assert summary[16:18] == (0.70, 0.035)  # economics ride along so das never hard-codes them
-    assert summary[18:] == (None, None, None, None)
+    assert summary[18:] == (None,) * 6
     assert len(miners) == 2
     ready = next(m for m in miners if m[2] == 16)
     assert ready[5] == 'ready' and ready[12] == 48.3 and ready[13] == 190.0 and ready[16] == 0.5 and ready[17] is None
@@ -97,10 +97,19 @@ def test_round_rows_carry_the_enforced_release():
             'runtime_pin': 'org/sparkinfer@abc',
             'model_sha256': 'ff',
             'model_file': 'org/model.gguf',
+            'runtime_image': 'entrius/sparkinfer:abc@sha256:00',
+            'attest': {'image': 'entrius/gt-attest:v1'},
         }
     )
     summary, _ = persist.round_rows('vali', dt.datetime.now(dt.timezone.utc), ROUND, {}, None, release)
-    assert summary[18:] == ('qwen', 'org/sparkinfer@abc', 'ff', 'org/model.gguf')
+    assert summary[18:] == (
+        'qwen',
+        'org/sparkinfer@abc',
+        'ff',
+        'org/model.gguf',
+        'entrius/sparkinfer:abc@sha256:00',
+        'entrius/gt-attest:v1',
+    )
 
 
 def test_default_loadout_keeps_model_file():


### PR DESCRIPTION
- `docker/attest` is its own image (`entrius/gt-attest:<tag>`, new `attest-image.yml`): one container per box beside the runtime, on every GPU. The sparkinfer image no longer ships the sidecar. `GET /info` self-report (telemetry only, nothing pays on it).
- `attest.py` judges every card the sidecar reports: `capacity` = passing cards, `score = speed credit × cards`, UUID dedupe across all cards. New check: the model must be resident on the card (free VRAM ≤ total − 0.8 × reservation, `SERVING_ATTEST_MODEL_RESIDENT_RATIO`) — a bare second GPU earns nothing.
- Verification is sampled per (hotkey, round): every baseline prompt and failed request, plus a random max(10, 20 %) of completed gateway requests (`SERVING_AUDIT_SAMPLE_MIN` / `_FRACTION`).
- Loadout: `runtime_image` (digest, written by the conformance job) and `attest.image`, both persisted per round (needs gittensor-db `serving/attest-image-columns`, das `serving/attest-image`, ui `compute/attest-image`, docs `docs/attest-image-multi-card`).
- Reference: `SERVING_ATTEST_REFERENCE_URL`, compose `attest` service (`GT_ATTEST_TAG`). Lium conformance rents a second pod for the attest image; `check_serving_runtime --attest-url`. Miner: `SERVING_BACKEND_CONCURRENCY` env override for multi-card boxes.

To land: dispatch `attest-image.yml` with tag `v1`, re-run sparkinfer conformance so `runtime_image` gets its digest, testnet miners switch to two containers.

https://claude.ai/code/session_01FJtQK6NCjUgYkGTopczEf4