### PR TITLE
Serving: persist tokens served and the per-token rate

### DIFF
--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -21,6 +21,7 @@ from gittensor.constants import SERVING_DB_RETENTION_DAYS, SERVING_EMISSION_SHAR
 from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.state import ServingState
 from gittensor.validator.emission_allocation import serving_share
+from gittensor.validator.serving.scoring import token_rate_usd
 from gittensor.validator.storage.database import create_database_connection
 from gittensor.validator.storage.queries import (
     BULK_INSERT_SERVING_MINER_ROUNDS,
@@ -43,7 +44,8 @@ def round_rows(
 
     ``card_equivalents`` and ``pool_share`` are what the next OSS round will pay on: settled scores (served tokens
     in card-hours) summed, priced through ``serving_share`` exactly as ``blend_emission_pools`` does. The economics
-    ($/card-hour, cap) and the enforced release (pin, digest) ride along so readers never hard-code them.
+    ($/card-hour, cap, $/M output tokens), the paid token volume and the enforced release (pin, digest) ride along
+    so readers never hard-code them.
     """
     windows: Dict[int, dict] = last_round.get('windows', {})
     card_equiv = sum(settled.values())
@@ -74,6 +76,8 @@ def round_rows(
         release.model_file if release else None,
         release.runtime_image if release else None,
         release.attest_image if release else None,
+        sum(int(w.get('tokens', 0)) for w in windows.values()),
+        token_rate_usd(release) * 1e6 if release else None,
     )
     miners = []
     for uid, w in windows.items():
@@ -99,6 +103,7 @@ def round_rows(
                 float(w.get('score', 0.0)),
                 float(settled.get(str(w.get('hotkey', '')), 0.0)),
                 (str(w.get('last_miss', '') or '')[:500]) or None,
+                int(w.get('tokens', 0)),
             )
         )
     return summary, miners

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -201,16 +201,18 @@ INSERT_SERVING_ROUND = """
 INSERT INTO serving_rounds (
     validator_hotkey, round_ts, served, gateway, baseline, passes, misses, strikes, neutral,
     ready, probation, quarantined, card_equivalents, pool_share, alpha_per_hour, alpha_usd,
-    gpu_hour_usd, pool_cap, model_id, release_id, runtime_pin, model_sha256, model_file, runtime_image, attest_image
-) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    gpu_hour_usd, pool_cap, model_id, release_id, runtime_pin, model_sha256, model_file, runtime_image, attest_image,
+    tokens, usd_per_m_tokens
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT (validator_hotkey, round_ts) DO NOTHING
 """
 
 BULK_INSERT_SERVING_MINER_ROUNDS = """
 INSERT INTO serving_miner_rounds (
     validator_hotkey, round_ts, uid, hotkey, model_id, release_id, status, window_mean, window_n, window_passed,
-    quarantined_until, served, credit, ttft_ms, decode_tps, capacity, round_score, settled_score, last_miss_reason
-) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    quarantined_until, served, credit, ttft_ms, decode_tps, capacity, round_score, settled_score, last_miss_reason,
+    tokens
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT (validator_hotkey, round_ts, uid, hotkey) DO NOTHING
 """
 

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -82,14 +82,15 @@ def test_round_rows_shape_and_pricing():
     assert 0 < summary[13] <= SERVING_EMISSION_SHARE_CAP  # priced share inside the cap
     assert summary[14:16] == (100.0, 1.0)
     assert summary[16:18] == (0.70, SERVING_EMISSION_SHARE_CAP)  # economics ride along so das never hard-codes them
-    assert summary[18:] == (None,) * 7
+    assert summary[18:25] == (None,) * 7
+    assert summary[25:] == (84_000, None)  # paid tokens across the fleet; no release -> no per-token rate
     assert len(miners) == 2
     ready = next(m for m in miners if m[2] == 16)
     assert ready[5] == 'qwen' and ready[6] == 'ready'  # release_id defaults to model_id
     assert ready[13] == 48.3 and ready[14] == 190.0 and ready[17] == 0.5 and ready[18] is None
-    assert ready[15] == 1.0  # the capacity column now carries admission only
+    assert ready[15] == 1.0 and ready[19] == 84_000  # capacity carries admission only; tokens is what was paid
     quarantined = next(m for m in miners if m[2] == 27)
-    assert quarantined[6] == 'quarantined' and quarantined[15] == 0.0
+    assert quarantined[6] == 'quarantined' and quarantined[15] == 0.0 and quarantined[19] == 0
     assert quarantined[10] == dt.datetime.fromtimestamp(1_800_000_000.0, dt.timezone.utc)
     assert quarantined[18].startswith('tokenization mismatch')
 
@@ -107,7 +108,7 @@ def test_round_rows_carry_the_enforced_release():
         }
     )
     summary, _ = persist.round_rows('vali', dt.datetime.now(dt.timezone.utc), ROUND, {}, None, release)
-    assert summary[18:] == (
+    assert summary[18:25] == (
         'qwen',
         'qwen',  # release_id defaults to model_id
         'org/sparkinfer@abc',
@@ -116,6 +117,7 @@ def test_round_rows_carry_the_enforced_release():
         'entrius/sparkinfer:abc@sha256:00',
         'entrius/gt-attest:v1',
     )
+    assert summary[26] == pytest.approx(0.694, abs=0.001)  # $/M output tokens at the fallback 280 tok/s
 
 
 def test_default_loadout_keeps_model_file():


### PR DESCRIPTION
Rebased onto `test` now that #1737 has merged; this carries only the persistence delta on top of pay-per-token.

**Requires the schema from entrius/gittensor-db PR "serving rounds: tokens served + per-token rate" applied to the DB first** — the inserts name the new columns, so a validator writing rounds before the migration lands will fail the insert.

- `serving_miner_rounds.tokens` — the output tokens the gateway saw each UID serve this round (already in the round report as `tokens`).
- `serving_rounds.tokens` — the fleet's paid tokens this round; `serving_rounds.usd_per_m_tokens` — `token_rate_usd(release) × 1e6` for the enforced release (≈ 0.694 today).

Both new values ride at the end of the existing tuples, so the column order of everything already persisted is unchanged. Tests updated (`test_serving_persist`); ruff / format / pyright / vulture / pytest green locally (reviewer re-verified post-rebase: 115 serving tests pass, pyright 0, SQL column/placeholder counts match 27/20).

https://claude.ai/code/session_01M181f9YMAnPHE9UzBuuZHW