### PR TITLE
serving miner: an attestation waits for prefill and holds admissions, never fills over one

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -211,6 +211,11 @@ SERVING_ATTEST_MEMORY_ROUNDS = 12  # a verdict older than this admits nothing un
 # reference recomputes at most SERVING_ATTEST_MAX_CARDS of them per round.
 SERVING_ATTEST_RTT_SLACK_MS = 2_000.0
 SERVING_ATTEST_MAX_CARDS = 8
+# Miner: before its sidecar fills the card, an attestation waits up to this long for admitted requests to get past
+# prefill (first content delta), refusing new admissions "busy" meanwhile. A prefill that starts under the fill
+# finds no scratch and sparkinfer 7498736 drops to a fallback whose output the reference rejects — a strike for an
+# honest card (2026-09-04/05, both mainnet cards). Decode is unaffected. Bounded well inside the RTT slack above.
+SERVING_ATTEST_PREFILL_DRAIN_S = 1.5
 # A card passes only with the model resident: free VRAM before the fill must be at most total minus this fraction of
 # the reservation (a bare 5090 shows ~32 GB free, one holding the model ~8 GB). A spare card with nothing loaded is
 # not a serving card.

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -276,10 +276,16 @@ SERVING_AUDIT_SAMPLE_FRACTION = 0.2
 SERVING_AUDIT_SAMPLE_MIN = 10
 SERVING_QUARANTINE_S = 3600.0
 # Each further strike on the same (hotkey, release) quarantines ESCALATION times longer, up to MAX_STEPS steps
-# (1 h, 4 h, 16 h, 64 h): one wrong answer costs an hour, a pattern of them costs days, and rotating to a fresh
-# hotkey to reset it costs a registration plus a settlement window from zero.
+# (1 h, 4 h, 16 h): one wrong answer costs an hour, a pattern of them costs most of a day, and rotating to a fresh
+# hotkey to reset it costs a registration plus a settlement window from zero. The ladder was 1/4/16/64 h until
+# 2026-09-05, on the premise that no honest runtime produces a wrong answer; the attest-fill/prefill collision
+# (neurons/serving_miner.py, handle_attest) showed an honest way, so the tail is bounded to what a miner can sit
+# out within a day. What actually stops intermittent cheating is the wiped window: every strike restarts probation.
 SERVING_QUARANTINE_ESCALATION = 4.0
-SERVING_QUARANTINE_MAX_STEPS = 3
+SERVING_QUARANTINE_MAX_STEPS = 2
+# Strikes are forgotten after this long without another: the ladder is about a pattern, not a history. A hotkey
+# struck twice months apart starts its next quarantine at the bottom, a repeat offender inside the week does not.
+SERVING_STRIKE_FORGET_S = 7 * 86_400.0
 # A wrong answer is a strike only while the reference agrees with most of the fleet this round. When fewer than
 # this fraction of the hotkeys judged this round passed anything, the reference is the odd one out (a driver or
 # image drift on this validator's box) and the round's band failures are misses, not strikes — otherwise one

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -71,6 +71,7 @@ from gittensor.constants import (
     SERVING_QUARANTINE_ESCALATION,
     SERVING_QUARANTINE_MAX_STEPS,
     SERVING_QUARANTINE_S,
+    SERVING_STRIKE_FORGET_S,
 )
 from gittensor.serving.backends import Message, expected_completion
 from gittensor.serving.loadout import WEIGHTS_DIR, ServingRelease
@@ -162,7 +163,8 @@ class AuditWindow:
     quarantine_s: float = SERVING_QUARANTINE_S
     _values: Dict[Tuple[str, str], Deque[float]] = field(default_factory=dict)
     _quarantine: Dict[Tuple[str, str], float] = field(default_factory=dict)  # (hotkey, release) -> until ts
-    _strikes: Dict[Tuple[str, str], int] = field(default_factory=dict)  # (hotkey, release) -> wrong answers, ever
+    _strikes: Dict[Tuple[str, str], int] = field(default_factory=dict)  # (hotkey, release) -> strikes on the ladder
+    _last_strike: Dict[Tuple[str, str], float] = field(default_factory=dict)  # (hotkey, release) -> ts of the last
 
     def record(self, hotkey: str, release_id: str, value: float) -> None:
         key = (hotkey, release_id)
