### PR TITLE
serving: cap the pool at 5%; the unreserved slice burns, never inflates OSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See full guide **[here](https://docs.gittensor.io/miner.html)**
 ### Compute miners (serving)
 
 Gittensor also pays verified GPU time: an RTX 5090 running the blessed inference release earns **$0.70 per
-verified GPU-hour** (paid in alpha, inside a 3.5% emission cap). Validators verify the traffic they route to you
+verified GPU-hour** (paid in alpha, inside a 5% emission cap). Validators verify the traffic they route to you
 against their own reference GPU — there is no separate audit prompt set — so a new miner sits in *probation*
 until its rolling window passes, then goes READY. One card = one payout; extra hotkeys on the same card share it.
 

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -168,9 +168,10 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # published in serving_loadout.json (`pricing`). No card count and no per-hotkey cap: served volume is the capacity
 # proof, and a real 5090 cannot out-decode its silicon. The only ceiling is SERVING_EMISSION_SHARE_CAP — above it the
 # fleet dilutes pro-rata by token share; what it does not earn recycles to RECYCLE_UID, never to OSS. With no price
-# data (testnet) the cap is paid pro-rata. Move OSS_EMISSION_SHARE in the same commit so the pools sum to 1.0.
+# data (testnet) the cap is paid pro-rata. The pools may sum under 1.0: the unreserved remainder burns every round
+# (blend_emission_pools recycles it to RECYCLE_UID), so shrinking this cap never inflates OSS.
 SERVING_GPU_HOUR_USD = 0.70
-SERVING_EMISSION_SHARE_CAP = 0.10
+SERVING_EMISSION_SHARE_CAP = 0.05
 # Output tok/s one card sustains under load on the blessed runtime, for a release without its own
 # `speed.aggregate_decode_tps` (sparkinfer 7498736 on a 5090: 279-282 at 16 concurrent, 2026-08-27).
 SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 280.0
@@ -179,8 +180,8 @@ SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 280.0
 # usable pricing at all the fleet is paid nothing: the alternative (the whole cap, split pro-rata) hands one verified
 # card the whole cap. A network with no price data to read - testnet - sets SERVING_PAY_CAP_WITHOUT_PRICING.
 SERVING_PRICING_MAX_AGE_S = 3600.0
-assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE, (
-    'emission pools must sum to 1.0'
+assert OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP <= 1.0 + EMISSION_SHARE_TOLERANCE, (
+    'emission pools must not exceed 1.0'
 )
 # Settlement is over the trailing hour: a miner's serving score is the mean of its last SERVING_SETTLEMENT_ROUNDS
 # round scores (missing rounds count 0), so the hour's served tokens are what is priced. Shorten it to move pay

--- a/gittensor/validator/emission_allocation.py
+++ b/gittensor/validator/emission_allocation.py
@@ -52,6 +52,9 @@ def blend_emission_pools(
 
     total_configured_share = sum(config.emission_share for config in master_repositories.values())
     recycle_share = max(0.0, 1.0 - total_configured_share) * OSS_EMISSION_SHARE
+    # The slice reserved for neither pool burns explicitly: weights are normalized on chain, so leaving it
+    # unallocated would silently redistribute it pro-rata instead.
+    recycle_share += max(0.0, 1.0 - OSS_EMISSION_SHARE - SERVING_EMISSION_SHARE_CAP)
 
     for allocation in calculate_repo_emission_breakdown(
         miner_evaluations, master_repositories, miner_uids, maintainer_uids_by_repo

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1034,10 +1034,21 @@ def test_stream_assembler_collects_token_ids():
     assert plain.apply(InferenceSynapse(messages=MSGS, model_id=release.model_id)).token_ids is None
 
 
-def test_emission_pools_sum_to_one():
-    from gittensor.constants import EMISSION_SHARE_TOLERANCE, OSS_EMISSION_SHARE, SERVING_EMISSION_SHARE_CAP
+def test_emission_pools_fit_in_one_and_the_slack_burns():
+    from gittensor.constants import (
+        EMISSION_SHARE_TOLERANCE,
+        OSS_EMISSION_SHARE,
+        RECYCLE_UID,
+        SERVING_EMISSION_SHARE_CAP,
+    )
+    from gittensor.validator.emission_allocation import blend_emission_pools
 
-    assert abs(OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP - 1.0) < EMISSION_SHARE_TOLERANCE
+    assert OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP <= 1.0 + EMISSION_SHARE_TOLERANCE
+    # An empty round burns the whole emission: OSS slack, the unfunded serving cap, and the slice reserved for
+    # neither pool all land on RECYCLE_UID, so on-chain normalization has nothing to redistribute.
+    rewards = blend_emission_pools({}, {}, {RECYCLE_UID, 1}, None, {}, None)
+    assert rewards[sorted({RECYCLE_UID, 1}).index(RECYCLE_UID)] == pytest.approx(1.0)
+    assert sum(rewards) == pytest.approx(1.0)
 
 
 def test_verify_rejects_malformed_reference():


### PR DESCRIPTION
Phase-0 sizing: the serving pool's ceiling drops from 10% to 5% of emissions (`SERVING_EMISSION_SHARE_CAP = 0.05`). At current mainnet prices (~2,950 α/day to miners, α ≈ $0.86) that funds roughly 7–8 flat-out 5090s at $0.70/GPU-hour before pro-rata dilution starts — the intended test-fleet scale — instead of ~15.

The deliberate part is where the freed 5% goes: nowhere. `OSS_EMISSION_SHARE` stays 0.90, the constants assert relaxes from "pools sum to 1.0" to "pools must not exceed 1.0", and `blend_emission_pools` adds the unreserved slice (`1 − OSS − CAP`) to `recycle_share` explicitly. Explicit matters: weights are normalized on chain, so leaving the slice unallocated would silently redistribute it pro-rata across everyone instead of burning it on RECYCLE_UID. Shrinking the serving cap therefore never inflates OSS payouts.

Below the cap nothing changes for miners — the pool was already demand-sized (verified card-equivalents × $0.70/h) with the unearned remainder of the cap burning every round. On testnet, where the cap is paid pro-rata (`allow_unpriced_cap`), soak payouts halve accordingly.

The `test_emission_pools_sum_to_one` invariant is replaced by `test_emission_pools_fit_in_one_and_the_slack_burns`: pools ≤ 1.0, and an empty round lands the entire emission on RECYCLE_UID with the rewards vector summing to 1.0. README's stale "3.5% emission cap" is corrected to 5% in passing.

Local CI: ruff check, format, pyright (0 errors), vulture, pytest — 782 passed. Docs-side percentage updates: entrius/gittensor-docs-ui PR to follow, cross-linked.

https://claude.ai/code/session_014c7dZFY9dzzhRxE4oFy96u