### PR TITLE
serving: bless sparkinfer 7498736

### DIFF
--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -18,13 +18,15 @@
       "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
       "audit_bank": "serving_audit_bank.json",
       "speed": {
-        "single_stream_decode_tps": 296.1,
-        "aggregate_decode_tps": 222.5,
-        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090, actions run 33535005600",
+        "single_stream_decode_tps": 443.6,
+        "aggregate_decode_tps": 280.0,
+        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 — queues past 16, wall 3.7 s -> 7 s)",
         "decode_per_request": {
-          "1": 296.1,
-          "6": 40.0,
-          "16": 15.8
+          "1": 443.6,
+          "6": 46.0,
+          "16": 19.4,
+          "24": 19.4,
+          "32": 19.5
         }
       },
       "attest": {

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -13,26 +13,25 @@
       "end_of_turn_token_id": 151645,
       "request_timeout": 60,
       "runtime_pin": "gittensor-ai-lab/sparkinfer@7498736",
-      "runtime_image": "entrius/sparkinfer:7498736",
+      "runtime_image": "entrius/sparkinfer:7498736@sha256:2ab51deb56af16d94ac0cd6c92756df5e5a42facb4c5ab8c5eb39224937e16a2",
       "model_file": "unsloth/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
       "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
       "audit_bank": "serving_audit_bank.json",
       "speed": {
-        "single_stream_decode_tps": 443.6,
-        "aggregate_decode_tps": 280.0,
-        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 — queues past 16, wall 3.7 s -> 7 s)",
+        "single_stream_decode_tps": 296.1,
+        "aggregate_decode_tps": 222.5,
+        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090, actions run 33535005600",
         "decode_per_request": {
-          "1": 443.6,
-          "6": 46.0,
-          "16": 19.4,
-          "24": 19.4,
-          "32": 19.5
+          "1": 296.1,
+          "6": 40.0,
+          "16": 15.8
         }
       },
       "attest": {
         "image": "entrius/gt-attest:v1",
         "iters": 3,
-        "vram_model_reserved_bytes": 24000000000
+        "vram_model_reserved_bytes": 24000000000,
+        "reference_wall_ms": 846.8
       }
     }
   ]


### PR DESCRIPTION
`entrius/sparkinfer:7498736` passed `scripts/check_serving_runtime.py` on a rented RTX 5090
(run https://github.com/entrius/gittensor/actions/runs/33535005600 — report in the
`serving-conformance-7498736` artifact). This bumps `runtime_pin`, pins `runtime_image` to the pushed
image's digest, and writes the release's
blessing-time speed facts (`speed.decode_per_request`, the per-request decode curve served traffic is
priced against) and attestation facts (`attest.*`). Update the sha named in the comments at
`gittensor/constants.py` and `gittensor/serving/audit.py` if the blessing rules changed.