### PR TITLE
serving: a saturated miner refuses busy instead of queueing

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -306,6 +306,9 @@ SERVING_VALIDATOR_TOKENS_PER_TEMPO = 50_000
 SERVING_BUDGET_REFUSAL_RATIO = 0.8
 BLOCKS_PER_TEMPO = 360
 SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (sparkinfer >= 12954e6 handles 24)
+# Gateway: extra miners tried after one refuses at capacity ("busy", runtime contract R6 lifted to the axon) before
+# the client gets a 429. Each busy leg is an immediate 403, so the tail cost is round trips, not generations.
+SERVING_GATEWAY_BUSY_RETRIES = 3
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 1024  # hard cap per request (API and miner both enforce)
 # Gateway: total characters across a request's messages (~4 per token). A prompt past the release's context makes

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -14,8 +14,10 @@ to probation (not yet READY) miners so new miners can earn a window; user keys
 only ever reach READY miners. Off unless keys are set. Binds loopback by
 default; put it behind the host reverse proxy / TLS like any other service.
 
-No queue: with no READY capacity it returns 429 so rejected demand stays
-visible.
+No queue, at either layer: a saturated miner refuses "busy" instead of
+queueing (runtime contract R6 at the axon), the gateway retries the next
+READY miner, and with no capacity left — none READY, or everyone tried
+refused — it returns 429 so rejected demand stays visible.
 
     OPENAI_BASE_URL=http://<host>:8790/v1 OPENAI_API_KEY=<key> ...
 """
@@ -32,9 +34,16 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from gittensor.constants import SERVING_MAX_PROMPT_CHARS, SERVING_MAX_TOKENS
+from gittensor.constants import SERVING_GATEWAY_BUSY_RETRIES, SERVING_MAX_PROMPT_CHARS, SERVING_MAX_TOKENS
 from gittensor.serving.loadout import ServingLoadout, ServingRelease
-from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState, finite_or_none
+from gittensor.serving.state import (
+    ReadyMiner,
+    RequestRecord,
+    ServedRequest,
+    ServingState,
+    finite_or_none,
+    is_busy_detail,
+)
 from gittensor.serving.stream import SSE_DONE, Event, consume_stream, sse_event
 from gittensor.synapses import InferenceSynapse
 
@@ -140,146 +149,175 @@ def build_app(
         want_logprobs = bool(body.get('logprobs', False))
         want_stream = bool(body.get('stream', False))
 
-        miner = state.acquire(release.release_id, probation=key in baseline)
-        if miner is None:
-            raise HTTPException(status_code=429, detail='no READY serving capacity')
-        inflight = state.inflight().get(miner.uid, 1)
-        state.charge_sent(miner.hotkey, max_tokens)
-
         request_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())
-        start = time.monotonic()
+        tried: Set[int] = set()  # uids that refused this request busy; the retry must land elsewhere
 
-        def finish(result: Optional[InferenceSynapse]) -> bool:
-            state.release(miner.uid)
-            ok = result is not None and result.completion is not None
-            # The miner's stream end, not the moment the user finished reading it: a slow client must not read as a
-            # slow card.
-            latency_ms = finite_or_none(getattr(result, 'observed_latency_ms', None)) if result else None
-            if latency_ms is None:
-                latency_ms = (time.monotonic() - start) * 1000.0
-            state.enqueue_served(
-                ServedRequest(
-                    ts=time.time(),
-                    uid=miner.uid,
-                    hotkey=miner.hotkey,
-                    model_id=release.model_id,
-                    release_id=release.release_id,
-                    messages=messages,
-                    ok=ok and (result.served_model_id == release.model_id if result else False),
-                    latency_ms=latency_ms,
-                    completion=result.completion if result else None,
-                    tokens=list(result.tokens) if result and result.tokens else None,
-                    token_ids=list(result.token_ids) if result and result.token_ids else None,
-                    token_bytes=list(result.token_bytes) if result and result.token_bytes else None,
-                    token_logprobs=list(result.token_logprobs) if result and result.token_logprobs else None,
-                    detail=str(getattr(getattr(result, 'dendrite', None), 'status_message', None) or '')
-                    if not ok
-                    else '',
-                    source='gateway',
-                    ttft_ms=finite_or_none(getattr(result, 'observed_ttft_ms', None)) if result else None,
-                    inflight=inflight,
-                    max_tokens=max_tokens,
+        for _ in range(1 + SERVING_GATEWAY_BUSY_RETRIES):
+            picked = state.acquire(release.release_id, probation=key in baseline, exclude=tried)
+            if picked is None:
+                raise HTTPException(
+                    status_code=429, detail='all serving capacity busy' if tried else 'no READY serving capacity'
                 )
-            )
-            state.record(
-                RequestRecord(
-                    ts=time.time(),
-                    kind='gateway',
-                    uid=miner.uid,
-                    ok=ok,
-                    latency_ms=latency_ms,
-                    completion_tokens=(result.usage or {}).get('completion_tokens', 0) if result else 0,
-                    ttft_ms=result.ttft_ms if result else None,
-                    decode_tps=result.decode_tps if result else None,
-                    detail='' if ok else 'miner returned no completion',
+            miner = picked
+            inflight = state.inflight().get(miner.uid, 1)
+            state.charge_sent(miner.hotkey, max_tokens)
+            start = time.monotonic()
+
+            def finish(result: Optional[InferenceSynapse]) -> bool:
+                state.release(miner.uid)
+                ok = result is not None and result.completion is not None
+                # The miner's stream end, not the moment the user finished reading it: a slow client must not read
+                # as a slow card.
+                latency_ms = finite_or_none(getattr(result, 'observed_latency_ms', None)) if result else None
+                if latency_ms is None:
+                    latency_ms = (time.monotonic() - start) * 1000.0
+                state.enqueue_served(
+                    ServedRequest(
+                        ts=time.time(),
+                        uid=miner.uid,
+                        hotkey=miner.hotkey,
+                        model_id=release.model_id,
+                        release_id=release.release_id,
+                        messages=messages,
+                        ok=ok and (result.served_model_id == release.model_id if result else False),
+                        latency_ms=latency_ms,
+                        completion=result.completion if result else None,
+                        tokens=list(result.tokens) if result and result.tokens else None,
+                        token_ids=list(result.token_ids) if result and result.token_ids else None,
+                        token_bytes=list(result.token_bytes) if result and result.token_bytes else None,
+                        token_logprobs=list(result.token_logprobs) if result and result.token_logprobs else None,
+                        detail=str(getattr(getattr(result, 'dendrite', None), 'status_message', None) or '')
+                        if not ok
+                        else '',
+                        source='gateway',
+                        ttft_ms=finite_or_none(getattr(result, 'observed_ttft_ms', None)) if result else None,
+                        inflight=inflight,
+                        max_tokens=max_tokens,
+                    )
                 )
-            )
-            return ok
+                state.record(
+                    RequestRecord(
+                        ts=time.time(),
+                        kind='gateway',
+                        uid=miner.uid,
+                        ok=ok,
+                        latency_ms=latency_ms,
+                        completion_tokens=(result.usage or {}).get('completion_tokens', 0) if result else 0,
+                        ttft_ms=result.ttft_ms if result else None,
+                        decode_tps=result.decode_tps if result else None,
+                        detail='' if ok else 'miner returned no completion',
+                    )
+                )
+                return ok
 
-        def failed() -> JSONResponse:
-            return JSONResponse(
-                status_code=502, content={'error': {'message': 'serving miner failed', 'uid': miner.uid}}
-            )
+            def failed() -> JSONResponse:
+                return JSONResponse(
+                    status_code=502, content={'error': {'message': 'serving miner failed', 'uid': miner.uid}}
+                )
 
-        def reshape(event: dict) -> dict:
-            """Relay a miner chunk to the client under our request id, without logprobs unless asked for."""
-            out = dict(event)
-            out['id'] = request_id
-            if not want_logprobs:
-                out['choices'] = [{k: v for k, v in c.items() if k != 'logprobs'} for c in event.get('choices') or []]
-            if 'usage' in event:
-                out['gittensor'] = {'served_uid': miner.uid, 'latency_ms': round((time.monotonic() - start) * 1000, 1)}
-            return out
+            def reshape(event: dict) -> dict:
+                """Relay a miner chunk to the client under our request id, without logprobs unless asked for."""
+                out = dict(event)
+                out['id'] = request_id
+                if not want_logprobs:
+                    out['choices'] = [
+                        {k: v for k, v in c.items() if k != 'logprobs'} for c in event.get('choices') or []
+                    ]
+                if 'usage' in event:
+                    out['gittensor'] = {
+                        'served_uid': miner.uid,
+                        'latency_ms': round((time.monotonic() - start) * 1000, 1),
+                    }
+                return out
 
-        if want_stream:
-            queue: 'asyncio.Queue[object]' = asyncio.Queue()
+            if want_stream:
+                queue: 'asyncio.Queue[object]' = asyncio.Queue()
 
-            async def relay(event: Event) -> None:
-                await queue.put(event)
+                async def relay(event: Event, queue=queue) -> None:
+                    await queue.put(event)
 
-            async def run() -> Optional[InferenceSynapse]:
-                try:
-                    return await _dispatch(get_dendrite(), miner, messages, max_tokens, release, request_timeout, relay)
-                finally:
-                    await queue.put(_END)
+                async def run(miner=miner, relay=relay, queue=queue) -> Optional[InferenceSynapse]:
+                    try:
+                        return await _dispatch(
+                            get_dendrite(), miner, messages, max_tokens, release, request_timeout, relay
+                        )
+                    finally:
+                        await queue.put(_END)
 
-            task = asyncio.create_task(run())
+                task = asyncio.create_task(run())
 
-            async def outcome() -> Optional[InferenceSynapse]:
-                try:  # a stream the assembler could not fold is a miss, never a leaked in-flight slot
-                    return await task
-                except Exception:
-                    return None
+                async def outcome(task=task) -> Optional[InferenceSynapse]:
+                    try:  # a stream the assembler could not fold is a miss, never a leaked in-flight slot
+                        return await task
+                    except Exception:
+                        return None
 
-            first = await queue.get()
-            if first is _END or first is None:  # nothing streamed before the miner gave up
-                finish(await outcome())
+                first = await queue.get()
+                if first is _END or first is None:  # nothing streamed before the miner gave up
+                    result = await outcome()
+                    finish(result)
+                    if _busy_refused(result):  # refused at capacity, nothing sent to the client: try elsewhere
+                        tried.add(miner.uid)
+                        continue
+                    return failed()
+
+                async def body_iter():
+                    event = first
+                    try:
+                        while event is not _END:
+                            yield SSE_DONE if event is None else sse_event(reshape(event))  # type: ignore[arg-type]
+                            event = await queue.get()
+                    finally:
+                        finish(await outcome())
+
+                return StreamingResponse(body_iter(), media_type='text/event-stream')
+
+            try:
+                result = await _dispatch(get_dendrite(), miner, messages, max_tokens, release, request_timeout)
+            except Exception:
+                result = None
+            if _busy_refused(result):  # refused at capacity: try elsewhere
+                finish(result)
+                tried.add(miner.uid)
+                continue
+            if not finish(result) or result is None:
                 return failed()
 
-            async def body_iter():
-                event = first
-                try:
-                    while event is not _END:
-                        yield SSE_DONE if event is None else sse_event(reshape(event))  # type: ignore[arg-type]
-                        event = await queue.get()
-                finally:
-                    finish(await outcome())
-
-            return StreamingResponse(body_iter(), media_type='text/event-stream')
-
-        try:
-            result = await _dispatch(get_dendrite(), miner, messages, max_tokens, release, request_timeout)
-        except Exception:
-            result = None
-        if not finish(result) or result is None:
-            return failed()
-
-        choice: Dict = {
-            'index': 0,
-            'message': {'role': 'assistant', 'content': result.completion},
-            'finish_reason': result.finish_reason or 'stop',
-        }
-        if want_logprobs and result.tokens and result.token_logprobs:
-            choice['logprobs'] = {
-                'content': [{'token': t, 'logprob': lp} for t, lp in zip(result.tokens, result.token_logprobs)]
+            choice: Dict = {
+                'index': 0,
+                'message': {'role': 'assistant', 'content': result.completion},
+                'finish_reason': result.finish_reason or 'stop',
             }
-        return {
-            'id': request_id,
-            'object': 'chat.completion',
-            'created': created,
-            'model': result.served_model_id or release.model_id,
-            'choices': [choice],
-            'usage': result.usage or {},
-            'gittensor': {
-                'served_uid': miner.uid,
-                'latency_ms': round((time.monotonic() - start) * 1000.0, 1),
-                'ttft_ms': finite_or_none(result.ttft_ms),
-                'decode_tps': finite_or_none(result.decode_tps),
-            },
-        }
+            if want_logprobs and result.tokens and result.token_logprobs:
+                choice['logprobs'] = {
+                    'content': [{'token': t, 'logprob': lp} for t, lp in zip(result.tokens, result.token_logprobs)]
+                }
+            return {
+                'id': request_id,
+                'object': 'chat.completion',
+                'created': created,
+                'model': result.served_model_id or release.model_id,
+                'choices': [choice],
+                'usage': result.usage or {},
+                'gittensor': {
+                    'served_uid': miner.uid,
+                    'latency_ms': round((time.monotonic() - start) * 1000.0, 1),
+                    'ttft_ms': finite_or_none(result.ttft_ms),
+                    'decode_tps': finite_or_none(result.decode_tps),
+                },
+            }
+
+        raise HTTPException(status_code=429, detail='all serving capacity busy')
 
     return app
+
+
+def _busy_refused(result: Optional[InferenceSynapse]) -> bool:
+    """Did the miner refuse this dispatch at capacity? Nothing was served and the axon status says busy."""
+    if result is None or result.completion is not None:
+        return False
+    return is_busy_detail(str(getattr(getattr(result, 'dendrite', None), 'status_message', None) or ''))
 
 
 async def _dispatch(

--- a/gittensor/serving/baseline.py
+++ b/gittensor/serving/baseline.py
@@ -7,8 +7,9 @@ Served traffic is the only audit, so every miner needs a few verified requests p
 showed up. These prompts only have to satisfy one thing: the reference can answer them (any text can be greedy
 decoded). They are template-shaped and a miner that wants to can recognise them; what stops it profiting from that
 is that a refusal or a wrong answer on any *other* request is judged the same way (a budget refusal is neutral only
-by the validator's own ledger; see ``forward.py``), so answering these and nothing else earns nothing extra. Mixing
-real user prompts into the baseline is not built.
+by the validator's own ledger, and a busy refusal, also neutral, earns nothing and tallies the card as full; see
+``forward.py``), so answering these and nothing else earns nothing extra. Mixing real user prompts into the
+baseline is not built.
 """
 
 import random

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -13,7 +13,9 @@ earn a window without a real user ever hitting an unverified card. Per-round
 pay scores (served tokens in card-equivalents) are settled over the trailing
 ``SERVING_SETTLEMENT_ROUNDS`` rounds; a READY miner's ``score`` is its routing
 weight (speed credit), separate from pay. Both threads also append to one
