### PR TITLE
serving: a burst cannot race past the busy gate — admission claims the slot atomically

### DIFF
--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -60,6 +60,11 @@ from neurons.base.neuron import BaseNeuron
 
 BTStreamingResponse = StreamingSynapse.BTStreamingResponse
 
+# A slot claim made at admission that the handler never picks up (verify failed, connection died) frees itself
+# after this grace; a claimed stream frees itself request_timeout + slack after it began, however it ended.
+SLOT_CLAIM_GRACE_S = 10.0
+SLOT_CLAIM_STREAM_SLACK_S = 30.0
+
 
 class ServingMiner(BaseNeuron):
     """Serves one release over an axon and answers inference challenges."""
@@ -87,9 +92,8 @@ class ServingMiner(BaseNeuron):
             verify_fn=partial(verify_attest, self),
         )
         # One card's worth by default; a multi-GPU box fronting N instances sets SERVING_BACKEND_CONCURRENCY=N x 16.
-        self.backend_slots = asyncio.Semaphore(
-            int(os.getenv('SERVING_BACKEND_CONCURRENCY', SERVING_BACKEND_CONCURRENCY))
-        )
+        self.slot_count = int(os.getenv('SERVING_BACKEND_CONCURRENCY', SERVING_BACKEND_CONCURRENCY))
+        self.slot_claims: Dict[int, float] = {}  # id(synapse) -> monotonic expiry
         self.seen_nonces: 'OrderedDict[str, None]' = OrderedDict()
         self.audit_budget: Dict[str, Tuple[int, int]] = {}  # validator hotkey -> (tempo, completion tokens used)
         self.attest_inflight: Set[str] = set()  # validator hotkeys with a challenge running on the sidecar now
@@ -127,11 +131,13 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BT
     """Stream the backend's completion for an audit or user request through the axon.
 
     Backend errors end the stream without ``[DONE]``; the validator scores that as a miss. Saturation never gets
-    this far: ``blacklist_inference`` refuses "busy" while every backend slot is taken, so the slot wait below only
-    absorbs the few requests that raced past the gate together.
+    this far: ``blacklist_inference`` claimed a slot atomically at admission, so nothing here waits — the claim is
+    extended for the stream's lifetime and released when it ends, however it ends.
     """
     max_tokens = max(1, min(int(synapse.max_tokens), SERVING_MAX_TOKENS))
     messages, logprobs = synapse.messages, synapse.logprobs
+    claim = id(synapse)
+    miner.slot_claims[claim] = time.monotonic() + miner.release.request_timeout + SLOT_CLAIM_STREAM_SLACK_S
 
     async def token_streamer(send) -> None:
         loop = asyncio.get_running_loop()
@@ -146,11 +152,13 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BT
             finally:
                 loop.call_soon_threadsafe(queue.put_nowait, None)
 
-        async with miner.backend_slots:
+        try:
             producer = loop.run_in_executor(None, produce)
             while (chunk := await queue.get()) is not None:
                 await send({'type': 'http.response.body', 'body': chunk, 'more_body': True})
             await producer
+        finally:
+            miner.slot_claims.pop(claim, None)
 
     return synapse.create_streaming_response(token_streamer)
 
@@ -242,10 +250,28 @@ async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) ->
     would decay every caller's TTFT. Before the caller gate and its budget charge, so a refused request costs the
     caller nothing. Attestation delegates to ``blacklist_caller`` and skips this: the sidecar has its own
     serialisation and a full backend must still pass attest rounds.
