### PR TITLE
serving: spread gateway traffic instead of sending it all to the top-scored miner

### DIFF
--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -15,6 +15,7 @@ Both threads also append to one request log (telemetry).
 """
 
 import math
+import random
 import threading
 import time
 from collections import deque
@@ -103,6 +104,7 @@ class ServingState:
     _sent_tokens: Dict[str, Deque[Tuple[float, int]]] = field(default_factory=dict)  # hotkey -> (ts, max_tokens)
     attest_round: int = 0
     last_round: dict = field(default_factory=dict)  # audit thread's summary of the last round, for /v1/serving/status
+    _rng: random.Random = field(default_factory=random.Random, repr=False)
     settlement_rounds: int = SERVING_SETTLEMENT_ROUNDS
     last_round_ts: float = 0.0
     ready_ttl_s: float = SERVING_READY_TTL_S
@@ -181,7 +183,12 @@ class ServingState:
             return list(self._ready.values()) if self._fresh() else []
 
     def acquire(self, release_id: Optional[str] = None, probation: bool = False) -> Optional[ReadyMiner]:
-        """Pick the READY miner (for ``release_id`` if given) with the fewest in-flight requests (ties -> higher score).
+        """Pick a READY miner (for ``release_id`` if given) with the fewest in-flight requests.
+
+        Among those, the choice is random, weighted by score: a better miner is sent more, but not everything.
+        Breaking the tie deterministically sends every request to one miner whenever requests do not overlap - at
+        one request per 20 s against sub-second completions, in-flight is always 0 - which loads that miner until
+        its own TTFT, and so its pay, falls, while the miner beside it is barely measured.
 
         With ``probation`` (baseline traffic) an idle probation miner is preferred, at most one request in flight
         each, so unverified miners get exactly the traffic they need to earn a window and no more.
@@ -203,9 +210,20 @@ class ServingState:
             candidates = [u for u, m in self._ready.items() if release_id is None or m.release_id == release_id]
             if not candidates:
                 return None
-            uid = min(candidates, key=lambda u: (self._inflight.get(u, 0), -self._ready[u].score))
+            fewest = min(self._inflight.get(u, 0) for u in candidates)
+            uid = self._weighted_choice([u for u in candidates if self._inflight.get(u, 0) == fewest])
             self._inflight[uid] = self._inflight.get(uid, 0) + 1
             return self._ready[uid]
+
+    def _weighted_choice(self, uids: List[int]) -> int:
+        """One of ``uids``, with probability proportional to score; uniform when no score separates them."""
+        if len(uids) == 1:
+            return uids[0]
+        weights = [max(0.0, self._ready[u].score) for u in uids]
+        total = sum(weights)
+        if total <= 0:
+            return self._rng.choice(uids)
+        return self._rng.choices(uids, weights=weights, k=1)[0]
 
     def release(self, uid: int) -> None:
         with self._lock:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import random
 import time
 from types import SimpleNamespace
 from typing import Dict
@@ -208,24 +209,54 @@ def _ready(uid: int, score: float = 1.0) -> ReadyMiner:
 
 
 def test_state_least_inflight_dispatch():
-    state = ServingState()
+    state = ServingState(_rng=random.Random(7))
     assert state.acquire() is None
     state.publish_round([_ready(1, 0.5), _ready(2, 1.0)], {})
     first = state.acquire()
-    assert first is not None and first.uid == 2  # tie on inflight -> higher score
-    second = state.acquire()
-    assert second is not None and second.uid == 1
-    third = state.acquire()
-    assert third is not None and third.uid == 2  # both at 1 inflight -> higher score again
-    state.release(2)
-    state.release(2)
-    again = state.acquire()
-    assert again is not None and again.uid == 2
+    assert first is not None
+    second = state.acquire()  # the idle miner is the only one with the fewest in flight
+    assert second is not None and second.uid != first.uid
+    assert state.inflight() == {1: 1, 2: 1}
+    state.release(first.uid)
+    again = state.acquire()  # ... and again once one of them frees up
+    assert again is not None and again.uid == first.uid
     state.publish_round([_ready(1)], {})
     only = state.acquire()
     assert only is not None and only.uid == 1
     state.record(RequestRecord(ts=0, kind='gateway', uid=1, ok=True, latency_ms=10))
     assert state.snapshot()['gateway_ok'] == 1
+
+
+def test_ready_routing_spreads_instead_of_always_picking_the_top_score():
+    """Soak 7: at one request per 20 s nothing overlaps, so a deterministic tie-break sent every request to one
+    miner - loading it until its own TTFT (1030 ms vs 461 ms) cut its credit to 0.68 while the other idled."""
+    from collections import Counter
+
+    state = ServingState(_rng=random.Random(0))
+    state.publish_round([_ready(1, 0.4), _ready(2, 1.0)], {})
+    picks = Counter()
+    for _ in range(400):
+        miner = state.acquire()
+        assert miner is not None
+        picks[miner.uid] += 1
+        state.release(miner.uid)
+    assert picks[1] > 0 and picks[2] > 0  # neither miner is starved of traffic
+    assert picks[2] > picks[1]  # the better-scoring miner is still preferred
+    assert state.inflight() == {1: 0, 2: 0}
+
+
+def test_ready_routing_is_uniform_when_no_score_separates_them():
+    from collections import Counter
+
+    state = ServingState(_rng=random.Random(1))
+    state.publish_round([_ready(1, 0.0), _ready(2, 0.0)], {})
+    picks = Counter()
+    for _ in range(200):
+        miner = state.acquire()
+        assert miner is not None
+        picks[miner.uid] += 1
+        state.release(miner.uid)
+    assert picks[1] > 0 and picks[2] > 0
 
 
 def test_acquire_filters_by_release():


### PR DESCRIPTION
Measured in soak 7, on two healthy 5090s.

`ServingState.acquire` picked `min(inflight, -score)`. At the soak's rate — one request per 20 s against sub-second completions — **requests never overlap, so in-flight is always 0** and the tie-break decides every single request. All of it went to one miner:

| | served | TTFT | credit |
|---|---|---|---|
| UID 16 | 12 | **1029 ms** | **0.681** |
| UID 27 | 3 | 461 ms | 0.945 |

Both cards are healthy and identical. The concentration is what raised UID 16's TTFT, and the TTFT band is what cut its pay — **the miner doing the work was paid less for doing it**, while the idle miner was barely measured at all. Left alone it oscillates: the loaded miner's score decays until it drops below the other, and then all the traffic swaps over.

Among the miners with the fewest in flight, the choice is now random weighted by score — a better miner is still sent more, neither is starved, and load no longer piles onto whoever is currently winning. `_rng` is a field on `ServingState` so tests are deterministic.

`test_state_least_inflight_dispatch` asserted the deterministic pick; it passed only because the default RNG happened to agree with it, so it was flaky as written. It now pins the part that is actually contractual (fewest in-flight wins outright) plus two distribution tests: weighted when scores differ, uniform when they do not.

This is the "weighted-random routing tie-break" item from `14-handoff` §5, with the soak numbers behind it. CI green (ruff, format, pyright, vulture, 760 tests).