-request log (telemetry).
+request log (telemetry). A miner that refuses a request at capacity ("busy")
+is retried elsewhere by the gateway and tallied here as headroom telemetry —
+never a strike; its refused tokens are unpaid, which is the whole penalty.
 """
 
 import math
@@ -22,7 +24,7 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Deque, Dict, List, Optional, Sequence, Tuple
+from typing import Deque, Dict, List, Optional, Sequence, Set, Tuple
 
 import bittensor as bt
 
@@ -89,6 +91,13 @@ def finite_or_none(value: Optional[float]) -> Optional[float]:
     return float(value) if value is not None and math.isfinite(value) else None
 
 
+def is_busy_detail(detail: Optional[str]) -> bool:
+    """A miner's saturation refusal ("busy: all backend slots in use") as it lands in an axon status message.
+    'budget' is excluded so the budget refusal keeps its own, ledger-gated path."""
+    text = (detail or '').lower()
+    return 'busy' in text and 'budget' not in text
+
+
 @dataclass
 class ServingState:
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
@@ -103,6 +112,7 @@ class ServingState:
     attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
     last_credit: Dict[str, float] = field(default_factory=dict)  # audit thread only: hotkey -> last measured credit
     _sent_tokens: Dict[str, Deque[Tuple[float, int]]] = field(default_factory=dict)  # hotkey -> (ts, max_tokens)
+    _busy: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> ts of each busy refusal
     attest_round: int = 0
     last_round: dict = field(default_factory=dict)  # audit thread's summary of the last round, for /v1/serving/status
     _rng: random.Random = field(default_factory=random.Random, repr=False)
@@ -183,6 +193,20 @@ class ServingState:
         with self._lock:
             return sum(n for ts, n in self._sent_tokens.get(hotkey, ()) if ts >= since)
 
+    def busy_refusal(self, hotkey: str, now: Optional[float] = None) -> None:
+        """A miner refused a request at capacity. Headroom telemetry, never a strike: the refusal already cost the
+        miner the tokens it did not serve."""
+        with self._lock:
+            self._busy.setdefault(hotkey, deque(maxlen=SERVING_REQUEST_LOG_SIZE)).append(
+                now if now is not None else time.time()
+            )
+
+    def busy_count(self, hotkey: str, window_s: float, now: Optional[float] = None) -> int:
+        """Busy refusals recorded for ``hotkey`` in the trailing ``window_s`` seconds."""
+        since = (now if now is not None else time.time()) - window_s
+        with self._lock:
+            return sum(1 for ts in self._busy.get(hotkey, ()) if ts >= since)
+
     def drain_served(self) -> List[ServedRequest]:
         """Audit thread: take every request served since the last round."""
         with self._lock:
@@ -197,7 +221,9 @@ class ServingState:
         with self._lock:
             return list(self._ready.values()) if self._fresh() else []
 
-    def acquire(self, release_id: Optional[str] = None, probation: bool = False) -> Optional[ReadyMiner]:
+    def acquire(
+        self, release_id: Optional[str] = None, probation: bool = False, exclude: Optional[Set[int]] = None
+    ) -> Optional[ReadyMiner]:
         """Pick a READY miner (for ``release_id`` if given) with the fewest in-flight requests.
 
         Among those, the choice is random, weighted by score: a better miner is sent more, but not everything.