@@ -172,18 +174,28 @@ class AuditWindow:
 
     def strike(self, hotkey: str, release_id: str, now: Optional[float] = None) -> float:
         """A wrong answer: wipe the window and quarantine the (hotkey, release) until the returned timestamp. Each
-        strike on the same (hotkey, release) quarantines ``SERVING_QUARANTINE_ESCALATION`` times longer than the last,
-        up to ``SERVING_QUARANTINE_MAX_STEPS`` steps: a strike costs a fresh hotkey an hour, a repeat offender days."""
+        strike within ``SERVING_STRIKE_FORGET_S`` of the last quarantines ``SERVING_QUARANTINE_ESCALATION`` times
+        longer, up to ``SERVING_QUARANTINE_MAX_STEPS`` steps: a strike costs a fresh hotkey an hour, a repeat offender
+        most of a day. A strike after a clean week starts the ladder over."""
         key = (hotkey, release_id)
+        now = now if now is not None else time.time()
         self._values.pop(key, None)
-        self._strikes[key] = self._strikes.get(key, 0) + 1
+        self._strikes[key] = self.strikes(hotkey, release_id, now) + 1
+        self._last_strike[key] = now
         step = min(self._strikes[key] - 1, SERVING_QUARANTINE_MAX_STEPS)
-        until = (now if now is not None else time.time()) + self.quarantine_s * SERVING_QUARANTINE_ESCALATION**step
+        until = now + self.quarantine_s * SERVING_QUARANTINE_ESCALATION**step
         self._quarantine[key] = until
         return until
 
-    def strikes(self, hotkey: str, release_id: str) -> int:
-        return self._strikes.get((hotkey, release_id), 0)
+    def strikes(self, hotkey: str, release_id: str, now: Optional[float] = None) -> int:
+        """Strikes still on the ladder: none once the last one is ``SERVING_STRIKE_FORGET_S`` old."""
+        key = (hotkey, release_id)
+        n = self._strikes.get(key, 0)
+        if n and (now if now is not None else time.time()) - self._last_strike.get(key, 0.0) > SERVING_STRIKE_FORGET_S:
+            self._strikes.pop(key, None)
+            self._last_strike.pop(key, None)
+            return 0
+        return n
 
     def quarantined_until(self, hotkey: str, release_id: str, now: Optional[float] = None) -> float:
         until = self._quarantine.get((hotkey, release_id), 0.0)
@@ -194,7 +206,7 @@ class AuditWindow:
             'size': self.size,
             'values': [[hk, rid, list(xs)] for (hk, rid), xs in self._values.items()],
             'quarantine': [[hk, rid, until] for (hk, rid), until in self._quarantine.items()],
-            'strikes': [[hk, rid, n] for (hk, rid), n in self._strikes.items()],
+            'strikes': [[hk, rid, n, self._last_strike.get((hk, rid), 0.0)] for (hk, rid), n in self._strikes.items()],
         }
 
     @classmethod
@@ -205,13 +217,15 @@ class AuditWindow:
                 window.record(str(hk), str(rid), float(x))
         for hk, rid, until in raw.get('quarantine', []):
             window._quarantine[(str(hk), str(rid))] = float(until)
-        for hk, rid, n in raw.get('strikes', []):
+        for hk, rid, n, *last in raw.get('strikes', []):
             window._strikes[(str(hk), str(rid))] = int(n)
+            if last:
+                window._last_strike[(str(hk), str(rid))] = float(last[0])
         return window
 
     def verdict(self, hotkey: str, release_id: str, now: Optional[float] = None) -> WindowVerdict:
         until = self.quarantined_until(hotkey, release_id, now)
-        strikes = self.strikes(hotkey, release_id)
+        strikes = self.strikes(hotkey, release_id, now)
         xs = self._values.get((hotkey, release_id))
         if not xs:
             return WindowVerdict(False, 0, 0.0, float('inf'), until, strikes)

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -21,7 +21,7 @@ SCHEMA = """
 CREATE TABLE IF NOT EXISTS audit_values (hotkey TEXT, release_id TEXT, seq INTEGER, value REAL,
     PRIMARY KEY (hotkey, release_id, seq));
 CREATE TABLE IF NOT EXISTS quarantine (hotkey TEXT, release_id TEXT, until REAL, strikes INTEGER DEFAULT 0,
-    PRIMARY KEY (hotkey, release_id));
+    last_strike REAL DEFAULT 0, PRIMARY KEY (hotkey, release_id));
 CREATE TABLE IF NOT EXISTS round_history (hotkey TEXT, seq INTEGER, score REAL, PRIMARY KEY (hotkey, seq));
 CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
 CREATE TABLE IF NOT EXISTS attest (hotkey TEXT PRIMARY KEY, status TEXT);
@@ -47,6 +47,8 @@ class ServingStore:
                 db.execute(f'ALTER TABLE {table} RENAME COLUMN model_id TO release_id')
             if table == 'quarantine' and columns and 'strikes' not in columns:
                 db.execute('ALTER TABLE quarantine ADD COLUMN strikes INTEGER DEFAULT 0')
+            if table == 'quarantine' and columns and 'last_strike' not in columns:
+                db.execute('ALTER TABLE quarantine ADD COLUMN last_strike REAL DEFAULT 0')
 
     def _connect(self) -> sqlite3.Connection:
         db = sqlite3.connect(self.path, timeout=10.0)
@@ -74,12 +76,12 @@ class ServingStore:
                 'INSERT INTO audit_values VALUES (?, ?, ?, ?)',
                 [(hk, rid, i, x) for hk, rid, xs in audits['values'] for i, x in enumerate(xs)],
             )
-            strikes = {(hk, rid): n for hk, rid, n in audits['strikes']}
+            strikes = {(hk, rid): (n, last) for hk, rid, n, last in audits['strikes']}
             keys = {(hk, rid) for hk, rid, _ in audits['quarantine']} | set(strikes)
             until = {(hk, rid): t for hk, rid, t in audits['quarantine']}
             db.executemany(
-                'INSERT INTO quarantine VALUES (?, ?, ?, ?)',
-                [(hk, rid, until.get((hk, rid), 0.0), strikes.get((hk, rid), 0)) for hk, rid in sorted(keys)],
+                'INSERT INTO quarantine VALUES (?, ?, ?, ?, ?)',
+                [(hk, rid, until.get((hk, rid), 0.0), *strikes.get((hk, rid), (0, 0.0))) for hk, rid in sorted(keys)],
             )
             db.executemany(
                 'INSERT INTO round_history VALUES (?, ?, ?)',
@@ -99,11 +101,13 @@ class ServingStore:
                 )
                 for hk, rid, x in values:
                     state.audits.record(hk, rid, x)
-                for hk, rid, until, strikes in db.execute('SELECT hotkey, release_id, until, strikes FROM quarantine'):
+                rows = db.execute('SELECT hotkey, release_id, until, strikes, last_strike FROM quarantine')
+                for hk, rid, until, strikes, last_strike in rows:
                     if float(until) > 0.0:
                         state.audits._quarantine[(hk, rid)] = float(until)
                     if int(strikes or 0) > 0:
                         state.audits._strikes[(hk, rid)] = int(strikes)
