### PR TITLE
conformance: pod_url died on every poll — backslashes in an f-string expression

### DIFF
--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -64,7 +64,10 @@ for p in json.load(sys.stdin):
     items = ports.items() if isinstance(ports, dict) else [(x.get("internal") or x.get("internal_port"), x.get("external") or x.get("external_port")) for x in ports]
     for internal, external in items:
         if str(internal) == port and external:
-            print(f"http://{p.get(\"ssh_ip\") or p.get(\"ip\")}:{external}")
+            # No backslashes or nested double quotes in the f-string: this program is single-quoted into
+            # python3 -c, and a backslash inside an f-string expression is a SyntaxError before 3.12.
+            host = p.get("ssh_ip") or p.get("ip")
+            print(f"http://{host}:{external}")
 ' "$1" "$2" || true
 }
 


### PR DESCRIPTION
Run 33437399771 (the first conformance attempt to get past renting) spent 54 minutes against two healthy, RUNNING pods it could not see: `pod_url()` is single-quoted into `python3 -c`, so its `\"` escapes reach Python literally, and a backslash inside an f-string expression is a SyntaxError before Python 3.12. Every port poll raised, `BASE` stayed empty, and the run failed with `runtime never answered on `.

Fix: hoist the host into a variable so the f-string needs no nested quotes at all.

https://claude.ai/code/session_0127EiXq8sXpk2k8vfW73xdp