@@ -207,8 +233,10 @@ class ServingState:
 
         With ``probation`` (baseline traffic) an idle probation miner is preferred, at most one request in flight
         each, so unverified miners get exactly the traffic they need to earn a window and no more.
+        ``exclude`` skips uids that already refused this request busy, so a retry lands elsewhere.
         Returns None when there is no capacity or the last audit round is older than the READY TTL.
         """
+        exclude = exclude or set()
         with self._lock:
             if not self._fresh():
                 return None
@@ -216,13 +244,19 @@ class ServingState:
                 idle = [
                     u
                     for u, m in self._probation.items()
-                    if (release_id is None or m.release_id == release_id) and self._inflight.get(u, 0) == 0
+                    if u not in exclude
+                    and (release_id is None or m.release_id == release_id)
+                    and self._inflight.get(u, 0) == 0
                 ]
                 if idle:
                     uid = min(idle)
                     self._inflight[uid] = 1
                     return self._probation[uid]
-            candidates = [u for u, m in self._ready.items() if release_id is None or m.release_id == release_id]
+            candidates = [
+                u
+                for u, m in self._ready.items()
+                if u not in exclude and (release_id is None or m.release_id == release_id)
+            ]
             if not candidates:
                 return None
             fewest = min(self._inflight.get(u, 0) for u in candidates)
@@ -260,7 +294,10 @@ class ServingState:
     def snapshot(self) -> dict:
         with self._lock:
             log = list(self._log)
+            since = time.time() - 3600.0  # busy refusals shown over the trailing hour, like settlement
+            busy = {hk: n for hk, q in self._busy.items() if (n := sum(1 for ts in q if ts >= since))}
             return {
+                'busy': busy,
                 'ready_uids': sorted(self._ready),
                 'probation_uids': sorted(self._probation),
                 'pending_verification': len(self._served),

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -67,7 +67,7 @@ from gittensor.constants import (
 from gittensor.serving.audit import AuditVerdict, Reference, reference_for, verify_served
 from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
 from gittensor.serving.loadout import ServingRelease, load_serving_loadout
-from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState
+from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState, is_busy_detail
 from gittensor.serving.store import ServingStore
 from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
@@ -188,6 +188,12 @@ def verify_served_round(
     def judge(req: ServedRequest) -> Optional[AuditVerdict]:
         if not req.ok and 'budget' in req.detail.lower() and budget_refusal_plausible(state, req.hotkey, staked_caller):
             return None  # this validator over-sent by its own ledger; not the miner's fault
+        if not req.ok and is_busy_detail(req.detail):
+            # Refused at capacity: neutral, unconditionally — no ledger can corroborate load other validators put
+            # on the card, and the refusal already cost the miner the tokens it did not serve. Failures are always
+            # sampled, so tallying here counts every refusal exactly once (headroom telemetry, /v1/serving/status).
+            state.busy_refusal(req.hotkey, now=req.ts)
+            return None
         if not req.ok:
             if req.source == 'gateway' and reference_rejects(reference, req.messages):
                 return None  # an honest runtime refuses this prompt too (over context, bad shape): not the miner's
@@ -550,9 +556,11 @@ def seed_ready_from_store(validator: 'Validator', state: ServingState, loadout=N
 def update_dormancy(
     state: ServingState, serving: Sequence[Tuple[int, str, bt.AxonInfo]], served: Sequence[ServedRequest]
 ) -> None:
-    """A completion resets a hotkey's dormancy count; a round of requests with none bumps it. Unasked = unchanged."""
+    """A completion resets a hotkey's dormancy count; a round of requests with none bumps it. Unasked = unchanged.
+    A busy refusal is an answer — the axon is alive, just full — else a saturated probation miner would go dormant
+    on refused baseline probes and starve out of the probe stream."""
     asked = {req.hotkey for req in served}
