### PR TITLE
serving: a baseline probe cuts off silence at 15 s, not honest slowness

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -286,6 +286,10 @@ SERVING_BASELINE_PER_ROUND = 2
 # up within the hour. A completion resets it. A serving-miner registry replaces this heuristic later.
 SERVING_DORMANT_AFTER_ROUNDS = 3
 SERVING_DORMANT_RETRY_ROUNDS = 12
+# A dead axon sends nothing, ever; an honest miner streams its first token in well under a second even at full load
+# (the full-credit TTFT line is 500 ms). Baseline probes cut off silence at this bound instead of holding the full
+# request_timeout for every non-compute axon; total time and the gateway path are untouched.
+SERVING_BASELINE_FIRST_BYTE_S = 15.0
 SERVING_API_DEFAULT_PORT = 8790
 # Miner: a hotkey may query for inference only with at least this much stake on the subnet (alpha, metagraph.S). Set so
 # that only the reference-running validator clears it (2026-08-26: one hotkey holds >1M alpha, the next 0.27M); every

--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -184,10 +184,12 @@ async def consume_stream(
         except StopAsyncIteration:
             break
         except asyncio.TimeoutError:
-            try:
-                await stream.aclose()
-            except Exception:
-                pass
+            aclose = getattr(stream, 'aclose', None)
+            if aclose is not None:
+                try:
+                    await aclose()
+                except Exception:
+                    pass
             raise TimeoutError(f'no first byte from the axon within {first_byte_s}s')
         waiting_first = False
         if isinstance(chunk, (bytes, bytearray)):

--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -15,6 +15,7 @@ so the miner can't tell the two apart and users get tokens as they decode.
   ``call_stream`` to a filled synapse, optionally relaying each event.
 """
 
+import asyncio
 import json
 import time
 from dataclasses import dataclass, field
@@ -163,13 +164,32 @@ async def consume_stream(
     synapse: InferenceSynapse,
     timeout: float,
     on_event: Optional[Callable[[Event], Awaitable[None]]] = None,
+    first_byte_s: Optional[float] = None,
 ) -> InferenceSynapse:
-    """Stream one inference from ``axon`` and return the filled synapse; relay each event to ``on_event`` if given."""
+    """Stream one inference from ``axon`` and return the filled synapse; relay each event to ``on_event`` if given.
+
+    ``first_byte_s`` bounds the wait for the axon's first yield only: silence past it raises ``TimeoutError``,
+    while a stream that answered promptly keeps the full ``timeout`` however long it runs.
+    """
     parser, assembler = SSEParser(), StreamAssembler()
     final: Optional[InferenceSynapse] = None
     started = time.monotonic()
     observed_ttft_ms: Optional[float] = None
-    async for chunk in dendrite.call_stream(target_axon=axon, synapse=synapse, timeout=timeout, deserialize=False):
+    stream = dendrite.call_stream(target_axon=axon, synapse=synapse, timeout=timeout, deserialize=False).__aiter__()
+    waiting_first = first_byte_s is not None
+    while True:
+        step = stream.__anext__()
+        try:
+            chunk = await (asyncio.wait_for(step, first_byte_s) if waiting_first else step)
+        except StopAsyncIteration:
+            break
+        except asyncio.TimeoutError:
+            try:
+                await stream.aclose()
+            except Exception:
+                pass
+            raise TimeoutError(f'no first byte from the axon within {first_byte_s}s')
+        waiting_first = False
         if isinstance(chunk, (bytes, bytearray)):
             for event in parser.feed(bytes(chunk)):
                 if observed_ttft_ms is None:

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -53,6 +53,7 @@ from gittensor.constants import (
     BLOCKS_PER_TEMPO,
     SERVING_AUDIT_SAMPLE_FRACTION,
     SERVING_AUDIT_SAMPLE_MIN,
+    SERVING_BASELINE_FIRST_BYTE_S,
     SERVING_BASELINE_PER_ROUND,
     SERVING_BUDGET_REFUSAL_RATIO,
     SERVING_DORMANT_AFTER_ROUNDS,
@@ -325,7 +326,9 @@ async def baseline_round(
         state.charge_sent(hotkey, max_tokens)
         started = time.monotonic()
         try:
-            response = await consume_stream(dendrite, axon, synapse, release.request_timeout)
+            response = await consume_stream(
+                dendrite, axon, synapse, release.request_timeout, first_byte_s=SERVING_BASELINE_FIRST_BYTE_S
+            )
         except Exception as e:
             response, err = None, repr(e)
         else:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1401,6 +1401,42 @@ def test_consume_stream_observes_time_to_first_token():
     assert miss.completion is None and miss.observed_ttft_ms is None
 
 
+def test_consume_stream_first_byte_bound_cuts_silence_not_slowness():
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.serving.stream import consume_stream
+    from gittensor.synapses import InferenceSynapse
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+    syn = InferenceSynapse(messages=MSGS, model_id=good.model_id, max_tokens=4, logprobs=True)
+
+    class Silent:
+        async def call_stream(self, **kw):
+            await asyncio.sleep(10)
+            yield kw['synapse']
+
+    with pytest.raises(TimeoutError, match='first byte'):
+        asyncio.run(consume_stream(Silent(), axon, syn, 60.0, first_byte_s=0.05))  # type: ignore[arg-type]
+
+    class SlowTail:
+        def __init__(self, inner):
+            self.inner = inner
+
+        async def call_stream(self, **kw):
+            first = True
+            async for chunk in self.inner.call_stream(**kw):
+                if not first:
+                    await asyncio.sleep(0.12)
+                first = False
+                yield chunk
+
+    inner, _ = _dendrite_echoing(good)
+    out = asyncio.run(consume_stream(SlowTail(inner), axon, syn.model_copy(), 5.0, first_byte_s=0.05))  # type: ignore[arg-type]
+    assert out.completion
+
+
 def test_latency_credit_uses_time_to_first_token_not_total_latency(monkeypatch):
     """A long answer that streamed promptly earns full credit; a slow first token does not."""
     from types import SimpleNamespace
@@ -1866,7 +1902,7 @@ def test_axon_that_answers_without_a_completion_gets_a_real_reason(monkeypatch):
     good = _echo_release()
     axon = SimpleNamespace(is_serving=True)
 
-    async def consume(_dendrite, _axon, synapse, _timeout):
+    async def consume(_dendrite, _axon, synapse, _timeout, **_kw):
         synapse.dendrite = bt.TerminalInfo(status_message='Success')
         return synapse  # unfilled: no completion, no served_model_id
 


### PR DESCRIPTION
Every `axon.is_serving` UID gets baseline probes (2/round pre-dormancy, then 2/hour), and most of those axons on mainnet are not compute miners — each probe to a dead one held the full 60 s `request_timeout`. A flat 15 s total timeout would false-miss honest miners instead: baseline prompts run to 512 tokens and a card at 16-way decodes ~15–19 tok/s per request (~30 s), and misses feed the audit window and dormancy — the soak-3 class of bug.

The two populations separate cleanly on the first byte: a dead axon never sends one, an honest miner streams its first token in well under a second even loaded (the full-credit TTFT line is 500 ms). `consume_stream` gains an optional `first_byte_s` that bounds only the wait for the stream's first yield (silence past it raises `TimeoutError`, counted as a miss with a real reason; the generator is closed); the baseline path passes `SERVING_BASELINE_FIRST_BYTE_S = 15.0`. Total time, and the gateway path, are untouched.

New test: `test_consume_stream_first_byte_bound_cuts_silence_not_slowness` — a silent stream raises at the bound; a stream with a prompt first byte and a slow tail past the bound completes.

Local CI: ruff check, ruff format --check, pyright (0 errors), vulture, pytest (770 passed).

https://claude.ai/code/session_011rz9LRxHEUXn37Jjqbxxh9