### PR TITLE
conformance: measure the runtime through an ssh tunnel, not the Lium port proxy

### DIFF
--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -174,7 +174,7 @@ jobs:
                })
              | .releases[0].attest = ((.releases[0].attest // {}) + {
                  iters: ($speed[0].attest.attest_iters // 3),
-                 vram_model_reserved_bytes: ($speed[0].attest.vram_model_reserved_bytes // 24000000000),
+                 vram_model_reserved_bytes: ($speed[0].attest.vram_model_reserved_bytes // .releases[0].attest.vram_model_reserved_bytes // 24000000000),
                  reference_wall_ms: $speed[0].attest.attest_ref_wall_ms
                })' \
             gittensor/validator/weights/serving_loadout.json > /tmp/loadout.json

--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -145,9 +145,12 @@ jobs:
       - name: Rent, boot, check, tear down
         env:
           CONFORMANCE_RENT_WAIT_MIN: "20"
+        # lium registers ~/.ssh/id_ed25519 with every pod it rents (the SDK reads only that path); the checker's
+        # ssh tunnel into the runtime pod uses the same key.
         run: |
-          ssh-keygen -t ed25519 -N '' -q -f "$RUNNER_TEMP/lium_ci"
-          LIUM_SSH_KEY_PATH="$RUNNER_TEMP/lium_ci" scripts/serving_conformance_on_lium.sh "$TAG" "conformance-$REF"
+          mkdir -p -m 700 ~/.ssh
+          [ -f ~/.ssh/id_ed25519 ] || ssh-keygen -t ed25519 -N '' -q -f ~/.ssh/id_ed25519
+          scripts/serving_conformance_on_lium.sh "$TAG" "conformance-$REF"
 
       - name: Upload the report
         if: always()

--- a/.github/workflows/sparkinfer-image.yml
+++ b/.github/workflows/sparkinfer-image.yml
@@ -145,7 +145,9 @@ jobs:
       - name: Rent, boot, check, tear down
         env:
           CONFORMANCE_RENT_WAIT_MIN: "20"
-        run: scripts/serving_conformance_on_lium.sh "$TAG" "conformance-$REF"
+        run: |
+          ssh-keygen -t ed25519 -N '' -q -f "$RUNNER_TEMP/lium_ci"
+          LIUM_SSH_KEY_PATH="$RUNNER_TEMP/lium_ci" scripts/serving_conformance_on_lium.sh "$TAG" "conformance-$REF"
 
       - name: Upload the report
         if: always()
@@ -163,6 +165,7 @@ jobs:
              | .releases[0].runtime_image = $image
              | .releases[0].speed = ((.releases[0].speed // {}) + {
                  single_stream_decode_tps: $speed[0].single_stream_decode_tps,
+                 aggregate_decode_tps: $speed[0].aggregate_decode_tps,
                  decode_per_request: $speed[0].decode_per_request,
                  measured_on: ($pin + " on a rented RTX 5090, actions run " + $run)
                })

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -340,6 +340,9 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
     }
 
 
+MODEL_RESIDENT_MIN_BYTES = 8_000_000_000
+
+
 def check_attest(rep: Report, base_url: str, timeout: float, attest_url: Optional[str] = None) -> Dict:
     """A1: the attest container beside the runtime (entrius/gt-attest, :8081 on the runtime's host unless
     ``attest_url`` says otherwise) answers a seeded challenge with a deterministic digest inside 3 s idle — the
@@ -365,11 +368,17 @@ def check_attest(rep: Report, base_url: str, timeout: float, attest_url: Optiona
     again = requests.post(f'{attest_url}/v1/attest', json={'seed': 12345, 'iters': 3, 'fill': True}, timeout=timeout)
     same = again.ok and (again.json().get('devices') or [again.json()])[0].get('digest') == dev.get('digest')
     rep.add('A1 digest deterministic for a seed', MUST, bool(same))
-    facts.update(
-        attest_ref_wall_ms=round(wall, 1),
-        attest_iters=3,
-        vram_model_reserved_bytes=int(dev.get('vram_total') or 0) - int(dev.get('vram_free_before') or 0),
-    )
+    facts.update(attest_ref_wall_ms=round(wall, 1), attest_iters=3)
+    # What the model holds on a card is only measurable on a card that holds it. The conformance attest pod is a
+    # bare gt-attest image, so its reservation is the attest server's own few hundred MB; writing that into the
+    # release would make every honest miner "under-filled" (expected free ~= the whole card).
+    reserved = int(dev.get('vram_total') or 0) - int(dev.get('vram_free_before') or 0)
+    if reserved >= MODEL_RESIDENT_MIN_BYTES:
+        facts['vram_model_reserved_bytes'] = reserved
+    else:
+        print(
+            f'      attest card holds {reserved / 1e9:.1f} GB, no model resident: vram_model_reserved_bytes not measured'
+        )
     return facts
 
 

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -32,7 +32,13 @@ trap cleanup EXIT
 # a bare .id there indexes a string and kills the run — and only ever when a matching card IS listed.
 # Prints the cheapest free 1x$GPU executor id not in $1 (space-separated ids already taken).
 free_node() {
-  lium ls --format json 2>/dev/null | jq -r --arg gpu "RTX$GPU" --arg taken " $1 " \
+  local listing
+  listing=$(lium ls --format json 2>/dev/null || true)
+  if ! printf '%s\n' "$listing" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    echo "lium ls returned no JSON listing this minute, retrying: ${listing:0:120}" >&2
+    return 0
+  fi
+  printf '%s\n' "$listing" | jq -r --arg gpu "RTX$GPU" --arg taken " $1 " \
     '[.[] | select(type == "object") | . as $n
        | select(($n.id | type) == "string" and $n.gpu_type == $gpu and $n.gpu_count == 1
                 and ($n.vram_gb // 0) >= 30 and ($n.download_mbps // 0) >= 150

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -24,7 +24,11 @@ RENT_WAIT_MIN="${CONFORMANCE_RENT_WAIT_MIN:-60}"
 BOOT_WAIT_MIN="${CONFORMANCE_BOOT_WAIT_MIN:-45}"
 mkdir -p "$OUT"
 
-cleanup() { lium rm "$POD" -y >/dev/null 2>&1 || true; lium rm "$ATTEST_POD" -y >/dev/null 2>&1 || true; }
+TUNNEL_PID=""
+cleanup() {
+  [ -n "$TUNNEL_PID" ] && kill "$TUNNEL_PID" >/dev/null 2>&1 || true
+  lium rm "$POD" -y >/dev/null 2>&1 || true; lium rm "$ATTEST_POD" -y >/dev/null 2>&1 || true
+}
 trap cleanup EXIT
 
 # `lium ls --gpu X --format json` returns [] even when cards are listed; filter the full listing instead.
@@ -33,7 +37,7 @@ trap cleanup EXIT
 # Prints the cheapest free 1x$GPU executor id not in $1 (space-separated ids already taken).
 free_node() {
   local listing
-  listing=$(lium ls --format json 2>/dev/null || true)
+  listing=$(lium ls --format json 2>/dev/null | sed -n '/^[[{]/,$p' || true)
   if ! printf '%s\n' "$listing" | jq -e 'type == "array"' >/dev/null 2>&1; then
     echo "lium ls returned no JSON listing this minute, retrying: ${listing:0:120}" >&2
     return 0
@@ -92,8 +96,33 @@ echo "runtime up at $BASE, attest at $ATTEST"
 curl -s "$ATTEST/info" | tee "$OUT/attest-info.json"; echo
 curl -s "$BASE/v1/models" | tee "$OUT/models.json"; echo
 
+# The checker talks to the runtime through an ssh tunnel, not the pod's public port: Lium's port proxy caps
+# concurrent connections per pod (~5 on some hosts), which serialises the 16-wide overload and speed bursts and
+# turns them into a false R6 failure and a straggler-dominated aggregate_decode_tps. One ssh connection carries
+# every stream, so the card is measured, not the proxy.
+SSH_URL=$(pod_url "$POD" 22); SSH_HP=${SSH_URL#http://}; SSH_HOST=${SSH_HP%%:*}; SSH_PORT=${SSH_HP##*:}
+[ -n "$SSH_HOST" ] && [ -n "$SSH_PORT" ] || { echo "runtime pod has no public ssh port"; lium ps; exit 2; }
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=15
+          -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p "$SSH_PORT")
+[ -n "${LIUM_SSH_KEY_PATH:-}" ] && SSH_OPTS+=(-i "$LIUM_SSH_KEY_PATH")
+TUNNEL="http://127.0.0.1:18080"
+for ((i = 0; i < 12; i++)); do
+  ssh "${SSH_OPTS[@]}" -N -L 18080:127.0.0.1:8080 "root@$SSH_HOST" 2>/dev/null &
+  TUNNEL_PID=$!
+  for ((j = 0; j < 5; j++)); do
+    sleep 2
+    curl -sf --max-time 5 "$TUNNEL/v1/models" >/dev/null 2>&1 && break 2
+    kill -0 "$TUNNEL_PID" 2>/dev/null || break
+  done
+  kill "$TUNNEL_PID" >/dev/null 2>&1 || true; TUNNEL_PID=""
+  sleep 10
+done
+[ -n "$TUNNEL_PID" ] && curl -sf --max-time 5 "$TUNNEL/v1/models" >/dev/null \
+  || { echo "ssh tunnel to root@$SSH_HOST:$SSH_PORT never carried /v1/models; not measuring through the port proxy"; exit 2; }
+echo "checker reaches the runtime through ssh root@$SSH_HOST:$SSH_PORT (tunnel $TUNNEL)"
+
 set +e
-uv run python scripts/check_serving_runtime.py --base-url "$BASE" --model-id "$MODEL_ID" --attest-url "$ATTEST" \
+uv run python scripts/check_serving_runtime.py --base-url "$TUNNEL" --model-id "$MODEL_ID" --attest-url "$ATTEST" \
   --determinism-count 30 --repeat 3 --parallel 16 --speed-json "$OUT/speed.json" 2>&1 | tee "$OUT/conformance.txt"
 RC=${PIPESTATUS[0]}
 set -e

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -104,7 +104,6 @@ SSH_URL=$(pod_url "$POD" 22); SSH_HP=${SSH_URL#http://}; SSH_HOST=${SSH_HP%%:*};
 [ -n "$SSH_HOST" ] && [ -n "$SSH_PORT" ] || { echo "runtime pod has no public ssh port"; lium ps; exit 2; }
 SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=15
           -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p "$SSH_PORT")
-[ -n "${LIUM_SSH_KEY_PATH:-}" ] && SSH_OPTS+=(-i "$LIUM_SSH_KEY_PATH")
 TUNNEL="http://127.0.0.1:18080"
 for ((i = 0; i < 12; i++)); do
   ssh "${SSH_OPTS[@]}" -N -L 18080:127.0.0.1:8080 "root@$SSH_HOST" 2>/dev/null &


### PR DESCRIPTION
Three of the four failures since the last conformance run were the harness, not the runtime — and the one pass it produced (#1740) carried a value that would have failed every honest miner.

**R6 failed twice on `91.224.44.226` with an image that passed on `91.224.44.81` on 8/31.** Rented that host with ssh and measured: a 2 s HTTP handler answers 16 parallel requests in **2.4 s … 38.5 s through the Lium-mapped port** and **2.2 s … 2.2 s on-box** — the port proxy caps concurrent connections at ~5 per pod (5 clean, 6+ serialise). That serialises the 16-wide overload and speed bursts: a false R6 failure, and an `aggregate_decode_tps` of 25.9/46.9 against 263 — the number the validator has priced tokens from since #1737 ($0.69/M would have read $7.5/M). Through one ssh connection the same 32 parallel finish in 2.5 … 3.6 s, so the checker now reaches the runtime over `ssh -L 18080:127.0.0.1:8080`. Lium's SDK registers only `~/.ssh/id_ed25519` with a pod (it ignores `LIUM_SSH_KEY_PATH` and the config file), so the workflow generates the key there. Run 33532638861 on the same host: **CONFORMANT**, R6 16×200 in 32.4 … 32.9 s.

**`attest.vram_model_reserved_bytes` was being measured on a card without the model.** The attest pod is a bare `gt-attest:v1` card, so the checker reported the attest server's own 573 MB; in the release that makes `attest.py` expect ~32 GB free on a 5090, and a card holding the 23.7 GB model can fill only ~8 GB < 0.6 × 32 GB → every honest miner `under-filled`. The checker now reports the field only from a card with ≥ 8 GB resident and the pin-bump keeps the loadout's existing value otherwise (jq fallback verified).

**Pin-bump now carries `aggregate_decode_tps`** into the loadout — #1737 made the checker emit it and derives the per-token rate from it, but the jq step only copied `single_stream_decode_tps` and `decode_per_request`.

**A non-JSON `lium ls` line killed run 33529543919** before renting (`jq: parse error … column 6` — the shape of a leading `Hint:`/`Error:` line). `free_node` now drops anything before the first `[`, checks the listing parses as an array, and otherwise logs and retries.

ruff / format / pyright clean on the checker; `bash -n`, `shellcheck -S warning`, YAML parse clean.

https://claude.ai/code/session_011rz9LRxHEUXn37Jjqbxxh9