### PR TITLE
serving: pay only what this validator measured (compute red-team round 1)

### DIFF
--- a/docker/attest/Dockerfile
+++ b/docker/attest/Dockerfile
@@ -17,7 +17,7 @@ ARG CUDA_ARCHS=120
 COPY docker/attest/gt_attest.cu /src/gt_attest.cu
 # -fmad=false: the summation is bit-identical on every card of the architecture (the validator's reference recomputes
 # the digest).
-RUN nvcc -O3 -fmad=false -gencode arch=compute_${CUDA_ARCHS},code=sm_${CUDA_ARCHS} \
+RUN nvcc -O3 -fmad=false -gencode arch=compute_${CUDA_ARCHS},code=sm_${CUDA_ARCHS} -Xcompiler -pthread \
         -o /src/gt_attest /src/gt_attest.cu -lnvidia-ml
 
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}

--- a/docker/attest/gt_attest.cu
+++ b/docker/attest/gt_attest.cu
@@ -6,6 +6,11 @@
 // TF32, no fast-math), so a validator's reference 5090 recomputes the same digest. One pass (--iters 3) is sized to
 // ~1.5 s on an idle 5090; two hotkeys sharing a card cannot both fill the free VRAM, and their chains run ~2x slower.
 //
+// Every device answers its own seed — the challenge seed plus the device index — and all devices run at the same
+// time, each on its own thread. A box with N cards therefore finishes in one card's wall time with N distinct
+// digests, while one card impersonating N has to run the chain N times in a row: the validator recomputes each
+// index's digest on its reference and holds the whole reply to one card's round trip.
+//
 //   gt_attest --seed <u64> [--iters 3] [--fill] [--device <i>|all] [--dim 1024] [--matrices 512]
 // prints one JSON object (or {"devices":[...]} for all) and exits 0; exit 2 = bad args, 3 = allocation failure.
 #include <cuda_runtime.h>
@@ -16,6 +21,7 @@
 #include <cstring>
 #include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 #define CHECK(x) do { cudaError_t e_ = (x); if (e_ != cudaSuccess) { std::fprintf(stderr, "{\"error\":\"%s at %s:%d\"}\n", cudaGetErrorString(e_), __FILE__, __LINE__); std::exit(3); } } while (0)
@@ -75,8 +81,9 @@ static std::string device_uuid(int dev) {
     return out;
 }
 
-static void run_device(int dev, uint64_t seed, int iters, bool fill, int d, int matrices, bool last) {
+static std::string run_device(int dev, uint64_t challenge_seed, int iters, bool fill, int d, int matrices) {
     auto t0 = std::chrono::steady_clock::now();
+    uint64_t seed = challenge_seed + (uint64_t)dev;  // per-device seed: index i answers seed + i
     CHECK(cudaSetDevice(dev));
     cudaDeviceProp prop; CHECK(cudaGetDeviceProperties(&prop, dev));
     size_t free_b = 0, total_b = 0; CHECK(cudaMemGetInfo(&free_b, &total_b));
@@ -106,8 +113,10 @@ static void run_device(int dev, uint64_t seed, int iters, bool fill, int d, int 
     }
     for (void* p : chunks) cudaFree(p);
     double ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
-    std::printf("{\"device\":%d,\"uuid\":\"%s\",\"name\":\"%s\",\"sm_count\":%d,\"vram_total\":%zu,\"vram_free_before\":%zu,\"filled_bytes\":%zu,\"dim\":%d,\"matrices\":%d,\"iters\":%d,\"digest\":\"%s\",\"wall_ms\":%.1f}%s\n",
-        dev, device_uuid(dev).c_str(), prop.name, prop.multiProcessorCount, total_b, free_b, filled, d, matrices, iters, sha.hex().c_str(), ms, last ? "" : ",");
+    char out[1024];
+    std::snprintf(out, sizeof out, "{\"device\":%d,\"uuid\":\"%s\",\"name\":\"%s\",\"sm_count\":%d,\"vram_total\":%zu,\"vram_free_before\":%zu,\"filled_bytes\":%zu,\"dim\":%d,\"matrices\":%d,\"iters\":%d,\"digest\":\"%s\",\"wall_ms\":%.1f}",
+        dev, device_uuid(dev).c_str(), prop.name, prop.multiProcessorCount, total_b, free_b, filled, d, matrices, iters, sha.hex().c_str(), ms);
+    return std::string(out);
 }
 
 int main(int argc, char** argv) {
@@ -125,8 +134,16 @@ int main(int argc, char** argv) {
     if (!have_seed || iters < 1 || d % TILE != 0 || d < TILE || matrices < 2) { std::fprintf(stderr, "usage: gt_attest --seed <u64> [--iters n] [--fill] [--device i|all] [--dim d] [--matrices m]\n"); return 2; }
     nvmlInit_v2();
     int count = 0; CHECK(cudaGetDeviceCount(&count));
-    if (device == "all") { std::printf("{\"devices\":["); for (int i = 0; i < count; i++) run_device(i, seed, iters, fill, d, matrices, i == count - 1); std::printf("]}\n"); }
-    else { int dev = std::atoi(device.c_str()); if (dev < 0 || dev >= count) { std::fprintf(stderr, "no device %d\n", dev); return 2; } run_device(dev, seed, iters, fill, d, matrices, true); }
+    if (device == "all") {
+        // every card at once, each on its own thread: N cards take one card's wall, one card faking N takes N
+        std::vector<std::string> out(count); std::vector<std::thread> threads;
+        for (int i = 0; i < count; i++) threads.emplace_back([&, i]() { out[i] = run_device(i, seed, iters, fill, d, matrices); });
+        for (auto& t : threads) t.join();
+        std::printf("{\"devices\":[");
+        for (int i = 0; i < count; i++) std::printf("%s%s", out[i].c_str(), i == count - 1 ? "" : ",");
+        std::printf("]}\n");
+    }
+    else { int dev = std::atoi(device.c_str()); if (dev < 0 || dev >= count) { std::fprintf(stderr, "no device %d\n", dev); return 2; } std::printf("%s\n", run_device(dev, seed, iters, fill, d, matrices).c_str()); }
     nvmlShutdown();
     return 0;
 }

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -271,6 +271,10 @@ SERVING_MIN_CALLER_STAKE = 1_000_000.0
 # miners several times over, worthless as free inference (~$0.05 of tokens). No shape limit, so a smaller
 # validator's audits look like any other request.
 SERVING_VALIDATOR_TOKENS_PER_TEMPO = 50_000
+# Validator: a miner's "budget spent" refusal is judged neutral (not a miss) only when this validator's own ledger
+# of max_tokens sent to that miner in the trailing tempo has reached this fraction of the allowance. The refusal
+# text is the miner's to write; the ledger is not. A staked caller has no budget and is never refused on one.
+SERVING_BUDGET_REFUSAL_RATIO = 0.8
 BLOCKS_PER_TEMPO = 360
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -286,6 +286,11 @@ BLOCKS_PER_TEMPO = 360
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)
+# Gateway: total characters across a request's messages (~4 per token). A prompt past the release's context makes
+# the runtime answer 400 — not the miner's fault, but every such request used to land in its window as a miss, so
+# one key holder could take any miner off READY with a few oversized prompts. The cap is set under the blessed
+# release's context; a request the runtime still rejects is checked against the reference before it counts.
+SERVING_MAX_PROMPT_CHARS = 16_000
 SERVING_DB_RETENTION_DAYS = 7  # validator: per-round serving rows older than this are pruned on each write
 SERVING_REQUEST_LOG_SIZE = 5_000  # in-memory ring of recent API/audit requests (telemetry)
 

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -254,6 +254,16 @@ SERVING_AUDIT_WINDOW_THRESHOLDS = ((1, 0.8),)
 SERVING_AUDIT_SAMPLE_FRACTION = 0.2
 SERVING_AUDIT_SAMPLE_MIN = 10
 SERVING_QUARANTINE_S = 3600.0
+# Each further strike on the same (hotkey, release) quarantines ESCALATION times longer, up to MAX_STEPS steps
+# (1 h, 4 h, 16 h, 64 h): one wrong answer costs an hour, a pattern of them costs days, and rotating to a fresh
+# hotkey to reset it costs a registration plus a settlement window from zero.
+SERVING_QUARANTINE_ESCALATION = 4.0
+SERVING_QUARANTINE_MAX_STEPS = 3
+# A wrong answer is a strike only while the reference agrees with most of the fleet this round. When fewer than
+# this fraction of the hotkeys judged this round passed anything, the reference is the odd one out (a driver or
+# image drift on this validator's box) and the round's band failures are misses, not strikes — otherwise one
+# drifted reference quarantines every honest miner each time its quarantine lifts. Needs two judged hotkeys to say.
+SERVING_STRIKE_MIN_FLEET_PASS = 0.5
 # Baseline traffic: every round the validator sends each serving axon this many baseline prompts of its own, at
 # random moments spread over the round (so they do not mark the round boundary), over the same path as user
 # traffic. Real traffic does not displace them — 2 x ~256 tokens per miner per round is noise for a card and well

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -192,7 +192,14 @@ SERVING_ATTEST_ITERS = 3
 SERVING_ATTEST_BUDGET_RATIO = 1.6
 SERVING_ATTEST_MIN_FILL_RATIO = 0.6
 SERVING_ATTEST_TIMEOUT = 45.0  # seconds: fill + chain on a 5090 is ~1.5 s; queued challenges show up as slow
-SERVING_ATTEST_UUID_MEMORY_ROUNDS = 12
+SERVING_ATTEST_UUID_MEMORY_ROUNDS = 12  # a verdict (and a UUID claim) older than this pays nothing until renewed
+# Every field of a card's report except the digest is the miner's own number, so the count of cards is held to two
+# things the validator measures itself: each device index answers its own seed (seed + index), which the reference
+# recomputes, and the whole reply must arrive within one card's budget plus this network slack — gt_attest runs the
+# cards in parallel, so N real cards take one card's wall and one card faking N takes N of them. At most
+# SERVING_ATTEST_MAX_CARDS are judged (and priced) per hotkey.
+SERVING_ATTEST_RTT_SLACK_MS = 2_000.0
+SERVING_ATTEST_MAX_CARDS = 8
 # A card counts only with the model resident: free VRAM before the fill must be at most total minus this fraction of
 # the reservation (a bare 5090 shows ~32 GB free, one holding the model ~8 GB). Every passing card is a card-hour, so
 # a multi-GPU hotkey earns per card it actually serves from — a second card with nothing loaded earns nothing.

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -168,6 +168,11 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # price data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
 SERVING_GPU_HOUR_USD = 0.70
 SERVING_EMISSION_SHARE_CAP = 0.035
+# Pricing the cap needs the chain's alpha/TAO price and the published TAO/USD rate. A round that cannot read them
+# reuses the last usable pricing for up to SERVING_PRICING_MAX_AGE_S, so a chain hiccup does not move pay. With no
+# usable pricing at all the fleet is paid nothing: the alternative (the whole cap, split pro-rata) hands one verified
+# card 3.5% of emissions. A network with no price data to read - testnet - sets SERVING_PAY_CAP_WITHOUT_PRICING.
+SERVING_PRICING_MAX_AGE_S = 3600.0
 assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -298,9 +298,11 @@ SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)
 # Gateway: total characters across a request's messages (~4 per token). A prompt past the release's context makes
 # the runtime answer 400 — not the miner's fault, but every such request used to land in its window as a miss, so
-# one key holder could take any miner off READY with a few oversized prompts. The cap is set under the blessed
-# release's context; a request the runtime still rejects is checked against the reference before it counts.
-SERVING_MAX_PROMPT_CHARS = 16_000
+# one key holder could take any miner off READY with a few oversized prompts. Sized from the blessed release on a
+# 5090 (2026-08-28: ctx 36864; TTFT 403 ms at 8.9k prompt tokens, 500 ms at ~11.5k, 1453 ms at 35.6k): ~10k tokens
+# keeps an honest prefill inside the full-credit TTFT band. A request the runtime still rejects is checked against
+# the reference before it counts.
+SERVING_MAX_PROMPT_CHARS = 40_000
 SERVING_DB_RETENTION_DAYS = 7  # validator: per-round serving rows older than this are pruned on each write
 SERVING_REQUEST_LOG_SIZE = 5_000  # in-memory ring of recent API/audit requests (telemetry)
 

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -212,7 +212,7 @@ SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per ro
 # falls linearly to 0 at ZERO, so a miner proxying to a GPU in another region or queueing requests loses credit
 # in proportion. Generation length does not enter (mini-soak 2026-08-27: total latency of 64-512-token answers
 # scored a perfect miner at 0.24). Same-region proxying is NOT visible here; that is the one-GPU-many-hotkeys
-# case, caught by the concurrent capacity probe.
+# case, caught by the attestation overlap and the decode floor under load.
 SERVING_LATENCY_FULL_CREDIT_MS = 500.0
 SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
 # Decode speed on served traffic. Each served request with at least SERVING_DECODE_MIN_TOKENS completion tokens

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -141,6 +141,7 @@ def build_app(
         if miner is None:
             raise HTTPException(status_code=429, detail='no READY serving capacity')
         inflight = state.inflight().get(miner.uid, 1)
+        state.charge_sent(miner.hotkey, max_tokens)
 
         request_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())
