### PR TITLE
Serving: pay per output token served; attestation becomes admission

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -152,7 +152,7 @@ RECYCLE_UID = 0
 
 # Combined scoring pool distributed by repository emission_share, then by per-repo PR/issue split.
 # Pools (OSS + SERVING) must sum to 1.0; anything unallocated within them recycles to RECYCLE_UID.
-OSS_EMISSION_SHARE = 0.965  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 37% of total)
+OSS_EMISSION_SHARE = 0.90  # repo emission_share values are fractions of THIS pool (sparkinfer 0.4 -> 36% of total)
 DEFAULT_ISSUE_DISCOVERY_SHARE = 0.5
 EMISSION_SHARE_TOLERANCE = 1e-9
 MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software, at maximum
@@ -160,49 +160,55 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # =============================================================================
 # Serving (sub-subnet B beta)
 # =============================================================================
-# Serving miners are paid an accounting price per verified GPU-hour, not a fixed slice: each READY card-equivalent
-# (capacity-weighted, so N hotkeys on one card sum to one card) earns SERVING_GPU_HOUR_USD, converted to an emission
-# share through the on-chain alpha/TAO price and the TAO/USD rate published in serving_loadout.json (`pricing`).
-# The share is capped at SERVING_EMISSION_SHARE_CAP; what the fleet does not earn recycles to RECYCLE_UID, never to
-# OSS. 2026-08-26 (2,950 alpha/day to miners, $0.85/alpha): $0.70/h funds ~5 cards inside the 3.5% cap. With no
-# price data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
+# Serving miners are paid per output token the gateway saw them serve, at a rate derived from the card-hour target:
+# rate = SERVING_GPU_HOUR_USD / (one card's aggregate decode tok/s x 3600), so a 5090 flat out for an hour (~1M
+# output tokens on the current runtime) earns exactly the card-hour and an idle one earns nothing. A round score is
+# those tokens in card-equivalents (tokens / (aggregate tok/s x round seconds)); the settled mean is priced at
+# SERVING_GPU_HOUR_USD, converted to an emission share through the on-chain alpha/TAO price and the TAO/USD rate
+# published in serving_loadout.json (`pricing`). No card count and no per-hotkey cap: served volume is the capacity
+# proof, and a real 5090 cannot out-decode its silicon. The only ceiling is SERVING_EMISSION_SHARE_CAP — above it the
+# fleet dilutes pro-rata by token share; what it does not earn recycles to RECYCLE_UID, never to OSS. With no price
+# data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
 SERVING_GPU_HOUR_USD = 0.70
-SERVING_EMISSION_SHARE_CAP = 0.035
+SERVING_EMISSION_SHARE_CAP = 0.10
+# Output tok/s one card sustains under load on the blessed runtime, for a release without its own
+# `speed.aggregate_decode_tps` (sparkinfer 7498736 on a 5090: 279-282 at 16 concurrent, 2026-08-27).
+SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 280.0
 # Pricing the cap needs the chain's alpha/TAO price and the published TAO/USD rate. A round that cannot read them
 # reuses the last usable pricing for up to SERVING_PRICING_MAX_AGE_S, so a chain hiccup does not move pay. With no
 # usable pricing at all the fleet is paid nothing: the alternative (the whole cap, split pro-rata) hands one verified
-# card 3.5% of emissions. A network with no price data to read - testnet - sets SERVING_PAY_CAP_WITHOUT_PRICING.
+# card the whole cap. A network with no price data to read - testnet - sets SERVING_PAY_CAP_WITHOUT_PRICING.
 SERVING_PRICING_MAX_AGE_S = 3600.0
 assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE, (
     'emission pools must sum to 1.0'
 )
 # Settlement is over the trailing hour: a miner's serving score is the mean of its last SERVING_SETTLEMENT_ROUNDS
-# round scores (missing rounds count 0), so a card verified for 45 of the last 60 minutes earns 75% of the price.
+# round scores (missing rounds count 0), so the hour's served tokens are what is priced. Shorten it to move pay
+# faster after a scoring change; the global moving_average_alpha is shared with OSS and is not the knob.
 SERVING_SETTLEMENT_ROUNDS = 12  # 12 x 5-minute audit rounds
 SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round is older than this
-# Hardware attestation (gittensor/validator/serving/attest.py, docker/attest). Each round a random
-# SERVING_ATTEST_COHORT_FRACTION of the READY miners (plus never-passed and last-round failures) is sent one fresh
-# seed at the same instant; the runtime image's gt_attest fills the card's free VRAM and runs a deterministic GEMM
-# chain. Expected digest and wall time come from the validator's own reference (same image). PASS needs the digest,
-# wall <= SERVING_ATTEST_BUDGET_RATIO x reference, and >= SERVING_ATTEST_MIN_FILL_RATIO of the free VRAM filled
-# (free = total - SERVING_VRAM_MODEL_RESERVED_BYTES; the release may override). Two hotkeys on one card cannot both
-# fill it at once (P(caught) = fraction^2 per round). Never a strike: capacity 0 that round, re-challenged next.
+# Hardware attestation (gittensor/validator/serving/attest.py, docker/attest) is admission, pass/fail per hotkey:
+# is there a real 5090 running the real model behind it? Nothing counts cards — pay is per token served. Each round
+# the least recently challenged SERVING_ATTEST_COHORT_FRACTION of the READY miners (plus never-passed and last-round
+# failures) is sent one fresh seed; the attest container's gt_attest fills the card's free VRAM and runs a
+# deterministic GEMM chain. Expected digest and wall time come from the validator's own reference (same image). A
+# card PASSES on the digest, wall <= SERVING_ATTEST_BUDGET_RATIO x reference, >= SERVING_ATTEST_MIN_FILL_RATIO of
+# the free VRAM filled (free = total - SERVING_VRAM_MODEL_RESERVED_BYTES; the release may override) and the model
+# resident; a hotkey passes with any passing card. Never a strike: not READY that round, re-challenged next.
 SERVING_ATTEST_COHORT_FRACTION = 0.5
 SERVING_ATTEST_ITERS = 3
 SERVING_ATTEST_BUDGET_RATIO = 1.6
 SERVING_ATTEST_MIN_FILL_RATIO = 0.6
 SERVING_ATTEST_TIMEOUT = 45.0  # seconds: fill + chain on a 5090 is ~1.5 s; queued challenges show up as slow
-SERVING_ATTEST_UUID_MEMORY_ROUNDS = 12  # a verdict (and a UUID claim) older than this pays nothing until renewed
-# Every field of a card's report except the digest is the miner's own number, so the count of cards is held to two
-# things the validator measures itself: each device index answers its own seed (seed + index), which the reference
-# recomputes, and the whole reply must arrive within one card's budget plus this network slack — gt_attest runs the
-# cards in parallel, so N real cards take one card's wall and one card faking N takes N of them. At most
-# SERVING_ATTEST_MAX_CARDS are judged (and priced) per hotkey.
+SERVING_ATTEST_MEMORY_ROUNDS = 12  # a verdict older than this admits nothing until renewed
+# Every field of a card's report except the digest is the miner's own number, so the whole reply must also arrive
+# within one card's budget plus this network slack. Each device index answers its own seed (seed + index); the
+# reference recomputes at most SERVING_ATTEST_MAX_CARDS of them per round.
 SERVING_ATTEST_RTT_SLACK_MS = 2_000.0
 SERVING_ATTEST_MAX_CARDS = 8
-# A card counts only with the model resident: free VRAM before the fill must be at most total minus this fraction of
-# the reservation (a bare 5090 shows ~32 GB free, one holding the model ~8 GB). Every passing card is a card-hour, so
-# a multi-GPU hotkey earns per card it actually serves from — a second card with nothing loaded earns nothing.
+# A card passes only with the model resident: free VRAM before the fill must be at most total minus this fraction of
+# the reservation (a bare 5090 shows ~32 GB free, one holding the model ~8 GB). A spare card with nothing loaded is
+# not a serving card.
 SERVING_ATTEST_MODEL_RESIDENT_RATIO = 0.8
 SERVING_VRAM_MODEL_RESERVED_BYTES = 24e9  # what sparkinfer holds with the model loaded (7498736 on a 5090: 23.7 GB)
 SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per round
@@ -212,7 +218,8 @@ SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per ro
 # falls linearly to 0 at ZERO, so a miner proxying to a GPU in another region or queueing requests loses credit
 # in proportion. Generation length does not enter (mini-soak 2026-08-27: total latency of 64-512-token answers
 # scored a perfect miner at 0.24). Same-region proxying is NOT visible here; that is the one-GPU-many-hotkeys
-# case, caught by the attestation overlap and the decode floor under load.
+# case, which pay-per-token makes pointless (the hotkeys split one card's tokens) and the decode floor catches
+# under load.
 SERVING_LATENCY_FULL_CREDIT_MS = 500.0
 SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
 # Decode speed on served traffic. Each served request with at least SERVING_DECODE_MIN_TOKENS completion tokens
@@ -221,7 +228,8 @@ SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
 # `speed.decode_per_request` curve, interpolated), so a miner busy with our own load is not penalised for it.
 # Credit = min(1, observed / expected); under SERVING_DECODE_FLOOR_RATIO it is 0 — a card shared between hotkeys or a
 # runtime that is not the blessed one is slower by integer factors under load, honest variance is +-10%. Round credit
-# is the mean over the round's served requests (misses 0), so availability, latency and speed price together.
+# is the mean over the round's served requests (misses 0); it is the routing weight, not a pay multiplier — a slow
+# card is sent less traffic and so serves fewer paid tokens.
 SERVING_DECODE_FLOOR_RATIO = 0.5
 SERVING_DECODE_TOLERANCE_RATIO = 0.8  # full credit down to this fraction of expected: the curve is measured on-box, the
 # validator observes stream delivery over the WAN (soak 5: honest cards read 0.75-0.96x); credit = min(1, ratio / this)

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -58,9 +58,11 @@ class ServingRelease:
     reference_api_key: Optional[str] = None  # bearer for a remote reference (sparkinfer --api-key)
     request_timeout: float = 60.0
     # Speed of one honest card on this exact runtime, measured at blessing time (scripts/check_serving_runtime.py
-    # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator prices capacity and latency
-    # against these, so the "one card" bar tracks the runtime as it gets faster. None -> the constants' defaults.
+    # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator credits speed against the
+    # curve and prices tokens against the aggregate, so the "one card" bar tracks the runtime as it gets faster and
+    # each release self-prices. None -> the constants' defaults.
     decode_per_request: Optional[Dict[int, float]] = None  # concurrent requests -> per-request decode tok/s, one card
+    aggregate_decode_tps: Optional[float] = None  # output tok/s one card sustains under load: the per-token rate's base
     # Attestation (docker/attest, image entrius/gt-attest — one container per box, beside the runtime). Miner side:
     # attest_url = that container (default: base_url host, port 8081). Validator side: attest_reference_url = the one
     # beside the reference (default: reference_url host, port 8081).
@@ -124,6 +126,7 @@ class ServingRelease:
             reference_api_key=raw.get('reference_api_key'),
             request_timeout=float(raw.get('request_timeout', 60.0)),
             decode_per_request={int(k): float(v) for k, v in (speed.get('decode_per_request') or {}).items()} or None,
+            aggregate_decode_tps=_optional_float(speed.get('aggregate_decode_tps')),
             attest_image=attest.get('image'),
             attest_url=attest.get('url') or _sidecar_url(raw.get('base_url')),
             attest_api_key=attest.get('api_key') or os.getenv('SERVING_ATTEST_API_KEY') or None,

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -10,8 +10,10 @@ to the audit loop (``enqueue_served`` / ``drain_served``) to be verified against
 the reference: served traffic *is* the audit. Miners that are not yet READY sit
 in *probation* and only receive traffic from baseline keys, so a new miner can
 earn a window without a real user ever hitting an unverified card. Per-round
