### PR TITLE
serving: TAO/USD is fetched live — 3 tries, 10-min cache, high fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,6 @@ SERVING_ENABLED=false
 # SERVING_BASELINE_API_KEYS=baseline-key
 # Baseline prompts the validator itself sends each serving miner per round (spread at random over the round).
 # SERVING_BASELINE_PER_ROUND=2
-# TAO/USD override for the serving GPU-hour price (default: `pricing.tao_usd` in serving_loadout.json).
-# SERVING_TAO_USD=228.79
 # SERVING_API_HOST=0.0.0.0
 # SERVING_API_PORT=8790
 # Host-side bind for the API port mapping in docker-compose.vali.yml (default 127.0.0.1:8790; 0.0.0.0:8790 = public).

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -164,8 +164,8 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # rate = SERVING_GPU_HOUR_USD / (one card's aggregate decode tok/s x 3600), so a 5090 flat out for an hour (~1M
 # output tokens on the current runtime) earns exactly the card-hour and an idle one earns nothing. A round score is
 # those tokens in card-equivalents (tokens / (aggregate tok/s x round seconds)); the settled mean is priced at
-# SERVING_GPU_HOUR_USD, converted to an emission share through the on-chain alpha/TAO price and the TAO/USD rate
-# published in serving_loadout.json (`pricing`). No card count and no per-hotkey cap: served volume is the capacity
+# SERVING_GPU_HOUR_USD, converted to an emission share through the on-chain alpha/TAO price and a live TAO/USD
+# rate (see below). No card count and no per-hotkey cap: served volume is the capacity
 # proof, and a real 5090 cannot out-decode its silicon. The only ceiling is SERVING_EMISSION_SHARE_CAP — above it the
 # fleet dilutes pro-rata by token share; what it does not earn recycles to RECYCLE_UID, never to OSS. With no price
 # data (testnet) the cap is paid pro-rata. The pools may sum under 1.0: the unreserved remainder burns every round
@@ -175,11 +175,15 @@ SERVING_EMISSION_SHARE_CAP = 0.05
 # Output tok/s one card sustains under load on the blessed runtime, for a release without its own
 # `speed.aggregate_decode_tps` (sparkinfer 7498736 on a 5090: 279-282 at 16 concurrent, 2026-08-27).
 SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 280.0
-# Pricing the cap needs the chain's alpha/TAO price and the published TAO/USD rate. A round that cannot read them
+# Pricing the cap needs the chain's alpha/TAO price and the live TAO/USD rate. A round that cannot read them
 # reuses the last usable pricing for up to SERVING_PRICING_MAX_AGE_S, so a chain hiccup does not move pay. With no
 # usable pricing at all the fleet is paid nothing: the alternative (the whole cap, split pro-rata) hands one verified
 # card the whole cap. A network with no price data to read - testnet - sets SERVING_PAY_CAP_WITHOUT_PRICING.
 SERVING_PRICING_MAX_AGE_S = 3600.0
+# TAO/USD is fetched live (validator/serving/pricing.py: 3 tries against a public feed, cached this long).
+# The fallback prices TAO deliberately HIGH: an unpriceable TAO must undersize the pool, never overpay it.
+SERVING_TAO_USD_REFRESH_S = 600.0
+SERVING_TAO_USD_FALLBACK = 400.0
 assert OSS_EMISSION_SHARE + SERVING_EMISSION_SHARE_CAP <= 1.0 + EMISSION_SHARE_TOLERANCE, (
     'emission pools must not exceed 1.0'
 )

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -164,7 +164,6 @@ def _sidecar_url(base: Optional[str], port: int = 8081) -> Optional[str]:
 @dataclass
 class ServingLoadout:
     releases: List[ServingRelease]
-    tao_usd: Optional[float] = None  # published TAO/USD rate (`pricing.tao_usd`); sizes the serving emission share
 
     def __post_init__(self) -> None:
         if not self.releases:
@@ -201,10 +200,7 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
     with open(loadout_path) as f:
         raw = json.load(f)
     entries = raw['releases'] if isinstance(raw, dict) and 'releases' in raw else [raw]
