### PR TITLE
serving: compose miner takes host ports and runtime/attest URLs from .env

### DIFF
--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -17,7 +17,7 @@ services:
       # already baked into the image; repeated here so nobody turns it off by accident (contract D1)
       SPARKINFER_DETERMINISTIC: "1"
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:${RUNTIME_PORT:-8080}:8080"
     volumes:
       - sparkmodels:/opt/sparkinfer/models
     deploy:
@@ -33,7 +33,7 @@ services:
     container_name: gt-miner-attest
     restart: unless-stopped
     ports:
-      - "127.0.0.1:8081:8081"
+      - "127.0.0.1:${ATTEST_PORT:-8081}:8081"
     deploy:
       resources:
         reservations:
@@ -54,8 +54,8 @@ services:
       HOTKEY_NAME: ${HOTKEY_NAME:?the registered hotkey}
       PORT: ${PORT:?axon port, reachable from the internet}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      SERVING_BASE_URL: http://runtime:8080
-      SERVING_ATTEST_URL: http://attest:8081
+      SERVING_BASE_URL: ${SERVING_BASE_URL:-http://runtime:8080}
+      SERVING_ATTEST_URL: ${SERVING_ATTEST_URL:-http://attest:8081}
       SERVING_RELEASE: ${SERVING_RELEASE:-}
     ports:
       - "${PORT:-8099}:${PORT:-8099}"

--- a/miner.env.example
+++ b/miner.env.example
@@ -23,3 +23,14 @@ LOG_LEVEL=info
 # GITTENSOR_IMAGE=entrius/gittensor:latest
 # Only once more than one release is blessed: the release id to serve (from the Current release card)
 # SERVING_RELEASE=
+
+# Host-side loopback ports for the runtime and attest containers, if 8080/8081 are already taken on the box.
+# Container-side ports (and the neuron's view of them) never change; pass the matching --base-url/--attest-url
+# to the conformance checker.
+# RUNTIME_PORT=8080
+# ATTEST_PORT=8081
+
+# GPU on another box or behind a proxy: point the neuron away from the compose services and start only it
+# (docker compose -f docker-compose.miner.yml up -d miner).
+# SERVING_BASE_URL=http://runtime:8080
+# SERVING_ATTEST_URL=http://attest:8081

--- a/miner.env.example
+++ b/miner.env.example
@@ -30,7 +30,8 @@ LOG_LEVEL=info
 # RUNTIME_PORT=8080
 # ATTEST_PORT=8081
 
-# GPU on another box or behind a proxy: point the neuron away from the compose services and start only it
-# (docker compose -f docker-compose.miner.yml up -d miner).
+# GPU on another box or behind a proxy: point the neuron away from the compose services and start only it —
+# --no-deps, or compose also starts the GPU services this box does not have and leaves them restart-looping
+# (docker compose -f docker-compose.miner.yml up -d --no-deps miner).
 # SERVING_BASE_URL=http://runtime:8080
 # SERVING_ATTEST_URL=http://attest:8081


### PR DESCRIPTION
Two friction items from the first live run of the #1746 flow on a real box:

- A box already using 8080/8081 died at `docker compose up` with `port is already allocated`. The loopback mappings now interpolate `RUNTIME_PORT` / `ATTEST_PORT` (defaults unchanged). Container-side ports and the neuron's compose-DNS view never move — only the host mapping for curl checks and the conformance checker, which then takes the matching `--base-url`/`--attest-url`.
- The GPU-elsewhere/proxy topology required abandoning compose entirely because `SERVING_BASE_URL`/`SERVING_ATTEST_URL` were hardcoded to the compose services. Both now default to the compose DNS names but read from `.env`, so a remote runtime is: set the URLs, `docker compose -f docker-compose.miner.yml up -d miner` (only the neuron).

`miner.env.example` documents both as commented-out entries. Verified with `docker compose config`: `RUNTIME_PORT=9080` publishes 9080 while attest keeps 8081, and an overridden `SERVING_BASE_URL` reaches the miner service env verbatim with the attest default intact. Docs note in the companion gittensor-docs-ui PR.

https://claude.ai/code/session_014c7dZFY9dzzhRxE4oFy96u