-    answered = {req.hotkey for req in served if req.completion}
+    answered = {req.hotkey for req in served if req.completion or (not req.ok and is_busy_detail(req.detail))}
     for _, hotkey, _ in serving:
         if hotkey in answered:
             state.dormant_rounds[hotkey] = 0

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -126,7 +126,9 @@ class ServingMiner(BaseNeuron):
 async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BTStreamingResponse:
     """Stream the backend's completion for an audit or user request through the axon.
 
-    Backend errors end the stream without ``[DONE]``; the validator scores that as a miss.
+    Backend errors end the stream without ``[DONE]``; the validator scores that as a miss. Saturation never gets
+    this far: ``blacklist_inference`` refuses "busy" while every backend slot is taken, so the slot wait below only
+    absorbs the few requests that raced past the gate together.
     """
     max_tokens = max(1, min(int(synapse.max_tokens), SERVING_MAX_TOKENS))
     messages, logprobs = synapse.messages, synapse.logprobs
@@ -235,6 +237,18 @@ def reserve_audit_budget(miner: ServingMiner, hotkey: str, tokens: int) -> bool:
 
 
 async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
+    """The axon's inference gate: a saturated backend refuses up front ("busy") instead of queueing — the runtime
+    contract's R6 lifted to the axon — so the gateway reroutes and the refusal is judged neutral; queueing instead
+    would decay every caller's TTFT. Before the caller gate and its budget charge, so a refused request costs the
+    caller nothing. Attestation delegates to ``blacklist_caller`` and skips this: the sidecar has its own
+    serialisation and a full backend must still pass attest rounds.
+    """
+    if miner.backend_slots.locked():
+        return True, 'busy: all backend slots in use'
+    return await blacklist_caller(miner, synapse)
+
+
+async def blacklist_caller(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:
     """Who may query: hotkeys staked at least SERVING_MIN_CALLER_STAKE alpha without limit (the gateway validator),
     and any validator-permit holder inside a per-tempo completion-token budget (an independent auditor).
 
@@ -272,7 +286,7 @@ async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) ->
 # one challenge at a time per caller: the sidecar fills the card's free VRAM and serialises challenges, so an open
 # door here is a free way to stall a competitor's runtime and queue every real validator's challenge behind it.
 async def blacklist_attest(miner: ServingMiner, synapse: AttestSynapse) -> Tuple[bool, str]:
-    refused, reason = await blacklist_inference(miner, _as_budget_free(synapse))
+    refused, reason = await blacklist_caller(miner, _as_budget_free(synapse))
     if refused:
         return True, reason
     hotkey = synapse.dendrite.hotkey if synapse.dendrite and synapse.dendrite.hotkey else ''

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -269,6 +269,26 @@ def test_acquire_filters_by_release():
     assert picked is not None and picked.uid == 1
 
 
+def test_acquire_excludes_uids_that_already_refused_busy():
+    state = ServingState(_rng=random.Random(7))
+    state.publish_round([_ready(1), _ready(2)], {})
+    picked = state.acquire(exclude={1})
+    assert picked is not None and picked.uid == 2
+    assert state.acquire(exclude={1, 2}) is None
+    state = ServingState()
+    state.publish_round([], {}, probation=[_ready(3)])
+    assert state.acquire(probation=True, exclude={3}) is None
+
+
+def test_busy_ledger_counts_within_window_and_shows_in_snapshot():
+    state = ServingState()
+    state.busy_refusal('hk1', now=time.time() - 10)
+    state.busy_refusal('hk1', now=time.time() - 7200)  # outside the snapshot's trailing hour
+    assert state.busy_count('hk1', 3600.0) == 1
+    assert state.busy_count('hk1', 8000.0) == 2
+    assert state.snapshot()['busy'] == {'hk1': 1}
+
+
 # --- gateway ----------------------------------------------------------------
 
 
@@ -318,6 +338,95 @@ def test_gateway_429_without_ready_miners(monkeypatch):
     client = _gateway_client(ServingState(), monkeypatch)
     r = client.post('/v1/chat/completions', json={'messages': MSGS}, headers={'Authorization': 'Bearer k1'})
     assert r.status_code == 429
+
+
+class _BusyResponse:
+    """What _dispatch returns when the miner's blacklist refused busy: a 403, nothing streamed."""
+
+    completion = None
+    tokens = None
+    token_ids = None
+    token_bytes = None
+    token_logprobs = None
+    usage = None
+    ttft_ms = None
+    decode_tps = None
+    served_model_id = None
+    finish_reason = None
+    dendrite = SimpleNamespace(status_message='Forbidden. Key is blacklisted: busy: all backend slots in use.')
+
+
+def _busy_then_serve_client(state: ServingState, monkeypatch, busy_first: int = 1):
+    """A gateway whose first ``busy_first`` dispatches refuse busy and the rest serve; returns (client, calls)."""
+    calls: list = []
+
+    async def fake_dispatch(dendrite, miner, messages, max_tokens, lo, timeout, on_event=None):
+        calls.append(miner.uid)
+        if len(calls) <= busy_first:
+            return _BusyResponse()
+        result = expected_completion(messages, max_tokens, lo.model_id)
+        if on_event is not None:  # replay the chunk sequence a miner would stream
+            from gittensor.serving.stream import SSEParser, result_to_sse
+
+            parser = SSEParser()
+            for chunk in result_to_sse(result, 'chatcmpl-miner', 0, logprobs=True):
+                for event in parser.feed(chunk):
+                    await on_event(event)
+        return _FakeResponse(result, lo.model_id)
+
+    monkeypatch.setattr('gittensor.serving.api._dispatch', fake_dispatch)
+    app = build_app(state, ServingLoadout(releases=[_echo_release()]), parse_api_keys('k1'), lambda: None, 5)
+    return TestClient(app), calls
+
+
+def test_gateway_retries_a_busy_miner_and_serves_from_the_next(monkeypatch):
+    """One miner refusing busy costs the request nothing: the gateway releases it and serves from the other."""
+    state = ServingState(_rng=random.Random(7))
+    state.publish_round([_ready(1), _ready(2)], {})
+    client, calls = _busy_then_serve_client(state, monkeypatch)
+    r = client.post(
+        '/v1/chat/completions', json={'messages': MSGS, 'max_tokens': 4}, headers={'Authorization': 'Bearer k1'}
+    )
+    assert r.status_code == 200
+    assert set(calls) == {1, 2} and r.json()['gittensor']['served_uid'] == calls[1]
+    assert state.inflight() == {1: 0, 2: 0}  # the busy leg released its slot
+    refused, served = state.drain_served()
+    assert not refused.ok and 'busy' in refused.detail and served.ok
+
+
+def test_gateway_429_when_every_ready_miner_refuses_busy(monkeypatch):
+    """Saturation surfaces as a clean 429, never as an invisible queue: rejected demand stays visible."""
+    state = ServingState(_rng=random.Random(7))
+    state.publish_round([_ready(1), _ready(2)], {})
+    client, calls = _busy_then_serve_client(state, monkeypatch, busy_first=99)
+    r = client.post(
+        '/v1/chat/completions', json={'messages': MSGS, 'max_tokens': 4}, headers={'Authorization': 'Bearer k1'}
+    )
+    assert r.status_code == 429 and r.json()['detail'] == 'all serving capacity busy'
+    assert set(calls) == {1, 2}  # both tried once; the exclude set stops a re-pick
+    assert state.inflight() == {1: 0, 2: 0}
+    drained = state.drain_served()
+    assert len(drained) == 2 and all(not q.ok and 'busy' in q.detail for q in drained)
+
+
+def test_gateway_stream_retries_busy_before_committing_to_the_stream(monkeypatch):
+    """A busy refusal streams nothing, so the retry happens before the client sees any bytes."""
+    state = ServingState(_rng=random.Random(7))
+    state.publish_round([_ready(1), _ready(2)], {})
+    client, calls = _busy_then_serve_client(state, monkeypatch)
+    with client.stream(
+        'POST',
+        '/v1/chat/completions',
+        json={'messages': MSGS, 'max_tokens': 4, 'stream': True},
+        headers={'Authorization': 'Bearer k1'},
+    ) as r:
+        assert r.status_code == 200
+        raw = b''.join(r.iter_bytes())
+    from gittensor.serving.stream import SSEParser
+
+    events = SSEParser().feed(raw)
+    assert events[-1] is None and set(calls) == {1, 2}  # a full stream, served by the miner that had room
+    assert state.inflight() == {1: 0, 2: 0}
 
 
 def test_gateway_chat_completion_roundtrip(monkeypatch):
@@ -1239,6 +1348,48 @@ def test_budget_refusal_is_neutral_only_by_the_validators_own_ledger(monkeypatch
     assert state.audits.verdict('hk1', good.model_id).mean == 0.5
 
 
+def test_busy_refusal_is_neutral_and_tallied_never_a_strike(monkeypatch):
+    """A miner refusing at capacity takes no window hit and earns nothing for the refused request; the refusal is
+    tallied as headroom telemetry at the request's own timestamp. Unconditional — no ledger can corroborate the
+    load other validators put on the card, and the refused tokens are already the penalty."""
+    from types import SimpleNamespace
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+    dendrite, _ = _dendrite_echoing(good)
+
+    def refused():
+        r = _served(1, good, ok=False)
+        r.detail = 'Forbidden. Key is blacklisted: busy: all backend slots in use.'
+        return r
+
+    state = ServingState(settlement_rounds=1)
+    state.enqueue_served(_served(1, good))
+    state.enqueue_served(refused())
+    _round(state, dendrite, [(1, 'hk1', axon)], good, monkeypatch)
+    w = state.audits.verdict('hk1', good.model_id)
+    assert w.n_audits == 1 and w.mean == 1.0  # the refusal never entered the window
+    assert state.busy_count('hk1', 3600.0, now=1.0) == 1  # tallied once, at the request's ts (0.0)
+    assert state.dormant_rounds.get('hk1', 0) == 0
+
+
+def test_busy_refusals_keep_a_hotkey_out_of_dormancy():
+    """A whole round of busy refusals is an alive-but-full card, not a dead axon; anything else starves a saturated
+    probation miner out of the probe stream."""
+    from types import SimpleNamespace
+
+    good = _echo_release()
+    fwd = fwd_module()
+    state = ServingState()
+    busy = _served(1, good, ok=False)
+    busy.detail = 'Forbidden. Key is blacklisted: busy: all backend slots in use.'
+    dead = _served(2, good, ok=False)
+    dead.detail = 'timeout'
+    serving = [(1, 'hk1', SimpleNamespace(is_serving=True)), (2, 'hk2', SimpleNamespace(is_serving=True))]
+    fwd.update_dormancy(state, serving, [busy, dead])  # type: ignore[arg-type]
+    assert state.dormant_rounds.get('hk1', 0) == 0 and state.dormant_rounds.get('hk2') == 1
+
+
 def test_sent_token_ledger_is_kept_at_dispatch(monkeypatch):
     """Gateway and baseline requests both charge the validator's own ledger with the max_tokens they asked for."""
     from gittensor.validator.serving.forward import baseline_round
@@ -1821,6 +1972,7 @@ def test_serving_miner_blacklists_non_validators(monkeypatch):
             block=720,
         ),
         audit_budget={},
+        backend_slots=asyncio.Semaphore(1),
     )
 
     def call(hotkey, max_tokens=64):