-scores are settled over the trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds.
-Both threads also append to one request log (telemetry).
+pay scores (served tokens in card-equivalents) are settled over the trailing
+``SERVING_SETTLEMENT_ROUNDS`` rounds; a READY miner's ``score`` is its routing
+weight (speed credit), separate from pay. Both threads also append to one
+request log (telemetry).
 """
 
 import math
@@ -33,7 +35,7 @@ class ReadyMiner:
     uid: int
     hotkey: str
     axon: bt.AxonInfo
-    score: float
+    score: float  # routing weight: the last measured speed credit
     release_id: str = ''  # release this miner passed audits for
 
 
@@ -99,7 +101,6 @@ class ServingState:
     _history: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> last N round scores
     dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
     attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
-    uuid_owner: Dict[str, Tuple[str, int]] = field(default_factory=dict)  # GPU UUID -> (hotkey, round last seen)
     last_credit: Dict[str, float] = field(default_factory=dict)  # audit thread only: hotkey -> last measured credit
     _sent_tokens: Dict[str, Deque[Tuple[float, int]]] = field(default_factory=dict)  # hotkey -> (ts, max_tokens)
     attest_round: int = 0
@@ -116,7 +117,7 @@ class ServingState:
         probation: Optional[List[ReadyMiner]] = None,
         summary: Optional[dict] = None,
     ) -> None:
-        """Audit thread: publish the READY and probation sets for the gateway and settle this round's scores.
+        """Audit thread: publish the READY and probation sets for the gateway and settle this round's pay scores.
 
         Every hotkey with history and no score this round records a 0, so a miner that vanishes stops earning
         within one settlement window.

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -25,7 +25,6 @@ CREATE TABLE IF NOT EXISTS quarantine (hotkey TEXT, release_id TEXT, until REAL,
 CREATE TABLE IF NOT EXISTS round_history (hotkey TEXT, seq INTEGER, score REAL, PRIMARY KEY (hotkey, seq));
 CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
 CREATE TABLE IF NOT EXISTS attest (hotkey TEXT PRIMARY KEY, status TEXT);
-CREATE TABLE IF NOT EXISTS uuid_owner (uuid TEXT PRIMARY KEY, hotkey TEXT, round INTEGER);
 CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
 CREATE TABLE IF NOT EXISTS last_credit (hotkey TEXT PRIMARY KEY, credit REAL);
 """
@@ -64,16 +63,11 @@ class ServingStore:
                 'round_history',
                 'dormant',
                 'attest',
-                'uuid_owner',
                 'meta',
                 'last_credit',
             ):
                 db.execute(f'DELETE FROM {table}')
             db.executemany('INSERT INTO last_credit VALUES (?, ?)', list(state.last_credit.items()))
-            db.executemany(
-                'INSERT INTO uuid_owner VALUES (?, ?, ?)',
-                [(uuid, hk, rnd) for uuid, (hk, rnd) in state.uuid_owner.items()],
-            )
             db.execute('INSERT INTO meta VALUES (?, ?)', ('attest_round', str(int(state.attest_round))))
             db.execute('INSERT INTO meta VALUES (?, ?)', ('last_round_ts', repr(float(state.last_round_ts))))
             db.executemany(
@@ -116,8 +110,6 @@ class ServingStore:
                     state.dormant_rounds[hk] = int(rounds)
                 for hk, st in db.execute('SELECT hotkey, status FROM attest'):
                     state.attest_status[hk] = json.loads(st)
-                for uuid, hk, rnd in db.execute('SELECT uuid, hotkey, round FROM uuid_owner'):
-                    state.uuid_owner[str(uuid)] = (str(hk), int(rnd))
                 for key, value in db.execute('SELECT key, value FROM meta'):
                     if key == 'attest_round':
                         state.attest_round = int(value)

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -41,9 +41,10 @@ def blend_emission_pools(
     is carved off the top and split evenly among those maintainers; the
     remainder scores normally. Repos with no listed maintainers are unaffected.
 
-    ``serving_scores`` are settled card-equivalents per UID; ``serving_share``
-    prices them at ``SERVING_GPU_HOUR_USD`` inside ``SERVING_EMISSION_SHARE_CAP``
-    and the pool is split pro-rata. Whatever the fleet does not earn recycles.
+    ``serving_scores`` are settled card-equivalents per UID (served output tokens
+    over what one card decodes in the hour); ``serving_share`` prices them at
+    ``SERVING_GPU_HOUR_USD`` inside ``SERVING_EMISSION_SHARE_CAP`` and the pool is
+    split pro-rata by token share. Whatever the fleet does not earn recycles.
     """
     sorted_uids = sorted(miner_uids)
     uid_index = {uid: idx for idx, uid in enumerate(sorted_uids)}
@@ -63,7 +64,7 @@ def blend_emission_pools(
         for uid, reward in allocation.issue_discovery_rewards.items():
             rewards[uid_index[uid]] += reward
 
-    # Serving pool: priced per verified GPU-hour inside the cap; unclaimed recycles.
+    # Serving pool: served tokens priced as card-hours inside the cap; unclaimed recycles.
     if SERVING_EMISSION_SHARE_CAP > 0:
         card_equiv = sum(serving_scores.values()) if serving_scores else 0.0
         share = serving_share(card_equiv, serving_pricing, allow_unpriced_cap)
@@ -203,11 +204,11 @@ def _repo_has_scorers(
 
 
 def serving_share(card_equiv: float, pricing: Optional[ServingPricing], allow_unpriced_cap: bool = False) -> float:
-    """Emission share that pays ``card_equiv`` verified cards ``SERVING_GPU_HOUR_USD`` each, capped.
+    """Emission share that pays ``card_equiv`` card-hours of served tokens ``SERVING_GPU_HOUR_USD`` each, capped.
 
     Without usable pricing the pool pays nothing and recycles, unless ``allow_unpriced_cap`` — a network with no
     price to read (testnet) — where the whole cap is paid pro-rata. Paying the cap on a priced network would hand
-    one verified card 3.5% of emissions the moment a price read failed.
+    one verified card the whole cap the moment a price read failed.
     """
     if card_equiv <= 0:
         return 0.0

--- a/gittensor/validator/serving/attest.py
+++ b/gittensor/validator/serving/attest.py
@@ -1,31 +1,25 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-"""Hardware attestation of serving miners (sub-subnet B beta).
+"""Hardware attestation of serving miners (sub-subnet B beta): admission, pass/fail per hotkey.
 
-Each round the least recently challenged half of the READY miners (plus every miner that has never passed and every
-miner that failed last round) is sent one fresh ``AttestSynapse`` — same seed, same instant. The miner's attest
-sidecar (docker/attest, image ``entrius/gt-attest``) answers with ``gt_attest`` on every GPU it can see, all at once:
-device ``i`` fills its free VRAM with a seeded stream and runs a deterministic fp32 GEMM chain on ``seed + i``,
-returning the GPU's UUID, bytes filled, a SHA-256 digest and wall time. The validator asks its own reference sidecar
-(same image) for index 0 first, and for each further index a miner claims, so every expected digest comes from an
-honest 5090 — no GPU code runs in the validator process.
+Attestation answers one question — is there a real 5090 running the real model behind this hotkey? — and nothing
+here counts cards: pay is per token served (forward.py), and a card cannot serve more tokens than its silicon
+decodes. Each round the least recently challenged half of the READY miners (plus every miner that has never passed
+and every miner that failed last round) is sent one fresh ``AttestSynapse``. The miner's attest sidecar
+(docker/attest, image ``entrius/gt-attest``) answers with ``gt_attest`` on every GPU it can see, all at once: device
+``i`` fills its free VRAM with a seeded stream and runs a deterministic fp32 GEMM chain on ``seed + i``, returning the
+GPU's UUID, bytes filled, a SHA-256 digest and wall time. The validator asks its own reference sidecar (same image)
+for index 0 first, and for each further index a miner claims, so every expected digest comes from an honest 5090 —
+no GPU code runs in the validator process.
 
 What the validator can measure itself is the digest and the round trip; every other field of a card's report is the
 miner's own number. So a card PASSES when its digest matches its index's, its wall is within
 ``SERVING_ATTEST_BUDGET_RATIO`` x the reference's, most of its free VRAM was filled and the model was resident before
-the fill — and the whole reply arrived within that budget plus ``SERVING_ATTEST_RTT_SLACK_MS``. Cards run in parallel
-on an honest box, so N cards take one card's wall; one card faking N runs the chain N times and misses the round trip.
-A hotkey's ``capacity`` is its passing cards (at most ``SERVING_ATTEST_MAX_CARDS``).
-
-Overlap is the mechanism against sharing: two hotkeys fronting one card cannot both fill its free VRAM at the same
-instant and their chains run ~2x slower, so a sharing pair is caught within a few rounds (P = fraction^2 per round).
-A GPU UUID belongs to the first hotkey that passed with it; another hotkey reporting the same UUID loses that card
-while the holder keeps it (a claim lapses after ``SERVING_ATTEST_UUID_MEMORY_ROUNDS`` unrenewed rounds). Two hotkeys
-claiming an unowned UUID in the same round both fail it. A failure is never a strike: capacity 0 for the round,
-re-challenged next round. Miners not in the cohort keep their last verdict until it is older than the memory window;
-a miner with no verdict yet is not READY (admission). A fault in this module is neutral for the cohort, never fatal
-for the round.
+the fill — and the whole reply arrived within that budget plus ``SERVING_ATTEST_RTT_SLACK_MS``. A hotkey passes with
+any passing card. A failure is never a strike: not READY for the round, re-challenged next round. Miners not in the
+cohort keep their last verdict until it is older than ``SERVING_ATTEST_MEMORY_ROUNDS``; a miner with no verdict yet
+is not READY. A fault in this module is neutral for the cohort, never fatal for the round.
 """
 
 import asyncio
@@ -42,11 +36,11 @@ from gittensor.constants import (
     SERVING_ATTEST_COHORT_FRACTION,
     SERVING_ATTEST_ITERS,
     SERVING_ATTEST_MAX_CARDS,
+    SERVING_ATTEST_MEMORY_ROUNDS,
     SERVING_ATTEST_MIN_FILL_RATIO,
     SERVING_ATTEST_MODEL_RESIDENT_RATIO,
     SERVING_ATTEST_RTT_SLACK_MS,
     SERVING_ATTEST_TIMEOUT,
-    SERVING_ATTEST_UUID_MEMORY_ROUNDS,
     SERVING_VRAM_MODEL_RESERVED_BYTES,
 )
 from gittensor.serving.loadout import ServingRelease
@@ -84,10 +78,6 @@ class AttestVerdict:
     cards: List[CardVerdict] = field(default_factory=list)
 
     @property
-    def capacity(self) -> int:
-        return sum(1 for c in self.cards if c.passed)
-
-    @property
     def uuids(self) -> List[str]:
         return [c.uuid for c in self.cards if c.passed and c.uuid]
 
@@ -97,7 +87,6 @@ class AttestVerdict:
             'reason': self.reason,
             'uuid': self.uuid,
             'uuids': self.uuids,
-            'capacity': self.capacity,
             'cards': [c.as_dict() for c in self.cards],
             'wall_ms': self.wall_ms,
             'filled_bytes': self.filled_bytes,
@@ -106,17 +95,14 @@ class AttestVerdict:
         }
 
 
-def status_capacity(
-    status: Optional[dict], round_no: Optional[int] = None, memory_rounds: int = SERVING_ATTEST_UUID_MEMORY_ROUNDS
-) -> int:
-    """Cards a stored attest status pays for (statuses persisted before ``capacity`` existed count one card). A
-    verdict older than ``memory_rounds`` — a miner the reference could not re-challenge for that long — pays nothing
-    until it is renewed."""
+def status_passed(
+    status: Optional[dict], round_no: Optional[int] = None, memory_rounds: int = SERVING_ATTEST_MEMORY_ROUNDS
+) -> bool:
+    """Does a stored attest status still admit the hotkey? A verdict older than ``memory_rounds`` — a miner the
+    reference could not re-challenge for that long — admits nothing until it is renewed."""
     if not status or not status.get('passed'):
-        return 0
-    if round_no is not None and round_no - int(status.get('round', round_no)) > memory_rounds:
-        return 0
-    return int(status.get('capacity', 1))
+        return False
+    return round_no is None or round_no - int(status.get('round', round_no)) <= memory_rounds
 
 
 def choose_cohort(
@@ -126,8 +112,7 @@ def choose_cohort(
     membership is still unpredictable), plus every never-attested hotkey and every last-round failure.
 
     Pure random sampling let one hotkey go unchallenged for many rounds (soak 6: the other of two was drawn three
-    rounds running); with recency first, every hotkey is challenged at least every ``1/fraction`` rounds while a
-    sharing pair still lands together within a few rounds.
+    rounds running); with recency first, every hotkey is challenged at least every ``1/fraction`` rounds.
     """
     rng = rng or secrets.SystemRandom()
     pool = list(hotkeys)
@@ -235,9 +220,9 @@ def judge(
     max_cards: int = SERVING_ATTEST_MAX_CARDS,
 ) -> AttestVerdict:
     """Every card the sidecar reported is judged on its own against its index's expected digest; the hotkey passes
-    with any passing card and its capacity is the count. ``elapsed_ms`` is the validator's own round trip for the
-    whole reply: past one card's budget plus the slack, no card passes, however each card's own wall reads. The
-    reason names the first failing card when one fails."""
+    with any passing card. ``elapsed_ms`` is the validator's own round trip for the whole reply: past one card's
+    budget plus the slack, no card passes, however each card's own wall reads. The reason names the first failing
+    card when one fails."""
     if response is None or response.devices is None:
         detail = getattr(response, 'error', None) or getattr(
             getattr(response, 'dendrite', None), 'status_message', None
@@ -308,61 +293,6 @@ async def send_challenges(
     return {hotkey: resp for (_, hotkey, _), resp in zip(targets, results)}
 
 
-def claim_uuids(
-    state: ServingState,
-    judged: Dict[str, AttestVerdict],
-    round_no: int,
-    memory_rounds: int = SERVING_ATTEST_UUID_MEMORY_ROUNDS,
-) -> Dict[str, List[str]]:
-    """Settle GPU ownership for this round's passing cards; hotkey -> UUIDs it loses.
-
-    A UUID belongs to the first hotkey that passed with it and stays its own while the claim is renewed within
-    ``memory_rounds``. Another hotkey reporting the holder's UUID loses that card; the holder keeps it — so a card
-    cannot be taken from a miner by naming its UUID. Two hotkeys naming an unowned UUID in the same round are the
-    sharing case the overlap is there to catch: both lose it.
-    """
-    for uuid, (owner, seen) in list(state.uuid_owner.items()):
-        if round_no - seen > memory_rounds:
-            del state.uuid_owner[uuid]
-    claims: Dict[str, List[str]] = {}
-    for hk in sorted(judged):
-        for uuid in judged[hk].uuids:
-            claims.setdefault(uuid, []).append(hk)
-    lost: Dict[str, List[str]] = {}
-    for uuid, hks in sorted(claims.items()):
-        owner = state.uuid_owner.get(uuid)
-        if owner is not None and owner[0] in hks:
-            keep: Optional[str] = owner[0]
-        elif len(hks) == 1 and owner is None:
-            keep = hks[0]
-        else:
-            keep = None  # unowned and contested this round (sharing), or owned by someone not answering now
-        if keep is not None:
-            state.uuid_owner[uuid] = (keep, round_no)
-        for hk in hks:
-            if hk != keep:
-                lost.setdefault(hk, []).append(uuid)
-    return lost
-
-
-def _apply_lost_cards(state: ServingState, hk: str, uuids: List[str]) -> None:
-    st = dict(state.attest_status.get(hk, {}))
-    cards = []
-    for card in st.get('cards', []):
-        if card.get('passed') and card.get('uuid') in uuids:
-            card = {**card, 'passed': False, 'reason': f'duplicate GPU {card.get("uuid")} (held by another hotkey)'}
-        cards.append(card)
-    passing = [c for c in cards if c.get('passed')]
-    st.update(
-        cards=cards,
-        uuids=[c['uuid'] for c in passing if c.get('uuid')],
-        capacity=len(passing),
-        passed=bool(passing),
-        reason=f'duplicate GPU {uuids[0]} (held by another hotkey)' if not passing else st.get('reason', 'ok'),
-    )
-    state.attest_status[hk] = st
-
-
 async def attest_round(
     state: ServingState,
     dendrite: bt.Dendrite,
@@ -370,20 +300,19 @@ async def attest_round(
     release: ServingRelease,
     rng=None,
     timeout: float = SERVING_ATTEST_TIMEOUT,
-) -> Dict[str, int]:
-    """Challenge this round's cohort, update ``state.attest_status``; return hotkey -> attested cards (0 = not
-    attested) for every candidate.
+) -> Dict[str, bool]:
+    """Challenge this round's cohort, update ``state.attest_status``; return hotkey -> admitted for every candidate.
 
-    Without an ``attest_reference_url`` (localnet / echo) attestation is off and every candidate counts as one card.
+    Without an ``attest_reference_url`` (localnet / echo) attestation is off and every candidate is admitted.
     If the reference itself fails, or anything in here does, nothing changes this round (neutral).
     """
     round_no = state.attest_round = getattr(state, 'attest_round', 0) + 1
     if not release.attest_reference_url:
-        return {hk: 1 for _, hk, _ in candidates}
+        return {hk: True for _, hk, _ in candidates}
     hotkeys = [hk for _, hk, _ in candidates]
 
-    def carried() -> Dict[str, int]:
-        return {hk: status_capacity(state.attest_status.get(hk), round_no) for hk in hotkeys}
+    def carried() -> Dict[str, bool]:
+        return {hk: status_passed(state.attest_status.get(hk), round_no) for hk in hotkeys}
 
     try:
         return await _attest_round(state, dendrite, candidates, release, round_no, rng, timeout)
@@ -400,7 +329,7 @@ async def _attest_round(
     round_no: int,
     rng,
     timeout: float,
-) -> Dict[str, int]:
+) -> Dict[str, bool]:
     hotkeys = [hk for _, hk, _ in candidates]
     cohort = set(choose_cohort(hotkeys, state.attest_status, rng=rng))
     seed = secrets.randbits(62)
@@ -409,7 +338,7 @@ async def _attest_round(
         expected0, ref_wall = await asyncio.to_thread(reference_challenge, release, seed, iters, timeout)
     except Exception as e:
         bt.logging.error(f'Serving: reference attestation failed, attest neutral this round: {e!r}')
-        return {hk: status_capacity(state.attest_status.get(hk), round_no) for hk in hotkeys}
+        return {hk: status_passed(state.attest_status.get(hk), round_no) for hk in hotkeys}
     targets = [(uid, hk, axon) for uid, hk, axon in candidates if hk in cohort]
     responses = await send_challenges(dendrite, targets, seed, iters, timeout)
     # One reference digest per device index any miner claimed (index i answers seed + i), at most MAX_CARDS.
@@ -422,20 +351,14 @@ async def _attest_round(
             bt.logging.warning(f'Serving: reference attestation for device index {i} failed: {e!r}')
             digests[i] = None
     now = time.time()
-    judged: Dict[str, AttestVerdict] = {}
     for uid, hk, _ in targets:
         resp, elapsed = responses.get(hk, (None, 0.0))
         verdict = judge(resp, lambda i: digests.get(i), ref_wall, release, elapsed_ms=elapsed)
-        judged[hk] = verdict
         state.attest_status[hk] = verdict.as_status(now, round_no)
         bt.logging.info(
             f'Serving: UID {uid} attest {"PASS" if verdict.passed else "FAIL"} '
             f'{verdict.wall_ms or 0:.0f} ms (ref {ref_wall:.0f}, rtt {elapsed:.0f}) fill '
-            f'{verdict.filled_bytes / 1e9:.1f} GB cards {verdict.capacity}/{len(verdict.cards)} '
+            f'{verdict.filled_bytes / 1e9:.1f} GB cards {len(verdict.uuids)}/{len(verdict.cards)} '
             f'uuid {verdict.uuid or "-"}{"" if verdict.reason.startswith("ok") else " — " + verdict.reason}'
         )
-    for hk, uuids in claim_uuids(state, judged, round_no).items():
-        uid = next((u for u, h, _ in candidates if h == hk), '?')
-        bt.logging.warning(f'Serving: UID {uid} attest FAIL — duplicate GPU {uuids[0]} across hotkeys')
-        _apply_lost_cards(state, hk, uuids)
-    return {hk: status_capacity(state.attest_status.get(hk), round_no) for hk in hotkeys}
+    return {hk: status_passed(state.attest_status.get(hk), round_no) for hk in hotkeys}

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -16,15 +16,21 @@ wipes the window and quarantines the hotkey. Miners whose window passes are
 published READY; serving axons that are not READY (and not quarantined) are
 published as *probation* so baseline traffic can give them a window.
 
-    round score = window passes (0/1) x mean speed credit over this round's served requests x attested cards
+    admitted    = window passes x speed credit > 0 x hardware attestation passes
+    round score = admitted x output tokens the gateway saw the miner serve, in card-equivalents
 
-Speed credit is measured on served traffic only (TTFT and decode rate against the
-blessing's curve at the load this validator imposed; ``scoring.py``); a round with
-nothing verified freezes at the last measured credit. ``attested cards`` is the
-miner's last hardware attestation verdict (``attest.py``: the least recently
-challenged half of the READY miners is challenged every round; a miner with no
-verdict yet stays on probation). Round scores are settled over the trailing
-``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
+Pay is per token served, counted from the gateway's own served-request records
+(never the miner's word) and priced against the release's aggregate decode speed
+(``scoring.card_equivalents``): a card flat out for the hour earns one card-hour,
+an idle one nothing, and no card count or per-hotkey cap enters — the only
+ceiling is the emission pool. Speed credit is measured on served traffic only
+(TTFT and decode rate against the blessing's curve at the load this validator
+imposed; ``scoring.py``) and is the READY miner's routing weight, so a slow card
+is sent less and serves fewer paid tokens; a round with nothing verified freezes
+at the last measured credit. Attestation (``attest.py``) is pass/fail admission:
+the least recently challenged half of the READY miners is challenged every round;
+a miner with no verdict yet stays on probation. Round scores are settled over the
+trailing ``SERVING_SETTLEMENT_ROUNDS`` rounds by ``ServingState``.
 """
 
 import asyncio
@@ -64,10 +70,14 @@ from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, Se
 from gittensor.serving.store import ServingStore
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
-from gittensor.validator.serving.attest import attest_round, status_capacity
+from gittensor.validator.serving.attest import attest_round, status_passed
 from gittensor.validator.serving.persist import ServingRoundStorage
-from gittensor.validator.serving.scoring import request_speed
-from gittensor.validator.utils.config import SERVING_PAY_CAP_WITHOUT_PRICING, STORE_DB_RESULTS
+from gittensor.validator.serving.scoring import card_equivalents, paid_tokens, request_speed, token_rate_usd
+from gittensor.validator.utils.config import (
+    SERVING_AUDIT_INTERVAL_S,
+    SERVING_PAY_CAP_WITHOUT_PRICING,
+    STORE_DB_RESULTS,
+)
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -149,21 +159,30 @@ def verify_served_round(
     last_miss: Optional[Dict[str, str]] = None,
     rng=None,
     staked_caller: bool = False,
-) -> Dict[str, List[RequestSpeed]]:
+) -> Tuple[Dict[str, List[RequestSpeed]], Dict[str, int]]:
     """Verify this round's audit sample of the requests served for ``release`` into the window; return per-request
-    speed per hotkey.
+    speed per hotkey and the output tokens each hotkey is paid for.
 
-    Reference calls run on a small thread pool; window updates stay on this thread. ``last_miss`` (hotkey ->
-    reason) is filled with the most recent miss or strike reason so the round report can show a miner why.
-    ``staked_caller``: this validator clears the miner's stake floor, so no miner has a budget to refuse it on.
+    Paid tokens are what the gateway saw served on user traffic: every unsampled completion, and every sampled one
+    the reference did not fail. Baseline prompts anchor eligibility, not income. Reference calls run on a small
+    thread pool; window updates stay on this thread. ``last_miss`` (hotkey -> reason) is filled with the most
+    recent miss or strike reason so the round report can show a miner why. ``staked_caller``: this validator clears
+    the miner's stake floor, so no miner has a budget to refuse it on.
     """
     summary = summary if summary is not None else {}
     last_miss = last_miss if last_miss is not None else {}
+    tokens: Dict[str, int] = {}
+
+    def pay(req: ServedRequest) -> None:
+        if req.source == 'gateway' and req.ok:
+            tokens[req.hotkey] = tokens.get(req.hotkey, 0) + paid_tokens(req)
+
     mine, skipped = sample_for_audit([req for req in served if req.release_id == release.release_id], rng=rng)
     for req in skipped:
         summary['served'] = summary.get('served', 0) + 1
         summary[req.source] = summary.get(req.source, 0) + 1
         summary['unsampled'] = summary.get('unsampled', 0) + 1
+        pay(req)
 
     def judge(req: ServedRequest) -> Optional[AuditVerdict]:
         if not req.ok and 'budget' in req.detail.lower() and budget_refusal_plausible(state, req.hotkey, staked_caller):
@@ -226,7 +245,10 @@ def verify_served_round(
         bump(req.source)
         if verdict is None:
             bump('neutral')
+            pay(req)
             continue
+        if verdict.passed:
+            pay(req)
         if not verdict.passed and not verdict.hard and req.uid in ready_uids:
             bt.logging.info(
                 f'Serving: READY UID {req.uid} missed a {req.source} request ({verdict.reason}; '
@@ -260,7 +282,7 @@ def verify_served_round(
                 detail=verdict.reason,
             )
         )
-    return speeds
+    return speeds, tokens
 
 
 def _mean(xs: List[float]) -> Optional[float]:
@@ -358,8 +380,10 @@ async def audit_round(
     loadout=None,
     attest_rng=None,
     staked_caller: bool = False,
+    round_s: float = SERVING_AUDIT_INTERVAL_S,
 ) -> Dict[str, float]:
-    """Verify served traffic, settle windows, attest READY miners; publish READY/probation; return hotkey -> score."""
+    """Verify served traffic, settle windows, attest READY miners; publish READY/probation; return hotkey -> pay
+    score (served tokens in card-equivalents over ``round_s``, the wall clock the tokens were served in)."""
     loadout = loadout or load_serving_loadout()
     served = state.drain_served()
     if not serving:
@@ -371,7 +395,8 @@ async def audit_round(
     active = [(uid, hotkey, axon) for uid, hotkey, axon in serving if not is_dormant(state, hotkey)]
     dormant = len(serving) - len(active)
 
-    best: Dict[str, Tuple[float, str]] = {hotkey: (0.0, '') for _, hotkey, _ in active}
+    # Per admitted hotkey, the release it is READY for: (pay, routing weight, release_id), best pay first.
+    admitted: Dict[str, Tuple[float, float, str]] = {}
     axon_of = {uid: axon for uid, _, axon in serving}
     probation: Dict[int, ReadyMiner] = {}
     summary: Dict[str, int] = {}
@@ -387,7 +412,9 @@ async def audit_round(
                 'set SERVING_REFERENCE_URL to a conformant runtime'
             )
             continue
-        speeds = verify_served_round(state, reference, release, served, summary, last_miss, staked_caller=staked_caller)
+        speeds, tokens = verify_served_round(
+            state, reference, release, served, summary, last_miss, staked_caller=staked_caller
+        )
         passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
         for uid, hotkey, axon in active:
             window = state.audits.verdict(hotkey, release.release_id)
@@ -406,13 +433,14 @@ async def audit_round(
                 'credit': round(credit, 4),
                 'ttft_ms': _mean([sp.ttft_ms for sp in round_speeds if sp.ttft_ms is not None]),
                 'decode_tps': _mean([sp.decode_tps for sp in round_speeds if sp.decode_tps is not None]),
-                'capacity': 0.0,
+                'tokens': tokens.get(hotkey, 0),
+                'attested': False,
                 'score': 0.0,
                 'last_miss': last_miss.get(hotkey, ''),
             }
             bt.logging.debug(
                 f'Serving: UID {uid} {release.release_id} window {window.as_dict()} '
-                f'served {len(round_speeds)} credit {credit:.3f}'
+                f'served {len(round_speeds)} credit {credit:.3f} tokens {tokens.get(hotkey, 0)}'
             )
             if window.passed and credit > 0.0:
                 passing.append((uid, hotkey, axon, credit))
@@ -424,13 +452,13 @@ async def audit_round(
             state, dendrite, [(uid, hotkey, axon) for uid, hotkey, axon, _ in passing], release, rng=attest_rng
         )
         for uid, hotkey, _, credit in passing:
-            cards = int(attested.get(hotkey, 0))
-            ok = cards > 0
-            score = credit * cards  # one card-hour per attested card at this speed
+            ok = bool(attested.get(hotkey, False))
+            # Pay is what the gateway saw served, nothing else: an admitted card with no traffic earns nothing.
+            score = card_equivalents(windows[uid]['tokens'], release, round_s) if ok else 0.0
             st = state.attest_status.get(hotkey, {})
             bt.logging.info(
-                f'Serving: UID {uid} {release.release_id} attested {"yes" if ok else "no"} cards {cards} '
-                f'speed credit {credit:.2f} score {score:.3f}'
+                f'Serving: UID {uid} {release.release_id} attested {"yes" if ok else "no"} '
+                f'speed credit {credit:.2f} tokens {windows[uid]["tokens"]} score {score:.4f} card-equivalents'
             )
             windows[uid].update(
                 attested=ok,
@@ -438,8 +466,7 @@ async def audit_round(
                 gpu_uuids=st.get('uuids', [st['uuid']] if st.get('uuid') else []),
                 attest_ms=st.get('wall_ms'),
                 attest_reason=st.get('reason', 'not attested yet'),
-                capacity=float(cards),
-                score=round(score, 4),
+                score=round(score, 6),
             )
             if not ok and not windows[uid]['last_miss']:
                 windows[uid]['last_miss'] = f'not attested: {st.get("reason", "not attested yet")}'
@@ -447,15 +474,15 @@ async def audit_round(
                 probation[uid] = ReadyMiner(
                     uid=uid, hotkey=hotkey, axon=axon_of[uid], score=0.0, release_id=release.release_id
                 )
-            if score > best[hotkey][0]:
-                best[hotkey] = (score, release.release_id)
+            if ok and (score, credit) > admitted.get(hotkey, (0.0, 0.0, ''))[:2]:
+                admitted[hotkey] = (score, credit, release.release_id)
 
-    scores = {hotkey: score for hotkey, (score, _) in best.items()}
+    scores = {hotkey: admitted.get(hotkey, (0.0,))[0] for _, hotkey, _ in active}
     ready: List[ReadyMiner] = []
     for uid, hotkey, axon in active:
-        score, release_id = best[hotkey]
-        if score > 0.0:
-            ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, release_id=release_id))
+        if hotkey in admitted:
+            _, credit, release_id = admitted[hotkey]
+            ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=credit, release_id=release_id))
             probation.pop(uid, None)
     for uid, report in windows.items():
         report['status'] = miner_status(report)
@@ -466,7 +493,9 @@ async def audit_round(
         f'Serving round: served {summary.get("served", 0)} (gateway {summary.get("gateway", 0)} / baseline '
         f'{summary.get("baseline", 0)}) · pass {summary.get("pass", 0)} · miss {summary.get("miss", 0)} · '
         f'strike {summary.get("strike", 0)} · neutral {summary.get("neutral", 0)} · READY {len(ready)} '
-        f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined} · dormant {dormant}'
+        f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined} · dormant {dormant} · '
+        f'paid {sum(w["tokens"] for w in windows.values())} output tokens at '
+        f'${token_rate_usd(loadout.releases[0]) * 1e6:.3f}/M'
     )
     return scores
 
@@ -491,22 +520,20 @@ def seed_ready_from_store(validator: 'Validator', state: ServingState, loadout=N
             if window.quarantined_until > 0.0:
                 quarantined.add(hotkey)
                 continue
-            if not window.passed:
+            if not window.passed or not status_passed(state.attest_status.get(hotkey), state.attest_round):
                 continue
-            # No measured credit on record pays nothing: the miner waits one live round in probation rather
+            # No measured credit on record routes nothing: the miner waits one live round in probation rather
             # than taking user traffic on an assumed speed.
-            score = state.last_credit.get(hotkey, 0.0) * status_capacity(
-                state.attest_status.get(hotkey), state.attest_round
-            )
-            if score > best.get(hotkey, (0.0, ''))[0]:
-                best[hotkey] = (score, release.release_id)
+            credit = state.last_credit.get(hotkey, 0.0)
+            if credit > best.get(hotkey, (0.0, ''))[0]:
+                best[hotkey] = (credit, release.release_id)
     ready: List[ReadyMiner] = []
     probation: List[ReadyMiner] = []
     fallback_release = loadout.primary.release_id
     for uid, hotkey, axon in active:
-        score, release_id = best.get(hotkey, (0.0, ''))
-        if score > 0.0:
-            ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=score, release_id=release_id))
+        credit, release_id = best.get(hotkey, (0.0, ''))
+        if credit > 0.0:
+            ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=credit, release_id=release_id))
         elif hotkey not in quarantined:
             probation.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=0.0, release_id=fallback_release))
     if ready or probation:
@@ -545,8 +572,9 @@ def skip_baseline(state: ServingState, hotkey: str) -> bool:
 
 
 def miner_status(report: dict) -> str:
-    """'ready' | 'quarantined' | 'probation' for one UID's round report."""
-    if report.get('score', 0.0) > 0.0:
+    """'ready' | 'quarantined' | 'probation' for one UID's round report. READY is admission, not pay: an attested
+    miner that served nothing this round is still routed."""
+    if report.get('attested'):
         return 'ready'
     if report.get('quarantined_until', 0.0) > 0.0:
         return 'quarantined'
@@ -607,7 +635,13 @@ class ServingAuditThread:
             try:
                 serving = get_serving_axons(self.validator)
                 loop.run_until_complete(
-                    audit_round(self.state, dendrite, serving, staked_caller=is_staked_caller(self.validator))
+                    audit_round(
+                        self.state,
+                        dendrite,
+                        serving,
+                        staked_caller=is_staked_caller(self.validator),
+                        round_s=self.interval_s,
+                    )
                 )
             except Exception as e:  # a serving fault must never take the validator down
                 # Nothing is published: the READY set stands until the TTL runs out and no hotkey records a zero

--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -41,9 +41,9 @@ def round_rows(
 ) -> tuple[tuple, list[tuple]]:
     """(serving_rounds row, serving_miner_rounds rows) for one audit round.
 
-    ``card_equivalents`` and ``pool_share`` are what the next OSS round will pay on: settled scores summed, priced
-    through ``serving_share`` exactly as ``blend_emission_pools`` does. The economics ($/GPU-hour, cap) and the
-    enforced release (pin, digest) ride along so readers never hard-code them.
+    ``card_equivalents`` and ``pool_share`` are what the next OSS round will pay on: settled scores (served tokens
+    in card-hours) summed, priced through ``serving_share`` exactly as ``blend_emission_pools`` does. The economics
+    ($/card-hour, cap) and the enforced release (pin, digest) ride along so readers never hard-code them.
     """
     windows: Dict[int, dict] = last_round.get('windows', {})
     card_equiv = sum(settled.values())
@@ -95,7 +95,7 @@ def round_rows(
                 float(w.get('credit', 0.0)),
                 w.get('ttft_ms'),
                 w.get('decode_tps'),
-                float(w.get('capacity', 0.0)),
+                1.0 if w.get('attested') else 0.0,  # the capacity column predates per-token pay: admission only
                 float(w.get('score', 0.0)),
                 float(settled.get(str(w.get('hotkey', '')), 0.0)),
                 (str(w.get('last_miss', '') or '')[:500]) or None,

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -1,33 +1,61 @@
 # The MIT License (MIT)
 # Copyright © 2025 Entrius
 
-"""Serving speed credit (sub-subnet B beta).
+"""Serving speed credit and token pay (sub-subnet B beta).
 
 Correctness is decided by the rolling ``AuditWindow`` (gittensor/serving/audit.py);
-this module only prices speed, on served traffic. Two validator-observed numbers
-per served request: time to first streamed token (network + queue + prefill) —
-1.0 up to SERVING_LATENCY_FULL_CREDIT_MS, 0.0 at SERVING_LATENCY_ZERO_CREDIT_MS —
-and decode rate, completion tokens over (total − TTFT), against what one honest
-card does on this runtime at the load this validator itself had in flight to the
-miner (the release's blessing-time curve). Credit = ttft_credit × decode_credit;
-decode under SERVING_DECODE_FLOOR_RATIO × expected is 0. A miner's round score is
-its window verdict (0/1) times the mean credit over the round's served requests —
-misses earn 0 credit, which folds availability in.
+this module prices speed and tokens, both on served traffic. Speed: two
+validator-observed numbers per served request — time to first streamed token
+(network + queue + prefill), 1.0 up to SERVING_LATENCY_FULL_CREDIT_MS, 0.0 at
+SERVING_LATENCY_ZERO_CREDIT_MS — and decode rate, completion tokens over
+(total − TTFT), against what one honest card does on this runtime at the load this
+validator itself had in flight to the miner (the release's blessing-time curve).
+Credit = ttft_credit × decode_credit; decode under SERVING_DECODE_FLOOR_RATIO ×
+expected is 0. The mean credit over a round's served requests is the miner's
+routing weight. Pay: the output tokens the gateway saw a hotkey serve in the
+round, in card-equivalents — ``tokens / (one card's aggregate decode tok/s ×
+round seconds)`` — so an hour flat out on one card is one card-hour
+(SERVING_GPU_HOUR_USD) and the per-token rate falls out of the release's speed.
 """
 
 from typing import Dict, Optional, Sequence, Tuple
 
 from gittensor.classes import RequestSpeed
 from gittensor.constants import (
+    SERVING_AGGREGATE_DECODE_TPS_FALLBACK,
     SERVING_DECODE_FLOOR_RATIO,
     SERVING_DECODE_MIN_TOKENS,
     SERVING_DECODE_PER_REQUEST_FALLBACK,
     SERVING_DECODE_TOLERANCE_RATIO,
+    SERVING_GPU_HOUR_USD,
     SERVING_LATENCY_FULL_CREDIT_MS,
     SERVING_LATENCY_ZERO_CREDIT_MS,
 )
 from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.state import ServedRequest
+
+
+def aggregate_decode_tps(release: ServingRelease) -> float:
+    """Output tok/s one honest card sustains under load on ``release``: the token rate's physical base."""
+    return release.aggregate_decode_tps or SERVING_AGGREGATE_DECODE_TPS_FALLBACK
+
+
+def token_rate_usd(release: ServingRelease) -> float:
+    """USD per output token: the card-hour target spread over what one card decodes in an hour."""
+    return SERVING_GPU_HOUR_USD / (aggregate_decode_tps(release) * 3600.0)
+
+
+def card_equivalents(tokens: int, release: ServingRelease, seconds: float) -> float:
+    """Cards it takes to decode ``tokens`` output tokens in ``seconds`` on ``release``: 1.0 is one card flat out."""
+    if tokens <= 0 or seconds <= 0:
+        return 0.0
+    return tokens / (aggregate_decode_tps(release) * seconds)
+
+
+def paid_tokens(req: ServedRequest) -> int:
+    """Output tokens the gateway saw ``req`` serve, never more than it asked for."""
+    n = len(req.tokens or [])
+    return min(n, req.max_tokens) if req.max_tokens > 0 else n
 
 
 def latency_credit(elapsed_ms: float, full_ms: Optional[float] = None, zero_ms: Optional[float] = None) -> float:

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -19,6 +19,7 @@
       "audit_bank": "serving_audit_bank.json",
       "speed": {
         "single_stream_decode_tps": 443.6,
+        "aggregate_decode_tps": 280.0,
         "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 — queues past 16, wall 3.7 s -> 7 s)",
         "decode_per_request": {
           "1": 443.6,

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -296,10 +296,11 @@ def _stream_once(base_url: str, model_id: str, messages, max_tokens: int, timeou
 def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float, burst: int, reps: int = 3) -> Dict:
     """Blessing-time speed facts for one honest card on this runtime, measured the way the validator measures.
 
-    ``single_stream``: one request at a time. ``probe_shaped``: ``burst`` concurrent requests, aggregate verified
-    tokens per second of decode time (batch wall-clock minus the first TTFT) — the number the capacity probe
-    compares a miner against. Client TTFT includes this client's RTT, so decode rates are RTT-free; the TTFT rows
-    are informational unless the client is on-box.
+    ``single_stream``: one request at a time. ``aggregate_decode_tps``: ``burst`` concurrent requests, aggregate
+    verified tokens per second of decode time (batch wall-clock minus the first TTFT) — what one card serves flat
+    out, so the per-token rate the validator pays at is SERVING_GPU_HOUR_USD over an hour of it. Client TTFT
+    includes this client's RTT, so decode rates are RTT-free; the TTFT rows are informational unless the client is
+    on-box.
     """
     prompts = make_prompts(burst * reps, seed=23)
     single = []
@@ -328,13 +329,11 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
         curve[6] = round(statistics.median(t / max(w - tt, 1e-3) for t, tt, w in r6), 1)
     return {
         'single_stream_decode_tps': round(single_tps, 1),
-        'probe_shaped_decode_tps': round(probe_tps, 1),
-        'probe_burst': burst,
+        # what the release carries as speed.aggregate_decode_tps: one card's output tok/s under load
+        'aggregate_decode_tps': round(probe_tps, 1),
+        'burst_concurrency': burst,
         'client_ttft_ms_median': round(statistics.median(t for _, t in single), 1),
         'max_tokens': max_tokens,
-        # what the release carries: capacity = aggregate / decode_tps_target capped at 1, 0 under the floor ratio
-        'decode_tps_target': round(probe_tps, 1),
-        'burst_concurrency': burst,
         # concurrent requests -> per-request decode tok/s of one honest card: the validator prices a served request
         # against this curve at the load it had in flight to the miner
         'decode_per_request': {str(k): v for k, v in sorted(curve.items())},
@@ -343,8 +342,8 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
 
 def check_attest(rep: Report, base_url: str, timeout: float, attest_url: Optional[str] = None) -> Dict:
     """A1: the attest container beside the runtime (entrius/gt-attest, :8081 on the runtime's host unless
-    ``attest_url`` says otherwise) answers a seeded challenge with a digest inside 3 s idle, and two simultaneous
-    challenges each take >= 1.6x a single one (the property the cohort check rests on)."""
+    ``attest_url`` says otherwise) answers a seeded challenge with a deterministic digest inside 3 s idle — the
+    admission check validators run; nothing counts cards."""
     from urllib.parse import urlsplit, urlunsplit
 
     parts = urlsplit(base_url)
@@ -366,22 +365,6 @@ def check_attest(rep: Report, base_url: str, timeout: float, attest_url: Optiona
     again = requests.post(f'{attest_url}/v1/attest', json={'seed': 12345, 'iters': 3, 'fill': True}, timeout=timeout)
     same = again.ok and (again.json().get('devices') or [again.json()])[0].get('digest') == dev.get('digest')
     rep.add('A1 digest deterministic for a seed', MUST, bool(same))
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
-        pair = list(
-            pool.map(
-                lambda _: requests.post(
-                    f'{attest_url}/v1/attest', json={'seed': 777, 'iters': 3, 'fill': True}, timeout=timeout
-                ).json(),
-                range(2),
-            )
-        )
-    walls = [float((r.get('devices') or [r])[0].get('wall_ms') or 0.0) + float(r.get('queued_ms') or 0.0) for r in pair]
-    rep.add(
-        'A1 two simultaneous challenges each >= 1.6x one',
-        MUST,
-        min(walls) >= 1.6 * wall,
-        f'{walls[0]:.0f} / {walls[1]:.0f} ms vs {wall:.0f}',
-    )
     facts.update(
         attest_ref_wall_ms=round(wall, 1),
         attest_iters=3,

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1000,12 +1000,29 @@ def _served(uid: int, release: ServingRelease, ok: bool = True, wrong: bool = Fa
     )
 
 
+ROUND_S = 300.0
+
+
 def _round(state, dendrite, serving, release, monkeypatch, probes: int = 0):
     import asyncio
 
     from gittensor.validator.serving import forward as fwd
 
-    return asyncio.run(fwd.audit_round(state, dendrite, serving, ServingLoadout(releases=[release])))  # type: ignore[arg-type]
+    return asyncio.run(
+        fwd.audit_round(state, dendrite, serving, ServingLoadout(releases=[release]), round_s=ROUND_S)  # type: ignore[arg-type]
+    )
+
+
+def _pay(tokens: int, release: ServingRelease, round_s: float = ROUND_S) -> float:
+    """The round score ``tokens`` gateway-served output tokens are worth: card-equivalents over the round."""
+    from gittensor.validator.serving.scoring import card_equivalents
+
+    return card_equivalents(tokens, release, round_s)
+
+
+def _weights(state) -> Dict[int, float]:
+    """Routing weight (speed credit) per READY UID."""
+    return {m.uid: m.score for m in state.ready_miners()}
 
 
 def test_verify_served_teacher_forces_the_completion():
@@ -1120,8 +1137,9 @@ def test_audit_round_verifies_served_traffic(monkeypatch):
     state.enqueue_served(_served(2, good, wrong=True))
 
     scores = _round(state, dendrite, serving, good, monkeypatch)
-    assert scores['hk1'] == pytest.approx(0.8)  # 4 of 5 served requests earned full latency credit
-    assert scores['hk2'] == 0.0 and scores['hk3'] == 0.0
+    assert scores['hk1'] == pytest.approx(_pay(4 * 8, good))  # paid for the 4 completions it served, not the miss
+    assert scores['hk2'] == 0.0 and scores['hk3'] == 0.0  # struck / unverified: nothing, whatever they served
+    assert _weights(state) == {1: pytest.approx(0.8)}  # 4 of 5 served requests earned full latency credit
     w1, w2 = state.audits.verdict('hk1', good.model_id), state.audits.verdict('hk2', good.model_id)
     assert w1.passed and w1.n_audits == 5 and w1.mean == 0.8
     assert not w2.passed and w2.n_audits == 0 and w2.quarantined_until > 0  # struck
@@ -1129,11 +1147,12 @@ def test_audit_round_verifies_served_traffic(monkeypatch):
     assert state.snapshot()['probation_uids'] == [3]  # the cheater is quarantined, not on probation
     assert sum(1 for r in state.recent(50) if r.kind == 'verify') == 7
 
-    # A round in which nothing of hk1's was verified freezes its credit at what was last measured (0.8) rather
-    # than crediting a perfect round the validator never observed.
+    # A round in which nothing of hk1's was served pays nothing but keeps it READY, at the credit last measured
+    # (0.8) rather than a perfect one the validator never observed.
     scores = _round(state, dendrite, serving, good, monkeypatch)
-    assert scores['hk1'] == 0.8 and [m.uid for m in state.ready_miners()] == [1]
+    assert scores['hk1'] == 0.0 and _weights(state) == {1: pytest.approx(0.8)}
     assert state.last_credit['hk1'] == 0.8
+    assert state.last_round['windows'][1]['status'] == 'ready' and state.last_round['windows'][1]['tokens'] == 0
 
 
 def test_baseline_round_spreads_prompts_and_queues_them_for_verification(monkeypatch):
@@ -1162,7 +1181,8 @@ def test_baseline_round_spreads_prompts_and_queues_them_for_verification(monkeyp
     for q in queued:
         state.enqueue_served(q)
     scores = _round(state, dendrite, serving, good, monkeypatch)
-    assert scores['hk1'] == 1.0 and scores['hk2'] == 0.0 and scores['hk3'] == 0.0
+    assert scores == {'hk1': 0.0, 'hk2': 0.0, 'hk3': 0.0}  # baseline prompts anchor eligibility, not income
+    assert _weights(state) == {1: 1.0}
     assert state.audits.verdict('hk1', good.model_id).n_audits == 2
     assert (
         state.audits.verdict('hk2', good.model_id).n_audits == 2
@@ -1396,7 +1416,8 @@ def test_latency_credit_uses_time_to_first_token_not_total_latency(monkeypatch):
     state.enqueue_served(prompt)
     state.enqueue_served(slow)
     scores = _round(state, dendrite, [(1, 'hk1', axon), (2, 'hk2', axon)], good, monkeypatch)
-    assert scores['hk1'] == 1.0 and scores['hk2'] == pytest.approx(0.5)
+    assert _weights(state) == {1: 1.0, 2: pytest.approx(0.5)}
+    assert scores['hk1'] == scores['hk2'] == pytest.approx(_pay(8, good))  # speed routes; tokens pay
 
 
 def test_ready_miner_misses_are_logged_with_a_reason(monkeypatch):
@@ -1440,11 +1461,11 @@ def test_audit_round_skips_release_without_reference(monkeypatch):
     from gittensor.validator.serving import forward as fwd
 
     scores = asyncio.run(
-        fwd.audit_round(state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[bad, good]))  # type: ignore[arg-type]
+        fwd.audit_round(state, dendrite, [(1, 'hk1', axon)], ServingLoadout(releases=[bad, good]), round_s=ROUND_S)  # type: ignore[arg-type]
     )
-    assert scores == {'hk1': 1.0}
+    assert scores == {'hk1': pytest.approx(_pay(8, good))}
     assert [m.uid for m in state.ready_miners()] == [1]
-    assert state.scores_for(['v', 'hk1']) == {1: 1.0}
+    assert state.scores_for(['v', 'hk1']) == {1: pytest.approx(_pay(8, good))}
     assert state.scores_for(['v', 'other']) == {}  # UID 1's hotkey changed since the round: nothing carries over
 
 
@@ -1513,6 +1534,96 @@ def test_release_speed_curve_parses(tmp_path):
     path = tmp_path / 'loadout.json'
     path.write_text(json.dumps(raw))
     assert load_serving_loadout(path).primary.decode_per_request == {1: 440.0, 16: 19.5}
+
+
+def test_token_pay_is_derived_from_the_release_speed(tmp_path):
+    """Only the card-hour target is hand-set: the per-token rate is that target over what one card decodes in an
+    hour, so a card flat out earns exactly the card-hour, 1.5 cards' worth of tokens earns 1.5, an idle card 0."""
+    from gittensor.constants import SERVING_AGGREGATE_DECODE_TPS_FALLBACK, SERVING_GPU_HOUR_USD
+    from gittensor.serving.loadout import load_serving_loadout
+    from gittensor.validator.serving.scoring import (
+        aggregate_decode_tps,
+        card_equivalents,
+        paid_tokens,
+        token_rate_usd,
+    )
+
+    release = _echo_release()
+    release.aggregate_decode_tps = 280.0
+    hour = int(280.0 * 3600)  # ~1.0M output tokens: one 5090 for an hour on the current runtime
+    assert card_equivalents(hour, release, 3600.0) == pytest.approx(1.0)
+    assert card_equivalents(hour // 2, release, 3600.0) == pytest.approx(0.5)
+    assert card_equivalents(1_500_000, release, 3600.0) * SERVING_GPU_HOUR_USD == pytest.approx(1.04, abs=0.01)
+    assert card_equivalents(hour // 12, release, 300.0) == pytest.approx(1.0)  # one 5-minute round flat out
+    assert card_equivalents(0, release, 300.0) == 0.0 and card_equivalents(100, release, 0.0) == 0.0
+    assert token_rate_usd(release) * 1e6 == pytest.approx(0.694, abs=0.001)  # $/M output
+    assert token_rate_usd(release) * hour == pytest.approx(SERVING_GPU_HOUR_USD)
+    bare = _echo_release()
+    assert aggregate_decode_tps(bare) == SERVING_AGGREGATE_DECODE_TPS_FALLBACK
+    raw = {'releases': [{'model_id': 'm', 'backend': 'echo', 'speed': {'aggregate_decode_tps': 400}}]}
+    path = tmp_path / 'loadout.json'
+    path.write_text(json.dumps(raw))
+    assert aggregate_decode_tps(load_serving_loadout(path).primary) == 400.0
+    assert load_serving_loadout().primary.aggregate_decode_tps  # the shipped release self-prices
+    # the gateway pays what it asked for at most: a runtime that streams past max_tokens is not paid for it
+    req = _served(1, release)
+    assert paid_tokens(req) == 8
+    req.max_tokens = 5
+    assert paid_tokens(req) == 5
+    req.tokens = None
+    assert paid_tokens(req) == 0
+
+
+def test_pay_counts_gateway_tokens_the_reference_did_not_fail():
+    """Unsampled completions pay in full; a sampled one pays only if it verified; a failed request and baseline
+    prompts pay nothing; a neutral verdict (reference hiccup) still pays what the gateway saw served."""
+    import random
+
+    from gittensor.validator.serving.forward import verify_served_round
+
+    good = _echo_release()
+    ref = EchoReference(good)
+    served = [_served(1, good) for _ in range(12)]  # min(10, 20%) sampled: 2 go unverified
+    served += [_served(2, good), _served(2, good, wrong=True), _served(2, good, ok=False)]
+    baseline = _served(3, good)
+    baseline.source = 'baseline'
+    served.append(baseline)
+    state = ServingState()
+    summary: Dict[str, int] = {}
+    speeds, tokens = verify_served_round(state, ref, good, served, summary, rng=random.Random(0))
+    assert summary['unsampled'] == 2 and len(speeds['hk1']) == 10
+    assert tokens == {'hk1': 12 * 8, 'hk2': 8}  # hk2: one completion paid, the wrong one and the miss are not
+    assert state.audits.verdict('hk2', good.release_id).quarantined_until > 0  # ... and the strike stands
+
+    class Flaky:
+        """A reference that cannot be reached: every verdict neutral."""
+
+        model_id = good.model_id
+        max_tokens = good.max_tokens
+
+        def case_for(self, messages, max_tokens=None):
+            raise ConnectionError('reference down')
+
+    state = ServingState()
+    _, tokens = verify_served_round(state, Flaky(), good, [_served(1, good)], {})  # type: ignore[arg-type]
+    assert tokens == {'hk1': 8}
+
+
+def test_emission_pool_is_the_only_ceiling(monkeypatch):
+    """Below the cap every token is paid at the full rate; above it the pool is split by token share."""
+    from gittensor.classes import ServingPricing
+    from gittensor.validator import emission_allocation as ea
+
+    monkeypatch.setattr(ea, 'SERVING_GPU_HOUR_USD', 0.70)
+    monkeypatch.setattr(ea, 'SERVING_EMISSION_SHARE_CAP', 0.17)
+    monkeypatch.setattr(ea, 'OSS_EMISSION_SHARE', 0.83)
+    pricing = ServingPricing(alpha_per_hour_to_miners=100.0, alpha_usd=0.7)  # one card-hour = 1% of emissions
+    uids = {0, 1, 2}
+    below = ea.blend_emission_pools({}, {}, uids, None, {1: 1.5, 2: 0.5}, pricing)  # 1.5M + 0.5M tokens/h
+    assert below[1] == pytest.approx(0.015) and below[2] == pytest.approx(0.005)  # full rate, no per-hotkey cap
+    above = ea.blend_emission_pools({}, {}, uids, None, {1: 30.0, 2: 10.0}, pricing)  # 40 card-hours > 17 cap
+    assert above[1] == pytest.approx(0.17 * 0.75) and above[2] == pytest.approx(0.17 * 0.25)
+    assert above[0] == pytest.approx(0.83)  # nothing of the serving cap recycles once it binds
 
 
 def test_serving_share_prices_gpu_hours_inside_the_cap(monkeypatch):
@@ -1830,8 +1941,9 @@ def test_attest_cohort_is_random_half_plus_unproven_and_failed():
 def test_attest_round_gates_pay_and_persists(monkeypatch, tmp_path):
     import asyncio
 
-    """No verdict -> probation; a failing cohort member scores 0; a passing one keeps its speed credit; non-cohort
-    members keep their last verdict; duplicate GPU UUIDs fail both; status survives the store."""
+    """No verdict -> probation; a failing cohort member is not admitted; a passing one is; non-cohort members keep
+    their last verdict; two hotkeys behind one card are both admitted (they split its tokens); status survives
+    the store."""
     import random
     from types import SimpleNamespace
 
@@ -1853,21 +1965,22 @@ def test_attest_round_gates_pay_and_persists(monkeypatch, tmp_path):
     state = ServingState()
     candidates = [(1, 'hk1', axons['hk1']), (2, 'hk2', axons['hk2']), (3, 'hk3', axons['hk3'])]
     out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
-    assert out == {'hk1': False, 'hk2': False, 'hk3': False}  # hk2 wrong digest; hk1/hk3 share GPU-1
+    assert out == {'hk1': True, 'hk2': False, 'hk3': True}  # hk2 wrong digest; nothing counts cards
     assert state.attest_status['hk2']['reason'] == 'digest mismatch'
-    assert 'duplicate GPU' in state.attest_status['hk1']['reason']
+    assert state.attest_status['hk1']['reason'] == 'ok' and 'capacity' not in state.attest_status['hk1']
 
-    replies[id(axons['hk3'])] = _attest_reply(uuid='GPU-3')
+    replies[id(axons['hk2'])] = _attest_reply(uuid='GPU-2')
     out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
-    assert out['hk1'] and out['hk3'] and not out['hk2']  # all three were re-challenged (none had passed)
+    assert out == {'hk1': True, 'hk2': True, 'hk3': True}  # the failure was re-challenged; the others carried
     store = ServingStore(tmp_path / 'serving.db')
     store.save(state)
     again = store.load(ServingState())
-    assert again.attest_status['hk1']['uuid'] == 'GPU-1' and again.attest_status['hk2']['passed'] is False
+    assert again.attest_status['hk1']['uuid'] == 'GPU-1' and again.attest_status['hk2']['passed'] is True
 
     monkeypatch.setattr(att, 'reference_challenge', lambda *a, **k: (_ for _ in ()).throw(RuntimeError('ref down')))
+    replies[id(axons['hk2'])] = _attest_reply(uuid='GPU-2', digest='wrong')
     neutral = asyncio.run(att.attest_round(state, dendrite, candidates, release))  # type: ignore[arg-type]
-    assert neutral == {'hk1': True, 'hk2': False, 'hk3': True}  # reference down: nothing changes
+    assert neutral == {'hk1': True, 'hk2': True, 'hk3': True}  # reference down: nothing changes
 
 
 def test_audit_round_requires_attestation_when_a_reference_is_configured(monkeypatch):
@@ -1889,7 +2002,7 @@ def test_audit_round_requires_attestation_when_a_reference_is_configured(monkeyp
     for uid in (1, 2):
         state.enqueue_served(_served(uid, release))
     scores = _round(state, dendrite, [(1, 'hk1', good), (2, 'hk2', bad)], release, monkeypatch)
-    assert scores == {'hk1': 1.0, 'hk2': 0.0}
+    assert scores == {'hk1': pytest.approx(_pay(8, release)), 'hk2': 0.0}
     snap = state.snapshot()
     assert snap['ready_uids'] == [1] and snap['probation_uids'] == [2]  # failed attest: not READY, not struck
     w = state.audits.verdict('hk2', release.model_id)
@@ -1985,34 +2098,35 @@ def _card(uuid: str, digest: str = 'd', wall_ms: float = 1500.0, filled: int = 8
     return dev
 
 
-def test_attest_judges_every_card_and_counts_capacity():
-    """One hotkey, N cards: each card is judged alone; capacity = passing cards; the reason names the first failure;
-    a card without the model resident earns nothing."""
+def test_attest_judges_every_card_and_admits_on_any():
+    """One hotkey, N cards: each card is judged alone; the hotkey passes with any passing card; the reason names the
+    first failure; a card without the model resident is not a serving card."""
     from gittensor.synapses import AttestSynapse
     from gittensor.validator.serving.attest import judge
 
     release = _attest_release()
     two = judge(AttestSynapse(seed=1, devices=[_card('GPU-a'), _card('GPU-b')]), 'd', 1400.0, release)
-    assert two.passed and two.capacity == 2 and two.uuids == ['GPU-a', 'GPU-b'] and two.reason == 'ok (2 cards)'
+    assert two.passed and two.uuids == ['GPU-a', 'GPU-b'] and two.reason == 'ok (2 cards)'
     one_bad = judge(
         AttestSynapse(seed=1, devices=[_card('GPU-a'), _card('GPU-b', wall_ms=9_000.0)]), 'd', 1400.0, release
     )
-    assert one_bad.passed and one_bad.capacity == 1 and one_bad.uuids == ['GPU-a']
+    assert one_bad.passed and one_bad.uuids == ['GPU-a']
     assert one_bad.reason.startswith('1/2 cards ok (too slow')
     none = judge(
         AttestSynapse(seed=1, devices=[_card('GPU-a', digest='x'), _card('GPU-b', digest='x')]), 'd', 1400.0, release
     )
-    assert not none.passed and none.capacity == 0 and none.reason == 'digest mismatch'
+    assert not none.passed and none.uuids == [] and none.reason == 'digest mismatch'
     loaded = judge(AttestSynapse(seed=1, devices=[_card('GPU-a', free_before=9e9)]), 'd', 1400.0, release)
     assert loaded.passed
     bare = judge(AttestSynapse(seed=1, devices=[_card('GPU-a', free_before=33e9)]), 'd', 1400.0, release)
     assert not bare.passed and bare.reason.startswith('model not resident')
     status = two.as_status(0.0, 1)
-    assert status['capacity'] == 2 and status['uuids'] == ['GPU-a', 'GPU-b'] and len(status['cards']) == 2
+    assert status['uuids'] == ['GPU-a', 'GPU-b'] and len(status['cards']) == 2 and 'capacity' not in status
 
 
-def test_attest_round_pays_per_card_and_dedupes_across_cards(monkeypatch):
-    """A two-card hotkey scores credit x 2; a second hotkey reporting one of those cards fails both."""
+def test_pay_follows_served_tokens_not_attested_cards(monkeypatch):
+    """A two-card hotkey and a one-card hotkey that served the same tokens are paid the same; the card count is
+    telemetry. Attestation admits, and a failed attest zeroes the round's pay however much was served."""
     import asyncio
     import random
     from types import SimpleNamespace
@@ -2035,24 +2149,11 @@ def test_attest_round_pays_per_card_and_dedupes_across_cards(monkeypatch):
     state = ServingState()
     candidates = [(1, 'hk1', axons['hk1']), (2, 'hk2', axons['hk2'])]
     out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
-    assert out == {'hk1': 2, 'hk2': 1}
-    assert att.status_capacity(state.attest_status['hk1']) == 2
-    assert att.status_capacity({'passed': True, 'uuid': 'GPU-old'}) == 1  # status persisted before capacity existed
+    assert out == {'hk1': True, 'hk2': True}
+    assert att.status_passed(state.attest_status['hk1']) and state.attest_status['hk1']['uuids'] == ['GPU-a', 'GPU-b']
+    assert att.status_passed({'passed': True, 'uuid': 'GPU-old'})  # a status persisted before this change
 
-    # hk1 holds GPU-b from the round it passed with it: a newcomer naming that UUID loses the card, hk1 keeps it
-    replies[id(axons['hk2'])] = AttestSynapse(seed=1, devices=[_card('GPU-b')])  # hk1's second card
-    state.attest_status = {}
-    out = asyncio.run(att.attest_round(state, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
-    assert out == {'hk1': 2, 'hk2': 0}
-    assert state.attest_status['hk2']['reason'] == 'duplicate GPU GPU-b (held by another hotkey)'
-    assert state.uuid_owner['GPU-b'][0] == 'hk1'
-    # the same collision with no holder on record (both new this round) is the sharing case: both lose it
-    fresh = ServingState()
-    out = asyncio.run(att.attest_round(fresh, dendrite, candidates, release, rng=random.Random(0)))  # type: ignore[arg-type]
-    assert out == {'hk1': 1, 'hk2': 0}  # hk1 keeps GPU-a, loses GPU-b; hk2 had only GPU-b
-    assert 'GPU-b' not in fresh.uuid_owner and fresh.uuid_owner['GPU-a'][0] == 'hk1'
-
-    # the audit round multiplies the speed credit by the attested cards
+    # the audit round pays the tokens the gateway saw served; the cards behind a hotkey do not enter
     good = _echo_release()
     good.attest_reference_url = 'http://ref:8081'
     good.vram_model_reserved_bytes = 24e9
@@ -2076,9 +2177,31 @@ def test_attest_round_pays_per_card_and_dedupes_across_cards(monkeypatch):
             attest_rng=random.Random(0),
         )
     )
-    assert scores['hk1'] == pytest.approx(2.0) and scores['hk2'] == pytest.approx(1.0)
+    assert scores['hk1'] == scores['hk2'] == pytest.approx(_pay(3 * 8, good))
     tele = state.snapshot()['last_round']['windows']
-    assert tele[1]['capacity'] == 2.0 and tele[1]['gpu_uuids'] == ['GPU-a', 'GPU-b'] and tele[2]['capacity'] == 1.0
+    assert tele[1]['gpu_uuids'] == ['GPU-a', 'GPU-b'] and tele[2]['gpu_uuids'] == ['GPU-c']
+    assert tele[1]['tokens'] == tele[2]['tokens'] == 24 and tele[1]['attested'] and tele[2]['attested']
+
+    # a hotkey that fails attestation is paid nothing for the round, whatever it served, and is not READY
+    for _ in range(3):
+        state.enqueue_served(_served(1, good))
+        state.enqueue_served(_served(2, good))
+    replies[id(axons['hk2'])] = AttestSynapse(seed=1, devices=[_card('GPU-c', digest='x')])
+    state.attest_status = {}
+    scores = asyncio.run(
+        fwd.audit_round(
+            state,
+            echo_dendrite,  # type: ignore[arg-type]
+            [(1, 'hk1', axons['hk1']), (2, 'hk2', axons['hk2'])],  # type: ignore[arg-type]
+            loadout=SimpleNamespace(releases=[good]),
+            attest_rng=random.Random(0),
+            round_s=ROUND_S,
+        )
+    )
+    assert scores == {'hk1': pytest.approx(_pay(24, good)), 'hk2': 0.0}
+    assert state.snapshot()['ready_uids'] == [1] and state.snapshot()['probation_uids'] == [2]
+    tele = state.snapshot()['last_round']['windows']
+    assert tele[2]['tokens'] == 24 and not tele[2]['attested'] and tele[2]['status'] == 'probation'
 
 
 def test_attest_cards_answer_their_own_index_and_the_round_trip_bounds_the_count():
@@ -2095,7 +2218,7 @@ def test_attest_cards_answer_their_own_index_and_the_round_trip_bounds_the_count
         1400.0,
         release,
     )
-    assert faked.capacity == 1 and faked.reason.startswith('1/2 cards ok (digest mismatch')
+    assert faked.uuids == ['GPU-a'] and faked.reason.startswith('1/2 cards ok (digest mismatch')
     honest = judge(
         AttestSynapse(seed=1, devices=[_card('GPU-a', digest='d0'), _card('GPU-b', digest='d1')]),
         per_index,
@@ -2103,15 +2226,15 @@ def test_attest_cards_answer_their_own_index_and_the_round_trip_bounds_the_count
         release,
         elapsed_ms=1500.0,
     )
-    assert honest.capacity == 2
+    assert honest.uuids == ['GPU-a', 'GPU-b']
     beyond = judge(
         AttestSynapse(seed=1, devices=[_card(f'GPU-{i}', digest=f'd{i}') for i in range(4)]), per_index, 1400.0, release
     )
-    assert beyond.capacity == 3 and 'no reference digest' in beyond.reason
+    assert len(beyond.uuids) == 3 and 'no reference digest' in beyond.reason
     slow = judge(
         AttestSynapse(seed=1, devices=[_card('GPU-a', digest='d0')]), per_index, 1400.0, release, elapsed_ms=9_000.0
     )
-    assert not slow.passed and slow.capacity == 0 and 'round trip' in slow.reason
+    assert not slow.passed and slow.uuids == [] and 'round trip' in slow.reason
     capped = judge(
         AttestSynapse(seed=1, devices=[_card(f'GPU-{i}', digest='d') for i in range(20)]),
         'd',
@@ -2119,12 +2242,12 @@ def test_attest_cards_answer_their_own_index_and_the_round_trip_bounds_the_count
         release,
         max_cards=3,
     )
-    assert capped.capacity == 3
+    assert len(capped.cards) == 3
 
 
 def test_attest_malformed_report_is_a_failed_card_not_a_crash():
     from gittensor.synapses import AttestSynapse
-    from gittensor.validator.serving.attest import judge, status_capacity
+    from gittensor.validator.serving.attest import judge, status_passed
 
     release = _attest_release()
     bad = judge(
@@ -2135,10 +2258,10 @@ def test_attest_malformed_report_is_a_failed_card_not_a_crash():
         AttestSynapse(seed=1, devices=[{'uuid': 'GPU-a', 'digest': 'd', 'vram_total': [1]}]), 'd', 1400.0, release
     )
     assert not nested.passed and nested.reason.startswith('malformed device report')
-    # a verdict the reference has not renewed for longer than the memory window pays nothing
-    stale = {'passed': True, 'capacity': 2, 'round': 1}
-    assert status_capacity(stale, round_no=13) == 2 and status_capacity(stale, round_no=14) == 0
-    assert status_capacity(stale) == 2
+    # a verdict the reference has not renewed for longer than the memory window admits nothing
+    stale = {'passed': True, 'round': 1}
+    assert status_passed(stale, round_no=13) and not status_passed(stale, round_no=14)
+    assert status_passed(stale) and not status_passed({'passed': False, 'round': 13}, round_no=13)
 
 
 def test_attest_fault_is_neutral_and_the_round_counter_persists(monkeypatch, tmp_path):
@@ -2157,14 +2280,14 @@ def test_attest_fault_is_neutral_and_the_round_counter_persists(monkeypatch, tmp
 
     dendrite = SimpleNamespace(call=call)
     state = ServingState()
-    assert asyncio.run(att.attest_round(state, dendrite, [(1, 'hk1', axon)], release)) == {'hk1': 1}  # type: ignore[arg-type]
+    assert asyncio.run(att.attest_round(state, dendrite, [(1, 'hk1', axon)], release)) == {'hk1': True}  # type: ignore[arg-type]
     monkeypatch.setattr(att, 'judge', lambda *a, **k: (_ for _ in ()).throw(RuntimeError('boom')))
-    assert asyncio.run(att.attest_round(state, dendrite, [(1, 'hk1', axon)], release)) == {'hk1': 1}  # type: ignore[arg-type]
-    assert state.attest_round == 2 and state.uuid_owner['GPU-1'] == ('hk1', 1)
+    assert asyncio.run(att.attest_round(state, dendrite, [(1, 'hk1', axon)], release)) == {'hk1': True}  # type: ignore[arg-type]
+    assert state.attest_round == 2
     store = ServingStore(tmp_path / 'serving.db')
     store.save(state)
     again = store.load(ServingState())
-    assert again.attest_round == 2 and again.uuid_owner == {'GPU-1': ('hk1', 1)}
+    assert again.attest_round == 2 and again.attest_status['hk1']['uuid'] == 'GPU-1'
 
 
 def test_reference_challenge_sends_the_bearer(monkeypatch):
@@ -2460,14 +2583,14 @@ def test_seed_ready_from_store_republishes_without_settling():
             state.audits.record(hk, release.release_id, 1.0)
     state.audits.strike('hk2', release.release_id)  # quarantined: neither READY nor probation
     state.last_credit.update({'hk1': 0.9, 'hk2': 0.9})  # hk4 passed its window but has no measured credit
-    state.attest_status['hk1'] = {'passed': True, 'capacity': 2, 'round': 0}
-    state.attest_status['hk4'] = {'passed': True, 'capacity': 1, 'round': 0}
+    state.attest_status['hk1'] = {'passed': True, 'round': 0}
+    state.attest_status['hk4'] = {'passed': True, 'round': 0}
     state.last_round_ts = time.time() - 60.0
 
     fwd.seed_ready_from_store(validator, state, loadout=loadout)  # type: ignore[arg-type]
     ready = state.ready_miners()
     assert [(m.uid, m.release_id) for m in ready] == [(1, release.release_id)]
-    assert ready[0].score == pytest.approx(1.8)  # the last measured credit times the attested cards
+    assert ready[0].score == pytest.approx(0.9)  # routed at the last measured credit
     assert state.snapshot()['probation_uids'] == [3, 4]
     assert state.settled_scores() == {}  # a seed pays nothing
 

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -10,6 +10,7 @@ persist = pytest.importorskip('gittensor.validator.serving.persist')
 forward = pytest.importorskip('gittensor.validator.serving.forward')
 state_module = pytest.importorskip('gittensor.serving.state')
 classes = pytest.importorskip('gittensor.classes')
+SERVING_EMISSION_SHARE_CAP = pytest.importorskip('gittensor.constants').SERVING_EMISSION_SHARE_CAP
 loadout = pytest.importorskip('gittensor.serving.loadout')
 
 ROUND = {
@@ -36,7 +37,8 @@ ROUND = {
             'credit': 1.0,
             'ttft_ms': 48.3,
             'decode_tps': 190.0,
-            'capacity': 1.0,
+            'tokens': 84_000,
+            'attested': True,
             'score': 1.0,
             'last_miss': '',
             'status': 'ready',
@@ -53,7 +55,8 @@ ROUND = {
             'credit': 0.0,
             'ttft_ms': None,
             'decode_tps': None,
-            'capacity': 0.0,
+            'tokens': 0,
+            'attested': False,
             'score': 0.0,
             'last_miss': 'tokenization mismatch (3 vs 4)',
             'status': 'quarantined',
@@ -76,16 +79,17 @@ def test_round_rows_shape_and_pricing():
     summary, miners = persist.round_rows('vali', ts, ROUND, {'hk16': 0.5, 'hk27': 1 / 12}, pricing)
     assert summary[:3] == ('vali', ts, 4)
     assert summary[12] == pytest.approx(0.5 + 1 / 12)  # card equivalents = settled sum
-    assert 0 < summary[13] <= 0.035  # priced share inside the cap
+    assert 0 < summary[13] <= SERVING_EMISSION_SHARE_CAP  # priced share inside the cap
     assert summary[14:16] == (100.0, 1.0)
-    assert summary[16:18] == (0.70, 0.035)  # economics ride along so das never hard-codes them
+    assert summary[16:18] == (0.70, SERVING_EMISSION_SHARE_CAP)  # economics ride along so das never hard-codes them
     assert summary[18:] == (None,) * 7
     assert len(miners) == 2
     ready = next(m for m in miners if m[2] == 16)
     assert ready[5] == 'qwen' and ready[6] == 'ready'  # release_id defaults to model_id
     assert ready[13] == 48.3 and ready[14] == 190.0 and ready[17] == 0.5 and ready[18] is None
+    assert ready[15] == 1.0  # the capacity column now carries admission only
     quarantined = next(m for m in miners if m[2] == 27)
-    assert quarantined[6] == 'quarantined'
+    assert quarantined[6] == 'quarantined' and quarantined[15] == 0.0
     assert quarantined[10] == dt.datetime.fromtimestamp(1_800_000_000.0, dt.timezone.utc)
     assert quarantined[18].startswith('tokenization mismatch')
 
@@ -123,7 +127,7 @@ def test_round_rows_report_the_share_that_will_actually_be_paid():
     summary, _ = persist.round_rows('vali', ts, ROUND, {'hk16': 1.0}, None)
     assert summary[13] == 0.0 and summary[14] is None and summary[15] is None  # unpriced: nothing is paid
     summary, _ = persist.round_rows('vali', ts, ROUND, {'hk16': 1.0}, None, None, True)
-    assert summary[13] == 0.035  # testnet: the cap, matching what blend_emission_pools pays
+    assert summary[13] == SERVING_EMISSION_SHARE_CAP  # testnet: the cap, matching what blend_emission_pools pays
 
 
 def test_store_round_writes_and_prunes():
@@ -160,9 +164,9 @@ def test_store_round_skips_before_first_round():
 
 
 def test_miner_status():
-    assert forward.miner_status({'score': 0.9}) == 'ready'
-    assert forward.miner_status({'score': 0.0, 'quarantined_until': 5.0}) == 'quarantined'
-    assert forward.miner_status({'score': 0.0, 'quarantined_until': 0.0}) == 'probation'
+    assert forward.miner_status({'attested': True, 'score': 0.0}) == 'ready'  # admitted, nothing served yet
+    assert forward.miner_status({'attested': False, 'quarantined_until': 5.0}) == 'quarantined'
+    assert forward.miner_status({'attested': False, 'quarantined_until': 0.0}) == 'probation'
 
 
 def test_settled_scores():


### PR DESCRIPTION
Implements the pay-per-token serving model from the 8/31 direction doc (§7, "Implementation touch-points"), shipping with phase 0.

## What changes

**Pay** — `score = window_pass × credit × attested_cards` becomes

```
admitted    = window passes × speed credit > 0 × attestation passes
round score = admitted × gateway-counted output tokens ÷ (aggregate_decode_tps × round seconds)
```

- Tokens are counted from the gateway's own `ServedRequest` records (`state.py`), never miner-reported, and capped at the request's `max_tokens`. Only gateway traffic pays; baseline prompts anchor eligibility. Unsampled completions pay in full, sampled ones pay only if they verified, a neutral (reference hiccup) verdict still pays.
- The per-token rate is derived, not set: `token_rate_usd = SERVING_GPU_HOUR_USD / (aggregate_decode_tps × 3600)` — $0.694/M output on the current release (`speed.aggregate_decode_tps: 280`, from the 2026-08-27 blessing measurement; `SERVING_AGGREGATE_DECODE_TPS_FALLBACK` for a release without one). Round scores stay in card-equivalents (1.0 = one card flat out), so `serving_share`, `pricing.py`, persistence and das read exactly as before: 1M tokens/h ≈ 1 card-hour ≈ $0.70, 1.5M ≈ $1.05.
- No card count, no per-hotkey cap. The only ceiling is `SERVING_EMISSION_SHARE_CAP`: below it full rate, above it pro-rata by token share, remainder recycles (unchanged allocator).
- Cap raised 3.5% → **10%** with `OSS_EMISSION_SHARE` 0.965 → 0.90 in the same commit (pools still sum to 1.0).

**Routing** — `ReadyMiner.score` is now the pure speed credit; READY is decoupled from pay, so an admitted card with no traffic this round stays routed (score 0, status `ready`). The settlement window (`SERVING_SETTLEMENT_ROUNDS`, still 12) is the transition knob; `moving_average_alpha` untouched.

**Attest** — per-hotkey pass/fail admission (digest + speed + fill + model-resident; a hotkey passes with any passing card). Removed: `capacity` counting, `status_capacity` → `status_passed`, GPU-UUID ownership (`claim_uuids`, `uuid_owner`, its store table), `SERVING_ATTEST_UUID_MEMORY_ROUNDS` → `SERVING_ATTEST_MEMORY_ROUNDS`. Per-index digests and the round-trip bound stay as the speed gate.

**Conformance** — the A1 "two simultaneous challenges each ≥ 1.6×" MUST is gone (it only existed to count cards), so `sparkinfer:7498736` passes; digest, ≤ 3 s idle and determinism stay. `--speed-json` now emits `aggregate_decode_tps` for the pin-bump PR to carry into the loadout.

## Compatibility notes

- `serving_miner_rounds.capacity` (DB/das/UI) is written as 1.0/0.0 = attested; the column predates this change. The round report gains `tokens` and `attested`; `capacity` is gone from it.
- Existing sqlite stores keep an orphan `uuid_owner` table; attest statuses persisted with `capacity` load fine.
- Log line per round now ends with `paid N output tokens at $x/M`.

## Tests

New: `test_token_pay_is_derived_from_the_release_speed`, `test_pay_counts_gateway_tokens_the_reference_did_not_fail`, `test_pay_follows_served_tokens_not_attested_cards`, `test_emission_pool_is_the_only_ceiling`; existing audit-round/attest/seed/persist tests updated to routing-weight vs pay.

Local CI green: `ruff check`, `ruff format --check`, `pyright` (0 errors), `vulture`, `pytest tests/` (769 passed).

Docs: entrius/gittensor-docs-ui PR "docs(compute): pay per token served; attest is admission" (compute-miner, compute-serving, plus the cap one-liners on core-concepts/miner/oss-contributions/validator).

https://claude.ai/code/session_01M181f9YMAnPHE9UzBuuZHW