### PR TITLE
serving: a reference 429 is backpressure — retried, then neutral, never a miner miss

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -217,6 +217,9 @@ SERVING_ATTEST_MAX_CARDS = 8
 SERVING_ATTEST_MODEL_RESIDENT_RATIO = 0.8
 SERVING_VRAM_MODEL_RESERVED_BYTES = 24e9  # what sparkinfer holds with the model loaded (7498736 on a 5090: 23.7 GB)
 SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per round
+# A reference 429 is R6 backpressure (a conformant runtime refuses at capacity instead of queueing) — a fact about
+# the reference's load, never about the miner's answer. Retried with backoff this many times, then neutral.
+SERVING_VERIFY_BUSY_RETRIES = 3
 # Latency credit on the validator-observed time to first streamed token (network + queue + prefill). An honest
 # 5090 reports TTFT ~26 ms on-box (2026-08-27 conformance) and a 64-token answer in ~165 ms (2026-08-22/24); add
 # validator<->miner RTT and an honest miner anywhere on earth lands well under FULL. Credit is flat to FULL and

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -62,6 +62,7 @@ from gittensor.constants import (
     SERVING_MIN_CALLER_STAKE,
     SERVING_STRIKE_MIN_FLEET_PASS,
     SERVING_VALIDATOR_TOKENS_PER_TEMPO,
+    SERVING_VERIFY_BUSY_RETRIES,
     SERVING_VERIFY_WORKERS,
 )
 from gittensor.serving.audit import AuditVerdict, Reference, reference_for, verify_served