@@ -171,6 +172,7 @@ def build_app(
                     source='gateway',
                     ttft_ms=finite_or_none(getattr(result, 'observed_ttft_ms', None)) if result else None,
                     inflight=inflight,
+                    max_tokens=max_tokens,
                 )
             )
             state.record(

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -91,7 +91,8 @@ def build_app(
                     'id': release.release_id,
                     'object': 'model',
                     'owned_by': 'gittensor',
-                    # release identity (contract P2): what every READY miner behind this endpoint is verified against
+                    # release identity (contract P2), informational: READY miners are verified by greedy conformance
+                    # against a reference running this release and by the attestation digest, not by these strings
                     'model_id': release.model_id,
                     'runtime_pin': release.runtime_pin,
                     'model_sha256': release.model_sha256,

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -32,7 +32,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from gittensor.constants import SERVING_MAX_TOKENS
+from gittensor.constants import SERVING_MAX_PROMPT_CHARS, SERVING_MAX_TOKENS
 from gittensor.serving.loadout import ServingLoadout, ServingRelease
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState, finite_or_none
 from gittensor.serving.stream import SSE_DONE, Event, consume_stream, sse_event
@@ -124,6 +124,8 @@ def build_app(
             )
         if body.get('n', 1) != 1:
             raise HTTPException(status_code=400, detail='n must be 1')
+        if sum(len(m['content']) + len(m['role']) for m in messages) > SERVING_MAX_PROMPT_CHARS:
+            raise HTTPException(status_code=413, detail=f'prompt exceeds {SERVING_MAX_PROMPT_CHARS} characters')
         wanted = body.get('model')
         try:  # `model` = a release_id (or a model_id: its first release); absent -> the primary release
             release = loadout.get(str(wanted)) if wanted else primary
@@ -150,7 +152,11 @@ def build_app(
         def finish(result: Optional[InferenceSynapse]) -> bool:
             state.release(miner.uid)
             ok = result is not None and result.completion is not None
-            latency_ms = (time.monotonic() - start) * 1000.0
+            # The miner's stream end, not the moment the user finished reading it: a slow client must not read as a
+            # slow card.
+            latency_ms = finite_or_none(getattr(result, 'observed_latency_ms', None)) if result else None
+            if latency_ms is None:
+                latency_ms = (time.monotonic() - start) * 1000.0
             state.enqueue_served(
                 ServedRequest(
                     ts=time.time(),
@@ -218,9 +224,16 @@ def build_app(
                     await queue.put(_END)
 
             task = asyncio.create_task(run())
+
+            async def outcome() -> Optional[InferenceSynapse]:
+                try:  # a stream the assembler could not fold is a miss, never a leaked in-flight slot
+                    return await task
+                except Exception:
+                    return None
+
             first = await queue.get()
             if first is _END or first is None:  # nothing streamed before the miner gave up
-                finish(await task)
+                finish(await outcome())
                 return failed()
 
             async def body_iter():
@@ -230,7 +243,7 @@ def build_app(
                         yield SSE_DONE if event is None else sse_event(reshape(event))  # type: ignore[arg-type]
                         event = await queue.get()
                 finally:
-                    finish(await task)
+                    finish(await outcome())
 
             return StreamingResponse(body_iter(), media_type='text/event-stream')
 

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -447,15 +447,25 @@ def verify_served(
     content_n = len(mine) - 1 if ended else len(mine)
     if content_n <= 0:
         return AuditVerdict(False, 0.0, float('inf'), 'empty completion')
+    appended = False
     if max_tokens is not None and content_n < max_tokens and not ended:
-        # Stopped short of the budget without an end-of-turn token: the model did not choose to stop here.
-        return AuditVerdict(
-            False, 0.0, float('inf'), f'stopped at {content_n} of {max_tokens} tokens without end-of-turn'
-        )
-    # The end-of-turn token is forced and judged like any other position: the reference's argmax there must be the
-    # end-of-turn, which is what makes an early stop the model's own decision and not the miner's.
+        # Stopped short of the budget with no end-of-turn token in the transcript (sparkinfer 7498736 lists only
+        # the content tokens on a natural stop). The validator appends the release's end-of-turn id itself and
+        # judges that position on the reference's argmax alone: the model must have chosen to stop here.
+        eos_id = release.end_of_turn_token_id if release is not None else None
+        if mine_ids is None or eos_id is None:
+            return AuditVerdict(
+                False, 0.0, float('inf'), f'stopped at {content_n} of {max_tokens} tokens without end-of-turn'
+            )
+        mine_ids, appended = mine_ids + [eos_id], True
+    # An end-of-turn position — the miner's or the appended one — is forced like any other: the reference's argmax
+    # there must be the end-of-turn, which is what makes an early stop the model's own decision and not the miner's.
     ref = reference.score_served(messages, completion, mine_ids)
-    argmax, ref_lp = ref.get('argmax') or [], ref.get('logprobs') or []
+    argmax, ref_lp = list(ref.get('argmax') or []), list(ref.get('logprobs') or [])
+    if appended:
+        if len(argmax) == len(mine) + 1 and argmax[-1] not in end_of_turn:
+            return AuditVerdict(False, 0.0, float('inf'), 'stopped early: the model would have continued', hard=True)
+        argmax, ref_lp = argmax[: len(mine)], ref_lp[: len(mine)]
     if len(argmax) != len(mine) or len(ref_lp) != len(mine):
         return AuditVerdict(False, 0.0, float('inf'), f'tokenization mismatch ({len(mine)} vs {len(argmax)})')
     if mine_ids and ref.get('bytes'):

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -68,6 +68,8 @@ from gittensor.constants import (
     SERVING_AUDIT_MIN_PREFIX_AGREEMENT,
     SERVING_AUDIT_WINDOW,
     SERVING_AUDIT_WINDOW_THRESHOLDS,
+    SERVING_QUARANTINE_ESCALATION,
+    SERVING_QUARANTINE_MAX_STEPS,
     SERVING_QUARANTINE_S,
 )
 from gittensor.serving.backends import Message, expected_completion
@@ -169,11 +171,14 @@ class AuditWindow:
         self._values[key].append(max(0.0, min(1.0, float(value))))
 
     def strike(self, hotkey: str, release_id: str, now: Optional[float] = None) -> float:
-        """A wrong answer: wipe the window and quarantine the (hotkey, release) until the returned timestamp."""
+        """A wrong answer: wipe the window and quarantine the (hotkey, release) until the returned timestamp. Each
+        strike on the same (hotkey, release) quarantines ``SERVING_QUARANTINE_ESCALATION`` times longer than the last,
+        up to ``SERVING_QUARANTINE_MAX_STEPS`` steps: a strike costs a fresh hotkey an hour, a repeat offender days."""
         key = (hotkey, release_id)
         self._values.pop(key, None)
         self._strikes[key] = self._strikes.get(key, 0) + 1
-        until = (now if now is not None else time.time()) + self.quarantine_s
+        step = min(self._strikes[key] - 1, SERVING_QUARANTINE_MAX_STEPS)
+        until = (now if now is not None else time.time()) + self.quarantine_s * SERVING_QUARANTINE_ESCALATION**step
         self._quarantine[key] = until
         return until
 

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -73,6 +73,8 @@ from gittensor.serving.backends import Message, expected_completion
 from gittensor.serving.loadout import WEIGHTS_DIR, ServingRelease
 from gittensor.serving.probe import compare, greedy, make_prompts, score
 
+MAX_TOKEN_ID = 1 << 21  # no released vocabulary is this large; anything past it is not a token id
+
 
 @dataclass
 class AuditCase:
@@ -395,6 +397,7 @@ def verify_served(
     end_of_turn: Sequence[str] = ('<|im_end|>', '<|endoftext|>', '</s>'),
     token_bytes: Optional[Sequence[Sequence[int]]] = None,
     release: Optional[ServingRelease] = None,
+    max_tokens: Optional[int] = None,
 ) -> AuditVerdict:
     """Verify a served (greedy) completion by teacher forcing it under the reference.
 
@@ -409,8 +412,19 @@ def verify_served(
     if completion is None or not tokens or token_logprobs is None or len(tokens) != len(token_logprobs):
         return AuditVerdict(False, 0.0, float('inf'), 'missing or malformed logprobs')
     mine, mine_lp = list(tokens), list(token_logprobs)
+    if max_tokens is not None and len(mine) > max_tokens + 1:  # + the end-of-turn token a runtime lists
+        return AuditVerdict(False, 0.0, float('inf'), f'{len(mine)} tokens for a {max_tokens}-token request')
+    # Everything below is the miner's data; a value the reference could not even be asked about is the miner's
+    # miss, never a reference fault (an exception here must not become a neutral verdict).
     mine_ids = list(token_ids) if token_ids and len(token_ids) == len(mine) else None
-    mine_bytes = [bytes(b) for b in token_bytes] if token_bytes and len(token_bytes) == len(mine) else None
+    if mine_ids is not None and not all(isinstance(i, int) and 0 <= i < MAX_TOKEN_ID for i in mine_ids):
+        return AuditVerdict(False, 0.0, float('inf'), 'malformed token ids')
+    mine_bytes: Optional[List[bytes]] = None
+    if token_bytes and len(token_bytes) == len(mine):
+        try:
+            mine_bytes = [bytes(b) for b in token_bytes]
+        except (TypeError, ValueError):
+            return AuditVerdict(False, 0.0, float('inf'), 'malformed token bytes')
     if mine and mine[-1] in end_of_turn:
         mine, mine_lp = mine[:-1], mine_lp[:-1]
         mine_ids = mine_ids[:-1] if mine_ids else None

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -40,8 +40,8 @@ publishes the miner while their mean clears ``SERVING_AUDIT_WINDOW_THRESHOLDS``
 — it absorbs transient misses; it is not there to average out model noise (that
 was the 1b8b962 design, 2026-08-22 notes).
 Missed or malformed responses enter the window as 0. The validator persists the
-window (``serving_audits.json`` next to ``state.npz``) so a restart is not a
-reset.
+window (``serving.db`` next to ``state.npz``, ``gittensor/serving/store.py``) so a
+restart is not a reset.
 
 There are no synthetic audit prompts: every request served through the gateway
 *is* the audit. ``verify_served`` teacher-forces the miner's completion under

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -54,6 +54,7 @@ outside the bands with aligned lengths) is a wrong answer, not a miss:
 """
 
 import json
+import re
 import secrets
 import time
 from collections import deque
@@ -281,13 +282,16 @@ class EchoReference:
         )
 
     def score_served(self, messages: List[Message], completion: str, token_ids: Optional[Sequence[int]] = None) -> dict:
-        """Teacher-forced scoring for the echo backend: the argmax is the expected token at every position."""
+        """Teacher-forced scoring for the echo backend: the argmax is the expected token at every position. The echo
+        model never stops early, so a forced position past the text (an end-of-turn token) scores as a wrong token."""
         tokens = completion.split(' ') if completion else []
-        ref = expected_completion(messages, max(1, len(tokens)), self.model_id)
-        argmax = list(ref.tokens or [])[: len(tokens)]
+        n = max(len(tokens), len(token_ids) if token_ids else 0)
+        ref = expected_completion(messages, max(1, n), self.model_id)
+        argmax = list(ref.tokens or [])[:n]
         ref_lp = list(ref.token_logprobs or [])
-        logprobs = [ref_lp[i] if i < len(ref_lp) and tokens[i] == argmax[i] else -20.0 for i in range(len(tokens))]
-        return {'tokens': tokens, 'logprobs': logprobs, 'argmax': argmax, 'usage': {}}
+        mine = tokens + ['<|im_end|>'] * (n - len(tokens))
+        logprobs = [ref_lp[i] if i < len(ref_lp) and mine[i] == argmax[i] else -20.0 for i in range(n)]
+        return {'tokens': mine, 'logprobs': logprobs, 'argmax': argmax, 'usage': {}}
 
     def __len__(self) -> int:
         return 1
@@ -361,8 +365,11 @@ def verify_response(
     min_prefix_agreement: float = SERVING_AUDIT_MIN_PREFIX_AGREEMENT,
     max_mean_abs_logprob_diff: float = SERVING_AUDIT_MAX_MEAN_ABS_LOGPROB_DIFF,
     max_abs_logprob_diff: float = SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF,
+    aligned: bool = False,
 ) -> AuditVerdict:
-    """Measure one audit against the reference; ``passed`` requires every band to hold."""
+    """Measure one audit against the reference; ``passed`` requires every band to hold. With ``aligned`` (the
+    reference scored exactly the miner's positions) a divergence at the first token is a wrong answer like any
+    other, not a miss a miner can choose over a strike."""
     if not tokens or token_logprobs is None or len(tokens) != len(token_logprobs):
         return AuditVerdict(False, 0.0, float('inf'), 'missing or malformed logprobs')
     if not case.reference_tokens or len(case.reference_logprobs) != len(case.reference_tokens):
@@ -370,7 +377,7 @@ def verify_response(
 
     prefix, agreement, overlap, diffs = compare(tokens, token_logprobs, case.reference_tokens, case.reference_logprobs)
     if prefix == 0:
-        return AuditVerdict(False, 0.0, float('inf'), 'diverged at first token', overlap)
+        return AuditVerdict(False, 0.0, float('inf'), 'diverged at first token', overlap, hard=aligned)
 
     mean_diff = sum(diffs) / len(diffs)
     max_diff = max(diffs)
@@ -425,31 +432,40 @@ def verify_served(
             mine_bytes = [bytes(b) for b in token_bytes]
         except (TypeError, ValueError):
             return AuditVerdict(False, 0.0, float('inf'), 'malformed token bytes')
-    if mine and mine[-1] in end_of_turn:
-        mine, mine_lp = mine[:-1], mine_lp[:-1]
-        mine_ids = mine_ids[:-1] if mine_ids else None
-        mine_bytes = mine_bytes[:-1] if mine_bytes else None
-    if not mine:
+    if release is not None and release.backend != 'echo' and mine_ids is None:
+        # A real runtime reports ids (contract R8); without them the text would be re-tokenized, and a miner
+        # could pick a text whose fresh tokenization never aligns \u2014 a miss it can repeat forever, never a strike.
+        return AuditVerdict(False, 0.0, float('inf'), 'no token ids')
+    ended = bool(mine) and mine[-1] in end_of_turn
+    if ended and mine_ids is None:  # the text path cannot force a position past the text; drop the end-of-turn
+        mine, mine_lp, mine_bytes, ended = mine[:-1], mine_lp[:-1], mine_bytes[:-1] if mine_bytes else None, False
+    content_n = len(mine) - 1 if ended else len(mine)
+    if content_n <= 0:
         return AuditVerdict(False, 0.0, float('inf'), 'empty completion')
+    if max_tokens is not None and content_n < max_tokens and not ended:
+        # Stopped short of the budget without an end-of-turn token: the model did not choose to stop here.
+        return AuditVerdict(
+            False, 0.0, float('inf'), f'stopped at {content_n} of {max_tokens} tokens without end-of-turn'
+        )
+    # The end-of-turn token is forced and judged like any other position: the reference's argmax there must be the
+    # end-of-turn, which is what makes an early stop the model's own decision and not the miner's.
     ref = reference.score_served(messages, completion, mine_ids)
     argmax, ref_lp = ref.get('argmax') or [], ref.get('logprobs') or []
     if len(argmax) != len(mine) or len(ref_lp) != len(mine):
         return AuditVerdict(False, 0.0, float('inf'), f'tokenization mismatch ({len(mine)} vs {len(argmax)})')
     if mine_ids and ref.get('bytes'):
-        # Bind the forced ids to what the user received. Exact on bytes when the miner reported them; the decoded
-        # text is only compared when it decodes cleanly (a multibyte character split across streamed tokens shows
-        # up as replacement characters in the stream's text and is not the miner's doing).
-        ref_bytes = b''.join(ref['bytes'])
-        if mine_bytes is not None:
-            if b''.join(mine_bytes) != ref_bytes:
-                return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the streamed bytes')
-        else:
-            text = ref_bytes.decode('utf-8', 'replace')
-            if '\ufffd' not in text and '\ufffd' not in completion and text != completion:
-                return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the completion')
+        # Bind the forced ids to what the user received: exact on bytes when the miner reported them, and the
+        # decoded text must be the completion \u2014 a multibyte character split across streamed tokens shows up as
+        # replacement characters in the stream's text, so each run of them stands for one or more non-ASCII
+        # characters and nothing else.
+        ref_bytes = b''.join(ref['bytes'][:content_n])
+        if mine_bytes is not None and b''.join(mine_bytes[:content_n]) != ref_bytes:
+            return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the streamed bytes')
+        if not spells(ref_bytes, completion):
+            return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the completion')
     case = AuditCase(messages=list(messages), max_tokens=len(mine), reference_tokens=argmax, reference_logprobs=ref_lp)
     if release is None:
-        return verify_response(case, mine, mine_lp)
+        return verify_response(case, mine, mine_lp, aligned=True)
     return verify_response(
         case,
         mine,
@@ -457,4 +473,19 @@ def verify_served(
         release.min_prefix_agreement,
         release.max_mean_abs_logprob_diff,
         release.max_abs_logprob_diff,
+        aligned=True,
     )
+
+
+def spells(ref_bytes: bytes, completion: str) -> bool:
+    """Does the decoded reference text read as ``completion``? Every maximal run of replacement characters in the
+    completion stands for one or more non-ASCII characters (a multibyte character split across streamed chunks);
+    nothing else may differ, so ASCII cannot be added, dropped or changed behind a valid transcript."""
+    text = ref_bytes.decode('utf-8', 'replace')
+    if '\ufffd' not in completion:
+        return text == completion
+    pattern = ''.join(
+        f'[^\\x00-\\x7f]{{1,{len(run)}}}' if run.startswith('\ufffd') else re.escape(run)
+        for run in re.findall('\ufffd+|[^\ufffd]+', completion)
+    )
+    return re.fullmatch(pattern, text, re.DOTALL) is not None

--- a/gittensor/serving/baseline.py
+++ b/gittensor/serving/baseline.py
@@ -4,11 +4,11 @@
 """Baseline prompts: what the validator sends serving miners when real traffic does not cover them.
 
 Served traffic is the only audit, so every miner needs a few verified requests per round whether or not a user
-showed up. These prompts only have to satisfy two things: the reference can answer them (any text can be greedy
-decoded) and a miner cannot pick them out of real traffic. The second is a matter of entropy and shape — random
-combinations, random lengths, random pasted code, prose as well as code — not of realism in any deeper sense; a
-small fixed bank and a fixed length were the tells the old synthetic audits had. Once real prompts exist, the
-validator with users can mix them in (``ServingState`` keeps them); validators without users run 100% baseline.
+showed up. These prompts only have to satisfy one thing: the reference can answer them (any text can be greedy
+decoded). They are template-shaped and a miner that wants to can recognise them; what stops it profiting from that
+is that a refusal or a wrong answer on any *other* request is judged the same way (a budget refusal is neutral only
+by the validator's own ledger; see ``forward.py``), so answering these and nothing else earns nothing extra. Mixing
+real user prompts into the baseline is not built.
 """
 
 import random

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -45,6 +45,7 @@ class ServingRelease:
     backend: str
     release_id: str = ''  # what the validator keys audits, quarantine and READY sets by; defaults to model_id
     max_tokens: int = 64
+    end_of_turn_token_id: Optional[int] = None  # the model's end-of-turn id; forced to verify an early stop
     base_url: Optional[str] = None  # miner side: the runtime this miner serves from
     runtime_pin: Optional[str] = None
     runtime_image: Optional[str] = None  # the blessed image by digest (entrius/sparkinfer:<tag>@sha256:...)
@@ -110,6 +111,9 @@ class ServingRelease:
             backend=raw['backend'],
             release_id=str(raw.get('release_id') or raw['model_id']),
             max_tokens=int(raw.get('max_tokens', 64)),
+            end_of_turn_token_id=int(raw['end_of_turn_token_id'])
+            if raw.get('end_of_turn_token_id') is not None
+            else None,
             base_url=raw.get('base_url'),
             runtime_pin=raw.get('runtime_pin'),
             runtime_image=raw.get('runtime_image'),

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -193,8 +193,8 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
         raw = json.load(f)
     entries = raw['releases'] if isinstance(raw, dict) and 'releases' in raw else [raw]
     pricing = raw.get('pricing') or {} if isinstance(raw, dict) else {}
-    tao_usd_env = os.getenv('SERVING_TAO_USD')
-    tao_usd = float(tao_usd_env) if tao_usd_env else (float(pricing['tao_usd']) if pricing.get('tao_usd') else None)
+    # The rate is the repo's, not the operator's: validators must price the same card the same way.
+    tao_usd = float(pricing['tao_usd']) if pricing.get('tao_usd') else None
     loadout = ServingLoadout(releases=[ServingRelease.from_dict(entry) for entry in entries], tao_usd=tao_usd)
 
     reference_override = os.getenv('SERVING_REFERENCE_URL')

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -66,6 +66,7 @@ class ServingRelease:
     attest_image: Optional[str] = None  # the attest container every box runs (entrius/gt-attest:<tag>)
     attest_url: Optional[str] = None
     attest_reference_url: Optional[str] = None
+    attest_reference_api_key: Optional[str] = None  # bearer for a keyed reference sidecar (ATTEST_API_KEY there)
     attest_iters: Optional[int] = None
     vram_model_reserved_bytes: Optional[float] = None
     ttft_full_ms: Optional[float] = None  # validator-observed TTFT up to which latency credit is 1.0
@@ -121,6 +122,7 @@ class ServingRelease:
             attest_image=attest.get('image'),
             attest_url=attest.get('url') or _sidecar_url(raw.get('base_url')),
             attest_reference_url=attest.get('reference_url') or _sidecar_url(raw.get('reference_url')),
+            attest_reference_api_key=attest.get('reference_api_key'),
             attest_iters=int(attest['iters']) if attest.get('iters') else None,
             vram_model_reserved_bytes=_optional_float(attest.get('vram_model_reserved_bytes')),
             ttft_full_ms=_optional_float(speed.get('ttft_full_ms')),
@@ -202,6 +204,9 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
     key_override = os.getenv('SERVING_REFERENCE_API_KEY')
     if key_override:
         loadout.primary.reference_api_key = key_override
+    attest_key_override = os.getenv('SERVING_ATTEST_REFERENCE_API_KEY')
+    if attest_key_override:
+        loadout.primary.attest_reference_api_key = attest_key_override
 
     lines = [
         f'Serving release {release.release_id}: model={release.model_id} backend={release.backend} pin={release.runtime_pin} '

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -65,6 +65,7 @@ class ServingRelease:
     # beside the reference (default: reference_url host, port 8081).
     attest_image: Optional[str] = None  # the attest container every box runs (entrius/gt-attest:<tag>)
     attest_url: Optional[str] = None
+    attest_api_key: Optional[str] = None  # miner side: bearer for its own sidecar (ATTEST_API_KEY there)
     attest_reference_url: Optional[str] = None
     attest_reference_api_key: Optional[str] = None  # bearer for a keyed reference sidecar (ATTEST_API_KEY there)
     attest_iters: Optional[int] = None
@@ -121,6 +122,7 @@ class ServingRelease:
             decode_per_request={int(k): float(v) for k, v in (speed.get('decode_per_request') or {}).items()} or None,
             attest_image=attest.get('image'),
             attest_url=attest.get('url') or _sidecar_url(raw.get('base_url')),
+            attest_api_key=attest.get('api_key') or os.getenv('SERVING_ATTEST_API_KEY') or None,
             attest_reference_url=attest.get('reference_url') or _sidecar_url(raw.get('reference_url')),
             attest_reference_api_key=attest.get('reference_api_key'),
             attest_iters=int(attest['iters']) if attest.get('iters') else None,

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -19,7 +19,7 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Deque, Dict, List, Optional, Sequence
+from typing import Deque, Dict, List, Optional, Sequence, Tuple
 
 import bittensor as bt
 
@@ -57,6 +57,7 @@ class ServedRequest:
     ttft_ms: Optional[float] = None  # validator-observed time to first streamed event
     inflight: int = 1  # this validator's requests in flight to the miner when this one was dispatched (incl. itself)
     release_id: str = ''  # the release this request was routed for; audited against that release's reference
+    max_tokens: int = 0  # what was asked for; a completion longer than this is not the runtime's
 
     def __post_init__(self) -> None:
         if not self.release_id:
@@ -99,6 +100,7 @@ class ServingState:
     dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
     attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
     last_credit: Dict[str, float] = field(default_factory=dict)  # audit thread only: hotkey -> last measured credit
+    _sent_tokens: Dict[str, Deque[Tuple[float, int]]] = field(default_factory=dict)  # hotkey -> (ts, max_tokens)
     attest_round: int = 0
     last_round: dict = field(default_factory=dict)  # audit thread's summary of the last round, for /v1/serving/status
     settlement_rounds: int = SERVING_SETTLEMENT_ROUNDS
@@ -149,6 +151,20 @@ class ServingState:
     def enqueue_served(self, served: ServedRequest) -> None:
         with self._lock:
             self._served.append(served)
+
+    def charge_sent(self, hotkey: str, max_tokens: int, now: Optional[float] = None) -> None:
+        """This validator's own ledger of what it asked each miner for: the miner charges a permitted validator's
+        per-tempo budget on ``max_tokens`` up front, so the validator keeps the same count to judge a refusal."""
+        with self._lock:
+            self._sent_tokens.setdefault(hotkey, deque(maxlen=SERVING_REQUEST_LOG_SIZE)).append(
+                (now if now is not None else time.time(), int(max_tokens))
+            )
+
+    def sent_tokens(self, hotkey: str, window_s: float, now: Optional[float] = None) -> int:
+        """``max_tokens`` this validator sent ``hotkey`` in the trailing ``window_s`` seconds."""
+        since = (now if now is not None else time.time()) - window_s
+        with self._lock:
+            return sum(n for ts, n in self._sent_tokens.get(hotkey, ()) if ts >= since)
 
     def drain_served(self) -> List[ServedRequest]:
         """Audit thread: take every request served since the last round."""

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -98,6 +98,7 @@ class ServingState:
     probe_history: Dict[str, Deque[float]] = field(default_factory=dict)  # audit thread only: hotkey -> last tps
     dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
     attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
+    last_credit: Dict[str, float] = field(default_factory=dict)  # audit thread only: hotkey -> last measured credit
     attest_round: int = 0
     last_round: dict = field(default_factory=dict)  # audit thread's summary of the last round, for /v1/serving/status
     settlement_rounds: int = SERVING_SETTLEMENT_ROUNDS

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -67,7 +67,7 @@ class ServedRequest:
 @dataclass
 class RequestRecord:
     ts: float
-    kind: str  # 'probe' | 'gateway'
+    kind: str  # 'verify' | 'gateway'
     uid: Optional[int]
     ok: bool
     latency_ms: Optional[float]  # None when the request produced no response
@@ -96,7 +96,6 @@ class ServingState:
     _served: Deque[ServedRequest] = field(default_factory=lambda: deque(maxlen=SERVING_REQUEST_LOG_SIZE))
     audits: AuditWindow = field(default_factory=AuditWindow)  # audit-loop thread only; persisted by the validator
     _history: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> last N round scores
-    probe_history: Dict[str, Deque[float]] = field(default_factory=dict)  # audit thread only: hotkey -> last tps
     dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
     attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
     uuid_owner: Dict[str, Tuple[str, int]] = field(default_factory=dict)  # GPU UUID -> (hotkey, round last seen)

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -99,6 +99,7 @@ class ServingState:
     probe_history: Dict[str, Deque[float]] = field(default_factory=dict)  # audit thread only: hotkey -> last tps
     dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
     attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
+    uuid_owner: Dict[str, Tuple[str, int]] = field(default_factory=dict)  # GPU UUID -> (hotkey, round last seen)
     last_credit: Dict[str, float] = field(default_factory=dict)  # audit thread only: hotkey -> last measured credit
     _sent_tokens: Dict[str, Deque[Tuple[float, int]]] = field(default_factory=dict)  # hotkey -> (ts, max_tokens)
     attest_round: int = 0

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -22,7 +22,6 @@ CREATE TABLE IF NOT EXISTS audit_values (hotkey TEXT, release_id TEXT, seq INTEG
     PRIMARY KEY (hotkey, release_id, seq));
 CREATE TABLE IF NOT EXISTS quarantine (hotkey TEXT, release_id TEXT, until REAL, strikes INTEGER DEFAULT 0,
     PRIMARY KEY (hotkey, release_id));
-CREATE TABLE IF NOT EXISTS probe_history (hotkey TEXT, seq INTEGER, tps REAL, PRIMARY KEY (hotkey, seq));
 CREATE TABLE IF NOT EXISTS round_history (hotkey TEXT, seq INTEGER, score REAL, PRIMARY KEY (hotkey, seq));
 CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
 CREATE TABLE IF NOT EXISTS attest (hotkey TEXT PRIMARY KEY, status TEXT);
@@ -62,7 +61,6 @@ class ServingStore:
             for table in (
                 'audit_values',
                 'quarantine',
-                'probe_history',
                 'round_history',
                 'dormant',
                 'attest',
@@ -89,10 +87,6 @@ class ServingStore:
                 [(hk, rid, until.get((hk, rid), 0.0), strikes.get((hk, rid), 0)) for hk, rid in sorted(keys)],
             )
             db.executemany(
-                'INSERT INTO probe_history VALUES (?, ?, ?)',
-                [(hk, i, x) for hk, xs in state.probe_history.items() for i, x in enumerate(xs)],
-            )
-            db.executemany(
                 'INSERT INTO round_history VALUES (?, ?, ?)',
                 [(hk, i, x) for hk, xs in state._history.items() for i, x in enumerate(xs)],
             )
@@ -115,8 +109,6 @@ class ServingStore:
                         state.audits._quarantine[(hk, rid)] = float(until)
                     if int(strikes or 0) > 0:
                         state.audits._strikes[(hk, rid)] = int(strikes)
-                for hk, x in db.execute('SELECT hotkey, tps FROM probe_history ORDER BY hotkey, seq'):
-                    state.probe_history.setdefault(hk, deque(maxlen=3)).append(float(x))
                 for hk, x in db.execute('SELECT hotkey, score FROM round_history ORDER BY hotkey, seq'):
                     state._history.setdefault(hk, deque(maxlen=state.settlement_rounds)).append(float(x))
                 for hk, rounds in db.execute('SELECT hotkey, rounds FROM dormant'):

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -26,6 +26,8 @@ CREATE TABLE IF NOT EXISTS probe_history (hotkey TEXT, seq INTEGER, tps REAL, PR
 CREATE TABLE IF NOT EXISTS round_history (hotkey TEXT, seq INTEGER, score REAL, PRIMARY KEY (hotkey, seq));
 CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
 CREATE TABLE IF NOT EXISTS attest (hotkey TEXT PRIMARY KEY, status TEXT);
+CREATE TABLE IF NOT EXISTS uuid_owner (uuid TEXT PRIMARY KEY, hotkey TEXT, round INTEGER);
+CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
 """
 
 
@@ -56,8 +58,22 @@ class ServingStore:
         """Snapshot the audit-thread state in one transaction (the tables are small: a few rows per hotkey)."""
         audits = state.audits.to_dict()
         with self._connect() as db:
-            for table in ('audit_values', 'quarantine', 'probe_history', 'round_history', 'dormant', 'attest'):
+            for table in (
+                'audit_values',
+                'quarantine',
+                'probe_history',
+                'round_history',
+                'dormant',
+                'attest',
+                'uuid_owner',
+                'meta',
+            ):
                 db.execute(f'DELETE FROM {table}')
+            db.executemany(
+                'INSERT INTO uuid_owner VALUES (?, ?, ?)',
+                [(uuid, hk, rnd) for uuid, (hk, rnd) in state.uuid_owner.items()],
+            )
+            db.execute('INSERT INTO meta VALUES (?, ?)', ('attest_round', str(int(state.attest_round))))
             db.executemany(
                 'INSERT INTO audit_values VALUES (?, ?, ?, ?)',
                 [(hk, rid, i, x) for hk, rid, xs in audits['values'] for i, x in enumerate(xs)],
@@ -104,6 +120,11 @@ class ServingStore:
                     state.dormant_rounds[hk] = int(rounds)
                 for hk, st in db.execute('SELECT hotkey, status FROM attest'):
                     state.attest_status[hk] = json.loads(st)
+                for uuid, hk, rnd in db.execute('SELECT uuid, hotkey, round FROM uuid_owner'):
+                    state.uuid_owner[str(uuid)] = (str(hk), int(rnd))
+                for key, value in db.execute('SELECT key, value FROM meta'):
+                    if key == 'attest_round':
+                        state.attest_round = int(value)
         except sqlite3.Error:
             pass
         return state

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
 CREATE TABLE IF NOT EXISTS attest (hotkey TEXT PRIMARY KEY, status TEXT);
 CREATE TABLE IF NOT EXISTS uuid_owner (uuid TEXT PRIMARY KEY, hotkey TEXT, round INTEGER);
 CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE IF NOT EXISTS last_credit (hotkey TEXT PRIMARY KEY, credit REAL);
 """
 
 
@@ -67,8 +68,10 @@ class ServingStore:
                 'attest',
                 'uuid_owner',
                 'meta',
+                'last_credit',
             ):
                 db.execute(f'DELETE FROM {table}')
+            db.executemany('INSERT INTO last_credit VALUES (?, ?)', list(state.last_credit.items()))
             db.executemany(
                 'INSERT INTO uuid_owner VALUES (?, ?, ?)',
                 [(uuid, hk, rnd) for uuid, (hk, rnd) in state.uuid_owner.items()],
@@ -125,6 +128,8 @@ class ServingStore:
                 for key, value in db.execute('SELECT key, value FROM meta'):
                     if key == 'attest_round':
                         state.attest_round = int(value)
+                for hk, credit in db.execute('SELECT hotkey, credit FROM last_credit'):
+                    state.last_credit[str(hk)] = float(credit)
         except sqlite3.Error:
             pass
         return state

--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -168,4 +168,5 @@ async def consume_stream(
             final = chunk  # the dendrite yields the header-filled synapse last
     result = assembler.apply(final if final is not None else synapse)
     result.observed_ttft_ms = observed_ttft_ms
+    result.observed_latency_ms = (time.monotonic() - started) * 1000.0  # the miner's stream, not the user's read
     return result

--- a/gittensor/synapses.py
+++ b/gittensor/synapses.py
@@ -67,6 +67,7 @@ class InferenceSynapse(bt.StreamingSynapse):
     finish_reason: Optional[str] = None
     usage: Optional[Dict[str, int]] = None
     observed_ttft_ms: Optional[float] = None  # set by the validator: wall-clock to the first streamed event
+    observed_latency_ms: Optional[float] = None  # set by the validator: wall-clock to the end of the miner's stream
 
     async def process_streaming_response(self, response):  # aiohttp ClientResponse
         async for chunk in response.content.iter_any():

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -26,6 +26,7 @@ def blend_emission_pools(
     maintainer_uids_by_repo: Optional[Dict[str, list[int]]] = None,
     serving_scores: Optional[Dict[int, float]] = None,
     serving_pricing: Optional[ServingPricing] = None,
+    allow_unpriced_cap: bool = False,
 ) -> np.ndarray:
     """Allocate the combined scoring pool by bounded repository emission_share.
 
@@ -65,7 +66,7 @@ def blend_emission_pools(
     # Serving pool: priced per verified GPU-hour inside the cap; unclaimed recycles.
     if SERVING_EMISSION_SHARE_CAP > 0:
         card_equiv = sum(serving_scores.values()) if serving_scores else 0.0
-        share = serving_share(card_equiv, serving_pricing)
+        share = serving_share(card_equiv, serving_pricing, allow_unpriced_cap)
         serving_rewards, serving_unallocated = _calculate_score_rewards(serving_scores or {}, share, miner_uids)
         for uid, reward in serving_rewards.items():
             rewards[uid_index[uid]] += reward
@@ -201,14 +202,19 @@ def _repo_has_scorers(
     return False
 
 
-def serving_share(card_equiv: float, pricing: Optional[ServingPricing]) -> float:
+def serving_share(card_equiv: float, pricing: Optional[ServingPricing], allow_unpriced_cap: bool = False) -> float:
     """Emission share that pays ``card_equiv`` verified cards ``SERVING_GPU_HOUR_USD`` each, capped.
 
-    Without usable pricing (no chain price, no published TAO/USD — testnet) the whole cap is paid pro-rata.
+    Without usable pricing the pool pays nothing and recycles, unless ``allow_unpriced_cap`` — a network with no
+    price to read (testnet) — where the whole cap is paid pro-rata. Paying the cap on a priced network would hand
+    one verified card 3.5% of emissions the moment a price read failed.
     """
     if card_equiv <= 0:
         return 0.0
     if pricing is None or not pricing.usable:
+        if not allow_unpriced_cap:
+            bt.logging.warning('Serving: no usable pricing this round; the serving pool pays nothing and recycles')
+            return 0.0
         return SERVING_EMISSION_SHARE_CAP
     want = card_equiv * SERVING_GPU_HOUR_USD / (pricing.alpha_per_hour_to_miners * pricing.alpha_usd)
     return min(SERVING_EMISSION_SHARE_CAP, want)

--- a/gittensor/validator/forward.py
+++ b/gittensor/validator/forward.py
@@ -15,6 +15,7 @@ from gittensor.validator.oss_contributions.reward import get_rewards
 from gittensor.validator.serving.pricing import serving_pricing
 from gittensor.validator.utils.config import (
     SERVING_ENABLED,
+    SERVING_PAY_CAP_WITHOUT_PRICING,
     VALIDATOR_STEPS_INTERVAL,
     VALIDATOR_WAIT,
 )
@@ -81,7 +82,13 @@ async def forward(self: 'Validator') -> None:
         pricing = serving_pricing(self) if SERVING_ENABLED and serving_scores else None
         self.last_serving_pricing = pricing  # the serving audit thread stamps it on the rounds it persists
         rewards = blend_emission_pools(
-            miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo, serving_scores, pricing
+            miner_evaluations,
+            master_repositories,
+            miner_uids,
+            maintainer_uids_by_repo,
+            serving_scores,
+            pricing,
+            SERVING_PAY_CAP_WITHOUT_PRICING,
         )
 
         self.update_scores(rewards, miner_uids, blacklisted_uids=sorted(penalized_uids))

--- a/gittensor/validator/serving/attest.py
+++ b/gittensor/validator/serving/attest.py
@@ -3,29 +3,36 @@
 
 """Hardware attestation of serving miners (sub-subnet B beta).
 
-Each round a random half of the READY miners (plus every miner that has never passed and every miner that failed
-last round) is sent one fresh ``AttestSynapse`` — same seed, same instant. The miner's attest sidecar (docker/attest,
-image ``entrius/gt-attest``) answers with ``gt_attest`` on every GPU it can see: it fills the card's free VRAM with a
-seeded stream and runs a deterministic fp32 GEMM chain, returning the GPU's UUID, bytes filled, a SHA-256 digest and
-wall time. The validator asks its own reference sidecar (same image) for the same seed first, so the expected digest
-and reference wall time come from an honest 5090 — no GPU code runs in the validator process.
+Each round the least recently challenged half of the READY miners (plus every miner that has never passed and every
+miner that failed last round) is sent one fresh ``AttestSynapse`` — same seed, same instant. The miner's attest
+sidecar (docker/attest, image ``entrius/gt-attest``) answers with ``gt_attest`` on every GPU it can see, all at once:
+device ``i`` fills its free VRAM with a seeded stream and runs a deterministic fp32 GEMM chain on ``seed + i``,
+returning the GPU's UUID, bytes filled, a SHA-256 digest and wall time. The validator asks its own reference sidecar
+(same image) for index 0 first, and for each further index a miner claims, so every expected digest comes from an
+honest 5090 — no GPU code runs in the validator process.
 
-A card PASSES when its digest matches, its wall is within ``SERVING_ATTEST_BUDGET_RATIO`` x the reference's, most of
-its free VRAM was filled, and the model was resident before the fill (free VRAM at most total minus
-``SERVING_ATTEST_MODEL_RESIDENT_RATIO`` x the reservation). A hotkey's ``capacity`` is its number of passing cards —
-one hotkey, N cards, N card-hours — and it is attested while at least one passes. Overlap is the mechanism: two
-hotkeys fronting one card cannot both fill its free VRAM at the same instant and their chains run ~2x slower, so a
-sharing pair is caught within a few rounds (P = fraction^2 per round). Two hotkeys reporting the same GPU UUID within
-``SERVING_ATTEST_UUID_MEMORY_ROUNDS`` rounds both fail. A failure is never a strike: capacity 0 for the round,
-re-challenged next round. Miners not in the cohort keep their last verdict; a miner with no verdict yet is not READY
-(admission).
+What the validator can measure itself is the digest and the round trip; every other field of a card's report is the
+miner's own number. So a card PASSES when its digest matches its index's, its wall is within
+``SERVING_ATTEST_BUDGET_RATIO`` x the reference's, most of its free VRAM was filled and the model was resident before
+the fill — and the whole reply arrived within that budget plus ``SERVING_ATTEST_RTT_SLACK_MS``. Cards run in parallel
+on an honest box, so N cards take one card's wall; one card faking N runs the chain N times and misses the round trip.
+A hotkey's ``capacity`` is its passing cards (at most ``SERVING_ATTEST_MAX_CARDS``).
+
+Overlap is the mechanism against sharing: two hotkeys fronting one card cannot both fill its free VRAM at the same
+instant and their chains run ~2x slower, so a sharing pair is caught within a few rounds (P = fraction^2 per round).
+A GPU UUID belongs to the first hotkey that passed with it; another hotkey reporting the same UUID loses that card
+while the holder keeps it (a claim lapses after ``SERVING_ATTEST_UUID_MEMORY_ROUNDS`` unrenewed rounds). Two hotkeys
+claiming an unowned UUID in the same round both fail it. A failure is never a strike: capacity 0 for the round,
+re-challenged next round. Miners not in the cohort keep their last verdict until it is older than the memory window;
+a miner with no verdict yet is not READY (admission). A fault in this module is neutral for the cohort, never fatal
+for the round.
 """
 
 import asyncio
 import secrets
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence, Tuple, cast
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 import bittensor as bt
 import requests
@@ -34,8 +41,10 @@ from gittensor.constants import (
     SERVING_ATTEST_BUDGET_RATIO,
     SERVING_ATTEST_COHORT_FRACTION,
     SERVING_ATTEST_ITERS,
+    SERVING_ATTEST_MAX_CARDS,
     SERVING_ATTEST_MIN_FILL_RATIO,
     SERVING_ATTEST_MODEL_RESIDENT_RATIO,
+    SERVING_ATTEST_RTT_SLACK_MS,
     SERVING_ATTEST_TIMEOUT,
     SERVING_ATTEST_UUID_MEMORY_ROUNDS,
     SERVING_VRAM_MODEL_RESERVED_BYTES,
@@ -43,6 +52,8 @@ from gittensor.constants import (
 from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.state import ServingState
 from gittensor.synapses import AttestSynapse
+
+ExpectedDigest = Union[str, Callable[[int], Optional[str]]]  # one digest for every index, or a digest per index
 
 
 @dataclass
@@ -95,9 +106,15 @@ class AttestVerdict:
         }
 
 
-def status_capacity(status: Optional[dict]) -> int:
-    """Cards a stored attest status pays for (statuses persisted before ``capacity`` existed count one card)."""
+def status_capacity(
+    status: Optional[dict], round_no: Optional[int] = None, memory_rounds: int = SERVING_ATTEST_UUID_MEMORY_ROUNDS
+) -> int:
+    """Cards a stored attest status pays for (statuses persisted before ``capacity`` existed count one card). A
+    verdict older than ``memory_rounds`` — a miner the reference could not re-challenge for that long — pays nothing
+    until it is renewed."""
     if not status or not status.get('passed'):
+        return 0
+    if round_no is not None and round_no - int(status.get('round', round_no)) > memory_rounds:
         return 0
     return int(status.get('capacity', 1))
 
@@ -128,9 +145,13 @@ def reference_challenge(release: ServingRelease, seed: int, iters: int, timeout:
     """(expected digest, reference wall ms) from the validator's own reference sidecar for ``seed``."""
     if not release.attest_reference_url:
         raise RuntimeError('no attest_reference_url on the release')
+    headers = (
+        {'Authorization': f'Bearer {release.attest_reference_api_key}'} if release.attest_reference_api_key else {}
+    )
     r = requests.post(
         f'{release.attest_reference_url.rstrip("/")}/v1/attest',
         json={'seed': seed, 'iters': iters, 'fill': False},
+        headers=headers,
         timeout=timeout,
     )
     r.raise_for_status()
@@ -145,7 +166,25 @@ def reference_challenge(release: ServingRelease, seed: int, iters: int, timeout:
 def judge_card(
     dev: dict,
     queued_ms: float,
-    expected_digest: str,
+    expected_digest: Optional[str],
+    ref_wall_ms: float,
+    release: ServingRelease,
+    budget_ratio: float,
+    min_fill_ratio: float,
+    resident_ratio: float,
+) -> CardVerdict:
+    try:
+        return _judge_card(
+            dev, queued_ms, expected_digest, ref_wall_ms, release, budget_ratio, min_fill_ratio, resident_ratio
+        )
+    except (TypeError, ValueError, AttributeError) as e:  # a field the miner typed that is not a number
+        return CardVerdict(False, f'malformed device report: {e!r}'[:200])
+
+
+def _judge_card(
+    dev: dict,
+    queued_ms: float,
+    expected_digest: Optional[str],
     ref_wall_ms: float,
     release: ServingRelease,
     budget_ratio: float,
@@ -153,10 +192,12 @@ def judge_card(
     resident_ratio: float,
 ) -> CardVerdict:
     if dev.get('error'):
-        return CardVerdict(False, f'challenge error: {dev["error"]}')
+        return CardVerdict(False, f'challenge error: {dev["error"]}'[:200])
     uuid = str(dev.get('uuid') or '')
     wall = float(dev.get('wall_ms') or 0.0) + queued_ms
     filled = int(dev.get('filled_bytes') or 0)
+    if expected_digest is None:
+        return CardVerdict(False, 'no reference digest for this device index', uuid, wall, filled)
     if str(dev.get('digest')) != expected_digest:
         return CardVerdict(False, 'digest mismatch', uuid, wall, filled)
     budget = budget_ratio * ref_wall_ms if ref_wall_ms > 0 else float('inf')
@@ -183,15 +224,20 @@ def judge_card(
 
 def judge(
     response: Optional[AttestSynapse],
-    expected_digest: str,
+    expected: ExpectedDigest,
     ref_wall_ms: float,
     release: ServingRelease,
     budget_ratio: float = SERVING_ATTEST_BUDGET_RATIO,
     min_fill_ratio: float = SERVING_ATTEST_MIN_FILL_RATIO,
     resident_ratio: float = SERVING_ATTEST_MODEL_RESIDENT_RATIO,
+    elapsed_ms: Optional[float] = None,
+    rtt_slack_ms: float = SERVING_ATTEST_RTT_SLACK_MS,
+    max_cards: int = SERVING_ATTEST_MAX_CARDS,
 ) -> AttestVerdict:
-    """Every card the sidecar reported is judged on its own; the hotkey passes with any passing card and its
-    capacity is the count. The reason names the first failing card when one fails."""
+    """Every card the sidecar reported is judged on its own against its index's expected digest; the hotkey passes
+    with any passing card and its capacity is the count. ``elapsed_ms`` is the validator's own round trip for the
+    whole reply: past one card's budget plus the slack, no card passes, however each card's own wall reads. The
+    reason names the first failing card when one fails."""
     if response is None or response.devices is None:
         detail = getattr(response, 'error', None) or getattr(
             getattr(response, 'dendrite', None), 'status_message', None
@@ -199,10 +245,28 @@ def judge(
         return AttestVerdict(False, f'no attestation ({detail or "timeout"})')
     if not response.devices:
         return AttestVerdict(False, 'no devices')
-    queued = float(response.queued_ms or 0.0)
+    budget = budget_ratio * ref_wall_ms if ref_wall_ms > 0 else float('inf')
+    if elapsed_ms is not None and elapsed_ms > budget + rtt_slack_ms:
+        return AttestVerdict(False, f'too slow: {elapsed_ms:.0f} ms round trip > {budget + rtt_slack_ms:.0f} ms')
+    try:
+        queued = float(response.queued_ms or 0.0)
+    except (TypeError, ValueError):
+        queued = 0.0
+    devices = [dev for dev in response.devices if isinstance(dev, dict)][:max_cards]
+    if not devices:
+        return AttestVerdict(False, 'malformed device report')
     cards = [
-        judge_card(dev, queued, expected_digest, ref_wall_ms, release, budget_ratio, min_fill_ratio, resident_ratio)
-        for dev in response.devices
+        judge_card(
+            dev,
+            queued,
+            expected if isinstance(expected, str) else expected(i),
+            ref_wall_ms,
+            release,
+            budget_ratio,
+            min_fill_ratio,
+            resident_ratio,
+        )
+        for i, dev in enumerate(devices)
     ]
     passing = [c for c in cards if c.passed]
     failing = [c for c in cards if not c.passed]
@@ -222,10 +286,12 @@ async def send_challenges(
     seed: int,
     iters: int,
     timeout: float = SERVING_ATTEST_TIMEOUT,
-) -> Dict[str, Optional[AttestSynapse]]:
-    """Fire the same challenge at every target at once; None where the call failed."""
+) -> Dict[str, Tuple[Optional[AttestSynapse], float]]:
+    """Fire the same challenge at every target at once; (response, round trip ms) per hotkey, None where the call
+    failed. The round trip is the validator's own clock on the whole reply."""
 
-    async def one(axon: bt.AxonInfo) -> Optional[AttestSynapse]:
+    async def one(axon: bt.AxonInfo) -> Tuple[Optional[AttestSynapse], float]:
+        started = time.monotonic()
         try:
             result = await dendrite.call(
                 target_axon=axon,
@@ -233,38 +299,68 @@ async def send_challenges(
                 timeout=timeout,
                 deserialize=False,
             )
-            return cast(AttestSynapse, result)
+            return cast(AttestSynapse, result), (time.monotonic() - started) * 1000.0
         except Exception as e:  # network / axon fault: judged as no attestation
             bt.logging.debug(f'Serving: attest call failed: {e!r}')
-            return None
+            return None, (time.monotonic() - started) * 1000.0
 
     results = await asyncio.gather(*(one(axon) for _, _, axon in targets))
     return {hotkey: resp for (_, hotkey, _), resp in zip(targets, results)}
 
 
-def _status_uuids(st: dict) -> List[str]:
-    uuids = st.get('uuids')
-    if uuids is None:
-        uuids = [st['uuid']] if st.get('uuid') else []
-    return [u for u in uuids if u]
+def claim_uuids(
+    state: ServingState,
+    judged: Dict[str, AttestVerdict],
+    round_no: int,
+    memory_rounds: int = SERVING_ATTEST_UUID_MEMORY_ROUNDS,
+) -> Dict[str, List[str]]:
+    """Settle GPU ownership for this round's passing cards; hotkey -> UUIDs it loses.
+
+    A UUID belongs to the first hotkey that passed with it and stays its own while the claim is renewed within
+    ``memory_rounds``. Another hotkey reporting the holder's UUID loses that card; the holder keeps it — so a card
+    cannot be taken from a miner by naming its UUID. Two hotkeys naming an unowned UUID in the same round are the
+    sharing case the overlap is there to catch: both lose it.
+    """
+    for uuid, (owner, seen) in list(state.uuid_owner.items()):
+        if round_no - seen > memory_rounds:
+            del state.uuid_owner[uuid]
+    claims: Dict[str, List[str]] = {}
+    for hk in sorted(judged):
+        for uuid in judged[hk].uuids:
+            claims.setdefault(uuid, []).append(hk)
+    lost: Dict[str, List[str]] = {}
+    for uuid, hks in sorted(claims.items()):
+        owner = state.uuid_owner.get(uuid)
+        if owner is not None and owner[0] in hks:
+            keep: Optional[str] = owner[0]
+        elif len(hks) == 1 and owner is None:
+            keep = hks[0]
+        else:
+            keep = None  # unowned and contested this round (sharing), or owned by someone not answering now
+        if keep is not None:
+            state.uuid_owner[uuid] = (keep, round_no)
+        for hk in hks:
+            if hk != keep:
+                lost.setdefault(hk, []).append(uuid)
+    return lost
 
 
-def dedupe_uuids(
-    state: ServingState, round_no: int, memory_rounds: int = SERVING_ATTEST_UUID_MEMORY_ROUNDS
-) -> Dict[str, str]:
-    """hotkey -> shared GPU UUID, for every passing hotkey whose card another hotkey also reported within
-    ``memory_rounds``."""
-    by_uuid: Dict[str, List[str]] = {}
-    for hk, st in state.attest_status.items():
-        if st.get('passed') and round_no - int(st.get('round', 0)) <= memory_rounds:
-            for uuid in _status_uuids(st):
-                by_uuid.setdefault(uuid, []).append(hk)
-    shared: Dict[str, str] = {}
-    for uuid, hks in sorted(by_uuid.items()):
-        if len(hks) > 1:
-            for hk in hks:
-                shared.setdefault(hk, uuid)
-    return shared
+def _apply_lost_cards(state: ServingState, hk: str, uuids: List[str]) -> None:
+    st = dict(state.attest_status.get(hk, {}))
+    cards = []
+    for card in st.get('cards', []):
+        if card.get('passed') and card.get('uuid') in uuids:
+            card = {**card, 'passed': False, 'reason': f'duplicate GPU {card.get("uuid")} (held by another hotkey)'}
+        cards.append(card)
+    passing = [c for c in cards if c.get('passed')]
+    st.update(
+        cards=cards,
+        uuids=[c['uuid'] for c in passing if c.get('uuid')],
+        capacity=len(passing),
+        passed=bool(passing),
+        reason=f'duplicate GPU {uuids[0]} (held by another hotkey)' if not passing else st.get('reason', 'ok'),
+    )
+    state.attest_status[hk] = st
 
 
 async def attest_round(
@@ -279,35 +375,67 @@ async def attest_round(
     attested) for every candidate.
 
     Without an ``attest_reference_url`` (localnet / echo) attestation is off and every candidate counts as one card.
-    If the reference itself fails, nothing changes this round (neutral).
+    If the reference itself fails, or anything in here does, nothing changes this round (neutral).
     """
     round_no = state.attest_round = getattr(state, 'attest_round', 0) + 1
     if not release.attest_reference_url:
         return {hk: 1 for _, hk, _ in candidates}
     hotkeys = [hk for _, hk, _ in candidates]
+
+    def carried() -> Dict[str, int]:
+        return {hk: status_capacity(state.attest_status.get(hk), round_no) for hk in hotkeys}
+
+    try:
+        return await _attest_round(state, dendrite, candidates, release, round_no, rng, timeout)
+    except Exception as e:  # a fault in judging must not take the round down; the cohort keeps its last verdict
+        bt.logging.error(f'Serving: attestation failed this round, attest neutral: {e!r}')
+        return carried()
+
+
+async def _attest_round(
+    state: ServingState,
+    dendrite: bt.Dendrite,
+    candidates: Sequence[Tuple[int, str, bt.AxonInfo]],
+    release: ServingRelease,
+    round_no: int,
+    rng,
+    timeout: float,
+) -> Dict[str, int]:
+    hotkeys = [hk for _, hk, _ in candidates]
     cohort = set(choose_cohort(hotkeys, state.attest_status, rng=rng))
-    seed = secrets.randbits(63)
+    seed = secrets.randbits(62)
     iters = release.attest_iters or SERVING_ATTEST_ITERS
     try:
-        expected, ref_wall = await asyncio.to_thread(reference_challenge, release, seed, iters, timeout)
+        expected0, ref_wall = await asyncio.to_thread(reference_challenge, release, seed, iters, timeout)
     except Exception as e:
         bt.logging.error(f'Serving: reference attestation failed, attest neutral this round: {e!r}')
-        return {hk: status_capacity(state.attest_status.get(hk)) for hk in hotkeys}
+        return {hk: status_capacity(state.attest_status.get(hk), round_no) for hk in hotkeys}
     targets = [(uid, hk, axon) for uid, hk, axon in candidates if hk in cohort]
     responses = await send_challenges(dendrite, targets, seed, iters, timeout)
+    # One reference digest per device index any miner claimed (index i answers seed + i), at most MAX_CARDS.
+    claimed = max((len(resp.devices) for resp, _ in responses.values() if resp is not None and resp.devices), default=1)
+    digests: Dict[int, Optional[str]] = {0: expected0}
+    for i in range(1, min(claimed, SERVING_ATTEST_MAX_CARDS)):
+        try:
+            digests[i] = (await asyncio.to_thread(reference_challenge, release, seed + i, iters, timeout))[0]
+        except Exception as e:
+            bt.logging.warning(f'Serving: reference attestation for device index {i} failed: {e!r}')
+            digests[i] = None
     now = time.time()
+    judged: Dict[str, AttestVerdict] = {}
     for uid, hk, _ in targets:
-        verdict = judge(responses.get(hk), expected, ref_wall, release)
+        resp, elapsed = responses.get(hk, (None, 0.0))
+        verdict = judge(resp, lambda i: digests.get(i), ref_wall, release, elapsed_ms=elapsed)
+        judged[hk] = verdict
         state.attest_status[hk] = verdict.as_status(now, round_no)
         bt.logging.info(
             f'Serving: UID {uid} attest {"PASS" if verdict.passed else "FAIL"} '
-            f'{verdict.wall_ms or 0:.0f} ms (ref {ref_wall:.0f}) fill {verdict.filled_bytes / 1e9:.1f} GB '
-            f'cards {verdict.capacity}/{len(verdict.cards)} uuid {verdict.uuid or "-"}'
-            f'{"" if verdict.reason.startswith("ok") else " — " + verdict.reason}'
+            f'{verdict.wall_ms or 0:.0f} ms (ref {ref_wall:.0f}, rtt {elapsed:.0f}) fill '
+            f'{verdict.filled_bytes / 1e9:.1f} GB cards {verdict.capacity}/{len(verdict.cards)} '
+            f'uuid {verdict.uuid or "-"}{"" if verdict.reason.startswith("ok") else " — " + verdict.reason}'
         )
-    for hk, uuid in dedupe_uuids(state, round_no).items():
-        st = state.attest_status.get(hk, {})
+    for hk, uuids in claim_uuids(state, judged, round_no).items():
         uid = next((u for u, h, _ in candidates if h == hk), '?')
-        bt.logging.warning(f'Serving: UID {uid} attest FAIL — duplicate GPU {uuid} across hotkeys')
-        state.attest_status[hk] = {**st, 'passed': False, 'capacity': 0, 'reason': f'duplicate GPU {uuid}'}
-    return {hk: status_capacity(state.attest_status.get(hk)) for hk in hotkeys}
+        bt.logging.warning(f'Serving: UID {uid} attest FAIL — duplicate GPU {uuids[0]} across hotkeys')
+        _apply_lost_cards(state, hk, uuids)
+    return {hk: status_capacity(state.attest_status.get(hk), round_no) for hk in hotkeys}

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -29,6 +29,7 @@ rounds by ``ServingState``.
 import asyncio
 import hashlib
 import math
+import os
 import random
 import secrets
 import threading
@@ -38,15 +39,20 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 import aiohttp
 import bittensor as bt
+import requests
 
 from gittensor.classes import RequestSpeed
 from gittensor.constants import (
+    BLOCKS_PER_TEMPO,
     SERVING_AUDIT_SAMPLE_FRACTION,
     SERVING_AUDIT_SAMPLE_MIN,
     SERVING_BASELINE_PER_ROUND,
+    SERVING_BUDGET_REFUSAL_RATIO,
     SERVING_DORMANT_AFTER_ROUNDS,
     SERVING_DORMANT_RETRY_ROUNDS,
     SERVING_MAX_TOKENS,
+    SERVING_MIN_CALLER_STAKE,
+    SERVING_VALIDATOR_TOKENS_PER_TEMPO,
     SERVING_VERIFY_WORKERS,
 )
 from gittensor.serving.audit import AuditVerdict, Reference, reference_for, verify_served
@@ -87,6 +93,18 @@ def sample_for_audit(
     return [r for i, r in enumerate(served) if i in keep], [r for i, r in enumerate(served) if i not in keep]
 
 
+def budget_refusal_plausible(
+    state: ServingState, hotkey: str, staked_caller: bool, now: Optional[float] = None
+) -> bool:
+    """Could ``hotkey`` honestly have refused this validator for budget? Only a permitted, unstaked caller has a
+    budget at all, and only once this validator's own ledger of ``max_tokens`` sent in the trailing tempo is near
+    the miner's per-tempo allowance. The refusal text is the miner's; the ledger is ours."""
+    if staked_caller:
+        return False
+    sent = state.sent_tokens(hotkey, BLOCKS_PER_TEMPO * 12.0, now)
+    return sent >= SERVING_BUDGET_REFUSAL_RATIO * SERVING_VALIDATOR_TOKENS_PER_TEMPO
+
+
 def verify_served_round(
     state: ServingState,
     reference: Reference,
@@ -95,12 +113,14 @@ def verify_served_round(
     summary: Optional[Dict[str, int]] = None,
     last_miss: Optional[Dict[str, str]] = None,
     rng=None,
+    staked_caller: bool = False,
 ) -> Dict[str, List[RequestSpeed]]:
     """Verify this round's audit sample of the requests served for ``release`` into the window; return per-request
     speed per hotkey.
 
     Reference calls run on a small thread pool; window updates stay on this thread. ``last_miss`` (hotkey ->
     reason) is filled with the most recent miss or strike reason so the round report can show a miner why.
+    ``staked_caller``: this validator clears the miner's stake floor, so no miner has a budget to refuse it on.
     """
     summary = summary if summary is not None else {}
     last_miss = last_miss if last_miss is not None else {}
@@ -111,8 +131,8 @@ def verify_served_round(
         summary['unsampled'] = summary.get('unsampled', 0) + 1
 
     def judge(req: ServedRequest) -> Optional[AuditVerdict]:
-        if not req.ok and 'budget' in req.detail.lower():  # this validator over-sent; not the miner's fault
-            return None
+        if not req.ok and 'budget' in req.detail.lower() and budget_refusal_plausible(state, req.hotkey, staked_caller):
+            return None  # this validator over-sent by its own ledger; not the miner's fault
         if not req.ok:
             return AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
         for attempt in range(2):  # a connection blip to the reference is retried once before going neutral
@@ -126,7 +146,17 @@ def verify_served_round(
                     token_ids=req.token_ids,
                     token_bytes=req.token_bytes,
                     release=release,
+                    max_tokens=req.max_tokens or None,
                 )
+            except requests.HTTPError as e:
+                status = getattr(getattr(e, 'response', None), 'status_code', 0) or 0
+                if 400 <= status < 500:  # the reference refused what the miner sent: the miner's answer, not a blip
+                    return AuditVerdict(False, 0.0, float('inf'), f'reference rejected the completion (HTTP {status})')
+                if attempt == 0:
+                    time.sleep(1.0)
+                    continue
+                bt.logging.warning(f'Serving: could not verify a request served by UID {req.uid}: {e!r}')
+                return None
             except Exception as e:  # reference hiccup: neither credit nor blame
                 if attempt == 0 and isinstance(e, (ConnectionError, OSError)) or 'Connect' in type(e).__name__:
                     time.sleep(1.0)
@@ -222,6 +252,7 @@ async def baseline_round(
             logprobs=True,
         )
         inflight = state.inflight().get(uid, 0) + 1
+        state.charge_sent(hotkey, max_tokens)
         started = time.monotonic()
         try:
             response = await consume_stream(dendrite, axon, synapse, release.request_timeout)
@@ -257,6 +288,7 @@ async def baseline_round(
                 source='baseline',
                 ttft_ms=getattr(response, 'observed_ttft_ms', None) if ok else None,
                 inflight=inflight,
+                max_tokens=max_tokens,
             )
         )
 
@@ -275,6 +307,7 @@ async def audit_round(
     serving: Sequence[Tuple[int, str, bt.AxonInfo]],
     loadout=None,
     attest_rng=None,
+    staked_caller: bool = False,
 ) -> Dict[str, float]:
     """Verify served traffic, settle windows, attest READY miners; publish READY/probation; return hotkey -> score."""
     loadout = loadout or load_serving_loadout()
@@ -304,7 +337,7 @@ async def audit_round(
                 'set SERVING_REFERENCE_URL to a conformant runtime'
             )
             continue
-        speeds = verify_served_round(state, reference, release, served, summary, last_miss)
+        speeds = verify_served_round(state, reference, release, served, summary, last_miss, staked_caller=staked_caller)
         passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
         for uid, hotkey, axon in active:
             window = state.audits.verdict(hotkey, release.release_id)
@@ -473,7 +506,9 @@ class ServingAuditThread:
             serving: List[Tuple[int, str, bt.AxonInfo]] = []
             try:
                 serving = get_serving_axons(self.validator)
-                loop.run_until_complete(audit_round(self.state, dendrite, serving))
+                loop.run_until_complete(
+                    audit_round(self.state, dendrite, serving, staked_caller=is_staked_caller(self.validator))
+                )
             except Exception as e:  # a serving fault must never take the validator down
                 bt.logging.error(f'Serving round failed, no serving scores this round: {e!r}')
                 self.state.publish_round([], {})
@@ -513,6 +548,16 @@ class ServingAuditThread:
 def probe_phase_offset(hotkey: str, interval_s: float) -> float:
     """Deterministic start offset in [0, interval) for this validator's audit clock."""
     return (int(hashlib.sha256(hotkey.encode()).hexdigest()[:8], 16) % 1_000_000) / 1_000_000 * interval_s
+
+
+def is_staked_caller(self: 'Validator') -> bool:
+    """Does this validator's hotkey clear the miners' stake floor (unlimited calls, no budget to be refused on)?"""
+    try:
+        return float(self.metagraph.S[self.uid]) >= float(
+            os.getenv('SERVING_MIN_CALLER_STAKE', SERVING_MIN_CALLER_STAKE)
+        )
+    except (IndexError, TypeError, ValueError, AttributeError):
+        return False
 
 
 def get_serving_axons(self: 'Validator') -> List[Tuple[int, str, bt.AxonInfo]]:

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -93,6 +93,22 @@ def sample_for_audit(
     return [r for i, r in enumerate(served) if i in keep], [r for i, r in enumerate(served) if i not in keep]
 
 
+def reference_rejects(reference: Reference, messages: List[Dict[str, str]]) -> bool:
+    """Would the validator's own reference refuse this prompt (HTTP 4xx on a one-token greedy)? Only a live
+    reference can be asked; anything else, or any other failure, is 'no', so the miss stands."""
+    case_for = getattr(reference, 'case_for', None)
+    if case_for is None:
+        return False
+    try:
+        case_for(messages, 1)
+    except requests.HTTPError as e:
+        status = getattr(getattr(e, 'response', None), 'status_code', 0) or 0
+        return 400 <= status < 500
+    except Exception:
+        return False
+    return False
+
+
 def budget_refusal_plausible(
     state: ServingState, hotkey: str, staked_caller: bool, now: Optional[float] = None
 ) -> bool:
@@ -134,6 +150,8 @@ def verify_served_round(
         if not req.ok and 'budget' in req.detail.lower() and budget_refusal_plausible(state, req.hotkey, staked_caller):
             return None  # this validator over-sent by its own ledger; not the miner's fault
         if not req.ok:
+            if req.source == 'gateway' and reference_rejects(reference, req.messages):
+                return None  # an honest runtime refuses this prompt too (over context, bad shape): not the miner's
             return AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
         for attempt in range(2):  # a connection blip to the reference is retried once before going neutral
             try:
@@ -276,7 +294,9 @@ async def baseline_round(
                 release_id=release.release_id,
                 messages=messages,
                 ok=ok,
-                latency_ms=(time.monotonic() - started) * 1000.0 if ok else None,
+                latency_ms=(getattr(response, 'observed_latency_ms', None) or (time.monotonic() - started) * 1000.0)
+                if ok
+                else None,
                 completion=response.completion if response is not None else None,
                 tokens=list(response.tokens) if response is not None and response.tokens else None,
                 token_ids=list(response.token_ids) if response is not None and response.token_ids else None,

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -52,6 +52,7 @@ from gittensor.constants import (
     SERVING_DORMANT_RETRY_ROUNDS,
     SERVING_MAX_TOKENS,
     SERVING_MIN_CALLER_STAKE,
+    SERVING_STRIKE_MIN_FLEET_PASS,
     SERVING_VALIDATOR_TOKENS_PER_TEMPO,
     SERVING_VERIFY_WORKERS,
 )
@@ -91,6 +92,23 @@ def sample_for_audit(
         if k < n:
             keep.difference_update(set(idxs) - set(rng.sample(idxs, k)))
     return [r for i, r in enumerate(served) if i in keep], [r for i, r in enumerate(served) if i not in keep]
+
+
+def reference_agrees_with_fleet(
+    served: Sequence[ServedRequest],
+    verdicts: Sequence[Optional[AuditVerdict]],
+    min_fleet_pass: float = SERVING_STRIKE_MIN_FLEET_PASS,
+) -> bool:
+    """Did at least ``min_fleet_pass`` of the hotkeys judged this round pass something? With two or more hotkeys
+    judged and most of them failing the bands, the reference — not the fleet — is what drifted."""
+    passed_by: Dict[str, bool] = {}
+    for req, verdict in zip(served, verdicts):
+        if verdict is None:
+            continue
+        passed_by[req.hotkey] = passed_by.get(req.hotkey, False) or verdict.passed
+    if len(passed_by) < 2 or not any(v.hard for v in verdicts if v is not None):
+        return True
+    return sum(passed_by.values()) / len(passed_by) >= min_fleet_pass
 
 
 def reference_rejects(reference: Reference, messages: List[Dict[str, str]]) -> bool:
@@ -188,6 +206,17 @@ def verify_served_round(
 
     def bump(key: str) -> None:
         summary[key] = summary.get(key, 0) + 1
+
+    if not reference_agrees_with_fleet(mine, verdicts):
+        # The reference is the odd one out this round (its own drift, not a fleet of wrong answers): band failures
+        # are misses, not strikes.
+        bump('reference_disagreement')
+        verdicts = [
+            AuditVerdict(False, v.prefix_agreement, v.mean_abs_logprob_diff, f'reference disagreement: {v.reason}')
+            if v is not None and v.hard
+            else v
+            for v in verdicts
+        ]
 
     ready_uids = {m.uid for m in state.ready_miners()}
     speeds: Dict[str, List[RequestSpeed]] = {}
@@ -530,8 +559,10 @@ class ServingAuditThread:
                     audit_round(self.state, dendrite, serving, staked_caller=is_staked_caller(self.validator))
                 )
             except Exception as e:  # a serving fault must never take the validator down
-                bt.logging.error(f'Serving round failed, no serving scores this round: {e!r}')
-                self.state.publish_round([], {})
+                # Nothing is published: the READY set stands until the TTL runs out and no hotkey records a zero
+                # for a round this validator did not run. Publishing an empty round here zeroed every settled
+                # score and blanked the gateway on any hiccup — a metagraph read, one malformed reply.
+                bt.logging.error(f'Serving round failed, nothing settled this round: {e!r}')
             if self.store is not None:
                 try:
                     self.store.save(self.state)

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -16,14 +16,15 @@ wipes the window and quarantines the hotkey. Miners whose window passes are
 published READY; serving axons that are not READY (and not quarantined) are
 published as *probation* so baseline traffic can give them a window.
 
-    round score = window passes (0/1) x mean speed credit over this round's served requests x attested (0/1)
+    round score = window passes (0/1) x mean speed credit over this round's served requests x attested cards
 
 Speed credit is measured on served traffic only (TTFT and decode rate against the
-blessing's curve at the load this validator imposed; ``scoring.py``). ``attested``
-is the miner's last hardware attestation verdict (``attest.py``: a random half of
-the READY miners is challenged every round; a miner with no verdict yet stays on
-probation). Round scores are settled over the trailing ``SERVING_SETTLEMENT_ROUNDS``
-rounds by ``ServingState``.
+blessing's curve at the load this validator imposed; ``scoring.py``); a round with
+nothing verified freezes at the last measured credit. ``attested cards`` is the
+miner's last hardware attestation verdict (``attest.py``: the least recently
+challenged half of the READY miners is challenged every round; a miner with no
+verdict yet stays on probation). Round scores are settled over the trailing
+``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
 """
 
 import asyncio

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -59,7 +59,7 @@ from gittensor.synapses import InferenceSynapse
 from gittensor.validator.serving.attest import attest_round
 from gittensor.validator.serving.persist import ServingRoundStorage
 from gittensor.validator.serving.scoring import request_speed
-from gittensor.validator.utils.config import STORE_DB_RESULTS
+from gittensor.validator.utils.config import SERVING_PAY_CAP_WITHOUT_PRICING, STORE_DB_RESULTS
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -309,7 +309,11 @@ async def audit_round(
         for uid, hotkey, axon in active:
             window = state.audits.verdict(hotkey, release.release_id)
             round_speeds = speeds.get(hotkey) or []
-            credit = sum(sp.credit for sp in round_speeds) / len(round_speeds) if round_speeds else 1.0
+            if round_speeds:
+                credit = sum(sp.credit for sp in round_speeds) / len(round_speeds)
+                state.last_credit[hotkey] = credit
+            else:  # nothing verified this round: freeze at the last measured credit, do not assume a perfect one
+                credit = state.last_credit.get(hotkey, 1.0)
             windows[uid] = {
                 **window.as_dict(),
                 'hotkey': hotkey,
@@ -488,6 +492,7 @@ class ServingAuditThread:
                     state=self.state,
                     pricing=getattr(self.validator, 'last_serving_pricing', None),
                     release=release,
+                    allow_unpriced_cap=SERVING_PAY_CAP_WITHOUT_PRICING,
                 )
             # The rest of the interval carries this validator's own baseline prompts, spread at random so nothing
             # marks the round boundary; they are verified next round alongside any user traffic.

--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -37,6 +37,7 @@ def round_rows(
     settled: Dict[str, float],
     pricing: Optional[ServingPricing],
     release: Optional[ServingRelease] = None,
+    allow_unpriced_cap: bool = False,
 ) -> tuple[tuple, list[tuple]]:
     """(serving_rounds row, serving_miner_rounds rows) for one audit round.
 
@@ -46,7 +47,7 @@ def round_rows(
     """
     windows: Dict[int, dict] = last_round.get('windows', {})
     card_equiv = sum(settled.values())
-    share = serving_share(card_equiv, pricing)
+    share = serving_share(card_equiv, pricing, allow_unpriced_cap)
     summary = (
         validator_hotkey,
         round_ts,
@@ -122,12 +123,15 @@ class ServingRoundStorage:
         pricing: Optional[ServingPricing],
         release: Optional[ServingRelease] = None,
         now: Optional[dt.datetime] = None,
+        allow_unpriced_cap: bool = False,
     ) -> bool:
         last_round = dict(state.last_round)
         if not last_round or not state.last_round_ts:
             return False
         round_ts = now or dt.datetime.fromtimestamp(state.last_round_ts, dt.timezone.utc)
-        summary, miners = round_rows(validator_hotkey, round_ts, last_round, state.settled_scores(), pricing, release)
+        summary, miners = round_rows(
+            validator_hotkey, round_ts, last_round, state.settled_scores(), pricing, release, allow_unpriced_cap
+        )
         conn = self._connection()
         if conn is None:
             return False

--- a/gittensor/validator/serving/pricing.py
+++ b/gittensor/validator/serving/pricing.py
@@ -7,11 +7,13 @@ Both inputs are ones every validator observes identically — the metagraph emis
 on-chain alpha/TAO price — plus the TAO/USD rate published in the loadout, so validators agree on the share.
 """
 
-from typing import TYPE_CHECKING, Optional
+import time
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import bittensor as bt
 
 from gittensor.classes import ServingPricing
+from gittensor.constants import SERVING_PRICING_MAX_AGE_S
 from gittensor.serving.loadout import load_serving_loadout
 
 if TYPE_CHECKING:
@@ -19,6 +21,8 @@ if TYPE_CHECKING:
 
 MINER_FRACTION_OF_NEURON_EMISSION = 0.5  # metagraph.E covers miners + validators (41% + 41%); miners get half
 MINUTES_PER_TEMPO = 72.0  # 360 blocks x 12 s
+
+_last_usable: Optional[Tuple[float, ServingPricing]] = None  # (ts, pricing): carries pay across a price-read blip
 
 
 def serving_pricing(self: 'Validator') -> Optional[ServingPricing]:
@@ -29,17 +33,32 @@ def serving_pricing(self: 'Validator') -> Optional[ServingPricing]:
         alpha_tao = float(getattr(info, 'price', 0.0) or 0.0)
         tao_usd = load_serving_loadout().tao_usd or 0.0
     except Exception as e:
-        bt.logging.warning(f'Serving: pricing unavailable ({e!r}); paying the cap pro-rata')
-        return None
+        bt.logging.warning(f'Serving: pricing unavailable ({e!r})')
+        return _recent_usable()
     pricing = ServingPricing(alpha_per_hour_to_miners=alpha_per_hour, alpha_usd=alpha_tao * tao_usd)
     if not pricing.usable:
         bt.logging.warning(
             f'Serving: pricing incomplete (alpha/h {alpha_per_hour:.1f}, alpha/TAO {alpha_tao:.6f}, '
-            f'TAO/USD {tao_usd:.2f}); paying the cap pro-rata'
+            f'TAO/USD {tao_usd:.2f})'
         )
-        return None
+        return _recent_usable()
     bt.logging.info(
         f'Serving: pricing {alpha_per_hour:.1f} alpha/h to miners, ${pricing.alpha_usd:.3f}/alpha '
         f'(alpha/TAO {alpha_tao:.6f} x TAO/USD {tao_usd:.2f})'
     )
+    global _last_usable
+    _last_usable = (time.time(), pricing)
+    return pricing
+
+
+def _recent_usable(now: Optional[float] = None) -> Optional[ServingPricing]:
+    """The last usable pricing while it is fresh enough to price this round; otherwise nothing."""
+    if _last_usable is None:
+        return None
+    ts, pricing = _last_usable
+    age = (now if now is not None else time.time()) - ts
+    if age > SERVING_PRICING_MAX_AGE_S:
+        bt.logging.warning(f'Serving: last usable pricing is {age / 60:.0f} min old; not pricing this round')
+        return None
+    bt.logging.info(f'Serving: reusing pricing from {age / 60:.0f} min ago')
     return pricing

--- a/gittensor/validator/utils/config.py
+++ b/gittensor/validator/utils/config.py
@@ -17,6 +17,9 @@ WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 # optional env vars
 STORE_DB_RESULTS = os.getenv('STORE_DB_RESULTS', 'false').lower() == 'true'
 SERVING_ENABLED = os.getenv('SERVING_ENABLED', 'false').lower() == 'true'
+# Testnet only: pay the whole serving cap pro-rata when there is no usable pricing to read. On a network that has a
+# price, leaving this false is what keeps a single verified card from earning the entire cap.
+SERVING_PAY_CAP_WITHOUT_PRICING = os.getenv('SERVING_PAY_CAP_WITHOUT_PRICING', 'false').lower() == 'true'
 SERVING_AUDIT_INTERVAL_S = float(
     os.getenv('SERVING_AUDIT_INTERVAL_S', '300')
 )  # wall-clock seconds between audit rounds

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -10,6 +10,7 @@
       "backend": "openai-compat",
       "base_url": "http://127.0.0.1:8080",
       "max_tokens": 64,
+      "end_of_turn_token_id": 151645,
       "request_timeout": 60,
       "runtime_pin": "gittensor-ai-lab/sparkinfer@7498736",
       "runtime_image": "entrius/sparkinfer:7498736",

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -36,7 +36,7 @@ import os
 import time
 from collections import OrderedDict
 from functools import partial
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Set, Tuple
 
 import bittensor as bt
 import requests
@@ -91,6 +91,7 @@ class ServingMiner(BaseNeuron):
         )
         self.seen_nonces: 'OrderedDict[str, None]' = OrderedDict()
         self.audit_budget: Dict[str, Tuple[int, int]] = {}  # validator hotkey -> (tempo, completion tokens used)
+        self.attest_inflight: Set[str] = set()  # validator hotkeys with a challenge running on the sidecar now
         bt.logging.info(f'ServingMiner axon: {self.axon}')
 
     async def forward(self, synapse: bt.Synapse) -> bt.Synapse:
@@ -157,21 +158,27 @@ async def handle_attest(miner: ServingMiner, synapse: AttestSynapse) -> AttestSy
     if not url:
         synapse.error = 'no attest_url on the release'
         return synapse
+    caller = synapse.dendrite.hotkey if synapse.dendrite and synapse.dendrite.hotkey else ''
+    key = miner.release.attest_api_key
 
     def call() -> dict:
         r = requests.post(
             f'{url.rstrip("/")}/v1/attest',
             json={'seed': int(synapse.seed), 'iters': int(synapse.iters), 'fill': bool(synapse.fill)},
+            headers={'Authorization': f'Bearer {key}'} if key else {},
             timeout=max(5.0, float(synapse.timeout or 45.0) - 2.0),
         )
         r.raise_for_status()
         return r.json()
 
+    miner.attest_inflight.add(caller)
     try:
         payload = await asyncio.get_running_loop().run_in_executor(None, call)
     except Exception as e:
         synapse.error = f'attest sidecar: {e!r}'[:300]
         return synapse
+    finally:
+        miner.attest_inflight.discard(caller)
     devices = payload.get('devices') or [payload]
     synapse.devices = [dict(d) for d in devices]
     synapse.wall_ms = float(devices[0].get('wall_ms') or 0.0) if devices else None
@@ -259,9 +266,28 @@ async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) ->
 
 
 # bt.Axon.attach asserts each hook's signature against the forward's synapse type, so the attestation hooks are
-# typed AttestSynapse and delegate to the inference gate. An attestation charges no tokens to a validator's budget.
+# typed AttestSynapse and delegate to the inference gate. An attestation charges no tokens to a validator's budget,
+# so it is open only to hotkeys that are actually validating (validator_trust > 0) or clear the stake floor, and to
+# one challenge at a time per caller: the sidecar fills the card's free VRAM and serialises challenges, so an open
+# door here is a free way to stall a competitor's runtime and queue every real validator's challenge behind it.
 async def blacklist_attest(miner: ServingMiner, synapse: AttestSynapse) -> Tuple[bool, str]:
-    return await blacklist_inference(miner, _as_budget_free(synapse))
+    refused, reason = await blacklist_inference(miner, _as_budget_free(synapse))
+    if refused:
+        return True, reason
+    hotkey = synapse.dendrite.hotkey if synapse.dendrite and synapse.dendrite.hotkey else ''
+    if reason != 'Staked caller' and not is_validating(miner, hotkey):
+        return True, 'Attestation is for validating hotkeys'
+    if hotkey in miner.attest_inflight:
+        return True, 'Attestation already in flight for this caller'
+    return False, reason
+
+
+def is_validating(miner: ServingMiner, hotkey: str) -> bool:
+    vtrust = getattr(miner.metagraph, 'validator_trust', None)
+    try:
+        return vtrust is not None and float(vtrust[miner.metagraph.hotkeys.index(hotkey)]) > 0.0
+    except (ValueError, IndexError, TypeError):
+        return False
 
 
 async def priority_attest(miner: ServingMiner, synapse: AttestSynapse) -> float:

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -27,8 +27,9 @@ The release comes from the shared serving loadout (SERVING_RELEASE picks a
 release_id, default = primary; openai-compat = a local
 sparkinfer_server; echo = deterministic GPU-free mock for localnet via
 SERVING_LOADOUT_PATH=.../serving_loadout.echo.json).
-Miners run this blessed neuron unmodified — serving reward is availability
-and correctness based, so there is nothing to gain by editing it.
+Nothing in this neuron is trusted by a validator: every number it reports is
+either recomputed on the validator's reference (tokens, logprobs, attestation
+digests) or measured on the validator's own clock. Editing it earns nothing.
 """
 
 import asyncio

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -677,6 +677,53 @@ def test_verify_served_early_stop_must_be_the_models_own():
     assert not no_ids.passed and no_ids.reason == 'no token ids'
 
 
+def test_early_stop_without_a_listed_end_of_turn_is_verified_by_forcing_the_releases_eos_id():
+    """sparkinfer 7498736 lists only the content tokens on a natural stop (measured 2026-08-28), so the validator
+    appends the release's end-of-turn id and asks the reference whether the model would have stopped there."""
+    from gittensor.serving.audit import verify_served
+
+    release = ServingRelease(model_id='m', backend='openai-compat', base_url='http://x', end_of_turn_token_id=151645)
+    tokens, logprobs, ids = ['Hi', ' there', '!'], [-0.1, -0.2, -0.3], [12675, 1017, 0]
+    forced_ids = []
+
+    class Reference:
+        model_id = 'm'
+
+        def __init__(self, stops: bool):
+            self.stops = stops
+
+        def score_served(self, messages, completion, token_ids=None):
+            forced_ids.append(list(token_ids))
+            k = len(token_ids)
+            argmax = tokens + (['<|im_end|>'] if self.stops else [' and']) if k == 4 else tokens[:k]
+            return {'tokens': tokens[:k], 'logprobs': (logprobs + [-0.5])[:k], 'argmax': argmax, 'usage': {}}
+
+        def sample(self):
+            raise NotImplementedError
+
+        def __len__(self):
+            return 1
+
+    msgs = [{'role': 'user', 'content': 'Say hi in three words.'}]
+    ok = verify_served(
+        Reference(True), msgs, 'Hi there!', tokens, logprobs, token_ids=ids, release=release, max_tokens=64
+    )
+    assert ok.passed and forced_ids[-1] == ids + [151645]
+    cut = verify_served(
+        Reference(False), msgs, 'Hi there!', tokens, logprobs, token_ids=ids, release=release, max_tokens=64
+    )
+    assert not cut.passed and cut.hard and 'would have continued' in cut.reason
+    full = verify_served(
+        Reference(False), msgs, 'Hi there!', tokens, logprobs, token_ids=ids, release=release, max_tokens=3
+    )
+    assert full.passed and forced_ids[-1] == ids  # used the whole budget: nothing to append
+    bare = ServingRelease(model_id='m', backend='openai-compat', base_url='http://x')
+    no_id = verify_served(
+        Reference(True), msgs, 'Hi there!', tokens, logprobs, token_ids=ids, release=bare, max_tokens=64
+    )
+    assert not no_id.passed and not no_id.hard and 'without end-of-turn' in no_id.reason
+
+
 def test_verified_bytes_must_spell_the_users_completion():
     from gittensor.serving.audit import spells
 

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -537,8 +537,10 @@ def test_verify_served_forces_miner_token_ids():
 
         def score_served(self, messages, completion, token_ids=None):
             calls.append(list(token_ids) if token_ids else None)
-            if token_ids:
-                return {'tokens': tokens, 'logprobs': logprobs, 'argmax': tokens, 'usage': {}}
+            if token_ids:  # exactly the forced positions; a forced end-of-turn is the model's own choice here
+                extra = len(token_ids) - len(tokens)
+                forced = tokens + ['<|im_end|>'] * extra
+                return {'tokens': forced, 'logprobs': logprobs + [0.0] * extra, 'argmax': forced, 'usage': {}}
             retok = tokens + ['x']  # a fresh tokenization of the text disagrees on length
             return {'tokens': retok, 'logprobs': logprobs + [0.0], 'argmax': retok, 'usage': {}}
 
@@ -554,7 +556,7 @@ def test_verify_served_forces_miner_token_ids():
     eos = verify_served(
         ref, good.messages, good.completion, tokens + ['<|im_end|>'], logprobs + [0.0], token_ids=ids + [7]
     )
-    assert eos.passed and calls[-1] == ids
+    assert eos.passed and calls[-1] == ids + [7]  # the end-of-turn position is forced and judged too
     fallback = verify_served(ref, good.messages, good.completion, tokens, logprobs)
     assert calls[-1] is None and 'tokenization mismatch' in fallback.reason
     short = verify_served(ref, good.messages, good.completion, tokens, logprobs, token_ids=ids[:-1])
@@ -569,13 +571,17 @@ def test_verify_served_forces_miner_token_ids():
     lie = verify_served(BindingReference(), good.messages, good.completion, tokens, logprobs, token_ids=ids)
     assert not lie.passed and not lie.hard and 'do not spell' in lie.reason
 
+    spelled = [(t if i == 0 else ' ' + t).encode() for i, t in enumerate(tokens)]  # what the forced ids spell
+
     class ExactReference(ForcingReference):
+        spell = spelled
+
         def score_served(self, messages, completion, token_ids=None):
             out = super().score_served(messages, completion, token_ids)
-            out['bytes'] = [t.encode() for t in tokens]  # what the forced ids spell
+            out['bytes'] = list(self.spell)
             return out
 
-    mine_bytes = [list(t.encode()) for t in tokens]
+    mine_bytes = [list(b) for b in spelled]
     assert verify_served(
         ExactReference(), good.messages, good.completion, tokens, logprobs, token_ids=ids, token_bytes=mine_bytes
     ).passed
@@ -588,8 +594,102 @@ def test_verify_served_forces_miner_token_ids():
     )
     # a multibyte character split across streamed tokens: the stream's text carries U+FFFD, the bytes are fine
     assert good.completion is not None
-    split_text = '\ufffd' + good.completion[1:]
-    assert verify_served(ExactReference(), good.messages, split_text, tokens, logprobs, token_ids=ids).passed
+
+    class AccentedReference(ExactReference):
+        spell = ['\u00e9'.encode() + spelled[0][1:]] + spelled[1:]
+
+    split_text = '\ufffd\ufffd' + good.completion[1:]
+    assert verify_served(AccentedReference(), good.messages, split_text, tokens, logprobs, token_ids=ids).passed
+    # ...but the text the user received cannot differ from what the verified bytes spell in any other way
+    padded = good.completion + ' visit example.com'
+    assert (
+        'do not spell' in verify_served(ExactReference(), good.messages, padded, tokens, logprobs, token_ids=ids).reason
+    )
+
+
+def test_verify_served_early_stop_must_be_the_models_own():
+    """Stopping short of max_tokens is fine only with an end-of-turn token the reference agrees on; a wrong first
+    token on aligned positions is a wrong answer; a real runtime must report token ids."""
+    from gittensor.serving.audit import verify_served
+
+    release = _echo_release()
+    good = _served(1, release)
+    tokens, logprobs = list(good.tokens or []), list(good.token_logprobs or [])
+    n = len(tokens)
+    ids = list(range(100, 100 + n))
+
+    class Reference:
+        model_id = release.model_id
+
+        def __init__(self, stops: bool):
+            self.stops = stops
+
+        def score_served(self, messages, completion, token_ids=None):
+            k = len(token_ids)
+            forced = tokens[:k]
+            if k > len(tokens):
+                forced = tokens + ['<|im_end|>']
+            argmax = list(forced)
+            if k > len(tokens) and not self.stops:
+                argmax[-1] = 'more'  # the model would have kept going
+            return {'tokens': forced, 'logprobs': (logprobs + [0.0])[:k], 'argmax': argmax, 'usage': {}}
+
+        def sample(self):
+            raise NotImplementedError
+
+        def __len__(self):
+            return 1
+
+    half = n // 2
+    short = verify_served(
+        Reference(True),
+        good.messages,
+        good.completion,
+        tokens[:half],
+        logprobs[:half],
+        token_ids=ids[:half],
+        max_tokens=n,
+    )
+    assert not short.passed and not short.hard and 'without end-of-turn' in short.reason
+    ended = verify_served(
+        Reference(True),
+        good.messages,
+        good.completion,
+        tokens + ['<|im_end|>'],
+        logprobs + [0.0],
+        token_ids=ids + [7],
+        max_tokens=n + 5,
+    )
+    assert ended.passed
+    faked = verify_served(
+        Reference(False),
+        good.messages,
+        good.completion,
+        tokens + ['<|im_end|>'],
+        logprobs + [0.0],
+        token_ids=ids + [7],
+        max_tokens=n + 5,
+    )
+    assert not faked.passed and faked.hard  # the reference's argmax at the end-of-turn position was not end-of-turn
+    wrong_first = verify_served(
+        Reference(True), good.messages, good.completion, ['zzz'] + tokens[1:], logprobs, token_ids=ids
+    )
+    assert not wrong_first.passed and wrong_first.hard and 'first token' in wrong_first.reason
+    real = ServingRelease(model_id=release.model_id, backend='openai-compat', base_url='http://x')
+    no_ids = verify_served(Reference(True), good.messages, good.completion, tokens, logprobs, release=real)
+    assert not no_ids.passed and no_ids.reason == 'no token ids'
+
+
+def test_verified_bytes_must_spell_the_users_completion():
+    from gittensor.serving.audit import spells
+
+    assert spells('héllo wörld'.encode(), 'héllo wörld')
+    assert spells('héllo'.encode(), 'h��llo')  # one é split across two streamed chunks
+    assert spells('h日本o'.encode(), 'h����o')
+    assert not spells('hello'.encode(), 'h�llo')  # a replacement character cannot stand for ASCII
+    assert not spells('héllo'.encode(), 'h��llo BUY NOW')
+    assert not spells('héllo'.encode(), 'x��llo')
+    assert not spells(b'hello', 'hello world')
 
 
 def test_stream_assembler_collects_token_ids():

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1615,6 +1615,61 @@ def test_miner_axon_hooks_match_their_forward_synapse_types():
             assert param.name == 'synapse' and getattr(param.annotation, '__name__', param.annotation) == syn
 
 
+def test_attest_is_for_validating_hotkeys_one_challenge_at_a_time(monkeypatch):
+    """A permit alone opened a free, unlimited, VRAM-filling call on every miner; now it takes validator_trust > 0
+    (or the stake floor), and one challenge per caller at a time. The miner sends its sidecar's bearer."""
+    import asyncio
+    from types import SimpleNamespace
+
+    import requests
+
+    from gittensor.synapses import AttestSynapse
+    from neurons.serving_miner import blacklist_attest, handle_attest
+
+    monkeypatch.setenv('SERVING_MIN_CALLER_STAKE', '100')
+    miner = SimpleNamespace(
+        metagraph=SimpleNamespace(
+            hotkeys=['vali', 'staked', 'permitted'],
+            S=[5.0, 100.0, 50.0],
+            validator_permit=[True, True, True],
+            validator_trust=[0.9, 0.0, 0.0],
+            block=720,
+        ),
+        audit_budget={},
+        attest_inflight=set(),
+        release=SimpleNamespace(attest_url='http://sidecar:8081', attest_api_key='sekrit'),
+    )
+
+    def gate(hotkey):
+        syn = AttestSynapse(seed=1)
+        assert syn.dendrite is not None
+        syn.dendrite.hotkey = hotkey
+        return asyncio.run(blacklist_attest(miner, syn))  # type: ignore[arg-type]
+
+    assert gate('vali') == (False, 'Permitted validator')
+    assert gate('staked') == (False, 'Staked caller')
+    assert gate('permitted') == (True, 'Attestation is for validating hotkeys')
+    assert gate('nobody') == (True, 'Unrecognized hotkey')
+    assert all(used == 0 for _, used in miner.audit_budget.values())  # nothing charged
+    miner.attest_inflight.add('vali')
+    assert gate('vali') == (True, 'Attestation already in flight for this caller')
+    miner.attest_inflight.clear()
+
+    seen = {}
+
+    def post(url, json, headers, timeout):
+        seen.update(url=url, headers=headers, inflight=set(miner.attest_inflight))
+        return SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'devices': [{'uuid': 'g'}], 'queued_ms': 1})
+
+    monkeypatch.setattr(requests, 'post', post)
+    syn = AttestSynapse(seed=1)
+    assert syn.dendrite is not None
+    syn.dendrite.hotkey = 'vali'
+    out = asyncio.run(handle_attest(miner, syn))  # type: ignore[arg-type]
+    assert out.devices == [{'uuid': 'g'}] and seen['headers'] == {'Authorization': 'Bearer sekrit'}
+    assert seen['inflight'] == {'vali'} and miner.attest_inflight == set()
+
+
 def _card(uuid: str, digest: str = 'd', wall_ms: float = 1500.0, filled: int = 8_000_000_000, free_before=None):
     dev = {'uuid': uuid, 'digest': digest, 'wall_ms': wall_ms, 'filled_bytes': filled, 'vram_total': 34e9}
     if free_before is not None:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -622,7 +622,7 @@ def test_verify_served_early_stop_must_be_the_models_own():
             self.stops = stops
 
         def score_served(self, messages, completion, token_ids=None):
-            k = len(token_ids)
+            k = len(token_ids or [])
             forced = tokens[:k]
             if k > len(tokens):
                 forced = tokens + ['<|im_end|>']
@@ -693,8 +693,8 @@ def test_early_stop_without_a_listed_end_of_turn_is_verified_by_forcing_the_rele
             self.stops = stops
 
         def score_served(self, messages, completion, token_ids=None):
-            forced_ids.append(list(token_ids))
-            k = len(token_ids)
+            forced_ids.append(list(token_ids or []))
+            k = len(token_ids or [])
             argmax = tokens + (['<|im_end|>'] if self.stops else [' and']) if k == 4 else tokens[:k]
             return {'tokens': tokens[:k], 'logprobs': (logprobs + [-0.5])[:k], 'argmax': argmax, 'usage': {}}
 
@@ -1178,7 +1178,11 @@ def test_budget_refusal_is_neutral_only_by_the_validators_own_ledger(monkeypatch
     state.enqueue_served(refused())
     asyncio.run(
         fwd_module().audit_round(
-            state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[good]), staked_caller=True
+            state,
+            dendrite,  # type: ignore[arg-type]
+            [(1, 'hk1', axon)],  # type: ignore[list-item]
+            ServingLoadout(releases=[good]),
+            staked_caller=True,
         )
     )
     assert state.audits.verdict('hk1', good.model_id).mean == 0.5

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -692,6 +692,90 @@ def test_verified_bytes_must_spell_the_users_completion():
     assert not spells(b'hello', 'hello world')
 
 
+def test_gateway_caps_prompt_size_and_stamps_the_miners_stream_end(monkeypatch):
+    """An oversized prompt is refused at the door (413), never sent to a miner. A request's latency is the end of
+    the miner's stream, not the moment a slow client finished reading it; and a stream the assembler cannot fold
+    releases the miner's in-flight slot like any other miss."""
+    from gittensor.constants import SERVING_MAX_PROMPT_CHARS
+    from gittensor.serving import api as api_module
+
+    good = _echo_release()
+    state = ServingState()
+    state.publish_round([ReadyMiner(uid=1, hotkey='hk1', axon=None, score=1.0, release_id=good.release_id)], {})  # type: ignore[arg-type]
+    app = build_app(state, ServingLoadout(releases=[good]), {'k'}, lambda: object(), 5.0)
+    client = TestClient(app)
+    headers = {'Authorization': 'Bearer k'}
+    big = client.post(
+        '/v1/chat/completions',
+        headers=headers,
+        json={'messages': [{'role': 'user', 'content': 'x' * (SERVING_MAX_PROMPT_CHARS + 1)}]},
+    )
+    assert big.status_code == 413 and state.inflight().get(1, 0) == 0 and not state.drain_served()
+
+    async def slow_reader_dispatch(dendrite, miner, messages, max_tokens, release, timeout, on_event=None):
+        syn = InferenceSynapse(messages=messages, model_id=release.model_id, max_tokens=max_tokens)
+        syn.completion, syn.served_model_id, syn.observed_latency_ms = 'hi', release.model_id, 12.0
+        if on_event is not None:
+            await on_event({'choices': [{'delta': {'content': 'hi'}}], 'model': release.model_id})
+            await on_event(None)
+        return syn
+
+    monkeypatch.setattr(api_module, '_dispatch', slow_reader_dispatch)
+    r = client.post('/v1/chat/completions', headers=headers, json={'messages': MSGS, 'stream': True})
+    assert r.status_code == 200
+    (served,) = state.drain_served()
+    assert served.ok and served.latency_ms == 12.0
+
+    async def broken_dispatch(dendrite, miner, messages, max_tokens, release, timeout, on_event=None):
+        if on_event is not None:
+            await on_event({'choices': [{'delta': {'content': 'hi'}}]})
+        raise AttributeError("'list' object has no attribute 'get'")
+
+    monkeypatch.setattr(api_module, '_dispatch', broken_dispatch)
+    r = client.post('/v1/chat/completions', headers=headers, json={'messages': MSGS, 'stream': True})
+    assert r.status_code == 200
+    (served,) = state.drain_served()
+    assert not served.ok and state.inflight().get(1, 0) == 0
+
+
+def test_runtime_rejected_prompt_is_checked_against_the_reference(monkeypatch):
+    """A gateway request the miner's runtime refused counts as a miss only if the validator's reference would have
+    answered it; when the reference refuses it too (over context) nobody is blamed. Baseline prompts are the
+    validator's own and never need the check."""
+    from types import SimpleNamespace
+
+    import requests
+
+    from gittensor.validator.serving.forward import verify_served_round
+
+    good = _echo_release()
+
+    class Reference(EchoReference):
+        def __init__(self, status):
+            super().__init__(good)
+            self.status = status
+
+        def case_for(self, messages, max_tokens=None):
+            if self.status:
+                err = requests.HTTPError('nope')
+                err.response = SimpleNamespace(status_code=self.status)
+                raise err
+
+    def run(reference, source='gateway'):
+        state = ServingState()
+        summary = {}
+        failed = _served(1, good, ok=False)
+        failed.source = source
+        verify_served_round(state, reference, good, [failed], summary)
+        return summary.get('neutral', 0), summary.get('miss', 0)
+
+    assert run(Reference(400)) == (1, 0)
+    assert run(Reference(500)) == (0, 1)
+    assert run(Reference(None)) == (0, 1)
+    assert run(Reference(400), source='baseline') == (0, 1)
+    assert run(EchoReference(good)) == (0, 1)
+
+
 def test_stream_assembler_collects_token_ids():
     from gittensor.serving.stream import SSEParser, StreamAssembler, result_to_sse
     from gittensor.synapses import InferenceSynapse

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 import time
-from collections import deque
 from types import SimpleNamespace
 from typing import Dict
 
@@ -449,7 +448,6 @@ def test_serving_store_round_trips_audit_thread_state(tmp_path):
         state.audits.record('hk', 'm', x)
     state.audits.record('hk2', 'm', 1.0)
     state.audits.strike('hk3', 'm', now=1000.0)
-    state.probe_history['hk'] = deque([180.0, 178.0], maxlen=3)
     state.publish_round([], {'hk': 0.9})
     state.publish_round([], {'hk': 1.0})
     state.dormant_rounds['dead'] = 2
@@ -461,7 +459,6 @@ def test_serving_store_round_trips_audit_thread_state(tmp_path):
     assert loaded.audits.quarantined_until('hk3', 'm', now=1500.0) == state.audits.quarantined_until(
         'hk3', 'm', now=1500.0
     )
-    assert list(loaded.probe_history['hk']) == [180.0, 178.0]
     assert loaded.settled_scores() == state.settled_scores()
     assert loaded.dormant_rounds == {'dead': 2}
 

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -866,21 +866,136 @@ def test_baseline_round_spreads_prompts_and_queues_them_for_verification(monkeyp
     )
 
 
-def test_budget_refusal_is_neutral_not_a_miss(monkeypatch):
+def test_budget_refusal_is_neutral_only_by_the_validators_own_ledger(monkeypatch):
+    """The refusal text is the miner's to write. It is neutral only when this validator's own count of max_tokens
+    sent in the trailing tempo is near the miner's allowance — and never for a staked caller, which has no budget."""
     from types import SimpleNamespace
+
+    from gittensor.constants import SERVING_VALIDATOR_TOKENS_PER_TEMPO
 
     good = _echo_release()
     axon = SimpleNamespace(is_serving=True)
     dendrite, _ = _dendrite_echoing(good)
+
+    def refused():
+        r = _served(1, good, ok=False)
+        r.detail = 'Validator audit budget spent (50000 tokens per tempo)'
+        return r
+
+    # An unstaked validator that sent almost nothing: the refusal is a lie -> a miss.
     state = ServingState(settlement_rounds=1)
     state.enqueue_served(_served(1, good))
-    refused = _served(1, good, ok=False)
-    refused.detail = 'Validator audit budget spent (50000 tokens per tempo)'
-    state.enqueue_served(refused)
-    state.enqueue_served(_served(1, good, ok=False))
+    state.enqueue_served(refused())
+    _round(state, dendrite, [(1, 'hk1', axon)], good, monkeypatch)
+    assert state.audits.verdict('hk1', good.model_id).mean == 0.5
+
+    # The same validator after sending the allowance: the refusal is plausible -> neutral.
+    state = ServingState(settlement_rounds=1)
+    state.charge_sent('hk1', SERVING_VALIDATOR_TOKENS_PER_TEMPO)
+    state.enqueue_served(_served(1, good))
+    state.enqueue_served(refused())
     _round(state, dendrite, [(1, 'hk1', axon)], good, monkeypatch)
     w = state.audits.verdict('hk1', good.model_id)
-    assert w.n_audits == 2 and w.mean == 0.5  # one pass, one real miss, the refusal ignored
+    assert w.n_audits == 1 and w.mean == 1.0
+
+    # A staked caller is never on a budget: the refusal is a miss however much it sent.
+    state = ServingState(settlement_rounds=1)
+    state.charge_sent('hk1', SERVING_VALIDATOR_TOKENS_PER_TEMPO)
+    state.enqueue_served(_served(1, good))
+    state.enqueue_served(refused())
+    asyncio.run(
+        fwd_module().audit_round(
+            state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[good]), staked_caller=True
+        )
+    )
+    assert state.audits.verdict('hk1', good.model_id).mean == 0.5
+
+
+def test_sent_token_ledger_is_kept_at_dispatch(monkeypatch):
+    """Gateway and baseline requests both charge the validator's own ledger with the max_tokens they asked for."""
+    from gittensor.validator.serving.forward import baseline_round
+
+    good = _echo_release()
+    state = ServingState()
+    state.publish_round([ReadyMiner(uid=1, hotkey='hk1', axon=None, score=1.0, release_id=good.release_id)], {})  # type: ignore[arg-type]
+    dendrite, _ = _dendrite_echoing(good)
+    app = build_app(state, ServingLoadout(releases=[good]), {'k'}, lambda: dendrite, 5.0)
+    client = TestClient(app)
+    r = client.post(
+        '/v1/chat/completions',
+        headers={'Authorization': 'Bearer k'},
+        json={'messages': [{'role': 'user', 'content': 'hi'}], 'max_tokens': 40},
+    )
+    assert r.status_code == 200
+    assert state.sent_tokens('hk1', 3600.0) == 40
+    axon = SimpleNamespace(is_serving=True)
+    asyncio.run(baseline_round(state, dendrite, [(1, 'hk1', axon)], good, 0.0, per_miner=1))  # type: ignore[arg-type]
+    assert state.sent_tokens('hk1', 3600.0) > 40
+    assert state.sent_tokens('hk1', 3600.0, now=time.time() + 7200) == 0
+
+
+def test_malformed_miner_data_is_a_miss_not_a_neutral():
+    """bytes out of range, ids out of range, more tokens than asked for: the miner's miss, judged before the
+    reference is ever asked. A reference that rejects the miner's ids (HTTP 4xx) is the same."""
+    from gittensor.serving.audit import verify_served
+
+    release = _echo_release()
+    ref = EchoReference(release)
+    good = _served(1, release)
+    tokens, logprobs = list(good.tokens or []), list(good.token_logprobs or [])
+    n = len(tokens)
+    bad_bytes = verify_served(ref, good.messages, good.completion, tokens, logprobs, token_bytes=[[256]] * n)
+    assert not bad_bytes.passed and not bad_bytes.hard and 'malformed token bytes' in bad_bytes.reason
+    bad_ids = verify_served(ref, good.messages, good.completion, tokens, logprobs, token_ids=[10**9] * n)
+    assert not bad_ids.passed and 'malformed token ids' in bad_ids.reason
+    neg_ids = verify_served(ref, good.messages, good.completion, tokens, logprobs, token_ids=[-1] * n)
+    assert not neg_ids.passed and 'malformed token ids' in neg_ids.reason
+    long = verify_served(ref, good.messages, good.completion, tokens, logprobs, max_tokens=n - 2)
+    assert not long.passed and 'tokens for a' in long.reason
+    assert verify_served(ref, good.messages, good.completion, tokens, logprobs, max_tokens=n).passed
+
+
+def test_reference_rejection_is_the_miners_miss_and_a_reference_fault_is_neutral(monkeypatch):
+    from types import SimpleNamespace
+
+    import requests
+
+    from gittensor.validator.serving.forward import verify_served_round
+
+    good = _echo_release()
+
+    class Rejecting:
+        model_id = good.model_id
+
+        def __init__(self, status):
+            self.status = status
+
+        def score_served(self, messages, completion, token_ids=None):
+            err = requests.HTTPError('nope')
+            err.response = SimpleNamespace(status_code=self.status)
+            raise err
+
+        def sample(self):
+            raise NotImplementedError
+
+        def __len__(self):
+            return 1
+
+    monkeypatch.setattr('gittensor.validator.serving.forward.time.sleep', lambda s: None)
+    state = ServingState()
+    summary = {}
+    verify_served_round(state, Rejecting(400), good, [_served(1, good)], summary)  # type: ignore[arg-type]
+    assert summary.get('miss') == 1 and state.audits.verdict('hk1', good.model_id).mean == 0.0
+    state = ServingState()
+    summary = {}
+    verify_served_round(state, Rejecting(503), good, [_served(1, good)], summary)  # type: ignore[arg-type]
+    assert summary.get('neutral') == 1 and state.audits.verdict('hk1', good.model_id).n_audits == 0
+
+
+def fwd_module():
+    from gittensor.validator.serving import forward as fwd
+
+    return fwd
 
 
 def test_baseline_prompts_vary_in_shape_and_length():

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1676,11 +1676,18 @@ def test_attest_round_pays_per_card_and_dedupes_across_cards(monkeypatch):
     assert att.status_capacity(state.attest_status['hk1']) == 2
     assert att.status_capacity({'passed': True, 'uuid': 'GPU-old'}) == 1  # status persisted before capacity existed
 
+    # hk1 holds GPU-b from the round it passed with it: a newcomer naming that UUID loses the card, hk1 keeps it
     replies[id(axons['hk2'])] = AttestSynapse(seed=1, devices=[_card('GPU-b')])  # hk1's second card
     state.attest_status = {}
     out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
-    assert out == {'hk1': 0, 'hk2': 0}
-    assert state.attest_status['hk1']['reason'] == 'duplicate GPU GPU-b'
+    assert out == {'hk1': 2, 'hk2': 0}
+    assert state.attest_status['hk2']['reason'] == 'duplicate GPU GPU-b (held by another hotkey)'
+    assert state.uuid_owner['GPU-b'][0] == 'hk1'
+    # the same collision with no holder on record (both new this round) is the sharing case: both lose it
+    fresh = ServingState()
+    out = asyncio.run(att.attest_round(fresh, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
+    assert out == {'hk1': 1, 'hk2': 0}  # hk1 keeps GPU-a, loses GPU-b; hk2 had only GPU-b
+    assert 'GPU-b' not in fresh.uuid_owner and fresh.uuid_owner['GPU-a'][0] == 'hk1'
 
     # the audit round multiplies the speed credit by the attested cards
     good = _echo_release()
@@ -1709,6 +1716,110 @@ def test_attest_round_pays_per_card_and_dedupes_across_cards(monkeypatch):
     assert scores['hk1'] == pytest.approx(2.0) and scores['hk2'] == pytest.approx(1.0)
     tele = state.snapshot()['last_round']['windows']
     assert tele[1]['capacity'] == 2.0 and tele[1]['gpu_uuids'] == ['GPU-a', 'GPU-b'] and tele[2]['capacity'] == 1.0
+
+
+def test_attest_cards_answer_their_own_index_and_the_round_trip_bounds_the_count():
+    """Device i answers seed + i, recomputed by the reference: one real digest repeated N times passes once. And the
+    whole reply must land within one card's budget plus the slack, however each card's own wall reads."""
+    from gittensor.synapses import AttestSynapse
+    from gittensor.validator.serving.attest import judge
+
+    release = _attest_release()
+    per_index = {0: 'd0', 1: 'd1', 2: 'd2'}.get
+    faked = judge(
+        AttestSynapse(seed=1, devices=[_card('GPU-a', digest='d0'), _card('GPU-b', digest='d0')]),
+        per_index,
+        1400.0,
+        release,
+    )
+    assert faked.capacity == 1 and faked.reason.startswith('1/2 cards ok (digest mismatch')
+    honest = judge(
+        AttestSynapse(seed=1, devices=[_card('GPU-a', digest='d0'), _card('GPU-b', digest='d1')]),
+        per_index,
+        1400.0,
+        release,
+        elapsed_ms=1500.0,
+    )
+    assert honest.capacity == 2
+    beyond = judge(
+        AttestSynapse(seed=1, devices=[_card(f'GPU-{i}', digest=f'd{i}') for i in range(4)]), per_index, 1400.0, release
+    )
+    assert beyond.capacity == 3 and 'no reference digest' in beyond.reason
+    slow = judge(
+        AttestSynapse(seed=1, devices=[_card('GPU-a', digest='d0')]), per_index, 1400.0, release, elapsed_ms=9_000.0
+    )
+    assert not slow.passed and slow.capacity == 0 and 'round trip' in slow.reason
+    capped = judge(
+        AttestSynapse(seed=1, devices=[_card(f'GPU-{i}', digest='d') for i in range(20)]),
+        'd',
+        1400.0,
+        release,
+        max_cards=3,
+    )
+    assert capped.capacity == 3
+
+
+def test_attest_malformed_report_is_a_failed_card_not_a_crash():
+    from gittensor.synapses import AttestSynapse
+    from gittensor.validator.serving.attest import judge, status_capacity
+
+    release = _attest_release()
+    bad = judge(
+        AttestSynapse(seed=1, devices=[{'uuid': 'GPU-a', 'digest': 'd', 'filled_bytes': 'x'}]), 'd', 1400.0, release
+    )
+    assert not bad.passed and bad.reason.startswith('malformed device report')
+    nested = judge(
+        AttestSynapse(seed=1, devices=[{'uuid': 'GPU-a', 'digest': 'd', 'vram_total': [1]}]), 'd', 1400.0, release
+    )
+    assert not nested.passed and nested.reason.startswith('malformed device report')
+    # a verdict the reference has not renewed for longer than the memory window pays nothing
+    stale = {'passed': True, 'capacity': 2, 'round': 1}
+    assert status_capacity(stale, round_no=13) == 2 and status_capacity(stale, round_no=14) == 0
+    assert status_capacity(stale) == 2
+
+
+def test_attest_fault_is_neutral_and_the_round_counter_persists(monkeypatch, tmp_path):
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.serving.store import ServingStore
+    from gittensor.validator.serving import attest as att
+
+    release = _attest_release()
+    monkeypatch.setattr(att, 'reference_challenge', lambda rel, seed, iters, timeout: ('d', 1400.0))
+    axon = SimpleNamespace(is_serving=True)
+
+    async def call(target_axon, synapse, timeout, deserialize):
+        return _attest_reply(uuid='GPU-1')
+
+    dendrite = SimpleNamespace(call=call)
+    state = ServingState()
+    assert asyncio.run(att.attest_round(state, dendrite, [(1, 'hk1', axon)], release)) == {'hk1': 1}  # type: ignore[arg-type]
+    monkeypatch.setattr(att, 'judge', lambda *a, **k: (_ for _ in ()).throw(RuntimeError('boom')))
+    assert asyncio.run(att.attest_round(state, dendrite, [(1, 'hk1', axon)], release)) == {'hk1': 1}  # type: ignore[arg-type]
+    assert state.attest_round == 2 and state.uuid_owner['GPU-1'] == ('hk1', 1)
+    store = ServingStore(tmp_path / 'serving.db')
+    store.save(state)
+    again = store.load(ServingState())
+    assert again.attest_round == 2 and again.uuid_owner == {'GPU-1': ('hk1', 1)}
+
+
+def test_reference_challenge_sends_the_bearer(monkeypatch):
+    import requests
+
+    from gittensor.validator.serving import attest as att
+
+    seen = {}
+
+    def post(url, json, headers, timeout):
+        seen.update(url=url, json=json, headers=headers)
+        return SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'digest': 'd', 'wall_ms': 800.0})
+
+    monkeypatch.setattr(requests, 'post', post)
+    release = _attest_release()
+    release.attest_reference_api_key = 'secret'
+    assert att.reference_challenge(release, 5, 3, 10.0) == ('d', 800.0)
+    assert seen['headers'] == {'Authorization': 'Bearer secret'} and seen['json']['seed'] == 5
 
 
 def test_sample_for_audit_keeps_baseline_and_failures_and_draws_the_rest():

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -776,6 +776,51 @@ def test_runtime_rejected_prompt_is_checked_against_the_reference(monkeypatch):
     assert run(EchoReference(good)) == (0, 1)
 
 
+def test_strikes_need_the_fleet_to_agree_with_the_reference():
+    """When most hotkeys judged this round fail the bands, the reference drifted: misses, not strikes."""
+    from gittensor.validator.serving.forward import verify_served_round
+
+    good = _echo_release()
+    ref = EchoReference(good)
+    state = ServingState()
+    summary = {}
+    served = [_served(1, good, wrong=True), _served(2, good, wrong=True), _served(3, good)]
+    verify_served_round(state, ref, good, served, summary)
+    assert summary.get('strike', 0) == 0 and summary.get('miss') == 2 and summary.get('reference_disagreement') == 1
+    assert state.audits.verdict('hk1', good.model_id).quarantined_until == 0.0
+    state = ServingState()
+    summary = {}
+    served = [_served(1, good, wrong=True), _served(2, good), _served(3, good)]
+    verify_served_round(state, ref, good, served, summary)
+    assert summary.get('strike') == 1 and state.audits.verdict('hk1', good.model_id).quarantined_until > 0.0
+    state = ServingState()
+    summary = {}
+    verify_served_round(state, ref, good, [_served(1, good, wrong=True)], summary)  # one hotkey: nothing to compare
+    assert summary.get('strike') == 1
+
+
+def test_quarantine_escalates_with_strikes():
+    w = AuditWindow(quarantine_s=100.0)
+    assert w.strike('hk', 'r', now=0.0) == 100.0
+    assert w.strike('hk', 'r', now=0.0) == 400.0
+    assert w.strike('hk', 'r', now=0.0) == 1600.0
+    assert w.strike('hk', 'r', now=0.0) == 6400.0
+    assert w.strike('hk', 'r', now=0.0) == 6400.0
+    assert w.strike('other', 'r', now=0.0) == 100.0
+
+
+def test_last_credit_survives_a_restart_and_tao_usd_is_the_repos(tmp_path, monkeypatch):
+    from gittensor.serving.store import ServingStore
+
+    state = ServingState()
+    state.last_credit['hk1'] = 0.75
+    store = ServingStore(tmp_path / 'serving.db')
+    store.save(state)
+    assert store.load(ServingState()).last_credit == {'hk1': 0.75}
+    monkeypatch.setenv('SERVING_TAO_USD', '1')
+    assert load_serving_loadout().tao_usd != 1.0
+
+
 def test_stream_assembler_collects_token_ids():
     from gittensor.serving.stream import SSEParser, StreamAssembler, result_to_sse
     from gittensor.synapses import InferenceSynapse
@@ -2197,7 +2242,7 @@ def test_strikes_count_up_and_survive_a_restart(tmp_path):
     store.save(ServingState(audits=w))
     again = store.load(ServingState(audits=AuditWindow(quarantine_s=100.0))).audits
     assert again.strikes('hk', 'r1') == 2 and again.strikes('hk', 'r2') == 1
-    assert again.quarantined_until('hk', 'r1', now=2050.0) == 2100.0
+    assert again.quarantined_until('hk', 'r1', now=2050.0) == 2400.0  # the second strike: 4x the first
 
 
 def test_store_migrates_a_model_id_keyed_database(tmp_path):

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import time
 from collections import deque
 from types import SimpleNamespace
 from typing import Dict
@@ -16,6 +17,7 @@ from gittensor.constants import (
     SERVING_AUDIT_MIN_PREFIX_AGREEMENT,
     SERVING_AUDIT_WINDOW,
     SERVING_AUDIT_WINDOW_THRESHOLDS,
+    SERVING_PRICING_MAX_AGE_S,
 )
 from gittensor.serving.api import build_app, parse_api_keys
 from gittensor.serving.audit import (
@@ -823,8 +825,11 @@ def test_audit_round_verifies_served_traffic(monkeypatch):
     assert state.snapshot()['probation_uids'] == [3]  # the cheater is quarantined, not on probation
     assert sum(1 for r in state.recent(50) if r.kind == 'verify') == 7
 
-    scores = _round(state, dendrite, serving, good, monkeypatch)  # quiet round: READY on the window, credit 1.0
-    assert scores['hk1'] == 1.0 and [m.uid for m in state.ready_miners()] == [1]
+    # A round in which nothing of hk1's was verified freezes its credit at what was last measured (0.8) rather
+    # than crediting a perfect round the validator never observed.
+    scores = _round(state, dendrite, serving, good, monkeypatch)
+    assert scores['hk1'] == 0.8 and [m.uid for m in state.ready_miners()] == [1]
+    assert state.last_credit['hk1'] == 0.8
 
 
 def test_baseline_round_spreads_prompts_and_queues_them_for_verification(monkeypatch):
@@ -1099,8 +1104,14 @@ def test_serving_share_prices_gpu_hours_inside_the_cap(monkeypatch):
     assert ea.serving_share(1.0, pricing) == pytest.approx(0.70 / (123.0 * 0.847))
     assert ea.serving_share(25.0, pricing) == pytest.approx(0.168, abs=0.001)
     assert ea.serving_share(100.0, pricing) == 0.17  # capped: 100 cards dilute
-    assert ea.serving_share(1.0, None) == 0.17  # no pricing (testnet): pay the cap pro-rata
-    assert ea.serving_share(1.0, ServingPricing(0.0, 0.847)) == 0.17
+    # No usable pricing pays nothing: on a priced network a failed read must not hand one card the whole cap.
+    assert ea.serving_share(1.0, None) == 0.0
+    assert ea.serving_share(1.0, ServingPricing(0.0, 0.847)) == 0.0
+    assert ea.serving_share(100.0, None) == 0.0
+    # ... unless the network has no price to read at all (testnet), where the cap is split pro-rata.
+    assert ea.serving_share(1.0, None, allow_unpriced_cap=True) == 0.17
+    assert ea.serving_share(1.0, ServingPricing(0.0, 0.847), allow_unpriced_cap=True) == 0.17
+    assert ea.serving_share(0.0, None, allow_unpriced_cap=True) == 0.0  # nothing verified is still nothing
 
 
 def test_blend_pays_serving_by_price_and_recycles_the_rest(monkeypatch):
@@ -1127,12 +1138,21 @@ def test_serving_pricing_reads_chain_and_loadout(monkeypatch):
         metagraph=SimpleNamespace(E=[100.0, 200.0], netuid=74),
         subtensor=SimpleNamespace(subnet=lambda netuid: SimpleNamespace(price=0.004)),
     )
+    monkeypatch.setattr(pr, '_last_usable', None)
     monkeypatch.setattr(pr, 'load_serving_loadout', lambda: SimpleNamespace(tao_usd=250.0))
     p = pr.serving_pricing(vali)  # type: ignore[arg-type]
     assert p is not None and p.alpha_per_hour_to_miners == pytest.approx(150.0 * 60 / 72) and p.alpha_usd == 1.0
+
+    # A read that comes back unusable, or throws, reuses the last usable pricing rather than dropping pay.
     monkeypatch.setattr(pr, 'load_serving_loadout', lambda: SimpleNamespace(tao_usd=None))
-    assert pr.serving_pricing(vali) is None  # type: ignore[arg-type]
+    assert pr.serving_pricing(vali) == p  # type: ignore[arg-type]
     vali.subtensor = SimpleNamespace(subnet=lambda netuid: (_ for _ in ()).throw(RuntimeError('rpc')))
+    assert pr.serving_pricing(vali) == p  # type: ignore[arg-type]
+
+    # Once that last good reading is older than the max age it is not reused, and nothing is priced.
+    monkeypatch.setattr(pr, '_last_usable', (time.time() - SERVING_PRICING_MAX_AGE_S - 1.0, p))
+    assert pr.serving_pricing(vali) is None  # type: ignore[arg-type]
+    monkeypatch.setattr(pr, '_last_usable', None)  # a validator that has never priced pays nothing
     assert pr.serving_pricing(vali) is None  # type: ignore[arg-type]
 
 
@@ -1174,7 +1194,7 @@ def test_oss_round_blends_latest_serving_scores(monkeypatch):
 
     seen = {}
 
-    def blend(evals, repos, uids, maintainers, serving_scores, pricing=None):
+    def blend(evals, repos, uids, maintainers, serving_scores, pricing=None, allow_unpriced_cap=False):
         seen['serving'] = serving_scores
         seen['pricing'] = pricing
         return [0.0]

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -118,9 +118,12 @@ def test_default_loadout_keeps_model_file():
     assert loadout.load_serving_loadout().primary.model_file.endswith('.gguf')
 
 
-def test_round_rows_without_pricing_pays_cap_pro_rata():
-    summary, _ = persist.round_rows('vali', dt.datetime.now(dt.timezone.utc), ROUND, {'hk16': 1.0}, None)
-    assert summary[13] == 0.035 and summary[14] is None and summary[15] is None
+def test_round_rows_report_the_share_that_will_actually_be_paid():
+    ts = dt.datetime.now(dt.timezone.utc)
+    summary, _ = persist.round_rows('vali', ts, ROUND, {'hk16': 1.0}, None)
+    assert summary[13] == 0.0 and summary[14] is None and summary[15] is None  # unpriced: nothing is paid
+    summary, _ = persist.round_rows('vali', ts, ROUND, {'hk16': 1.0}, None, None, True)
+    assert summary[13] == 0.035  # testnet: the cap, matching what blend_emission_pools pays
 
 
 def test_store_round_writes_and_prunes():


### PR DESCRIPTION
Fixes for the compute sub-subnet red-team round of 2026-08-28, one commit per class of failure. Each commit body describes the failure mode in plain language; the audit with the full ranked list is in the private repo docs (`redteam/SECURITY_AUDIT_compute_round1.md`).

The shape they share: the validator recomputed exactly one number it did not receive from the miner (the attest digest), and every other number that became pay was the miner's — or, when malformed, turned into a **neutral** verdict, and a round with nothing judged paid full credit. A miner could earn one passing window honestly, make every later audit neutral, claim N cards, and be paid N× on every validator while users got 502s.

## By commit

**1. Pricing fails closed; credit freezes when nothing was verified.** `serving_share()` returned the whole 3.5 % cap whenever pricing was unusable — a transient `subtensor.subnet()` failure or a missing `pricing.tao_usd` handed one verified card the entire pool. Unpriced now pays nothing and recycles; testnet opts in with `SERVING_PAY_CAP_WITHOUT_PRICING=true`; the last usable reading carries for `SERVING_PRICING_MAX_AGE_S` (1 h); `round_rows()` reports the same. And `credit = … if round_speeds else 1.0` gave full speed credit to a miner none of whose requests were verified; it now freezes at the last measured credit (`ServingState.last_credit`), only a never-measured hotkey starts at 1.0.

**2. A neutral verdict needs a cause this validator can see.** A "budget spent" refusal was matched by substring on the *miner's* status string, and malformed bytes/ids raised before the reference was asked and were filed as reference hiccups — neutral touches neither the window nor the speed credit. Now the validator keeps its own ledger of the `max_tokens` it sent each miner; a budget refusal is neutral only when that ledger is near the allowance and never for a staked caller. Malformed miner data, over-length completions, and reference HTTP 4xx on the miner's own ids are soft misses.

**3. A card count the validator measures; a GPU that cannot be taken by naming it.** Per-card attestation judged the digest against the reference and took `uuid`/`wall_ms`/`filled_bytes`/residency from the miner, with one seed for every card: one 5090 could answer with N entries and be paid as N cards. Now device *i* answers `seed + i`, the reference recomputes one digest per claimed index, `gt_attest` runs cards in parallel, and the whole reply must arrive within one card's budget plus `SERVING_ATTEST_RTT_SLACK_MS` — N real cards take one card's wall, one card faking N takes N; at most `SERVING_ATTEST_MAX_CARDS`. A malformed entry (`filled_bytes: "x"`) used to raise through the round and zero everyone; casts are guarded and any attest fault is neutral for the cohort. A UUID belongs to the first hotkey that passed with it — a newcomer naming it loses the card, the holder keeps it; two new claimants in one round both fail (the sharing case). A verdict the reference has not renewed within the memory window pays nothing. The reference sidecar gets a bearer (`attest.reference_api_key` / `SERVING_ATTEST_REFERENCE_API_KEY`); `attest_round` and UUID ownership persist.

**4. Attestation is for validating hotkeys, one challenge at a time.** Any permit holder could send unlimited budget-free challenges that fill a competitor's VRAM under the sidecar's global lock, stalling its runtime and queueing every real validator's challenge into "too slow". Now `validator_trust > 0` (or the stake floor), one in flight per caller; the miner sends its sidecar's bearer (`attest.api_key` / `SERVING_ATTEST_API_KEY`).

**5. An early stop is the model's own; the user's text is the verified text.** One correct token per request was a full-credit answer (and fell under the decode-pricing floor); a wrong first token or omitted ids was always a soft miss, never a strike; the completion the user received was never compared with the verified bytes (and skipped on any U+FFFD). Now an answer short of `max_tokens` must end in an end-of-turn token that is forced and judged (the reference's argmax there must be end-of-turn), first-token divergence on aligned positions is a wrong answer, a real runtime must report ids, and the decoded bytes must read as the completion — replacement-character runs stand only for split non-ASCII characters.

**6. Gateway hygiene.** No prompt-size bound, so a key holder could take any miner off READY with over-context prompts that were blamed without asking the reference; latency was stamped when the *client* finished reading, so a slow reader was a slow card; an SSE event the assembler could not fold leaked the miner's in-flight slot across rounds. Now `SERVING_MAX_PROMPT_CHARS` (413), a runtime rejection is checked against the reference first, latency is the end of the miner's stream, and the slot is released however the stream ends.

**7. A failed round settles nothing; strikes need the fleet to agree.** Any exception in the round zeroed every settled hotkey and blanked the gateway; a drifted reference struck every honest miner each time quarantine lifted. A failed round now publishes nothing (READY stands until the TTL), `last_credit` persists, `SERVING_TAO_USD` is gone (the rate is the loadout's), band failures are misses when fewer than half the judged hotkeys passed anything, and quarantine escalates 1 h → 4 → 16 → 64.

**8. Rot.** Docstrings describing the pre-#1718/#1721/#1725 design and the dead `probe_history`.

**9. Early stop verified by forcing the release's end-of-turn id; prompt cap sized from measured prefill.** Measured on a rented 5090: sparkinfer 7498736 lists only the content tokens on a natural stop (no `<|im_end|>` entry), so commit 5's rule would have missed every honest short answer. `/v1/score` does score an appended id, so the validator appends `end_of_turn_token_id` (151645, in the loadout) itself and requires the reference's argmax there to be end-of-turn — hard when the model would have continued. Prompt cap is 40k chars (~10k tokens; TTFT 500 ms at ~11.5k of a 36864 context).

## Measured on a rented 5090 + RTX 6000 Ada (2026-08-28, ~$0.75)
- Hostile `completion_token_ids` (1e9, −1, 100k-long, empty): HTTP 400 each, server alive — a soft miss under commit 2, never a reference DoS.
- `/v1/score` returns `bytes` and `token_ids`; scoring an appended end-of-turn id returns its argmax and bytes.
- Attest fill during 16 concurrent 512-token decodes: 16/16 still succeed (+2 % latency). Fill took 6.1 GB of 6.4 GB free with model+KV at ~27 GB — the 0.6 × (total − 24 GB) fill floor is tight under load; calibrate `vram_model_reserved_bytes` at blessing under load.
- **The attest digest is bit-identical on sm_89** (RTX 6000 Ada; wall +7 %). Attestation proves a CUDA card ran the seed now, not a 5090 — a stated non-goal, now measured; served-traffic speed remains the only 5090 discriminator.
- The attest sidecar's `GET /info` answers with no auth on the documented Lium layout: set `ATTEST_API_KEY` (both sides send bearers now); docs to follow.
- Still unconfirmed: the rebuilt `entrius/gt-attest` image (per-device seeds, threads) on a two-card box. Until miners run it, every miner reports index 0 only, which still passes.

## Not in this PR (decisions, not code)
- No cross-validator consensus on serving verdicts: serving pay is Yuma-clipped unless the stake majority runs a reference.
- The 1M-alpha caller gate: which mainnet hotkey clears it today, and what a whale that does gets.

CI: ruff, format, vulture, 757 tests green; pyright's 40 errors are the pre-existing `bittensor` import resolution in `tests/`, identical on `test`.

https://claude.ai/code/session_01WVxb9UNM7sK7HY5BYXUVrf

