### PR TITLE
serving api: usage stream chunk is opt-in; non-positive max_tokens is a 400

### DIFF
--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -141,13 +141,18 @@ def build_app(
             release = loadout.get(str(wanted)) if wanted else primary
         except KeyError:
             raise HTTPException(status_code=404, detail=f'model {wanted!r} is not served; see /v1/models')
+        raw_max = body.get('max_tokens', body.get('max_completion_tokens'))
         try:
-            max_tokens = int(body.get('max_tokens') or body.get('max_completion_tokens') or release.max_tokens)
+            max_tokens = int(raw_max) if raw_max is not None else release.max_tokens
         except (TypeError, ValueError):
             raise HTTPException(status_code=400, detail='max_tokens must be an integer')
-        max_tokens = max(1, min(max_tokens, SERVING_MAX_TOKENS))
+        if max_tokens <= 0:
+            raise HTTPException(status_code=400, detail='max_tokens must be positive')
+        max_tokens = min(max_tokens, SERVING_MAX_TOKENS)
         want_logprobs = bool(body.get('logprobs', False))
         want_stream = bool(body.get('stream', False))
+        stream_options = body.get('stream_options')
+        include_usage = isinstance(stream_options, dict) and bool(stream_options.get('include_usage'))
 
         request_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())
@@ -266,7 +271,11 @@ def build_app(
                     event = first
                     try:
                         while event is not _END:
-                            yield SSE_DONE if event is None else sse_event(reshape(event))  # type: ignore[arg-type]
+                            if event is None:
+                                yield SSE_DONE
+                            # OpenAI emits the choices-less usage chunk only when stream_options asks for it.
+                            elif include_usage or event.get('choices') or 'usage' not in event:  # type: ignore[union-attr]
+                                yield sse_event(reshape(event))  # type: ignore[arg-type]
                             event = await queue.get()
                     finally:
                         finish(await outcome())

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -419,6 +419,36 @@ def test_gateway_429_when_every_ready_miner_refuses_busy(monkeypatch):
     assert len(drained) == 2 and all(not q.ok and 'busy' in q.detail for q in drained)
 
 
+def test_gateway_stream_usage_chunk_is_opt_in(monkeypatch):
+    """OpenAI emits the choices-less usage chunk only under stream_options.include_usage."""
+    state = ServingState(_rng=random.Random(7))
+    state.publish_round([_ready(1)], {})
+    client = _gateway_client(state, monkeypatch)
+    headers = {'Authorization': 'Bearer k1'}
+
+    def stream(body):
+        r = client.post('/v1/chat/completions', headers=headers, json=body)
+        assert r.status_code == 200 and 'data: [DONE]' in r.text
+        return [json.loads(line[6:]) for line in r.text.splitlines() if line.startswith('data: {')]
+
+    plain = stream({'messages': MSGS, 'stream': True})
+    assert plain and all(c['choices'] for c in plain)
+    opted = stream({'messages': MSGS, 'stream': True, 'stream_options': {'include_usage': True}})
+    assert any(not c['choices'] and 'usage' in c for c in opted)
+
+
+def test_gateway_rejects_nonpositive_max_tokens(monkeypatch):
+    state = ServingState(_rng=random.Random(7))
+    state.publish_round([_ready(1)], {})
+    client = _gateway_client(state, monkeypatch)
+    headers = {'Authorization': 'Bearer k1'}
+    for bad in (0, -3):
+        r = client.post('/v1/chat/completions', headers=headers, json={'messages': MSGS, 'max_tokens': bad})
+        assert r.status_code == 400 and 'positive' in r.json()['detail']
+    ok = client.post('/v1/chat/completions', headers=headers, json={'messages': MSGS})
+    assert ok.status_code == 200  # absent still defaults to the release's max_tokens
+
+
 def test_gateway_stream_retries_busy_before_committing_to_the_stream(monkeypatch):
     """A busy refusal streams nothing, so the retry happens before the client sees any bytes."""
     state = ServingState(_rng=random.Random(7))
@@ -465,7 +495,7 @@ def test_gateway_streams_sse(monkeypatch):
     with client.stream(
         'POST',
         '/v1/chat/completions',
-        json={'messages': MSGS, 'max_tokens': 4, 'stream': True},
+        json={'messages': MSGS, 'max_tokens': 4, 'stream': True, 'stream_options': {'include_usage': True}},
         headers={'Authorization': 'Bearer k1'},
     ) as r:
         assert r.status_code == 200


### PR DESCRIPTION
Fixes #1749 — the two gateway-side OpenAI-compat nits from the first live probe run.

- The final streamed chunk (`choices: []` + `usage` + the `gittensor` metadata) is now emitted only when the client asks via `stream_options: {"include_usage": true}`, matching OpenAI; strict parsers that expect a choice in every chunk no longer see the extra one. The miner→validator stream is untouched — the audit's `consume_stream` still folds usage from the miner's own chunks; only the client-facing relay filters.
- `max_tokens: 0` or negative is a 400 (`max_tokens must be positive`). This also fixes a quieter wart the probe couldn't distinguish: `0` was falsy, so it silently fell through to the release default (64) rather than clamping — an explicit non-positive value now errors instead of serving something the caller didn't ask for. Absent still defaults to the release's `max_tokens`; the 1024 cap is unchanged.

Tests: new `test_gateway_stream_usage_chunk_is_opt_in` and `test_gateway_rejects_nonpositive_max_tokens`; `test_gateway_streams_sse` now opts in, keeping its coverage of the usage/metadata chunk shape. Full local CI green (ruff, format, pyright 0 errors, vulture, 784 tests).

https://claude.ai/code/session_014c7dZFY9dzzhRxE4oFy96u