### PR TITLE
serving: a replacement run stands for zero or more characters, not one or more

### DIFF
--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -494,13 +494,19 @@ def verify_served(
 
 def spells(ref_bytes: bytes, completion: str) -> bool:
     """Does the decoded reference text read as ``completion``? Every maximal run of replacement characters in the
-    completion stands for one or more non-ASCII characters (a multibyte character split across streamed chunks);
-    nothing else may differ, so ASCII cannot be added, dropped or changed behind a valid transcript."""
+    completion stands for zero or more non-ASCII characters; nothing else may differ, so ASCII cannot be added,
+    dropped or changed behind a valid transcript.
+
+    Zero, not one: a runtime that splits a multibyte character across two chunks decodes the first chunk on its
+    own and streams U+FFFD for it, then streams the whole character once its bytes are in - so the run is beside
+    the character it stands for rather than in place of it, and the reference has nothing there to consume.
+    Measured on the blessed pin in soak 7: the caller was streamed "**<r>U+2308 m/2 <r>U+2309**" where the
+    reference reads "**U+2308 m/2 U+2309**", and requiring one character per run failed honest miners."""
     text = ref_bytes.decode('utf-8', 'replace')
     if '\ufffd' not in completion:
         return text == completion
     pattern = ''.join(
-        f'[^\\x00-\\x7f]{{1,{len(run)}}}' if run.startswith('\ufffd') else re.escape(run)
+        f'[^\\x00-\\x7f]{{0,{len(run)}}}' if run.startswith('\ufffd') else re.escape(run)
         for run in re.findall('\ufffd+|[^\ufffd]+', completion)
     )
     return re.fullmatch(pattern, text, re.DOTALL) is not None

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -2407,3 +2407,23 @@ def test_completion_keeps_the_deltas_when_the_bytes_cannot_be_trusted():
     none_reported.content, none_reported.tokens = 'hello', []
     none_reported.done = True
     assert none_reported.text() == 'hello'
+
+
+def test_spells_accepts_a_character_the_runtime_re_emitted_after_the_damaged_chunk():
+    """Soak 7, blessed pin: the caller was streamed '**<FFFD>⌈m/2<FFFD>⌉**' where the reference reads
+    '**⌈m/2⌉**' — the runtime streamed U+FFFD for the split first chunk and then the whole character. The run
+    sits beside the character it stands for, not in place of it, so honest miners were being missed."""
+    from gittensor.serving.audit import spells
+
+    assert spells('**⌈m/2⌉** and **m** children'.encode(), '**�⌈m/2�⌉** and **m** children')
+    assert spells('a⌈b'.encode(), 'a�b')  # the run does stand in for the character
+    assert spells('a⌈b'.encode(), 'a��b')  # ... or for a run of them
+
+
+def test_spells_still_refuses_altered_or_dropped_ascii():
+    from gittensor.serving.audit import spells
+
+    assert not spells('abc'.encode(), 'a�')  # ASCII dropped behind a replacement run
+    assert not spells('abc'.encode(), 'abd')
+    assert not spells('a⌈bc'.encode(), 'a�bd')  # ASCII changed beside a valid run
+    assert not spells('ab'.encode(), 'a�b�c')  # ASCII added


### PR DESCRIPTION
An honest miner running the blessed pin was missed twice during soak 7 — `token ids do not spell the completion`, once at 384 tokens and again at 128. Both cost a window slot for a completion that was correct.

Captured directly from the pod: sparkinfer splits a multibyte character across two streamed chunks, decodes the first chunk on its own (so it streams **U+FFFD**), and then streams **the whole character** once the remaining bytes arrive. The caller receives

```
between **<FFFD>⌈m/2<FFFD>⌉** and **m** children
```

where the reference reads `between **⌈m/2⌉** and **m** children`.

`spells()` modelled a replacement run as standing *in place of* one or more non-ASCII characters (`{1,n}`). Here the run sits *beside* the character it stands for — the character is present too — so the reference has nothing at that position for the run to consume and the match fails. Verified against the captured strings: `{1,n}` → False, `{0,n}` → True.

Zero-or-more is what the runtime actually does. The guarantee the check exists for is unchanged: ASCII still cannot be added, dropped or changed behind a run, and the existing `not spells(b'hello', 'h<FFFD>llo')` case still refuses. Tests cover the re-emitted-character shape from the soak plus the alter/drop/add cases.

Related: #1732 removes the damage at source for the assembled completion (rebuilding it from per-token bytes), which fixes the same miss where every token reported bytes. This one covers the transcript check itself, which has to hold whenever bytes are missing or partial. They are independent and each stands alone.

CI green (ruff, format, pyright, vulture, 760 tests).