+
+    Admission and accounting are one atomic step: ``claim_slot`` counts this request against the slots the moment
+    it is admitted, with no await in between, so a burst cannot race past a capacity check that only samples
+    slots already handed to running streams. A claim the handler never picks up expires on its own.
     """
-    if miner.backend_slots.locked():
+    if not claim_slot(miner, synapse):
         return True, 'busy: all backend slots in use'
-    return await blacklist_caller(miner, synapse)
+    blocked, reason = await blacklist_caller(miner, synapse)
+    if blocked:
+        miner.slot_claims.pop(id(synapse), None)
+    return blocked, reason
+
+
+def claim_slot(miner: ServingMiner, synapse: InferenceSynapse) -> bool:
+    now = time.monotonic()
+    for key, expiry in list(miner.slot_claims.items()):
+        if expiry <= now:
+            del miner.slot_claims[key]
+    if len(miner.slot_claims) >= miner.slot_count:
+        return False
+    miner.slot_claims[id(synapse)] = now + SLOT_CLAIM_GRACE_S
+    return True
 
 
 async def blacklist_caller(miner: ServingMiner, synapse: InferenceSynapse) -> Tuple[bool, str]:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1972,7 +1972,8 @@ def test_serving_miner_blacklists_non_validators(monkeypatch):
             block=720,
         ),
         audit_budget={},
-        backend_slots=asyncio.Semaphore(1),
+        slot_count=99,
+        slot_claims={},
     )
 
     def call(hotkey, max_tokens=64):
@@ -2605,7 +2606,8 @@ def test_miner_refuses_a_request_routed_for_another_release():
     miner = SimpleNamespace(
         release=ServingRelease(model_id='qwen', backend='echo', release_id='qwen-fast'),
         metagraph=SimpleNamespace(hotkeys=['vali'], S=[2_000_000.0]),
-        backend_slots=asyncio.Semaphore(1),
+        slot_count=99,
+        slot_claims={},
     )
     syn = InferenceSynapse(messages=MSGS, model_id='qwen', release_id='qwen-slow', max_tokens=4)
     syn.dendrite = bt.TerminalInfo(hotkey='vali')
@@ -2628,7 +2630,8 @@ def test_miner_refuses_busy_before_charging_budget_and_attest_bypasses_it():
         metagraph=SimpleNamespace(
             hotkeys=['auditor'], S=[100.0], validator_permit=[True], validator_trust=[1.0], block=720
         ),
-        backend_slots=asyncio.Semaphore(0),
+        slot_count=0,
+        slot_claims={},
         audit_budget={},
         attest_inflight=set(),
     )
@@ -2640,9 +2643,64 @@ def test_miner_refuses_busy_before_charging_budget_and_attest_bypasses_it():
     att = AttestSynapse(seed=1)
     att.dendrite = bt.TerminalInfo(hotkey='auditor')
     assert not asyncio.run(blacklist_attest(miner, att))[0]  # type: ignore[arg-type]
-    miner.backend_slots = asyncio.Semaphore(1)
+    miner.slot_count = 1
     assert not asyncio.run(blacklist_inference(miner, syn))[0]  # type: ignore[arg-type]
     assert miner.audit_budget['auditor'][1] == 4
+    assert len(miner.slot_claims) == 1  # the admitted request holds its slot from the moment of admission
+
+
+def test_burst_admissions_never_exceed_slots():
+    """40 simultaneous admission checks against 16 slots admit exactly 16 — the race #1743 shipped with: a gate
+    that samples slots already handed to running streams admits an entire burst before any stream has begun."""
+    from neurons.serving_miner import blacklist_inference
+
+    miner = SimpleNamespace(
+        release=ServingRelease(model_id='qwen', backend='echo', release_id='qwen-fast'),
+        metagraph=SimpleNamespace(hotkeys=['vali'], S=[2_000_000.0]),
+        slot_count=16,
+        slot_claims={},
+    )
+
+    async def burst():
+        syns = []
+        for _ in range(40):
+            syn = InferenceSynapse(messages=MSGS, model_id='qwen', max_tokens=4)
+            syn.dendrite = bt.TerminalInfo(hotkey='vali')
+            syns.append(syn)
+        return syns, await asyncio.gather(*(blacklist_inference(miner, s) for s in syns))  # type: ignore[arg-type]
+
+    syns, verdicts = asyncio.run(burst())
+    admitted = [v for v in verdicts if not v[0]]
+    refused = [v for v in verdicts if v[0]]
+    assert len(admitted) == 16 and len(refused) == 24
+    assert all('busy' in reason for _, reason in refused)
+    assert len(miner.slot_claims) == 16
+    del syns
+
+
+def test_slot_claims_expire_and_a_refused_caller_releases_one():
+    from neurons.serving_miner import blacklist_inference
+
+    miner = SimpleNamespace(
+        release=ServingRelease(model_id='qwen', backend='echo', release_id='qwen-fast'),
+        metagraph=SimpleNamespace(hotkeys=['vali'], S=[2_000_000.0]),
+        slot_count=1,
+        slot_claims={},
+    )
+    syn = InferenceSynapse(messages=MSGS, model_id='qwen', max_tokens=4)
+    syn.dendrite = bt.TerminalInfo(hotkey='stranger')
+    assert asyncio.run(blacklist_inference(miner, syn)) == (True, 'Unrecognized hotkey')  # type: ignore[arg-type]
+    assert miner.slot_claims == {}  # a caller-gate refusal does not hold the slot it briefly claimed
+
+    syn.dendrite = bt.TerminalInfo(hotkey='vali')
+    assert not asyncio.run(blacklist_inference(miner, syn))[0]  # type: ignore[arg-type]
+    assert len(miner.slot_claims) == 1
+    other = InferenceSynapse(messages=MSGS, model_id='qwen', max_tokens=4)
+    other.dendrite = bt.TerminalInfo(hotkey='vali')
+    blocked, reason = asyncio.run(blacklist_inference(miner, other))  # type: ignore[arg-type]
+    assert blocked and 'busy' in reason
+    miner.slot_claims[next(iter(miner.slot_claims))] = 0.0  # the handler never ran; the claim ages out
+    assert not asyncio.run(blacklist_inference(miner, other))[0]  # type: ignore[arg-type]
 
 
 def test_strikes_count_up_and_survive_a_restart(tmp_path):


### PR DESCRIPTION
Live verification of #1743 on the testnet fleet (soak 11, 40-wide saturation waves against one 16-slot miner) showed the busy gate almost never fires under the load it was built for: **3 refusals in 20 minutes of saturation**, 33 requests *queued* through to completion at a 33 s median, the overflow timed out into 502s and audit **misses**, and UID 27 was knocked out of READY — the exact failure #1743 set out to prevent.

Mechanism: `blacklist_inference` sampled `Semaphore.locked()`, but the slots are acquired later, inside the streaming body. A burst passes admission before any of its members holds a slot, then the whole burst queues on `async with miner.backend_slots` — the queue the PR claimed to remove. The refusal *plumbing* was fine: the 3 refusals that did fire were judged neutral and tallied.

Fix: admission and accounting become one atomic step. `claim_slot` reaps expired claims, refuses when the ledger is full, and records the claim — with no await between check and claim, so simultaneous admissions serialize on the event loop. The handler extends its claim for the stream's lifetime (`request_timeout` + slack) and releases it in `finally`; a claim whose handler never runs (verify failure, dropped connection) ages out after 10 s; a caller-gate refusal releases the slot it briefly claimed. The in-stream semaphore wait is deleted.

New tests: `test_burst_admissions_never_exceed_slots` (40 simultaneous admissions against 16 slots → exactly 16 admitted — fails on the old code) and claim expiry/caller-refusal release. Existing #1743 tests updated from the semaphore stubs to the ledger.

Local CI: ruff, format, pyright (0 errors), vulture, full pytest (780 passed). Deploying this branch to the testnet miner for a saturation re-run; results will be commented here.

https://claude.ai/code/session_01Y6PJz4CJhpEDbNKMKD41nA