### PR TITLE
serving: docker-only miner onboarding — published images, one compose file

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,15 @@
 name: Build and Push Docker Image
 
+# Publishes the neuron image (root Dockerfile) and the conformance checker built from it
+# (docker/checker.Dockerfile), so a miner pulls a known-good build instead of cloning the repo:
+# main -> entrius/gittensor:latest + entrius/gt-checker:latest, test -> the :test tags.
+
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+      - test
 
 jobs:
   build-and-push:
@@ -13,16 +18,33 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Resolve the tag from the branch
+        id: tag
+        run: |
+          REF="${{ github.ref_name }}"
+          echo "tag=$([ "$REF" = main ] && echo latest || echo "$REF")" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push the neuron image
+        id: neuron
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
           push: true
-          tags: entrius/gittensor:latest,entrius/gittensor:${{ github.sha }}
+          tags: entrius/gittensor:${{ steps.tag.outputs.tag }},entrius/gittensor:${{ github.sha }}
+
+      - name: Build and push the conformance checker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/checker.Dockerfile
+          push: true
+          build-args: |
+            BASE_IMAGE=entrius/gittensor@${{ steps.neuron.outputs.digest }}
+          tags: entrius/gt-checker:${{ steps.tag.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -61,18 +61,19 @@ verified GPU-hour** (paid in alpha, inside a 3.5% emission cap). Validators veri
 against their own reference GPU — there is no separate audit prompt set — so a new miner sits in *probation*
 until its rolling window passes, then goes READY. One card = one payout; extra hotkeys on the same card share it.
 
+No clone, no build — every image is published on Docker Hub:
+
 ```bash
-# 1. Runtime: the pinned sparkinfer build + SHA-pinned model. Current tag + sha: gittensor.io/compute ("Current
-#    release", copy-paste command) or gittensor/validator/weights/serving_loadout.json
-docker run -d --name sparkinfer --gpus all -p 8080:8080 -v sparkmodels:/opt/sparkinfer/models \
-  -e MODEL_SHA256=<model_sha256 from the loadout> -e SPARKINFER_DETERMINISTIC=1 entrius/sparkinfer:<runtime_pin>
+# 1. The whole box (runtime + attest + neuron) from one compose file. Fill .env from the
+#    "Current release" card on gittensor.io/compute (images + model sha) plus wallet/network/port.
+curl -O https://raw.githubusercontent.com/entrius/gittensor/main/docker-compose.miner.yml
+curl -o .env https://raw.githubusercontent.com/entrius/gittensor/main/miner.env.example
+nano .env
+docker compose -f docker-compose.miner.yml up -d
 
-# 2. Prove it is conformant before you serve
-uv run python scripts/check_serving_runtime.py --base-url http://127.0.0.1:8080 --model-id qwen3.6-35b-a3b
-
-# 3. Miner neuron (env from .env.example: NETUID, WALLET_NAME, HOTKEY_NAME, SUBTENSOR_NETWORK, PORT, ...)
-docker run -d --env-file .env --network host -v ~/.bittensor/wallets:/root/.bittensor/wallets:ro \
-  --entrypoint /app/scripts/serving-miner-entrypoint.sh gittensor-miner
+# 2. Prove the box is conformant before you serve (model id from the same card)
+docker run --rm --network host entrius/gt-checker \
+  --base-url http://127.0.0.1:8080 --model-id qwen3.6-35b-a3b --attest-url http://127.0.0.1:8081
 ```
 
 Your status (READY / probation / quarantined, window, throughput, estimated payout, last miss reason) is on

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -9,7 +9,7 @@
 # by compose DNS; the loopback mapping is for your own curl checks and the conformance checker.
 services:
   runtime:
-    image: ${SPARKINFER_IMAGE:?runtime image from the Current release card on gittensor.io/compute}
+    image: ${RUNTIME_IMAGE:?runtime image from the Current release card on gittensor.io/compute}
     container_name: gt-miner-runtime
     restart: unless-stopped
     environment:

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -1,0 +1,74 @@
+# The whole serving miner box (see the Compute Miner guide): the blessed runtime, the attestation sidecar
+# and the miner neuron. Fill .env from miner.env.example — the image tags and model sha come from the
+# "Current release" card on gittensor.io/compute, never from a doc page — then:
+#
+#   docker compose -f docker-compose.miner.yml up -d
+#
+# Needs an RTX 5090 with the NVIDIA container toolkit; without one the runtime and attest services fail to
+# start (the neuron alone earns nothing). Runtime and attest stay on host loopback — the neuron reaches them
+# by compose DNS; the loopback mapping is for your own curl checks and the conformance checker.
+services:
+  runtime:
+    image: ${SPARKINFER_IMAGE:?runtime image from the Current release card on gittensor.io/compute}
+    container_name: gt-miner-runtime
+    restart: unless-stopped
+    environment:
+      MODEL_SHA256: ${MODEL_SHA256:?model sha256 from the Current release card on gittensor.io/compute}
+      # already baked into the image; repeated here so nobody turns it off by accident (contract D1)
+      SPARKINFER_DETERMINISTIC: "1"
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - sparkmodels:/opt/sparkinfer/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+  attest:
+    image: ${ATTEST_IMAGE:?attest image from the Current release card on gittensor.io/compute}
+    container_name: gt-miner-attest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8081:8081"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+  miner:
+    image: ${GITTENSOR_IMAGE:-entrius/gittensor:latest}
+    container_name: gt-miner
+    restart: unless-stopped
+    entrypoint: /app/scripts/serving-miner-entrypoint.sh
+    environment:
+      SUBTENSOR_NETWORK: ${SUBTENSOR_NETWORK:?finney for mainnet, test for testnet}
+      NETUID: ${NETUID:?74 for mainnet, 422 for testnet}
+      WALLET_NAME: ${WALLET_NAME:?the wallet whose hotkey you registered}
+      HOTKEY_NAME: ${HOTKEY_NAME:?the registered hotkey}
+      PORT: ${PORT:?axon port, reachable from the internet}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      SERVING_BASE_URL: http://runtime:8080
+      SERVING_ATTEST_URL: http://attest:8081
+      SERVING_RELEASE: ${SERVING_RELEASE:-}
+    ports:
+      - "${PORT:-8099}:${PORT:-8099}"
+    volumes:
+      - ${WALLET_PATH:-~/.bittensor/wallets}:/root/.bittensor/wallets:ro
+    depends_on:
+      - runtime
+      - attest
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  sparkmodels:

--- a/docker/checker.Dockerfile
+++ b/docker/checker.Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.4
+# Containerized conformance checker: scripts/check_serving_runtime.py without cloning the repo. CPU-only —
+# it talks to the runtime and attest containers over HTTP, so --network host is the documented run mode:
+#
+#   docker run --rm --network host entrius/gt-checker \
+#     --base-url http://127.0.0.1:8080 --model-id <model id> --attest-url http://127.0.0.1:8081
+#
+# Built FROM the published neuron image (.github/workflows/docker-publish.yml) so the checker always matches
+# the repo revision it shipped with.
+ARG BASE_IMAGE=entrius/gittensor:latest
+FROM ${BASE_IMAGE}
+ENTRYPOINT ["python", "scripts/check_serving_runtime.py"]

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -14,7 +14,9 @@ The loadout is a repo-pinned JSON file (same distribution rail as
 master_repositories.json) that miner and validator both load, so both sides
 agree on the releases by construction. ``SERVING_LOADOUT_PATH`` overrides the
 file (``serving_loadout.echo.json`` for a GPU-free localnet);
-``SERVING_REFERENCE_URL`` (+ ``SERVING_REFERENCE_API_KEY``) points the
+``SERVING_BASE_URL`` (+ ``SERVING_ATTEST_URL``) points the primary
+release's miner side at its runtime and attest containers (compose service
+DNS); ``SERVING_REFERENCE_URL`` (+ ``SERVING_REFERENCE_API_KEY``) points the
 primary release at a reference runtime — on the validator's own GPU or any
 reachable conformant copy, e.g. a rented 5090. Replacing this loader with a validator-signed,
 traffic-driven schedule (Gepetto-lite) is the planned upgrade path.
@@ -203,6 +205,14 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
     # The rate is the repo's, not the operator's: validators must price the same card the same way.
     tao_usd = float(pricing['tao_usd']) if pricing.get('tao_usd') else None
     loadout = ServingLoadout(releases=[ServingRelease.from_dict(entry) for entry in entries], tao_usd=tao_usd)
+
+    base_override = os.getenv('SERVING_BASE_URL')
+    if base_override:
+        loadout.primary.base_url = base_override
+        loadout.primary.attest_url = _sidecar_url(base_override)
+    attest_override = os.getenv('SERVING_ATTEST_URL')
+    if attest_override:
+        loadout.primary.attest_url = attest_override
 
     reference_override = os.getenv('SERVING_REFERENCE_URL')
     if reference_override:

--- a/miner.env.example
+++ b/miner.env.example
@@ -1,0 +1,25 @@
+# Serving miner env for docker-compose.miner.yml — copy to .env next to it and fill in.
+# The three release values come from the "Current release" card on https://gittensor.io/compute
+# (never from a doc page — a pin bump would strand a copied value).
+
+SPARKINFER_IMAGE=   # "Image" on the Current release card (tag or tag@sha256)
+ATTEST_IMAGE=       # "Attest image" on the Current release card
+MODEL_SHA256=       # model sha256 on the Current release card
+
+WALLET_NAME=default
+HOTKEY_NAME=default
+# Host path to your bittensor wallets, mounted read-only into the neuron
+# WALLET_PATH=~/.bittensor/wallets
+
+# finney + 74 = mainnet, test + 422 = testnet
+SUBTENSOR_NETWORK=
+NETUID=
+
+# Axon port — must be reachable from the internet (validators call you)
+PORT=8099
+
+LOG_LEVEL=info
+# Neuron image: entrius/gittensor:latest tracks main (mainnet); entrius/gittensor:test tracks the test branch
+# GITTENSOR_IMAGE=entrius/gittensor:latest
+# Only once more than one release is blessed: the release id to serve (from the Current release card)
+# SERVING_RELEASE=

--- a/miner.env.example
+++ b/miner.env.example
@@ -2,7 +2,7 @@
 # The three release values come from the "Current release" card on https://gittensor.io/compute
 # (never from a doc page — a pin bump would strand a copied value).
 
-SPARKINFER_IMAGE=   # "Image" on the Current release card (tag or tag@sha256)
+RUNTIME_IMAGE=      # "Runtime image" on the Current release card (tag or tag@sha256)
 ATTEST_IMAGE=       # "Attest image" on the Current release card
 MODEL_SHA256=       # model sha256 on the Current release card
 

--- a/scripts/serving-miner-entrypoint.sh
+++ b/scripts/serving-miner-entrypoint.sh
@@ -15,6 +15,12 @@ if [ -z "$SUBTENSOR_NETWORK" ]; then echo "SUBTENSOR_NETWORK is required" && exi
 if [ -z "$PORT" ]; then echo "PORT is required" && exit 1; fi
 if [ -z "$LOG_LEVEL" ]; then echo "LOG_LEVEL is required" && exit 1; fi
 
+HOTKEY_FILE="/root/.bittensor/wallets/${WALLET_NAME}/hotkeys/${HOTKEY_NAME}"
+if [ $# -eq 0 ] && [ ! -f "$HOTKEY_FILE" ]; then
+  echo "hotkey not found at ${HOTKEY_FILE}: mount your wallet dir (WALLET_PATH) and check WALLET_NAME/HOTKEY_NAME"
+  exit 1
+fi
+
 exec python neurons/serving_miner.py \
   --netuid ${NETUID} \
   --wallet.name ${WALLET_NAME} \

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -100,6 +100,16 @@ def test_reference_url_env_override_and_release_lookup(monkeypatch):
     assert isinstance(reference_for(loadout.primary), EchoReference)
 
 
+def test_base_url_env_override_points_miner_at_compose_services(monkeypatch):
+    monkeypatch.setenv('SERVING_LOADOUT_PATH', str(ECHO_LOADOUT_PATH))
+    monkeypatch.setenv('SERVING_BASE_URL', 'http://runtime:8080')
+    loadout = load_serving_loadout()
+    assert loadout.primary.base_url == 'http://runtime:8080'
+    assert loadout.primary.attest_url == 'http://runtime:8081'
+    monkeypatch.setenv('SERVING_ATTEST_URL', 'http://attest:8081')
+    assert load_serving_loadout().primary.attest_url == 'http://attest:8081'
+
+
 def test_live_reference_wins_over_bank(monkeypatch):
     from gittensor.serving import audit
 


### PR DESCRIPTION
A docs review costed compute-miner onboarding at "a competent evening". The friction was concentrated in four places: the neuron image had to be built from a clone, the three containers were hand-wired `docker run`s, the conformance checker required a full repo checkout with uv, and the docs had drifted (SSH clone forms, §6 still calling gittensor.io/compute "upcoming"). This is the repo half of fixing that; the docs half is entrius/gittensor-docs-ui#39. Setup becomes: register a hotkey, fill a handful of vars in `.env` from the Current release card, `docker compose up -d` — about twenty minutes.

What changed:

- `docker-publish.yml` now publishes on pushes to `test` as well as `main` (`entrius/gittensor:test` / `:latest` + sha tags), and additionally builds `entrius/gt-checker` from the just-pushed neuron image's digest (`docker/checker.Dockerfile` is a two-line `FROM` + `ENTRYPOINT`), so both the neuron and the conformance checker are pulled, never built by miners.
- `docker-compose.miner.yml` + `miner.env.example`: runtime, attest and neuron wired together — GPU reservations on the two GPU services, the model volume persisted, restart policies, runtime/attest published on host loopback for curl checks and the checker. Network selection has no default: `SUBTENSOR_NETWORK`, `NETUID`, `PORT`, wallet vars and the three release values are `:?`-required, so an empty value fails at `docker compose up` with a message naming the variable and pointing at the release card. Pins stay env-var-indirected — nothing in the compose file or example env hardcodes a release value.
- `SERVING_BASE_URL` / `SERVING_ATTEST_URL` env overrides in `gittensor/serving/loadout.py` (mirroring the existing `SERVING_REFERENCE_URL` pattern, with a test) let the compose neuron reach the runtime and attest services by compose DNS instead of requiring host networking.
- `serving-miner-entrypoint.sh` refuses a missing hotkey file with a one-line message naming the path and the vars to check — the first failure every new miner hits is no longer a stack trace.
- The README compute-miner quick start is now pull/compose-based.

Test evidence:

- Local CI: `ruff check`, `ruff format --check`, `pyright` (0 errors), `vulture`, `pytest tests/` — 779 passed.
- `docker compose -f docker-compose.miner.yml config` validates with a filled env (inline comments in `miner.env.example` parse cleanly); every required var left empty fails legibly. On this GPU-less box the GPU services fail with `could not select device driver "nvidia" with capabilities: [[gpu]]` while the config parses — going further needs a 5090 box.
- Neuron and checker images built locally; the checker runs its report in-container and flags parse (`--help` is shadowed by bittensor's import-time parser — pre-existing, identical outside the container, left alone).
- The neuron image under the compose entrypoint with a nonexistent wallet prints `hotkey not found at /root/.bittensor/wallets/nosuch/hotkeys/nosuch: mount your wallet dir (WALLET_PATH) and check WALLET_NAME/HOTKEY_NAME` and exits 1.

Scoring, audit, attest and gateway logic untouched; `serving_loadout.json` and the runtime pin untouched; nothing deployed anywhere.

https://claude.ai/code/session_014c7dZFY9dzzhRxE4oFy96u