### PR TITLE
serving: a caller gets the characters the model wrote, not replacement characters

### DIFF
--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -101,11 +101,24 @@ class StreamAssembler:
                 if usage.get(name) is not None:
                     setattr(self, name, float(usage[name]))
 
+    def text(self) -> str:
+        """The completion as the caller should receive it.
+
+        A runtime decodes each token to text on its own, so a multibyte character split across two tokens arrives
+        as U+FFFD in both deltas: a completion reading "between **<r>U+2308 m/2 <r>U+2309**" where the model wrote
+        the ceiling brackets. The per-token bytes do not have that problem, so when every token reported them and
+        they decode cleanly they are the completion; otherwise the deltas stand as sent.
+        """
+        if not self.token_bytes or len(self.token_bytes) != len(self.tokens):
+            return self.content
+        decoded = b''.join(bytes(b) for b in self.token_bytes).decode('utf-8', 'replace')
+        return self.content if '\ufffd' in decoded else decoded
+
     def apply(self, synapse: InferenceSynapse) -> InferenceSynapse:
         """Write the assembled response onto ``synapse``; an unfinished stream leaves ``completion`` None (a miss)."""
         if not self.done:
             return synapse
-        synapse.completion = self.content
+        synapse.completion = self.text()
         synapse.served_model_id = self.model_id
         synapse.tokens = self.tokens or None
         synapse.token_ids = self.token_ids if self.token_ids and len(self.token_ids) == len(self.tokens) else None

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -2332,3 +2332,47 @@ def test_release_audit_bands_override_the_constants():
         loose.max_mean_abs_logprob_diff,
         loose.max_abs_logprob_diff,
     ).passed
+
+
+def test_completion_is_rebuilt_from_token_bytes_when_a_character_is_split():
+    """A multibyte character split across two tokens reaches the deltas as U+FFFD; the bytes still spell it.
+
+    Shape taken from a live 5090 serving the blessed pin: sparkinfer split U+2308 across two tokens, so the
+    caller received '**�⌈m/2�⌉**' for '**⌈m/2⌉**'.
+    """
+    from gittensor.serving.stream import StreamAssembler
+
+    ceiling, close = '⌈'.encode(), '⌉'.encode()  # 3 bytes each
+    pieces = [b'**', ceiling[:1], ceiling[1:], b'm/2', close[:1], close[1:], b'**']
+    a = StreamAssembler()
+    for raw in pieces:
+        a.content += raw.decode('utf-8', 'replace')  # what the runtime sent as delta text
+        a.tokens.append(raw.decode('utf-8', 'replace'))
+        a.token_bytes.append(list(raw))
+        a.token_logprobs.append(-0.1)
+    a.done = True
+
+    assert '�' in a.content  # the damage, as the runtime emitted it
+    assert a.text() == '**⌈m/2⌉**'
+    assert a.apply(InferenceSynapse(messages=MSGS, model_id='m')).completion == '**⌈m/2⌉**'
+
+
+def test_completion_keeps_the_deltas_when_the_bytes_cannot_be_trusted():
+    from gittensor.serving.stream import StreamAssembler
+
+    partial = StreamAssembler()  # a runtime that reports bytes for only some tokens
+    partial.content, partial.tokens = 'ab', ['a', 'b']
+    partial.token_bytes = [[97]]
+    partial.done = True
+    assert partial.text() == 'ab'
+
+    truncated = StreamAssembler()  # bytes that do not decode: keep what the caller was streamed
+    truncated.content, truncated.tokens = 'a�', ['a', '�']
+    truncated.token_bytes = [[97], [0xE2, 0x88]]
+    truncated.done = True
+    assert truncated.text() == 'a�'
+
+    none_reported = StreamAssembler()  # logprobs off: no bytes at all
+    none_reported.content, none_reported.tokens = 'hello', []
+    none_reported.done = True
+    assert none_reported.text() == 'hello'


### PR DESCRIPTION
Found during soak 7, on the blessed pin, on a real 5090.

A runtime decodes each token to text independently, so a **multibyte character split across two tokens** reaches the stream as U+FFFD in *both* deltas. A 384-token completion came back as:

```
between **<U+FFFD>⌈m/2<U+FFFD>⌉** and **m** children
```

where the model wrote `between **⌈m/2⌉** and **m** children`. The gateway returns that assembled text to the caller, so **this is what a paying user receives.**

Reproduced directly against the pod: of 384 tokens, every one reported `bytes`, none were missing, and `b''.join(token_bytes)` decodes to the correct text — only the concatenated `delta.content` is damaged. So the information was never lost, just discarded.

`StreamAssembler.text()` now assembles the completion from the per-token bytes when every token reported them and they decode cleanly; a partial or undecodable byte list leaves the deltas exactly as sent. The audit already treats those bytes as ground truth (#1724 binds the miner's token ids to them), so this makes the text the caller sees agree with the bytes the validator verifies.

This also removes one source of the `token ids do not spell the completion` soft miss: that check has to skip whenever either side carries U+FFFD, which is precisely when a character was split.

**Not fixed here:** streaming callers still receive the runtime's deltas verbatim. Repairing those needs buffering across token boundaries so a split character is held until complete — a separate change with real latency implications.

Tests use the exact token shape captured from the live pod. CI green (ruff, format, pyright, vulture, 760 tests).