### PR TITLE
fix(conformance): free_node died whenever a matching card was actually listed

### DIFF
--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -28,10 +28,16 @@ cleanup() { lium rm "$POD" -y >/dev/null 2>&1 || true; lium rm "$ATTEST_POD" -y 
 trap cleanup EXIT
 
 # `lium ls --gpu X --format json` returns [] even when cards are listed; filter the full listing instead.
+# The element is bound to $n before the `taken` test: inside jq's contains(), `.` is the string being searched, so
+# a bare .id there indexes a string and kills the run — and only ever when a matching card IS listed.
 # Prints the cheapest free 1x$GPU executor id not in $1 (space-separated ids already taken).
 free_node() {
   lium ls --format json 2>/dev/null | jq -r --arg gpu "RTX$GPU" --arg taken " $1 " \
-    '[.[] | select(.gpu_type == $gpu and .gpu_count == 1 and .vram_gb >= 30 and .download_mbps >= 150 and ($taken | contains(" " + .id + " ") | not))] | sort_by(.price_per_hour) | .[0].id // empty'
+    '[.[] | select(type == "object") | . as $n
+       | select(($n.id | type) == "string" and $n.gpu_type == $gpu and $n.gpu_count == 1
+                and ($n.vram_gb // 0) >= 30 and ($n.download_mbps // 0) >= 150
+                and ($taken | contains(" " + $n.id + " ") | not))]
+     | sort_by(.price_per_hour // 1e9) | .[0].id // empty'
 }
 
 echo "renting 2x 1x$GPU: entrius/sparkinfer:$REF + $ATTEST_IMAGE (waiting up to ${RENT_WAIT_MIN} min for free cards)"


### PR DESCRIPTION
`scripts/serving_conformance_on_lium.sh` could never rent a pod.

Inside jq's `contains()`, `.` is the string being searched — so in

```jq
select(.gpu_type == $gpu and ... and ($taken | contains(" " + .id + " ") | not))
```

the `.id` was indexed on `$taken`, a string, giving `jq: error: Cannot index string with string "id"` and exit 5.

Because `and` short-circuits, that clause is only reached once an entry has already matched `gpu_type`, `gpu_count`, `vram_gb` and `download_mbps` — so **the filter failed exactly when a 5090 was available, and looked healthy on every listing where none were**. Reproduced against a live listing: the run dies ~2 s in, before renting anything.

Binds the element to `$n` first, and skips non-object / field-missing entries instead of aborting — the listing churns and one malformed entry should not cost the rental.

Verified against a captured live listing: two distinct 5090 ids are selected, and the second correctly excludes the first.

Found while running the conformance job after setting `LIUM_API_KEY` — with the key in place this was the next failure. No pods were rented in any of the failed runs.