+                        state.audits._last_strike[(hk, rid)] = float(last_strike or 0.0)
                 for hk, x in db.execute('SELECT hotkey, score FROM round_history ORDER BY hotkey, seq'):
                     state._history.setdefault(hk, deque(maxlen=state.settlement_rounds)).append(float(x))
                 for hk, rounds in db.execute('SELECT hotkey, rounds FROM dormant'):

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -70,14 +70,23 @@ def latency_credit(elapsed_ms: float, full_ms: Optional[float] = None, zero_ms: 
 
 
 def expected_decode_tps(curve: Optional[Dict[int, float]], inflight: int) -> float:
-    """Per-request decode tok/s one honest card delivers at ``inflight`` concurrent requests (piecewise-linear)."""
+    """Per-request decode tok/s one honest card delivers at ``inflight`` concurrent requests.
+
+    The curve's points are per-request rates; between them the interpolation runs on the card's *aggregate* rate
+    (per-request x concurrency), the quantity that is actually flat once a batch forms, and the per-request rate is
+    that aggregate over ``inflight``. A straight line between per-request points instead sits far above the real
+    hyperbola: with points at 1 and 6 only, an honest 5090 at 2-5 concurrent read 0.32-0.48x expected — under the
+    floor, zero credit, exactly where every traffic burst spends its time (#1753). Past the last point the
+    per-request rate holds: a runtime that queues beyond its batch keeps each stream's rate and grows TTFT.
+    """
     points: Sequence[Tuple[int, float]] = sorted(curve.items()) if curve else SERVING_DECODE_PER_REQUEST_FALLBACK
     n = max(1, int(inflight))
     if n <= points[0][0]:
         return points[0][1]
     for (n0, t0), (n1, t1) in zip(points, points[1:]):
         if n <= n1:
-            return t0 + (t1 - t0) * (n - n0) / (n1 - n0)
+            a0, a1 = n0 * t0, n1 * t1
+            return (a0 + (a1 - a0) * (n - n0) / (n1 - n0)) / n
     return points[-1][1]
 
 

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -16,10 +16,16 @@
       "speed": {
         "single_stream_decode_tps": 443.6,
         "aggregate_decode_tps": 280.0,
-        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 \u2014 queues past 16, wall 3.7 s -> 7 s)",
+        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 \u2014 queues past 16, wall 3.7 s -> 7 s). Per-request points 2-12 re-measured on-box on compute3 card 1 (RTX 5090), 2026-09-05, 64 tokens x 3 reps, median: single 408.2, aggregate flat 285-289 from 2 up (#1753)",
         "decode_per_request": {
           "1": 443.6,
-          "6": 46.0,
+          "2": 144.3,
+          "3": 96.7,
+          "4": 72.6,
+          "5": 58.5,
+          "6": 50.2,
+          "8": 37.8,
+          "12": 25.5,
           "16": 19.4,
           "24": 19.4,
           "32": 19.5

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -34,6 +34,7 @@ digests) or measured on the validator's own clock. Editing it earns nothing.
 
 import asyncio
 import os
+import re
 import time
 from collections import OrderedDict
 from functools import partial
@@ -47,6 +48,7 @@ from bittensor_wallet import Keypair
 
 from gittensor.constants import (
     BLOCKS_PER_TEMPO,
+    SERVING_ATTEST_PREFILL_DRAIN_S,
     SERVING_BACKEND_CONCURRENCY,
     SERVING_MAX_TOKENS,
     SERVING_MIN_CALLER_STAKE,
@@ -64,6 +66,15 @@ BTStreamingResponse = StreamingSynapse.BTStreamingResponse
 # after this grace; a claimed stream frees itself request_timeout + slack after it began, however it ended.
 SLOT_CLAIM_GRACE_S = 10.0
 SLOT_CLAIM_STREAM_SLACK_S = 30.0
+# A request counts as prefilling from admission until its first content delta. An entry older than this was never
+# picked up or is a runtime that stopped answering; it no longer holds an attestation back.
+PREFILL_STALE_S = 15.0
+# The admission hold an attestation puts up can never outlive the challenge by more than this, however the sidecar
+# call ends.
+ATTEST_HOLD_MAX_S = 10.0
+# The first stream chunk carrying text (content or reasoning): the runtime is past prefill and decoding. The role
+# chunk (``"content": null``) and a logprobs-only chunk (``"content": ""``) arrive before or without one.
+_FIRST_CONTENT = re.compile(rb'"(?:reasoning_)?content"\s*:\s*"[^"]')
 
 
 class ServingMiner(BaseNeuron):
@@ -97,6 +108,8 @@ class ServingMiner(BaseNeuron):
         self.seen_nonces: 'OrderedDict[str, None]' = OrderedDict()
         self.audit_budget: Dict[str, Tuple[int, int]] = {}  # validator hotkey -> (tempo, completion tokens used)
         self.attest_inflight: Set[str] = set()  # validator hotkeys with a challenge running on the sidecar now
+        self.prefilling: Dict[int, float] = {}  # id(synapse) -> monotonic admission; cleared at the first content
+        self.attest_hold_until: float = 0.0  # monotonic; inference admissions refuse "busy" while a challenge fills
         bt.logging.info(f'ServingMiner axon: {self.axon}')
 
     async def forward(self, synapse: bt.Synapse) -> bt.Synapse:
@@ -138,6 +151,7 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BT
     messages, logprobs = synapse.messages, synapse.logprobs
     claim = id(synapse)
     miner.slot_claims[claim] = time.monotonic() + miner.release.request_timeout + SLOT_CLAIM_STREAM_SLACK_S
+    marks = prefill_marks(miner)
 
     async def token_streamer(send) -> None:
         loop = asyncio.get_running_loop()
@@ -146,6 +160,8 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BT
         def produce() -> None:
             try:
                 for chunk in miner.backend.stream(messages, max_tokens, logprobs):
+                    if claim in marks and _FIRST_CONTENT.search(chunk):
+                        marks.pop(claim, None)  # decoding now: an attestation may fill the card
                     loop.call_soon_threadsafe(queue.put_nowait, chunk)
             except Exception as e:  # backend down/overloaded: the stream ends unfinished
                 bt.logging.warning(f'ServingMiner backend error: {e}')
@@ -159,12 +175,22 @@ async def handle_inference(miner: ServingMiner, synapse: InferenceSynapse) -> BT
             await producer
         finally:
             miner.slot_claims.pop(claim, None)
+            marks.pop(claim, None)
 
     return synapse.create_streaming_response(token_streamer)
 
 
 async def handle_attest(miner: ServingMiner, synapse: AttestSynapse) -> AttestSynapse:
-    """Run the validator's hardware challenge on this miner's runtime (attest sidecar, docker/attest)."""
+    """Run the validator's hardware challenge on this miner's runtime (attest sidecar, docker/attest).
+
+    The challenge fills the card's free VRAM for about a second. A prefill that starts inside that window cannot
+    get its scratch and the runtime drops to a fallback pass whose output the reference rejects — a strike for an
+    honest card, on the validator's own challenge (both mainnet cards were quarantined this way on 2026-09-04/05).
+    Decode is unaffected (its buffers are warm), so the fill is serialised against prefill only: new inference
+    admissions refuse "busy" (neutral to the validator, rerouted by the gateway) from here until the sidecar
+    answers, and the fill waits up to ``SERVING_ATTEST_PREFILL_DRAIN_S`` for admitted requests to reach their first
+    content delta. The wait is bounded so a slow prefill costs the challenge some round-trip slack, never the round.
+    """
     url = miner.release.attest_url
     if not url:
         synapse.error = 'no attest_url on the release'
@@ -183,18 +209,53 @@ async def handle_attest(miner: ServingMiner, synapse: AttestSynapse) -> AttestSy
         return r.json()
 
     miner.attest_inflight.add(caller)
+    miner.attest_hold_until = time.monotonic() + ATTEST_HOLD_MAX_S
     try:
+        await drain_prefill(miner)
         payload = await asyncio.get_running_loop().run_in_executor(None, call)
     except Exception as e:
         synapse.error = f'attest sidecar: {e!r}'[:300]
         return synapse
     finally:
         miner.attest_inflight.discard(caller)
+        if not miner.attest_inflight:  # another caller's challenge keeps the hold up
+            miner.attest_hold_until = 0.0
     devices = payload.get('devices') or [payload]
     synapse.devices = [dict(d) for d in devices]
     synapse.wall_ms = float(devices[0].get('wall_ms') or 0.0) if devices else None
     synapse.queued_ms = float(payload.get('queued_ms') or 0.0)
     return synapse
+
+
+def prefill_marks(miner: ServingMiner) -> Dict[int, float]:
+    marks = getattr(miner, 'prefilling', None)
+    if marks is None:
+        marks = miner.prefilling = {}
+    return marks
+
+
+def prefilling(miner: ServingMiner, now: Optional[float] = None) -> int:
+    """Admitted requests still before their first content delta, dropping marks nobody will clear."""
+    now = time.monotonic() if now is None else now
+    marks = prefill_marks(miner)
+    for key, started in list(marks.items()):
+        if now - started > PREFILL_STALE_S:
+            del marks[key]
+    return len(marks)
+
+
+async def drain_prefill(miner: ServingMiner, max_wait_s: float = SERVING_ATTEST_PREFILL_DRAIN_S) -> bool:
+    """Wait, at most ``max_wait_s``, until no admitted request is prefilling. True when the card is clear."""
+    deadline = time.monotonic() + max_wait_s
+    while prefilling(miner):
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(0.02)
+    return True
+
+
+def attest_holding(miner: ServingMiner, now: Optional[float] = None) -> bool:
+    return (time.monotonic() if now is None else now) < getattr(miner, 'attest_hold_until', 0.0)
 
 
 async def verify_inference(miner: ServingMiner, synapse: InferenceSynapse) -> None:
@@ -249,17 +310,21 @@ async def blacklist_inference(miner: ServingMiner, synapse: InferenceSynapse) ->
     contract's R6 lifted to the axon — so the gateway reroutes and the refusal is judged neutral; queueing instead
     would decay every caller's TTFT. Before the caller gate and its budget charge, so a refused request costs the
     caller nothing. Attestation delegates to ``blacklist_caller`` and skips this: the sidecar has its own
-    serialisation and a full backend must still pass attest rounds.
+    serialisation and a full backend must still pass attest rounds. The reverse holds too: while a challenge is
+    filling the card (``handle_attest``) every admission is refused busy, so no prefill lands on an empty card.
 
     Admission and accounting are one atomic step: ``claim_slot`` counts this request against the slots the moment
     it is admitted, with no await in between, so a burst cannot race past a capacity check that only samples
     slots already handed to running streams. A claim the handler never picks up expires on its own.
     """
+    if attest_holding(miner):
+        return True, 'busy: hardware attestation is filling the card'
     if not claim_slot(miner, synapse):
         return True, 'busy: all backend slots in use'
     blocked, reason = await blacklist_caller(miner, synapse)
     if blocked:
         miner.slot_claims.pop(id(synapse), None)
+        prefill_marks(miner).pop(id(synapse), None)
     return blocked, reason
 
 
@@ -271,6 +336,7 @@ def claim_slot(miner: ServingMiner, synapse: InferenceSynapse) -> bool:
     if len(miner.slot_claims) >= miner.slot_count:
         return False
     miner.slot_claims[id(synapse)] = now + SLOT_CLAIM_GRACE_S
+    prefill_marks(miner)[id(synapse)] = now  # prefilling from admission; an attestation must not fill over it
     return True
 
 

--- a/neurons/serving_miner.py
+++ b/neurons/serving_miner.py
@@ -69,9 +69,10 @@ SLOT_CLAIM_STREAM_SLACK_S = 30.0
 # A request counts as prefilling from admission until its first content delta. An entry older than this was never
 # picked up or is a runtime that stopped answering; it no longer holds an attestation back.
 PREFILL_STALE_S = 15.0
-# The admission hold an attestation puts up can never outlive the challenge by more than this, however the sidecar
-# call ends.
-ATTEST_HOLD_MAX_S = 10.0
+# The admission hold an attestation puts up is cleared when the sidecar answers; this is its safety cap if the
+# handler dies without clearing it. It matches the sidecar call's timeout: a challenge queued behind another on the
+# sidecar still fills the card when its turn comes, and admissions must stay refused until then.
+ATTEST_HOLD_MAX_S = 45.0
 # The first stream chunk carrying text (content or reasoning): the runtime is past prefill and decoding. The role
 # chunk (``"content": null``) and a logprobs-only chunk (``"content": ""``) arrive before or without one.
 _FIRST_CONTENT = re.compile(rb'"(?:reasoning_)?content"\s*:\s*"[^"]')
@@ -209,7 +210,7 @@ async def handle_attest(miner: ServingMiner, synapse: AttestSynapse) -> AttestSy
         return r.json()
 
     miner.attest_inflight.add(caller)
-    miner.attest_hold_until = time.monotonic() + ATTEST_HOLD_MAX_S
+    miner.attest_hold_until = time.monotonic() + max(5.0, float(synapse.timeout or ATTEST_HOLD_MAX_S))
     try:
         await drain_prefill(miner)
         payload = await asyncio.get_running_loop().run_in_executor(None, call)

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -323,10 +323,15 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
     single_tps = statistics.median(t for t, _ in single)
     probe_tps = statistics.median(aggregate)
     curve = {1: round(single_tps, 1), burst: round(statistics.median(per_request), 1)}
-    if burst != 6:  # a mid point so the validator's interpolation follows the real curve
-        with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
-            r6 = list(pool.map(lambda m: _stream_once(base_url, model_id, m, max_tokens, timeout), prompts[:6]))
-        curve[6] = round(statistics.median(t / max(w - tt, 1e-3) for t, tt, w in r6), 1)
+    # Every step from 2 to 6 plus 8 and 12: the validator interpolates on aggregate rate between points, but the
+    # 1 -> 2 knee (a batch forms and the aggregate drops before it flattens) is not interpolable from either side,
+    # and 2-5 in flight is where every traffic burst spends its time (#1753).
+    for k in (2, 3, 4, 5, 6, 8, 12):
+        if k >= burst:
+            break
+        with concurrent.futures.ThreadPoolExecutor(max_workers=k) as pool:
+            rk = list(pool.map(lambda m: _stream_once(base_url, model_id, m, max_tokens, timeout), prompts[:k]))
+        curve[k] = round(statistics.median(t / max(w - tt, 1e-3) for t, tt, w in rk), 1)
     return {
         'single_stream_decode_tps': round(single_tps, 1),
         # what the release carries as speed.aggregate_decode_tps: one card's output tok/s under load

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -5,7 +5,7 @@ import json
 import random
 import time
 from types import SimpleNamespace
-from typing import Dict
+from typing import Any, Dict
 
 import bittensor as bt
 import pytest
@@ -3068,7 +3068,7 @@ def test_seed_ready_from_store_republishes_without_settling():
     assert state.ready_miners() == []
 
 
-def _attest_miner(**over) -> SimpleNamespace:
+def _attest_miner(**over) -> Any:  # a ServingMiner stand-in; Any so the hooks accept it
     miner = SimpleNamespace(
         release=SimpleNamespace(attest_url='http://sidecar:8081', attest_api_key='', request_timeout=30.0),
         metagraph=SimpleNamespace(hotkeys=['vali'], S=[2_000_000.0], validator_permit=[True], validator_trust=[1.0]),
@@ -3094,7 +3094,7 @@ def test_attest_holds_admissions_and_waits_for_prefill_to_clear(monkeypatch):
     from neurons import serving_miner as sm
 
     miner = _attest_miner()
-    events: Dict[str, float] = {}
+    events: Dict[str, Any] = {}
 
     class _Resp:
         def raise_for_status(self):

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1025,14 +1025,23 @@ def test_strikes_need_the_fleet_to_agree_with_the_reference():
     assert summary.get('strike') == 1
 
 
-def test_quarantine_escalates_with_strikes():
+def test_quarantine_escalates_with_strikes_and_forgets_after_a_clean_week():
+    """1 h, 4 h, 16 h and it stays there (64 h was cut 2026-09-05: an honest runtime can strike, see handle_attest).
+    A strike after SERVING_STRIKE_FORGET_S without one starts the ladder over."""
+    from gittensor.constants import SERVING_STRIKE_FORGET_S
+
     w = AuditWindow(quarantine_s=100.0)
     assert w.strike('hk', 'r', now=0.0) == 100.0
     assert w.strike('hk', 'r', now=0.0) == 400.0
     assert w.strike('hk', 'r', now=0.0) == 1600.0
-    assert w.strike('hk', 'r', now=0.0) == 6400.0
-    assert w.strike('hk', 'r', now=0.0) == 6400.0
+    assert w.strike('hk', 'r', now=0.0) == 1600.0
+    assert w.strike('hk', 'r', now=0.0) == 1600.0
     assert w.strike('other', 'r', now=0.0) == 100.0
+    assert w.strikes('hk', 'r', now=SERVING_STRIKE_FORGET_S) == 5  # inside the week: the ladder stands
+    assert w.verdict('hk', 'r', now=SERVING_STRIKE_FORGET_S + 1.0).strikes == 0  # a clean week: forgotten
+    later = SERVING_STRIKE_FORGET_S + 1.0
+    assert w.strike('hk', 'r', now=later) == later + 100.0  # and the next strike costs an hour again
+    assert w.strike('hk', 'r', now=later + 10.0) == later + 10.0 + 400.0  # a repeat inside the week escalates
 
 
 def test_last_credit_survives_a_restart(tmp_path):
@@ -2877,14 +2886,32 @@ def test_strikes_count_up_and_survive_a_restart(tmp_path):
     w.strike('hk', 'r1', now=1000.0)
     w.strike('hk', 'r1', now=2000.0)
     w.strike('hk', 'r2', now=1000.0)
-    assert w.strikes('hk', 'r1') == 2 and w.strikes('hk', 'r2') == 1 and w.strikes('hk2', 'r1') == 0
+    now = 3000.0
+    assert w.strikes('hk', 'r1', now) == 2 and w.strikes('hk', 'r2', now) == 1 and w.strikes('hk2', 'r1', now) == 0
     assert w.verdict('hk', 'r1', now=3000.0).as_dict()['strikes'] == 2
 
     store = ServingStore(tmp_path / 'serving.db')
     store.save(ServingState(audits=w))
     again = store.load(ServingState(audits=AuditWindow(quarantine_s=100.0))).audits
-    assert again.strikes('hk', 'r1') == 2 and again.strikes('hk', 'r2') == 1
+    assert again.strikes('hk', 'r1', now) == 2 and again.strikes('hk', 'r2', now) == 1
     assert again.quarantined_until('hk', 'r1', now=2050.0) == 2400.0  # the second strike: 4x the first
+    assert again._last_strike[('hk', 'r1')] == 2000.0  # the forget clock survives the restart too
+    assert again.strikes('hk', 'r1') == 0  # ...so by wall-clock time (1970 + 2000 s) they are long forgotten
+
+
+def test_store_adds_the_last_strike_column_to_an_older_database(tmp_path):
+    import sqlite3
+
+    from gittensor.serving.store import ServingStore
+
+    path = tmp_path / 'serving.db'
+    with sqlite3.connect(path) as db:
+        db.execute('CREATE TABLE quarantine (hotkey TEXT, release_id TEXT, until REAL, strikes INTEGER DEFAULT 0)')
+        db.execute('CREATE TABLE audit_values (hotkey TEXT, release_id TEXT, seq INTEGER, value REAL)')
+        db.execute('INSERT INTO quarantine VALUES (?, ?, ?, ?)', ('hk', 'r', 0.0, 3))
+    loaded = ServingStore(path).load(ServingState(audits=AuditWindow(quarantine_s=100.0))).audits
+    assert loaded._strikes[('hk', 'r')] == 3 and loaded._last_strike[('hk', 'r')] == 0.0
+    assert loaded.strikes('hk', 'r') == 0  # a pre-upgrade strike carries no clock: forgotten on first look
 
 
 def test_store_migrates_a_model_id_keyed_database(tmp_path):

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1788,7 +1788,9 @@ def test_decode_speed_prices_served_requests_against_the_blessing_curve():
     curve = {1: 440.0, 6: 46.0, 16: 19.0}
     assert expected_decode_tps(curve, 1) == 440.0 and expected_decode_tps(curve, 0) == 440.0
     assert expected_decode_tps(curve, 16) == 19.0 and expected_decode_tps(curve, 40) == 19.0
-    assert expected_decode_tps(curve, 11) == pytest.approx(32.5)  # linear between 6 and 16
+    # between points the aggregate (per-request x n) is interpolated, then divided by n: 6 -> 276, 16 -> 304 tok/s
+    assert expected_decode_tps(curve, 11) == pytest.approx((276.0 + (304.0 - 276.0) * 0.5) / 11)
+    assert expected_decode_tps(curve, 3) == pytest.approx((440.0 + (276.0 - 440.0) * 0.4) / 3)  # 124.8, not 282.4
     assert expected_decode_tps(None, 6) == 46.0  # constants' fallback curve
     assert decode_credit(440.0, 440.0) == 1.0 and decode_credit(600.0, 440.0) == 1.0  # never more than one card
     assert decode_credit(352.0, 440.0) == 1.0  # 0.8x: inside the tolerance for WAN-observed decode
@@ -3218,3 +3220,26 @@ def test_inference_stream_clears_the_prefill_mark_at_the_first_content_delta():
     reasoning = b'data: {"choices":[{"index":0,"delta":{"reasoning_content":"th"},"logprobs":null}]}\n\n'
     assert sm._FIRST_CONTENT.search(reasoning)  # a thinking model's first text counts too
     assert not sm._FIRST_CONTENT.search(chunks[0]) and not sm._FIRST_CONTENT.search(chunks[1])
+
+
+def test_shipped_curve_pays_an_honest_card_in_full_at_2_to_5_concurrent():
+    """#1753: the blessed curve had points at 1 and 6 only, and the straight line between them sat far above what a
+    5090 does at 2-5 streams, so an honest card read 0.32-0.48x expected there — under the floor, zero credit. The
+    curve now carries measured points 2-12 and interpolates on aggregate rate. The rows are the issue's on-box
+    measurement of an unshared, correctly pinned card."""
+    from gittensor.validator.serving.scoring import decode_credit, expected_decode_tps
+
+    release = load_serving_loadout().primary
+    assert release.decode_per_request is not None
+    miner_measured = {1: 426.8, 2: 148.2, 3: 91.8, 4: 74.7, 5: 59.9, 6: 49.6, 8: 37.5}
+    for n, observed in miner_measured.items():
+        expected = expected_decode_tps(release.decode_per_request, n)
+        assert observed / expected >= 0.8, (n, observed, expected)  # inside the WAN tolerance: full credit
+        assert decode_credit(observed, expected) == 1.0
+    # and between the sparse tail points a queued stream is still expected at the last measured rate, not below it
+    assert expected_decode_tps(release.decode_per_request, 20) == pytest.approx(
+        (16 * 19.4 + (24 * 19.4 - 16 * 19.4) * 0.5) / 20
+    )
+    assert expected_decode_tps(release.decode_per_request, 64) == 19.5
+    # a card genuinely shared between two hotkeys still reads under the floor at 1 in flight
+    assert decode_credit(144.3, expected_decode_tps(release.decode_per_request, 1)) == 0.0

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -3037,3 +3037,157 @@ def test_seed_ready_from_store_republishes_without_settling():
     state.last_round_ts = time.time() - state.ready_ttl_s - 1.0
     fwd.seed_ready_from_store(validator, state, loadout=loadout)  # type: ignore[arg-type]  # past the TTL: no trust
     assert state.ready_miners() == []
+
+
+def _attest_miner(**over) -> SimpleNamespace:
+    miner = SimpleNamespace(
+        release=SimpleNamespace(attest_url='http://sidecar:8081', attest_api_key='', request_timeout=30.0),
+        metagraph=SimpleNamespace(hotkeys=['vali'], S=[2_000_000.0], validator_permit=[True], validator_trust=[1.0]),
+        audit_budget={},
+        attest_inflight=set(),
+        slot_count=99,
+        slot_claims={},
+        prefilling={},
+        attest_hold_until=0.0,
+    )
+    for k, v in over.items():
+        setattr(miner, k, v)
+    return miner
+
+
+def test_attest_holds_admissions_and_waits_for_prefill_to_clear(monkeypatch):
+    """The 2026-09-04/05 mainnet quarantines: the sidecar's VRAM fill landed on a prefill in flight, sparkinfer fell
+    back to a pass whose output the reference rejects, and the validator's own challenge struck an honest card. Now
+    a challenge refuses new admissions "busy" (neutral, rerouted) and its fill waits for admitted requests to reach
+    their first content delta."""
+    from gittensor.serving.state import is_busy_detail
+    from gittensor.synapses import AttestSynapse
+    from neurons import serving_miner as sm
+
+    miner = _attest_miner()
+    events: Dict[str, float] = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {'devices': [{'wall_ms': 700.0, 'filled_bytes': 8_000_000_000}], 'queued_ms': 0.0}
+
+    def fake_post(url, **kw):
+        events['fill'] = time.monotonic()
+        return _Resp()
+
+    monkeypatch.setattr(sm.requests, 'post', fake_post)
+
+    async def scenario():
+        req = InferenceSynapse(messages=MSGS, model_id='m', max_tokens=4)
+        req.dendrite = bt.TerminalInfo(hotkey='vali')
+        assert not (await sm.blacklist_inference(miner, req))[0]  # admitted: prefilling from this moment
+        assert sm.prefilling(miner) == 1
+
+        async def user_traffic_meanwhile():
+            await asyncio.sleep(0.15)
+            late = InferenceSynapse(messages=MSGS, model_id='m', max_tokens=4)
+            late.dendrite = bt.TerminalInfo(hotkey='vali')
+            blocked, reason = await sm.blacklist_inference(miner, late)
+            events['refused'] = (blocked, reason)
+            miner.prefilling.pop(id(req))  # the admitted request reaches its first content delta
+            events['cleared'] = time.monotonic()
+
+        att = AttestSynapse(seed=7)
+        att.dendrite = bt.TerminalInfo(hotkey='vali')
+        side = asyncio.ensure_future(user_traffic_meanwhile())
+        out = await sm.handle_attest(miner, att)
+        await side
+        return out
+
+    out = asyncio.run(scenario())
+    assert out.error is None and out.wall_ms == 700.0
+    blocked, reason = events['refused']
+    assert blocked and is_busy_detail(reason) and 'attestation' in reason  # busy, never a miss
+    assert events['fill'] >= events['cleared']  # the fill waited for the prefill to finish
+    assert events['fill'] - events['cleared'] < 0.2
+    assert miner.attest_hold_until == 0.0 and miner.attest_inflight == set()
+    fresh = InferenceSynapse(messages=MSGS, model_id='m', max_tokens=4)
+    fresh.dendrite = bt.TerminalInfo(hotkey='vali')
+    assert not asyncio.run(sm.blacklist_inference(miner, fresh))[0]  # admissions reopen with the challenge
+
+
+def test_attest_prefill_wait_is_bounded_and_ignores_stale_marks():
+    """A prefill that never reports its first content delays the fill by at most the drain bound, never the round;
+    a mark nobody cleared (handler never ran, runtime stopped answering) holds nothing back."""
+    from neurons import serving_miner as sm
+
+    miner = _attest_miner(prefilling={1: time.monotonic()})
+    t0 = time.monotonic()
+    assert asyncio.run(sm.drain_prefill(miner, max_wait_s=0.2)) is False
+    assert 0.2 <= time.monotonic() - t0 < 0.6
+    miner.prefilling = {1: time.monotonic() - sm.PREFILL_STALE_S - 1.0}
+    t0 = time.monotonic()
+    assert asyncio.run(sm.drain_prefill(miner, max_wait_s=0.2)) is True
+    assert time.monotonic() - t0 < 0.1 and miner.prefilling == {}
+    assert asyncio.run(sm.drain_prefill(_attest_miner(), max_wait_s=0.2)) is True  # nothing admitted: no wait
+
+
+def test_attest_hold_outlives_one_caller_while_another_still_fills(monkeypatch):
+    """Two validators challenging at once: the hold stands until the last fill returns."""
+    from gittensor.synapses import AttestSynapse
+    from neurons import serving_miner as sm
+
+    miner = _attest_miner(attest_inflight={'other-vali'})
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {'devices': [{'wall_ms': 700.0}], 'queued_ms': 0.0}
+
+    monkeypatch.setattr(sm.requests, 'post', lambda url, **kw: _Resp())
+    att = AttestSynapse(seed=7)
+    att.dendrite = bt.TerminalInfo(hotkey='vali')
+    asyncio.run(sm.handle_attest(miner, att))
+    assert miner.attest_inflight == {'other-vali'} and sm.attest_holding(miner)
+    miner.attest_inflight.clear()
+    miner.attest_hold_until = 0.0
+    assert not sm.attest_holding(miner)
+
+
+def test_inference_stream_clears_the_prefill_mark_at_the_first_content_delta():
+    """sparkinfer streams a role chunk (content null) before prefill finishes and may stream logprobs-only chunks
+    (content ""); neither means decoding. The mark clears at the first chunk carrying text and the slot at the end."""
+    from neurons import serving_miner as sm
+
+    chunks = [
+        b'data: {"choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null}]}\n\n',
+        b'data: {"choices":[{"index":0,"delta":{"content":""},"logprobs":{"content":[]}}]}\n\n',
+        b'data: {"choices":[{"index":0,"delta":{"content":"Hi"},"logprobs":null}]}\n\n',
+        b'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+        b'data: [DONE]\n\n',
+    ]
+    seen = []
+
+    class Backend:
+        def stream(self, messages, max_tokens, logprobs):
+            for chunk in chunks:
+                seen.append(sm.prefilling(miner))  # state left by the previous chunk
+                yield chunk
+
+    miner = _attest_miner(backend=Backend())
+    syn = InferenceSynapse(messages=MSGS, model_id='m', max_tokens=4)
+    syn.dendrite = bt.TerminalInfo(hotkey='vali')
+    assert sm.claim_slot(miner, syn) and sm.prefilling(miner) == 1
+    sent = []
+
+    async def run():
+        response = await sm.handle_inference(miner, syn)
+        await response.token_streamer(lambda msg: sent.append(msg) or asyncio.sleep(0))
+
+    asyncio.run(run())
+    assert seen == [1, 1, 1, 0, 0]  # role and logprobs-only chunks keep the mark; "Hi" clears it
+    assert [m['body'] for m in sent] == chunks
+    assert miner.prefilling == {} and miner.slot_claims == {}
+    reasoning = b'data: {"choices":[{"index":0,"delta":{"reasoning_content":"th"},"logprobs":null}]}\n\n'
+    assert sm._FIRST_CONTENT.search(reasoning)  # a thinking model's first text counts too
+    assert not sm._FIRST_CONTENT.search(chunks[0]) and not sm._FIRST_CONTENT.search(chunks[1])


### PR DESCRIPTION
## What broke

Both mainnet compute cards (UIDs 33 and 111) are quarantined on `WRONG answer` strikes, 3 strikes each, quarantine until ~22:30 UTC 09-05, and the next strike would have been 64 h. The strikes were caused by the validator's own hardware attestation.

- The attest sidecar fills all free VRAM minus 256 MB (8.7 GB on a 5090 with the model resident) for about a second.
- A chat request whose prefill starts inside that window fails sparkinfer's batched-prefill scratch allocation and takes the token-loop fallback. On pin 7498736 that fallback emits logprobs around −24 on tokens the reference scores at −0.06, so the reference rejects the completion and the band failure on aligned lengths is a hard strike.
- On compute3 every `[prefill] scratch alloc failed ... free=14/32110 MB -> fallback` line sits within 0.5 s of an `attest PASS` for UID 111 (5 of 5, three of which became strikes). UID 33's two strikes each follow its own attest by one round.
- Reproduced on our quarantined card: attest fill + 2,773-token prefill → prefix agreement 0.21, mean logprob drift 22 (production signature). A 400-token decode with the fill fired mid-stream verified bit-exact, so this is prefill-only.
- It never showed in the soaks because the traffic generator sends one-line prompts (a few MB of scratch, inside the 256 MB headroom) at a few requests per minute. Mainnet brought 8k-token contexts at 100+ requests per round.

## Commit 1: the miner serialises attest against prefill

`handle_attest` now:

- refuses new inference admissions with `busy: hardware attestation is filling the card` from the challenge's arrival until the sidecar answers. A busy refusal is neutral to the validator and rerouted by the gateway; cost is about a second per five minutes;
- waits up to `SERVING_ATTEST_PREFILL_DRAIN_S = 1.5 s` for every admitted request to reach its first content delta before calling the sidecar. The role chunk (`"content": null`) and logprobs-only chunks (`"content": ""`) do not count; `reasoning_content` does;
- bounds the wait, so a slow prefill costs some RTT slack (2 s), never the round. Marks are set at admission in `claim_slot` so a request between the gate and its handler is covered, and go stale after 15 s;
- keeps the hold up until the last of two concurrent validators' fills returns.

This also covers other validators' attests, which a validator-side exemption could not.

## Commit 2: the quarantine ladder caps at 16 h and strikes are forgotten after a clean week

- `SERVING_QUARANTINE_MAX_STEPS` 3 → 2: the ladder is 1 h, 4 h, 16 h and stays there. The 64 h tail rested on "no honest runtime produces a wrong answer", which this incident disproved. What stops intermittent cheating is the wiped window (every strike restarts probation), not the tail.
- `SERVING_STRIKE_FORGET_S = 7 days`: a strike carries the time of the last one; after a clean week the count falls off the ladder, in memory and in `serving.db` (new `last_strike` column, migrated in place). A pre-upgrade strike has no clock and is forgotten on first look, so the validator's restart onto this build clears the existing 3-strike counts for 33 and 111 by itself. The running quarantine `until` is untouched and expires on its own.

## Commit 3: the decode curve interpolates on aggregate rate and carries measured points at 2-12 in flight

Closes #1753. Same trigger as the strikes (real concurrency for the first time), different mechanism: pay, not admission.

- `expected_decode_tps` interpolates on the aggregate rate (per-request × n), the quantity that is flat once a batch forms, and divides by n. A straight line between per-request points at 1 and 6 sat far above the real hyperbola, so an honest 5090 at 2-5 concurrent read 0.32-0.48× expected: under the floor, zero decode credit. Past the last point the per-request rate holds, since a runtime that queues keeps each stream's rate and grows TTFT.
- The loadout carries points re-measured on-box on compute3 card 1 (2026-09-05, 64 tokens × 3 reps, median): 144.3 / 96.7 / 72.6 / 58.5 / 50.2 / 37.8 / 25.5 at 2 / 3 / 4 / 5 / 6 / 8 / 12; aggregate flat at 285-289 from 2 up. That matches the issue's on-box table within a few percent. The 1 and 16-32 points and `aggregate_decode_tps` (which sets the per-token rate) are the 08-27 blessing, unchanged: this re-shapes credit, it does not re-price the subnet.
- The conformance harness now measures 2-6, 8 and 12 for every future blessing, so a re-pin cannot ship the sparse curve again.
- Regression test: the issue's measured rows for an unshared, correctly pinned card all land inside the WAN tolerance (full credit) against the shipped curve; a card shared between two hotkeys still reads under the floor at 1 in flight.

## Rollout

- Miners get commit 1 via `entrius/gittensor:latest` once it reaches `main`; docker-only miners need to pull. UID 33's operator should be told this was on us.
- The validator picks up commits 2 and 3 on the same image; watchtower restarts it, which is what loads the forgotten strikes.
- Pinned for later: sparkinfer should refuse (503) rather than degrade when the scratch alloc fails under `DETERMINISTIC=1`; the reference logs ~20 `server overloaded` refusals per round from `SERVING_VERIFY_WORKERS = 8` (those verdicts go neutral: paid, unverified).

Tests: 7 new or updated in `tests/validator/test_serving.py`; full suite 793 passed.

https://claude.ai/code/session_01VLHbUgm7AwGThJj8taFFVR