@@ -125,17 +126,25 @@ def reference_agrees_with_fleet(
 
 def reference_rejects(reference: Reference, messages: List[Dict[str, str]]) -> bool:
     """Would the validator's own reference refuse this prompt (HTTP 4xx on a one-token greedy)? Only a live
-    reference can be asked; anything else, or any other failure, is 'no', so the miss stands."""
+    reference can be asked; anything else, or any other failure, is 'no', so the miss stands. A saturated
+    reference (429, R6 backpressure) can rule neither way: retried, then the miss is excused as neutral."""
     case_for = getattr(reference, 'case_for', None)
     if case_for is None:
         return False
-    try:
-        case_for(messages, 1)
-    except requests.HTTPError as e:
-        status = getattr(getattr(e, 'response', None), 'status_code', 0) or 0
-        return 400 <= status < 500
-    except Exception:
-        return False
+    for attempt in range(1 + SERVING_VERIFY_BUSY_RETRIES):
+        try:
+            case_for(messages, 1)
+            return False
+        except requests.HTTPError as e:
+            status = getattr(getattr(e, 'response', None), 'status_code', 0) or 0
+            if status == 429:
+                if attempt < SERVING_VERIFY_BUSY_RETRIES:
+                    time.sleep(2.0 * (attempt + 1))
+                    continue
+                return True
+            return 400 <= status < 500
+        except Exception:
+            return False
     return False
 
 
@@ -198,7 +207,9 @@ def verify_served_round(
             if req.source == 'gateway' and reference_rejects(reference, req.messages):
                 return None  # an honest runtime refuses this prompt too (over context, bad shape): not the miner's
             return AuditVerdict(False, 0.0, float('inf'), req.detail or 'no completion')
-        for attempt in range(2):  # a connection blip to the reference is retried once before going neutral
+        # A connection blip to the reference is retried once, a saturated reference (429) with backoff until a
+        # slot frees; only after that does the verdict go neutral.
+        for attempt in range(1 + max(1, SERVING_VERIFY_BUSY_RETRIES)):
             try:
                 return verify_served(
                     reference,
@@ -213,6 +224,12 @@ def verify_served_round(
                 )
             except requests.HTTPError as e:
                 status = getattr(getattr(e, 'response', None), 'status_code', 0) or 0
+                if status == 429:  # R6 backpressure: the reference is full — its load, never the miner's answer
+                    if attempt < SERVING_VERIFY_BUSY_RETRIES:
+                        time.sleep(2.0 * (attempt + 1))
+                        continue
+                    bt.logging.warning(f'Serving: reference saturated (429); request by UID {req.uid} unverified')
+                    return None
                 if 400 <= status < 500:  # the reference refused what the miner sent: the miner's answer, not a blip
                     return AuditVerdict(False, 0.0, float('inf'), f'reference rejected the completion (HTTP {status})')
                 if attempt == 0:

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -993,7 +993,9 @@ def test_runtime_rejected_prompt_is_checked_against_the_reference(monkeypatch):
         verify_served_round(state, reference, good, [failed], summary)
         return summary.get('neutral', 0), summary.get('miss', 0)
 
+    monkeypatch.setattr('gittensor.validator.serving.forward.time.sleep', lambda s: None)
     assert run(Reference(400)) == (1, 0)
+    assert run(Reference(429)) == (1, 0)  # saturated reference rules neither way: the miss is excused
     assert run(Reference(500)) == (0, 1)
     assert run(Reference(None)) == (0, 1)
     assert run(Reference(400), source='baseline') == (0, 1)
@@ -1518,6 +1520,48 @@ def test_reference_rejection_is_the_miners_miss_and_a_reference_fault_is_neutral
     summary = {}
     verify_served_round(state, Rejecting(503), good, [_served(1, good)], summary)  # type: ignore[arg-type]
     assert summary.get('neutral') == 1 and state.audits.verdict('hk1', good.model_id).n_audits == 0
+    state = ServingState()
+    summary = {}
+    _, tokens = verify_served_round(state, Rejecting(429), good, [_served(1, good)], summary)  # type: ignore[arg-type]
+    assert summary.get('neutral') == 1 and summary.get('miss', 0) == 0
+    assert state.audits.verdict('hk1', good.model_id).n_audits == 0  # no window damage from reference saturation
+    assert tokens.get('hk1', 0) > 0  # the gateway saw the tokens served; an unverifiable round still pays them
+
+
+def test_reference_429_is_retried_until_a_slot_frees(monkeypatch):
+    """R6 backpressure: the reference refusing at capacity is retried with backoff, and the verdict that lands
+    once a slot frees is the real one — a burst never turns the ready set's audits into misses."""
+    from types import SimpleNamespace
+
+    import requests
+
+    from gittensor.constants import SERVING_VERIFY_BUSY_RETRIES
+    from gittensor.validator.serving.forward import verify_served_round
+
+    good = _echo_release()
+
+    class Saturated(EchoReference):
+        def __init__(self, busy_calls):
+            super().__init__(good)
+            self.busy_calls = busy_calls
+            self.slept = []
+
+        def score_served(self, messages, completion, token_ids=None):
+            if self.busy_calls > 0:
+                self.busy_calls -= 1
+                err = requests.HTTPError('too many requests')
+                err.response = SimpleNamespace(status_code=429)
+                raise err
+            return super().score_served(messages, completion, token_ids=token_ids)
+
+    ref = Saturated(SERVING_VERIFY_BUSY_RETRIES)
+    monkeypatch.setattr('gittensor.validator.serving.forward.time.sleep', ref.slept.append)
+    state = ServingState()
+    summary = {}
+    verify_served_round(state, ref, good, [_served(1, good)], summary)
+    assert summary.get('pass') == 1 and summary.get('neutral', 0) == 0
+    assert state.audits.verdict('hk1', good.model_id).n_audits == 1
+    assert len(ref.slept) == SERVING_VERIFY_BUSY_RETRIES and ref.slept == sorted(ref.slept)  # backoff grows
 
 
 def fwd_module():


### PR DESCRIPTION
A burst of real traffic was knocking the entire READY set into probation: the audit round after the burst fans sampled requests into the reference, and if the reference (a conformant runtime, which R6 requires to 429 at capacity instead of queueing) refuses, the 429 fell into the generic 4xx bracket in `judge()` — \"reference rejected the completion\" — a miss recorded against every sampled miner. The reference being full is a fact about the reference's load, never about the miner's answer.

Changes:

- `judge()`: HTTP 429 from `verify_served` is carved out of the 4xx-equals-miss bracket and treated as backpressure — retried with growing backoff (`SERVING_VERIFY_BUSY_RETRIES`, sleeps off the hot path in the audit thread's worker pool) so a transiently full reference still yields a real verdict; only persistent saturation goes neutral.
- `reference_rejects()`: the inverse hole — a reference 429 used to count as \"the reference refuses this prompt too\", excusing a *failed* miner request while correct ones got misses. Now retried the same way; persistent 429 stays neutral (unverifiable, unpaid since the request wasn't ok).
- Miner-side busy refusals (#1743) already went neutral; this closes the reference-side path of the same symptom.

Exploit surface: a neutral verdict on a served request still pays, but miners never talk to the reference and can't pace the validator's verify pool (8 workers vs 16+ runtime slots), so a dedicated reference can't be pushed into 429 by miner behavior; the retry-until-slot-frees semantics keep neutral as rare as the existing 5xx path even on a shared reference.

Tests: 429-then-success produces the real verdict with growing backoff; persistent 429 is neutral with no window damage (and pays what the gateway saw, matching the 5xx path); a failed request under a saturated reference is excused, not a miss.

https://claude.ai/code/session_01KzvxiWssubC2YZJpBz9GBy