### PR TITLE
serving: a restart republishes READY from the durable store

### DIFF
--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -135,6 +135,20 @@ class ServingState:
             self.last_round = dict(summary or {})
             self.last_round_ts = time.time()
 
+    def seed_ready(self, miners: List[ReadyMiner], probation: Optional[List[ReadyMiner]] = None) -> None:
+        """Startup: republish the READY set derived from the durable store, without settling a score round.
+
+        Routing eligibility only — ``_history`` is untouched, so nothing is paid for a round this validator
+        did not run, and ``last_round_ts`` keeps the restored value: the TTL counts from the round that
+        actually measured these miners, so trust never outlives what an uninterrupted validator would have had.
+        """
+        with self._lock:
+            self._ready = {m.uid: m for m in miners}
+            self._probation = {m.uid: m for m in (probation or []) if m.uid not in self._ready}
+            live = set(self._ready) | set(self._probation)
+            self._inflight = {uid: self._inflight.get(uid, 0) for uid in live}
+            self.last_round = {'seeded': True, 'ready': len(self._ready), 'probation': len(self._probation)}
+
     def scores_for(self, hotkeys: Sequence[str]) -> Dict[int, float]:
         """Trailing-window settled scores keyed by current UID (missing rounds count 0); a UID whose hotkey
         changed since the rounds carries nothing over."""

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -75,6 +75,7 @@ class ServingStore:
                 [(uuid, hk, rnd) for uuid, (hk, rnd) in state.uuid_owner.items()],
             )
             db.execute('INSERT INTO meta VALUES (?, ?)', ('attest_round', str(int(state.attest_round))))
+            db.execute('INSERT INTO meta VALUES (?, ?)', ('last_round_ts', repr(float(state.last_round_ts))))
             db.executemany(
                 'INSERT INTO audit_values VALUES (?, ?, ?, ?)',
                 [(hk, rid, i, x) for hk, rid, xs in audits['values'] for i, x in enumerate(xs)],
@@ -120,6 +121,8 @@ class ServingStore:
                 for key, value in db.execute('SELECT key, value FROM meta'):
                     if key == 'attest_round':
                         state.attest_round = int(value)
+                    elif key == 'last_round_ts':
+                        state.last_round_ts = float(value)
                 for hk, credit in db.execute('SELECT hotkey, credit FROM last_credit'):
                     state.last_credit[str(hk)] = float(credit)
         except sqlite3.Error:

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -64,7 +64,7 @@ from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, Se
 from gittensor.serving.store import ServingStore
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
-from gittensor.validator.serving.attest import attest_round
+from gittensor.validator.serving.attest import attest_round, status_capacity
 from gittensor.validator.serving.persist import ServingRoundStorage
 from gittensor.validator.serving.scoring import request_speed
 from gittensor.validator.utils.config import SERVING_PAY_CAP_WITHOUT_PRICING, STORE_DB_RESULTS
@@ -471,6 +471,52 @@ async def audit_round(
     return scores
 
 
+def seed_ready_from_store(validator: 'Validator', state: ServingState, loadout=None) -> None:
+    """Startup: republish the READY set from the durable verdicts so a restart does not 429 the gateway.
+
+    Routing eligibility only — no scores settle from a seed, so nothing is paid for a round this validator did
+    not run. ``last_round_ts`` comes restored from the store and is left alone: a restart longer than the READY
+    TTL seeds nothing and the gateway waits for a live round, exactly as if the validator had never stopped.
+    """
+    if time.time() - state.last_round_ts > state.ready_ttl_s:
+        return
+    loadout = loadout or load_serving_loadout()
+    serving = get_serving_axons(validator)
+    active = [(uid, hotkey, axon) for uid, hotkey, axon in serving if not is_dormant(state, hotkey)]
+    best: Dict[str, Tuple[float, str]] = {}
+    quarantined: set[str] = set()
+    for release in loadout.releases:
+        for _, hotkey, _ in active:
+            window = state.audits.verdict(hotkey, release.release_id)
+            if window.quarantined_until > 0.0:
+                quarantined.add(hotkey)
+                continue
+            if not window.passed:
+                continue
+            # No measured credit on record pays nothing: the miner waits one live round in probation rather
+            # than taking user traffic on an assumed speed.
+            score = state.last_credit.get(hotkey, 0.0) * status_capacity(
+                state.attest_status.get(hotkey), state.attest_round
+            )
+            if score > best.get(hotkey, (0.0, ''))[0]:
+                best[hotkey] = (score, release.release_id)
+    ready: List[ReadyMiner] = []
+    probation: List[ReadyMiner] = []
+    fallback_release = loadout.primary.release_id
+    for uid, hotkey, axon in active:
+        score, release_id = best.get(hotkey, (0.0, ''))
+        if score > 0.0:
+            ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, release_id=release_id))
+        elif hotkey not in quarantined:
+            probation.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=0.0, release_id=fallback_release))
+    if ready or probation:
+        state.seed_ready(ready, probation)
+        bt.logging.info(
+            f'Serving: seeded READY {sorted(m.uid for m in ready)} · probation {sorted(m.uid for m in probation)} '
+            f'from the durable store ({time.time() - state.last_round_ts:.0f}s since its last round)'
+        )
+
+
 def update_dormancy(
     state: ServingState, serving: Sequence[Tuple[int, str, bt.AxonInfo]], served: Sequence[ServedRequest]
 ) -> None:
@@ -548,6 +594,10 @@ class ServingAuditThread:
         # connector caps a session at 100 connections, which would queue late miners on the validator and skew
         # their measured throughput. Uncapped connector for the audit dendrite only.
         dendrite._session = loop.run_until_complete(_unlimited_session())
+        try:
+            seed_ready_from_store(self.validator, self.state)
+        except Exception as e:  # a seed is best-effort: the first live round publishes either way
+            bt.logging.warning(f'Serving: could not seed READY from the durable store ({e!r})')
         # Validators audit on the same interval; a per-hotkey phase offset keeps their attest cohorts from landing on a
         # miner at the same instant and each reading half a card.
         self._stop.wait(probe_phase_offset(self.validator.wallet.hotkey.ss58_address, self.interval_s))

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -2427,3 +2427,50 @@ def test_spells_still_refuses_altered_or_dropped_ascii():
     assert not spells('abc'.encode(), 'abd')
     assert not spells('a⌈bc'.encode(), 'a�bd')  # ASCII changed beside a valid run
     assert not spells('ab'.encode(), 'a�b�c')  # ASCII added
+
+
+def test_store_persists_the_round_timestamp(tmp_path):
+    from gittensor.serving.store import ServingStore
+
+    store = ServingStore(tmp_path / 'serving.db')
+    state = ServingState()
+    state.last_round_ts = 123.5
+    store.save(state)
+    assert store.load(ServingState()).last_round_ts == 123.5
+
+
+def test_seed_ready_from_store_republishes_without_settling():
+    """A restart within the READY TTL republishes the durable verdicts so the gateway does not 429 until the
+    first live round; nothing settles from a seed, and a miner without a measured credit or attest on record
+    waits in probation rather than taking user traffic on an assumed speed."""
+    from gittensor.validator.serving import forward as fwd
+
+    release = _echo_release()
+    loadout = ServingLoadout(releases=[release])
+    axons = [SimpleNamespace(is_serving=True) for _ in range(5)]
+    validator = SimpleNamespace(
+        uid=0,
+        metagraph=SimpleNamespace(
+            hotkeys=['vali', 'hk1', 'hk2', 'hk3', 'hk4'], axons=axons, validator_trust=[0, 0, 0, 0, 0]
+        ),
+    )
+    state = ServingState()
+    for hk in ('hk1', 'hk2', 'hk4'):
+        for _ in range(6):
+            state.audits.record(hk, release.release_id, 1.0)
+    state.audits.strike('hk2', release.release_id)  # quarantined: neither READY nor probation
+    state.last_credit.update({'hk1': 0.9, 'hk2': 0.9})  # hk4 passed its window but has no measured credit
+    state.attest_status['hk1'] = {'passed': True, 'capacity': 2, 'round': 0}
+    state.attest_status['hk4'] = {'passed': True, 'capacity': 1, 'round': 0}
+    state.last_round_ts = time.time() - 60.0
+
+    fwd.seed_ready_from_store(validator, state, loadout=loadout)  # type: ignore[arg-type]
+    ready = state.ready_miners()
+    assert [(m.uid, m.release_id) for m in ready] == [(1, release.release_id)]
+    assert ready[0].score == pytest.approx(1.8)  # the last measured credit times the attested cards
+    assert state.snapshot()['probation_uids'] == [3, 4]
+    assert state.settled_scores() == {}  # a seed pays nothing
+
+    state.last_round_ts = time.time() - state.ready_ttl_s - 1.0
+    fwd.seed_ready_from_store(validator, state, loadout=loadout)  # type: ignore[arg-type]  # past the TTL: no trust
+    assert state.ready_miners() == []


### PR DESCRIPTION
Every validator redeploy 429s the gateway for ~5 minutes (seen on every soak redeploy; 16-handoff §3 item 5): `store.load()` restores the audit windows, `last_credit` and the attest verdicts, but the READY set is only ever set by `publish_round` at the end of a live audit round — and the audit loop's per-hotkey phase offset delays that first round by up to a full interval.

**Fix**
- `ServingStore` persists `last_round_ts` (a `meta` key) and restores it on load.
- At audit-loop start, `seed_ready_from_store` rebuilds READY/probation from the durable verdicts against the current metagraph: window passed and not quarantined, score = last measured credit × `status_capacity` of the persisted attest verdict. A hotkey with no measured credit or attest on record seeds into probation, never READY.
- The seed publishes through `ServingState.seed_ready`, which does **not** settle scores: `_history` is untouched, so nothing is paid for a round this validator did not run (the #1730 invariant — seeding restores routing eligibility, never payment). Settling through `publish_round` with empty scores would also have recorded a zero round against every hotkey with history.
- `last_round_ts` keeps the restored value, so the READY TTL (900 s) counts from the round that actually measured the miners: a quick redeploy is seamless, an outage past the TTL seeds nothing and waits for a live round — the same trust a validator that never stopped would have had. A dead-backend seeded READY drops out as misses within one round, same as in steady state.

https://claude.ai/code/session_0127EiXq8sXpk2k8vfW73xdp