-    pricing = raw.get('pricing') or {} if isinstance(raw, dict) else {}
-    # The rate is the repo's, not the operator's: validators must price the same card the same way.
-    tao_usd = float(pricing['tao_usd']) if pricing.get('tao_usd') else None
-    loadout = ServingLoadout(releases=[ServingRelease.from_dict(entry) for entry in entries], tao_usd=tao_usd)
+    loadout = ServingLoadout(releases=[ServingRelease.from_dict(entry) for entry in entries])
 
     base_override = os.getenv('SERVING_BASE_URL')
     if base_override:

--- a/gittensor/validator/serving/pricing.py
+++ b/gittensor/validator/serving/pricing.py
@@ -3,18 +3,25 @@
 
 """What the serving pool has to pay with: alpha/hour flowing to miners and what one alpha is worth in USD.
 
-Both inputs are ones every validator observes identically — the metagraph emission column and the subnet's
-on-chain alpha/TAO price — plus the TAO/USD rate published in the loadout, so validators agree on the share.
+Two inputs every validator observes identically — the metagraph emission column and the subnet's on-chain
+alpha/TAO price — plus a live TAO/USD rate refetched from a public feed at most every
+``SERVING_TAO_USD_REFRESH_S``. Independent validators read the same feed inside the same window, so the
+share stays agreed to within spot noise; with the feed down the last fetched rate carries, and the
+cold-start fallback is deliberately high so an unpriceable TAO undersizes the pool instead of overpaying it.
 """
 
 import time
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import bittensor as bt
+import requests
 
 from gittensor.classes import ServingPricing
-from gittensor.constants import SERVING_PRICING_MAX_AGE_S
-from gittensor.serving.loadout import load_serving_loadout
+from gittensor.constants import (
+    SERVING_PRICING_MAX_AGE_S,
+    SERVING_TAO_USD_FALLBACK,
+    SERVING_TAO_USD_REFRESH_S,
+)
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -22,7 +29,44 @@ if TYPE_CHECKING:
 MINER_FRACTION_OF_NEURON_EMISSION = 0.5  # metagraph.E covers miners + validators (41% + 41%); miners get half
 MINUTES_PER_TEMPO = 72.0  # 360 blocks x 12 s
 
+TAO_USD_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=bittensor&vs_currencies=usd'
+
 _last_usable: Optional[Tuple[float, ServingPricing]] = None  # (ts, pricing): carries pay across a price-read blip
+_tao_usd_cache: Optional[Tuple[float, float]] = None  # (checked_ts, rate): the last fetched TAO/USD
+
+
+def _fetch_tao_usd() -> Optional[float]:
+    for attempt in range(3):
+        try:
+            r = requests.get(TAO_USD_URL, timeout=5)
+            r.raise_for_status()
+            rate = float(r.json()['bittensor']['usd'])
+            if rate > 0:
+                return rate
+        except Exception as e:
+            bt.logging.warning(f'Serving: TAO/USD fetch {attempt + 1}/3 failed ({e!r})')
+    return None
+
+
+def tao_usd_rate(now: Optional[float] = None) -> float:
+    """Live TAO/USD for sizing the pool, refetched at most every ``SERVING_TAO_USD_REFRESH_S``.
+
+    A failed refresh (3 tries) keeps the last fetched rate until the next window; before anything has been
+    fetched the fallback prices TAO deliberately high, so failure undersizes the pool rather than overpaying.
+    """
+    global _tao_usd_cache
+    ts = now if now is not None else time.time()
+    if _tao_usd_cache is not None and ts - _tao_usd_cache[0] < SERVING_TAO_USD_REFRESH_S:
+        return _tao_usd_cache[1]
+    rate = _fetch_tao_usd()
+    if rate is None:
+        if _tao_usd_cache is None:
+            bt.logging.warning(f'Serving: no TAO/USD fetched yet; fallback ${SERVING_TAO_USD_FALLBACK:.0f}')
+            return SERVING_TAO_USD_FALLBACK
+        rate = _tao_usd_cache[1]
+        bt.logging.warning(f'Serving: TAO/USD refresh failed; keeping {rate:.2f} until the next window')
+    _tao_usd_cache = (ts, rate)
+    return rate
 
 
 def serving_pricing(self: 'Validator') -> Optional[ServingPricing]:
@@ -31,7 +75,7 @@ def serving_pricing(self: 'Validator') -> Optional[ServingPricing]:
         alpha_per_hour = alpha_per_tempo * 60.0 / MINUTES_PER_TEMPO
         info = self.subtensor.subnet(int(self.metagraph.netuid))
         alpha_tao = float(getattr(info, 'price', 0.0) or 0.0)
-        tao_usd = load_serving_loadout().tao_usd or 0.0
+        tao_usd = tao_usd_rate()
     except Exception as e:
         bt.logging.warning(f'Serving: pricing unavailable ({e!r})')
         return _recent_usable()

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -1,8 +1,4 @@
 {
-  "pricing": {
-    "tao_usd": 228.79,
-    "updated": "2026-08-26"
-  },
   "releases": [
     {
       "release_id": "qwen3.6-35b-a3b-sparkinfer-7498736",
@@ -20,7 +16,7 @@
       "speed": {
         "single_stream_decode_tps": 443.6,
         "aggregate_decode_tps": 280.0,
-        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 — queues past 16, wall 3.7 s -> 7 s)",
+        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 \u2014 queues past 16, wall 3.7 s -> 7 s)",
         "decode_per_request": {
           "1": 443.6,
           "6": 46.0,

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1033,7 +1033,7 @@ def test_quarantine_escalates_with_strikes():
     assert w.strike('other', 'r', now=0.0) == 100.0
 
 
-def test_last_credit_survives_a_restart_and_tao_usd_is_the_repos(tmp_path, monkeypatch):
+def test_last_credit_survives_a_restart(tmp_path):
     from gittensor.serving.store import ServingStore
 
     state = ServingState()
@@ -1041,8 +1041,6 @@ def test_last_credit_survives_a_restart_and_tao_usd_is_the_repos(tmp_path, monke
     store = ServingStore(tmp_path / 'serving.db')
     store.save(state)
     assert store.load(ServingState()).last_credit == {'hk1': 0.75}
-    monkeypatch.setenv('SERVING_TAO_USD', '1')
-    assert load_serving_loadout().tao_usd != 1.0
 
 
 def test_stream_assembler_collects_token_ids():
@@ -1925,7 +1923,55 @@ def test_blend_pays_serving_by_price_and_recycles_the_rest(monkeypatch):
     assert sum(rewards) == pytest.approx(1.0)
 
 
-def test_serving_pricing_reads_chain_and_loadout(monkeypatch):
+def test_tao_usd_rate_caches_carries_and_falls_back(monkeypatch):
+    from gittensor.validator.serving import pricing as pr
+
+    calls = []
+    monkeypatch.setattr(pr, '_fetch_tao_usd', lambda: calls.append(1) or 220.5)
+    monkeypatch.setattr(pr, '_tao_usd_cache', None)
+    assert pr.tao_usd_rate(now=0.0) == 220.5
+    assert pr.tao_usd_rate(now=1.0) == 220.5 and len(calls) == 1  # cached inside the refresh window
+    monkeypatch.setattr(pr, '_fetch_tao_usd', lambda: None)
+    assert pr.tao_usd_rate(now=10_000.0) == 220.5  # refresh failed: the last fetched rate carries
+    assert pr.tao_usd_rate(now=10_001.0) == 220.5  # ... and is re-stamped, so no retry until the next window
+    monkeypatch.setattr(pr, '_tao_usd_cache', None)
+    assert pr.tao_usd_rate(now=20_000.0) == pr.SERVING_TAO_USD_FALLBACK  # nothing ever fetched
+
+
+def test_fetch_tao_usd_retries_then_gives_up(monkeypatch):
+    import requests as rq
+
+    from gittensor.validator.serving import pricing as pr
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {'bittensor': {'usd': 220.5}}
+
+    attempts = []
+
+    def flaky_get(url, timeout):
+        attempts.append(url)
+        if len(attempts) < 3:
+            raise rq.ConnectionError('down')
+        return _Resp()
+
+    monkeypatch.setattr(pr.requests, 'get', flaky_get)
+    assert pr._fetch_tao_usd() == 220.5 and len(attempts) == 3
+
+    down = []
+
+    def dead_get(url, timeout):
+        down.append(url)
+        raise rq.ConnectionError('down')
+
+    monkeypatch.setattr(pr.requests, 'get', dead_get)
+    assert pr._fetch_tao_usd() is None and len(down) == 3
+
+
+def test_serving_pricing_reads_chain_and_feed(monkeypatch):
     from types import SimpleNamespace
 
     from gittensor.validator.serving import pricing as pr
@@ -1935,12 +1981,12 @@ def test_serving_pricing_reads_chain_and_loadout(monkeypatch):
         subtensor=SimpleNamespace(subnet=lambda netuid: SimpleNamespace(price=0.004)),
     )
     monkeypatch.setattr(pr, '_last_usable', None)
-    monkeypatch.setattr(pr, 'load_serving_loadout', lambda: SimpleNamespace(tao_usd=250.0))
+    monkeypatch.setattr(pr, 'tao_usd_rate', lambda: 250.0)
     p = pr.serving_pricing(vali)  # type: ignore[arg-type]
     assert p is not None and p.alpha_per_hour_to_miners == pytest.approx(150.0 * 60 / 72) and p.alpha_usd == 1.0
 
     # A read that comes back unusable, or throws, reuses the last usable pricing rather than dropping pay.
-    monkeypatch.setattr(pr, 'load_serving_loadout', lambda: SimpleNamespace(tao_usd=None))
+    vali.subtensor = SimpleNamespace(subnet=lambda netuid: SimpleNamespace(price=0.0))
     assert pr.serving_pricing(vali) == p  # type: ignore[arg-type]
     vali.subtensor = SimpleNamespace(subnet=lambda netuid: (_ for _ in ()).throw(RuntimeError('rpc')))
     assert pr.serving_pricing(vali) == p  # type: ignore[arg-type]


### PR DESCRIPTION
The TAO/USD leg of serving pricing was the only non-live input: alpha/TAO and emissions are read from the chain every round, but the USD rate was a hand-edited `pricing.tao_usd` in the loadout — already 4% stale eight days after it was written, and guaranteed to drift forever.

Now `serving_pricing()` gets the rate from `tao_usd_rate()`:

- fetched from CoinGecko's free simple-price endpoint, up to 3 tries with a 5s timeout each;
- cached for `SERVING_TAO_USD_REFRESH_S` (10 min), so one fetch covers a couple of rounds and a failed run doesn't hammer the API — after 3 failures it quits until the next window;
- a failed refresh keeps pricing on the last fetched rate; with nothing fetched yet (cold start with the feed down) the fallback is `SERVING_TAO_USD_FALLBACK = $400` — deliberately HIGH, so an unpriceable TAO undersizes the pool rather than overpaying it.

The repo-pinned `pricing` block is removed from `serving_loadout.json` and the `tao_usd` field from the loadout model — one source of truth, nothing left to go stale. The dead `SERVING_TAO_USD` env lines in `.env.example` are gone too (#1730 removed the code behind them; per-operator override stays out, so a validator still cannot re-price the fleet by hand — validators now converge on the same public feed inside the same 10-minute window instead of the same JSON, with residual divergence well inside per-validator measurement noise and bounded by the 5% cap either way).

Tests: fetch retry/give-up, cache window, carry-through-outage, cold-start fallback, and the pricing integration test now stubs the feed instead of the loadout. Full local CI green — 786 passed, ruff/format/pyright/vulture clean.

https://claude.ai/code/session_014c7dZFY9dzzhRxE4oFy96u