@@ -2453,6 +2605,7 @@ def test_miner_refuses_a_request_routed_for_another_release():
     miner = SimpleNamespace(
         release=ServingRelease(model_id='qwen', backend='echo', release_id='qwen-fast'),
         metagraph=SimpleNamespace(hotkeys=['vali'], S=[2_000_000.0]),
+        backend_slots=asyncio.Semaphore(1),
     )
     syn = InferenceSynapse(messages=MSGS, model_id='qwen', release_id='qwen-slow', max_tokens=4)
     syn.dendrite = bt.TerminalInfo(hotkey='vali')
@@ -2462,6 +2615,34 @@ def test_miner_refuses_a_request_routed_for_another_release():
     assert not asyncio.run(blacklist_inference(miner, syn))[0]  # type: ignore[arg-type]
     syn.release_id = ''  # a caller that does not name a release is served as before
     assert not asyncio.run(blacklist_inference(miner, syn))[0]  # type: ignore[arg-type]
+
+
+def test_miner_refuses_busy_before_charging_budget_and_attest_bypasses_it():
+    """Every backend slot taken -> "busy" up front (R6 at the axon), before the budget charge; a freed slot serves
+    and charges as before. Attestation skips the gate: a full card must still pass attest rounds."""
+    from gittensor.synapses import AttestSynapse
+    from neurons.serving_miner import blacklist_attest, blacklist_inference
+
+    miner = SimpleNamespace(
+        release=ServingRelease(model_id='qwen', backend='echo', release_id='qwen-fast'),
+        metagraph=SimpleNamespace(
+            hotkeys=['auditor'], S=[100.0], validator_permit=[True], validator_trust=[1.0], block=720
+        ),
+        backend_slots=asyncio.Semaphore(0),
+        audit_budget={},
+        attest_inflight=set(),
+    )
+    syn = InferenceSynapse(messages=MSGS, model_id='qwen', max_tokens=4)
+    syn.dendrite = bt.TerminalInfo(hotkey='auditor')
+    blocked, reason = asyncio.run(blacklist_inference(miner, syn))  # type: ignore[arg-type]
+    assert blocked and 'busy' in reason
+    assert miner.audit_budget == {}
+    att = AttestSynapse(seed=1)
+    att.dendrite = bt.TerminalInfo(hotkey='auditor')
+    assert not asyncio.run(blacklist_attest(miner, att))[0]  # type: ignore[arg-type]
+    miner.backend_slots = asyncio.Semaphore(1)
+    assert not asyncio.run(blacklist_inference(miner, syn))[0]  # type: ignore[arg-type]
+    assert miner.audit_budget['auditor'][1] == 4
 
 
 def test_strikes_count_up_and_survive_a_restart(tmp_path):

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -67,3 +67,4 @@ _.ttl_get_block  # unused method (gittensor/utils/misc.py:91)
 _.get_help  # unused method (gittensor/cli/issue_commands/help.py:180)
 add_validator_args  # unused function (gittensor/utils/config.py:81)
 neuron_type  # class attr read by BaseNeuron.should_set_weights (neurons/serving_miner.py:47)
