### PR TITLE
serving: a first-byte timeout is a miss, never the audit thread's death

### DIFF
--- a/gittensor/serving/stream.py
+++ b/gittensor/serving/stream.py
@@ -178,19 +178,34 @@ async def consume_stream(
     stream = dendrite.call_stream(target_axon=axon, synapse=synapse, timeout=timeout, deserialize=False).__aiter__()
     waiting_first = first_byte_s is not None
     while True:
-        step = stream.__anext__()
-        try:
-            chunk = await (asyncio.wait_for(step, first_byte_s) if waiting_first else step)
-        except StopAsyncIteration:
-            break
-        except asyncio.TimeoutError:
-            aclose = getattr(stream, 'aclose', None)
-            if aclose is not None:
+        if waiting_first:
+            # Not wait_for: its cancellation can surface as a bare CancelledError (BaseException) from the
+            # dendrite's stream machinery, and one escaping probe kills the whole audit thread. Cancel explicitly,
+            # absorb whatever the cancelled step raises, and report the timeout as an ordinary TimeoutError.
+            step_task = asyncio.ensure_future(stream.__anext__())
+            done, _ = await asyncio.wait({step_task}, timeout=first_byte_s)
+            if not done:
+                step_task.cancel()
                 try:
-                    await aclose()
-                except Exception:
+                    await step_task
+                except BaseException:
                     pass
-            raise TimeoutError(f'no first byte from the axon within {first_byte_s}s')
+                aclose = getattr(stream, 'aclose', None)
+                if aclose is not None:
+                    try:
+                        await aclose()
+                    except BaseException:
+                        pass
+                raise TimeoutError(f'no first byte from the axon within {first_byte_s}s')
+            try:
+                chunk = step_task.result()
+            except StopAsyncIteration:
+                break
+        else:
+            try:
+                chunk = await stream.__anext__()
+            except StopAsyncIteration:
+                break
         waiting_first = False
         if isinstance(chunk, (bytes, bytearray)):
             for event in parser.feed(bytes(chunk)):

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -335,6 +335,8 @@ async def baseline_round(
             response = await consume_stream(
                 dendrite, axon, synapse, release.request_timeout, first_byte_s=SERVING_BASELINE_FIRST_BYTE_S
             )
+        except asyncio.CancelledError as e:  # a cancelled probe is this hotkey's miss, never the thread's death
+            response, err = None, repr(e)
         except Exception as e:
             response, err = None, repr(e)
         else:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1588,6 +1588,30 @@ def test_consume_stream_first_byte_bound_cuts_silence_not_slowness():
     assert out.completion
 
 
+def test_first_byte_timeout_never_leaks_cancellation():
+    """The audit thread died in soak 11 when the first-byte cancel surfaced as a bare CancelledError."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from gittensor.serving.stream import consume_stream
+    from gittensor.synapses import InferenceSynapse
+
+    good = _echo_release()
+    axon = SimpleNamespace(is_serving=True)
+    syn = InferenceSynapse(messages=MSGS, model_id=good.model_id, max_tokens=4, logprobs=True)
+
+    class Stubborn:
+        async def call_stream(self, **kw):
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                raise asyncio.CancelledError('fresh cancel from stream internals')
+            yield kw['synapse']
+
+    with pytest.raises(TimeoutError, match='first byte'):
+        asyncio.run(consume_stream(Stubborn(), axon, syn, 60.0, first_byte_s=0.05))  # type: ignore[arg-type]
+
+
 def test_latency_credit_uses_time_to_first_token_not_total_latency(monkeypatch):
     """A long answer that streamed promptly earns full credit; a slow first token does not."""
     from types import SimpleNamespace


### PR DESCRIPTION
Soak 11 found this within an hour of #1742 going live: the validator's `serving-audits` thread died at 01:20:46 UTC on the first dead-axon probe after a redeploy —

```
Exception in thread serving-audits:
  File "gittensor/validator/serving/forward.py", line 684, in _run
  File "gittensor/validator/serving/forward.py", line 381, in baseline_round
  File "gittensor/validator/serving/forward.py", line 335, in one
  File "gittensor/serving/stream.py", line 183, in consume_stream
asyncio.exceptions.CancelledError
```

`wait_for`'s timeout cancellation can surface from the dendrite's stream machinery as a bare `CancelledError` — a `BaseException`, which sails past `baseline_round`'s `except Exception`, through the gather, and kills the audit loop. The gateway thread keeps answering (429s), so the failure looks like a healthy validator that silently stopped running rounds — on mainnet this would be a validator that stops setting meaningful serving weights until someone notices.

Two changes: `consume_stream`'s first-byte bound no longer uses `wait_for` — it cancels the step explicitly, absorbs whatever the cancelled step raises, and reports a plain `TimeoutError`; and `baseline_round` treats a `CancelledError` from one probe as that hotkey's miss (the audit thread has no cancellation path of its own, so nothing legitimate is swallowed).

Regression test: a stream that re-raises a fresh `CancelledError` when cancelled must produce `TimeoutError`, not thread death. Local CI: ruff, format, pyright (0 errors), vulture, full pytest (781 passed).

Sibling of #1744 (both out of soak-11 verification); the testnet validator is being redeployed from this branch to continue the soak.

https://claude.ai/code/session_01Y6PJz4CJhpEDbNKMKD41nA