+_.busy_count  # busy-ledger reader, exercised in tests; snapshot computes its hour view inline under the same lock


### PR DESCRIPTION
An overloaded serving miner queues requests on its backend-slot semaphore today: TTFT climbs, the latency credit bleeds pay, requests past the timeout land in the audit window as misses, and honest saturation can knock a miner out of READY — dumping its load on fewer survivors until the whole fleet un-READYs and the gateway finally 429s. The gateway docstring's "rejected demand stays visible" was only true at zero READY capacity.

**Miner** — `blacklist_inference` refuses `busy: all backend slots in use` while every slot is taken (runtime contract R6 lifted to the axon), before the caller gate, so a refused request burns no validator budget. The caller/stake/budget gate moved to `blacklist_caller`; attestation delegates there directly, so a full backend still passes attest rounds. Multi-GPU capacity is already expressed by `SERVING_BACKEND_CONCURRENCY` (N×16), so the busy threshold scales by cards with no new config.

**Gateway** — `acquire()` takes an `exclude` set; `chat_completions` retries up to `SERVING_GATEWAY_BUSY_RETRIES` further miners on a busy refusal (in the stream path before any byte reaches the client) and answers `429 all serving capacity busy` only when everyone tried refused — distinct from `no READY serving capacity`. Each busy leg releases its in-flight slot and is enqueued like any served request.

**Scoring** — a busy refusal is neutral in `judge()`: no window entry, never a strike, pays 0 by construction (a refusal has no completion tokens). Neutrality is unconditional — the validator cannot corroborate load other validators put on the card, and the miner is the only party that sees its aggregate load; the refused tokens are the whole penalty. `update_dormancy` counts a busy refusal as an answer, else a saturated probation miner would go dormant on refused baseline probes and starve out of the probe stream.

**Telemetry** — every refusal is tallied once (at the request's own timestamp) in a per-hotkey busy ledger, exposed as `busy` in `/v1/serving/status` over the trailing hour: a headroom signal for the fleet, deliberately not load-bearing for pay or admission.

Tests: miner busy gate precedes the budget charge and attest bypasses it; gateway retry, all-busy 429, and stream-path retry; neutral verdict + tally; dormancy; `acquire(exclude=…)`; busy ledger/snapshot. ruff, format, pyright, vulture, and the full suite (778) pass.

https://claude.ai/code/session_01A1HhTgco2WEnsKHSoZtcjV