### PR TITLE
serving: pay prefill as card-time beside decode

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -160,10 +160,12 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # =============================================================================
 # Serving (sub-subnet B beta)
 # =============================================================================
-# Serving miners are paid per output token the gateway saw them serve, at a rate derived from the card-hour target:
-# rate = SERVING_GPU_HOUR_USD / (one card's aggregate decode tok/s x 3600), so a 5090 flat out for an hour (~1M
-# output tokens on the current runtime) earns exactly the card-hour and an idle one earns nothing. A round score is
-# those tokens in card-equivalents (tokens / (aggregate tok/s x round seconds)); the settled mean is priced at
+# Serving miners are paid for the card-time the gateway saw them serve: output tokens at the decode rate and
+# prompt tokens (prefill) at the prefill rate, both derived from the card-hour target:
+# rate = SERVING_GPU_HOUR_USD / (one card's aggregate tok/s x 3600), so a 5090 flat out for an hour (~1M output
+# tokens on the current runtime, or ~86M prompt tokens) earns exactly the card-hour and an idle one earns nothing. A
+# round score is that card-time in card-equivalents ((tokens / decode tok/s + prompt tokens / prefill tok/s) /
+# round seconds); the settled mean is priced at
 # SERVING_GPU_HOUR_USD, converted to an emission share through the on-chain alpha/TAO price and a live TAO/USD
 # rate (see below). No card count and no per-hotkey cap: served volume is the capacity
 # proof, and a real 5090 cannot out-decode its silicon. The only ceiling is SERVING_EMISSION_SHARE_CAP — above it the
@@ -175,6 +177,17 @@ SERVING_EMISSION_SHARE_CAP = 0.05
 # Output tok/s one card sustains under load on the blessed runtime, for a release without its own
 # `speed.aggregate_decode_tps` (sparkinfer 7498736 on a 5090: 279-282 at 16 concurrent, 2026-08-27).
 SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 280.0
+# Prompt tok/s one card prefills on the blessed runtime, for a release without its own `speed.prefill_tps`. Prefill
+# is paid as card-time exactly like decode, so a 30k-token prompt with a 150-token answer pays for the ~1.3 s of
+# prefill it cost the card and not only the 0.5 s of decode; at this rate a prompt token is worth ~1/85 of an output
+# token, which is also why claiming prompt tokens is not worth lying about. Derived from the 2026-08-28 5090 TTFT
+# readings behind SERVING_MAX_PROMPT_CHARS (8.9k prompt tokens in 403 ms, 35.6k in 1453 ms; RTT included, so this
+# understates the card). Re-measure with scripts/check_serving_runtime.py --speed-json (`prefill_tps`) and carry it
+# on the release.
+SERVING_PREFILL_TPS_FALLBACK = 24_000.0
+# The prompt token count is what the miner's runtime reported (usage.prompt_tokens). Pay is clamped to what the
+# prompt could honestly tokenize to: one token per character plus this many chat-template tokens per message.
+SERVING_PROMPT_TEMPLATE_TOKENS = 16
 # Pricing the cap needs the chain's alpha/TAO price and the live TAO/USD rate. A round that cannot read them
 # reuses the last usable pricing for up to SERVING_PRICING_MAX_AGE_S, so a chain hiccup does not move pay. With no
 # usable pricing at all the fleet is paid nothing: the alternative (the whole cap, split pro-rata) hands one verified

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -199,6 +199,7 @@ def build_app(
                         ttft_ms=finite_or_none(getattr(result, 'observed_ttft_ms', None)) if result else None,
                         inflight=inflight,
                         max_tokens=max_tokens,
+                        prompt_tokens=int((result.usage or {}).get('prompt_tokens') or 0) if result else 0,
                     )
                 )
                 state.record(

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -65,6 +65,7 @@ class ServingRelease:
     # each release self-prices. None -> the constants' defaults.
     decode_per_request: Optional[Dict[int, float]] = None  # concurrent requests -> per-request decode tok/s, one card
     aggregate_decode_tps: Optional[float] = None  # output tok/s one card sustains under load: the per-token rate's base
+    prefill_tps: Optional[float] = None  # prompt tok/s one card prefills: the per-prompt-token rate's base
     # Attestation (docker/attest, image entrius/gt-attest — one container per box, beside the runtime). Miner side:
     # attest_url = that container (default: base_url host, port 8081). Validator side: attest_reference_url = the one
     # beside the reference (default: reference_url host, port 8081).
@@ -129,6 +130,7 @@ class ServingRelease:
             request_timeout=float(raw.get('request_timeout', 60.0)),
             decode_per_request={int(k): float(v) for k, v in (speed.get('decode_per_request') or {}).items()} or None,
             aggregate_decode_tps=_optional_float(speed.get('aggregate_decode_tps')),
+            prefill_tps=_optional_float(speed.get('prefill_tps')),
             attest_image=attest.get('image'),
             attest_url=attest.get('url') or _sidecar_url(raw.get('base_url')),
             attest_api_key=attest.get('api_key') or os.getenv('SERVING_ATTEST_API_KEY') or None,

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -63,6 +63,9 @@ class ServedRequest:
     inflight: int = 1  # this validator's requests in flight to the miner when this one was dispatched (incl. itself)
     release_id: str = ''  # the release this request was routed for; audited against that release's reference
     max_tokens: int = 0  # what was asked for; a completion longer than this is not the runtime's
+    prompt_tokens: int = (
+        0  # prompt tokens the miner's runtime reported (usage.prompt_tokens); paid as prefill card-time
+    )
 
     def __post_init__(self) -> None:
         if not self.release_id:

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -17,7 +17,8 @@ published READY; serving axons that are not READY (and not quarantined) are
 published as *probation* so baseline traffic can give them a window.
 
     admitted    = window passes x speed credit > 0 x hardware attestation passes
-    round score = admitted x output tokens the gateway saw the miner serve, in card-equivalents
+    round score = admitted x card-time the gateway saw the miner serve (output tokens at the decode rate,
+                  prompt tokens at the prefill rate), in card-equivalents
 
 Pay is per token served, counted from the gateway's own served-request records
 (never the miner's word) and priced against the release's aggregate decode speed
@@ -74,7 +75,14 @@ from gittensor.serving.stream import consume_stream
 from gittensor.synapses import InferenceSynapse
 from gittensor.validator.serving.attest import attest_round, status_passed
 from gittensor.validator.serving.persist import ServingRoundStorage
-from gittensor.validator.serving.scoring import card_equivalents, paid_tokens, request_speed, token_rate_usd
+from gittensor.validator.serving.scoring import (
+    card_equivalents,
+    paid_prompt_tokens,
+    paid_tokens,
+    prompt_token_rate_usd,
+    request_speed,
+    token_rate_usd,
+)
 from gittensor.validator.utils.config import (
     SERVING_AUDIT_INTERVAL_S,
     SERVING_PAY_CAP_WITHOUT_PRICING,
@@ -169,6 +177,7 @@ def verify_served_round(
     last_miss: Optional[Dict[str, str]] = None,
     rng=None,
     staked_caller: bool = False,
+    prompt_tokens: Optional[Dict[str, int]] = None,
 ) -> Tuple[Dict[str, List[RequestSpeed]], Dict[str, int]]:
     """Verify this round's audit sample of the requests served for ``release`` into the window; return per-request
     speed per hotkey and the output tokens each hotkey is paid for.
@@ -176,16 +185,19 @@ def verify_served_round(
     Paid tokens are what the gateway saw served on user traffic: every unsampled completion, and every sampled one
     the reference did not fail. Baseline prompts anchor eligibility, not income. Reference calls run on a small
     thread pool; window updates stay on this thread. ``last_miss`` (hotkey -> reason) is filled with the most
-    recent miss or strike reason so the round report can show a miner why. ``staked_caller``: this validator clears
+    recent miss or strike reason so the round report can show a miner why. ``prompt_tokens`` (hotkey -> count) is
+    filled with the prompt tokens paid as prefill on the same requests. ``staked_caller``: this validator clears
     the miner's stake floor, so no miner has a budget to refuse it on.
     """
     summary = summary if summary is not None else {}
     last_miss = last_miss if last_miss is not None else {}
+    prompt_tokens = prompt_tokens if prompt_tokens is not None else {}
     tokens: Dict[str, int] = {}
 
     def pay(req: ServedRequest) -> None:
         if req.source == 'gateway' and req.ok:
             tokens[req.hotkey] = tokens.get(req.hotkey, 0) + paid_tokens(req)
+            prompt_tokens[req.hotkey] = prompt_tokens.get(req.hotkey, 0) + paid_prompt_tokens(req)
 
     mine, skipped = sample_for_audit([req for req in served if req.release_id == release.release_id], rng=rng)
     for req in skipped:
@@ -389,6 +401,9 @@ async def baseline_round(
                 ttft_ms=getattr(response, 'observed_ttft_ms', None) if ok else None,
                 inflight=inflight,
                 max_tokens=max_tokens,
+                prompt_tokens=int((getattr(response, 'usage', None) or {}).get('prompt_tokens') or 0)
+                if response is not None
+                else 0,
             )
         )
 
@@ -411,7 +426,8 @@ async def audit_round(
     round_s: float = SERVING_AUDIT_INTERVAL_S,
 ) -> Dict[str, float]:
     """Verify served traffic, settle windows, attest READY miners; publish READY/probation; return hotkey -> pay
-    score (served tokens in card-equivalents over ``round_s``, the wall clock the tokens were served in)."""
+    score (served output and prompt tokens in card-equivalents over ``round_s``, the wall clock they were served
+    in)."""
     loadout = loadout or load_serving_loadout()
     served = state.drain_served()
     if not serving:
@@ -440,8 +456,9 @@ async def audit_round(
                 'set SERVING_REFERENCE_URL to a conformant runtime'
             )
             continue
+        prompt: Dict[str, int] = {}
         speeds, tokens = verify_served_round(
-            state, reference, release, served, summary, last_miss, staked_caller=staked_caller
+            state, reference, release, served, summary, last_miss, staked_caller=staked_caller, prompt_tokens=prompt
         )
         passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
         for uid, hotkey, axon in active:
@@ -462,13 +479,15 @@ async def audit_round(
                 'ttft_ms': _mean([sp.ttft_ms for sp in round_speeds if sp.ttft_ms is not None]),
                 'decode_tps': _mean([sp.decode_tps for sp in round_speeds if sp.decode_tps is not None]),
                 'tokens': tokens.get(hotkey, 0),
+                'prompt_tokens': prompt.get(hotkey, 0),
                 'attested': False,
                 'score': 0.0,
                 'last_miss': last_miss.get(hotkey, ''),
             }
             bt.logging.debug(
                 f'Serving: UID {uid} {release.release_id} window {window.as_dict()} '
-                f'served {len(round_speeds)} credit {credit:.3f} tokens {tokens.get(hotkey, 0)}'
+                f'served {len(round_speeds)} credit {credit:.3f} tokens {tokens.get(hotkey, 0)} '
+                f'prompt {prompt.get(hotkey, 0)}'
             )
             if window.passed and credit > 0.0:
                 passing.append((uid, hotkey, axon, credit))
@@ -482,11 +501,14 @@ async def audit_round(
         for uid, hotkey, _, credit in passing:
             ok = bool(attested.get(hotkey, False))
             # Pay is what the gateway saw served, nothing else: an admitted card with no traffic earns nothing.
-            score = card_equivalents(windows[uid]['tokens'], release, round_s) if ok else 0.0
+            score = (
+                card_equivalents(windows[uid]['tokens'], release, round_s, windows[uid]['prompt_tokens']) if ok else 0.0
+            )
             st = state.attest_status.get(hotkey, {})
             bt.logging.info(
                 f'Serving: UID {uid} {release.release_id} attested {"yes" if ok else "no"} '
-                f'speed credit {credit:.2f} tokens {windows[uid]["tokens"]} score {score:.4f} card-equivalents'
+                f'speed credit {credit:.2f} tokens {windows[uid]["tokens"]} prompt {windows[uid]["prompt_tokens"]} '
+                f'score {score:.4f} card-equivalents'
             )
             windows[uid].update(
                 attested=ok,
@@ -523,7 +545,9 @@ async def audit_round(
         f'strike {summary.get("strike", 0)} · neutral {summary.get("neutral", 0)} · READY {len(ready)} '
         f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined} · dormant {dormant} · '
         f'paid {sum(w["tokens"] for w in windows.values())} output tokens at '
-        f'${token_rate_usd(loadout.releases[0]) * 1e6:.3f}/M'
+        f'${token_rate_usd(loadout.releases[0]) * 1e6:.3f}/M + '
+        f'{sum(w.get("prompt_tokens", 0) for w in windows.values())} prompt tokens at '
+        f'${prompt_token_rate_usd(loadout.releases[0]) * 1e6:.4f}/M'
     )
     return scores
 

--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -21,7 +21,7 @@ from gittensor.constants import SERVING_DB_RETENTION_DAYS, SERVING_EMISSION_SHAR
 from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.state import ServingState
 from gittensor.validator.emission_allocation import serving_share
-from gittensor.validator.serving.scoring import token_rate_usd
+from gittensor.validator.serving.scoring import prompt_token_rate_usd, token_rate_usd
 from gittensor.validator.storage.database import create_database_connection
 from gittensor.validator.storage.queries import (
     BULK_INSERT_SERVING_MINER_ROUNDS,
@@ -42,10 +42,10 @@ def round_rows(
 ) -> tuple[tuple, list[tuple]]:
     """(serving_rounds row, serving_miner_rounds rows) for one audit round.
 
-    ``card_equivalents`` and ``pool_share`` are what the next OSS round will pay on: settled scores (served tokens
-    in card-hours) summed, priced through ``serving_share`` exactly as ``blend_emission_pools`` does. The economics
-    ($/card-hour, cap, $/M output tokens), the paid token volume and the enforced release (pin, digest) ride along
-    so readers never hard-code them.
+    ``card_equivalents`` and ``pool_share`` are what the next OSS round will pay on: settled scores (served
+    card-time in card-hours) summed, priced through ``serving_share`` exactly as ``blend_emission_pools`` does. The
+    economics ($/card-hour, cap, $/M output and $/M prompt tokens), the paid output and prompt token volumes and the
+    enforced release (pin, digest) ride along so readers never hard-code them.
     """
     windows: Dict[int, dict] = last_round.get('windows', {})
     card_equiv = sum(settled.values())
@@ -78,6 +78,8 @@ def round_rows(
         release.attest_image if release else None,
         sum(int(w.get('tokens', 0)) for w in windows.values()),
         token_rate_usd(release) * 1e6 if release else None,
+        sum(int(w.get('prompt_tokens', 0)) for w in windows.values()),
+        prompt_token_rate_usd(release) * 1e6 if release else None,
     )
     miners = []
     for uid, w in windows.items():
@@ -104,6 +106,7 @@ def round_rows(
                 float(settled.get(str(w.get('hotkey', '')), 0.0)),
                 (str(w.get('last_miss', '') or '')[:500]) or None,
                 int(w.get('tokens', 0)),
+                int(w.get('prompt_tokens', 0)),
             )
         )
     return summary, miners

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -12,10 +12,12 @@ SERVING_LATENCY_ZERO_CREDIT_MS — and decode rate, completion tokens over
 validator itself had in flight to the miner (the release's blessing-time curve).
 Credit = ttft_credit × decode_credit; decode under SERVING_DECODE_FLOOR_RATIO ×
 expected is 0. The mean credit over a round's served requests is the miner's
-routing weight. Pay: the output tokens the gateway saw a hotkey serve in the
-round, in card-equivalents — ``tokens / (one card's aggregate decode tok/s ×
-round seconds)`` — so an hour flat out on one card is one card-hour
-(SERVING_GPU_HOUR_USD) and the per-token rate falls out of the release's speed.
+routing weight. Pay: the card-time the gateway saw a hotkey serve in the round,
+in card-equivalents — ``(output tokens / one card's aggregate decode tok/s +
+prompt tokens / one card's prefill tok/s) / round seconds`` — so an hour flat
+out on one card is one card-hour (SERVING_GPU_HOUR_USD) whether it spent it
+decoding or prefilling, and both per-token rates fall out of the release's speed.
+Prompt tokens are the miner-reported count, clamped to what the prompt could hold.
 """
 
 from typing import Dict, Optional, Sequence, Tuple
@@ -30,6 +32,8 @@ from gittensor.constants import (
     SERVING_GPU_HOUR_USD,
     SERVING_LATENCY_FULL_CREDIT_MS,
     SERVING_LATENCY_ZERO_CREDIT_MS,
+    SERVING_PREFILL_TPS_FALLBACK,
+    SERVING_PROMPT_TEMPLATE_TOKENS,
 )
 from gittensor.serving.loadout import ServingRelease
 from gittensor.serving.state import ServedRequest
@@ -45,17 +49,44 @@ def token_rate_usd(release: ServingRelease) -> float:
     return SERVING_GPU_HOUR_USD / (aggregate_decode_tps(release) * 3600.0)
 
 
-def card_equivalents(tokens: int, release: ServingRelease, seconds: float) -> float:
-    """Cards it takes to decode ``tokens`` output tokens in ``seconds`` on ``release``: 1.0 is one card flat out."""
-    if tokens <= 0 or seconds <= 0:
+def prefill_tps(release: ServingRelease) -> float:
+    """Prompt tok/s one honest card prefills on ``release``: the prompt-token rate's physical base."""
+    return release.prefill_tps or SERVING_PREFILL_TPS_FALLBACK
+
+
+def prompt_token_rate_usd(release: ServingRelease) -> float:
+    """USD per prompt token: the card-hour target spread over what one card prefills in an hour."""
+    return SERVING_GPU_HOUR_USD / (prefill_tps(release) * 3600.0)
+
+
+def card_equivalents(tokens: int, release: ServingRelease, seconds: float, prompt_tokens: int = 0) -> float:
+    """Cards it takes to decode ``tokens`` output tokens and prefill ``prompt_tokens`` in ``seconds`` on
+    ``release``: 1.0 is one card flat out. Both are card-time on the same card, so the two per-token rates fall
+    out of one card-hour and shifting work between prompt and completion never changes what it is worth."""
+    if seconds <= 0:
         return 0.0
-    return tokens / (aggregate_decode_tps(release) * seconds)
+    decode_s = max(tokens, 0) / aggregate_decode_tps(release)
+    prefill_s = max(prompt_tokens, 0) / prefill_tps(release)
+    return (decode_s + prefill_s) / seconds
 
 
 def paid_tokens(req: ServedRequest) -> int:
     """Output tokens the gateway saw ``req`` serve, never more than it asked for."""
     n = len(req.tokens or [])
     return min(n, req.max_tokens) if req.max_tokens > 0 else n
+
+
+def prompt_token_ceiling(messages: Sequence[Dict[str, str]]) -> int:
+    """The most prompt tokens ``messages`` can honestly tokenize to: one per character plus the chat template."""
+    chars = sum(len(m.get('content') or '') + len(m.get('role') or '') for m in messages)
+    return chars + SERVING_PROMPT_TEMPLATE_TOKENS * len(messages)
+
+
+def paid_prompt_tokens(req: ServedRequest) -> int:
+    """Prompt tokens ``req`` is paid prefill for: what the miner's runtime reported, never more than the prompt
+    could hold. The count is miner-reported (the gateway does not tokenize), so the clamp bounds a lie to a few x
+    of a rate that is already ~1/85 of an output token's."""
+    return max(0, min(int(req.prompt_tokens or 0), prompt_token_ceiling(req.messages)))
 
 
 def latency_credit(elapsed_ms: float, full_ms: Optional[float] = None, zero_ms: Optional[float] = None) -> float:

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -202,8 +202,10 @@ INSERT INTO serving_rounds (
     validator_hotkey, round_ts, served, gateway, baseline, passes, misses, strikes, neutral,
     ready, probation, quarantined, card_equivalents, pool_share, alpha_per_hour, alpha_usd,
     gpu_hour_usd, pool_cap, model_id, release_id, runtime_pin, model_sha256, model_file, runtime_image, attest_image,
-    tokens, usd_per_m_tokens
-) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    tokens, usd_per_m_tokens, prompt_tokens, usd_per_m_prompt_tokens
+) VALUES (
+    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+)
 ON CONFLICT (validator_hotkey, round_ts) DO NOTHING
 """
 
@@ -211,8 +213,8 @@ BULK_INSERT_SERVING_MINER_ROUNDS = """
 INSERT INTO serving_miner_rounds (
     validator_hotkey, round_ts, uid, hotkey, model_id, release_id, status, window_mean, window_n, window_passed,
     quarantined_until, served, credit, ttft_ms, decode_tps, capacity, round_score, settled_score, last_miss_reason,
-    tokens
-) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    tokens, prompt_tokens
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT (validator_hotkey, round_ts, uid, hotkey) DO NOTHING
 """
 

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -293,14 +293,71 @@ def _stream_once(base_url: str, model_id: str, messages, max_tokens: int, timeou
     return tokens, ttft if ttft is not None else float('inf'), time.monotonic() - started
 
 
+def _prefill_once(base_url: str, model_id: str, messages, timeout: float) -> Tuple[int, float]:
+    """One streamed 1-token greedy request: (prompt tokens the runtime reported, client-observed TTFT s)."""
+    from gittensor.serving.stream import SSEParser
+
+    body = {
+        'model': model_id,
+        'messages': messages,
+        'max_tokens': 1,
+        'temperature': 0,
+        'stream': True,
+        'stream_options': {'include_usage': True},
+    }
+    parser = SSEParser()
+    started = time.monotonic()
+    ttft = None
+    prompt_tokens = 0
+    with requests.post(
+        f'{base_url}/v1/chat/completions', headers=auth_headers(API_KEY), json=body, stream=True, timeout=timeout
+    ) as r:
+        r.raise_for_status()
+        for chunk in r.iter_content(chunk_size=None):
+            if ttft is None:
+                ttft = time.monotonic() - started
+            for event in parser.feed(chunk):
+                if event and isinstance(event.get('usage'), dict):
+                    prompt_tokens = int(event['usage'].get('prompt_tokens') or prompt_tokens)
+    return prompt_tokens, ttft if ttft is not None else float('inf')
+
+
+def prefill_profile(base_url: str, model_id: str, timeout: float, reps: int = 3, chars: int = 32_000) -> Dict:
+    """Prompt tok/s one honest card prefills: what the release carries as ``speed.prefill_tps``.
+
+    TTFT on a ~``chars``-character prompt minus TTFT on a short one, over the extra prompt tokens the runtime
+    reported: this client's RTT, the queue and the single decode step cancel, leaving the prefill pass. Measured one
+    request at a time, so it is the card's rate, not a batched one. The validator pays prompt tokens at
+    SERVING_GPU_HOUR_USD over an hour of this.
+    """
+    short = make_prompts(reps, seed=29)
+    filler = 'The quick brown fox jumps over the lazy dog while the validator audits every served request. '
+    long_text = (filler * (chars // len(filler) + 1))[:chars]
+    rates = []
+    long_tokens = 0
+    for messages in short:
+        _prefill_once(base_url, model_id, messages, timeout)  # warm
+        short_tokens, short_ttft = _prefill_once(base_url, model_id, messages, timeout)
+        long_messages = [{'role': 'user', 'content': f'{long_text}\n\n{messages[-1]["content"]}'}]
+        long_tokens, long_ttft = _prefill_once(base_url, model_id, long_messages, timeout)
+        extra_tokens, extra_s = long_tokens - short_tokens, long_ttft - short_ttft
+        if extra_tokens > 0 and extra_s > 0:
+            rates.append(extra_tokens / extra_s)
+    return {
+        'prefill_tps': round(statistics.median(rates), 1) if rates else None,
+        'prefill_prompt_tokens': long_tokens,
+        'prefill_reps': len(rates),
+    }
+
+
 def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float, burst: int, reps: int = 3) -> Dict:
     """Blessing-time speed facts for one honest card on this runtime, measured the way the validator measures.
 
     ``single_stream``: one request at a time. ``aggregate_decode_tps``: ``burst`` concurrent requests, aggregate
     verified tokens per second of decode time (batch wall-clock minus the first TTFT) — what one card serves flat
-    out, so the per-token rate the validator pays at is SERVING_GPU_HOUR_USD over an hour of it. Client TTFT
-    includes this client's RTT, so decode rates are RTT-free; the TTFT rows are informational unless the client is
-    on-box.
+    out, so the per-token rate the validator pays at is SERVING_GPU_HOUR_USD over an hour of it. ``prefill_tps``:
+    see ``prefill_profile``. Client TTFT includes this client's RTT, so decode rates are RTT-free; the TTFT rows
+    are informational unless the client is on-box.
     """
     prompts = make_prompts(burst * reps, seed=23)
     single = []
@@ -337,6 +394,8 @@ def speed_profile(base_url: str, model_id: str, max_tokens: int, timeout: float,
         # concurrent requests -> per-request decode tok/s of one honest card: the validator prices a served request
         # against this curve at the load it had in flight to the miner
         'decode_per_request': {str(k): v for k, v in sorted(curve.items())},
+        # what the release carries as speed.prefill_tps: prompt tok/s one card prefills; prompt tokens are paid at it
+        **prefill_profile(base_url, model_id, timeout, reps),
     }
 
 
@@ -399,7 +458,8 @@ def main() -> int:
     ap.add_argument(
         '--speed-json',
         default=None,
-        help='also measure the speed profile (single-stream and probe-shaped decode tok/s) and write it here',
+        help='also measure the speed profile (single-stream and probe-shaped decode tok/s, prefill tok/s) and '
+        'write it here',
     )
     ap.add_argument(
         '--speed-burst', type=int, default=16, help='concurrent requests in the saturation burst (blessed concurrency)'

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1843,12 +1843,21 @@ def test_release_speed_curve_parses(tmp_path):
 def test_token_pay_is_derived_from_the_release_speed(tmp_path):
     """Only the card-hour target is hand-set: the per-token rate is that target over what one card decodes in an
     hour, so a card flat out earns exactly the card-hour, 1.5 cards' worth of tokens earns 1.5, an idle card 0."""
-    from gittensor.constants import SERVING_AGGREGATE_DECODE_TPS_FALLBACK, SERVING_GPU_HOUR_USD
+    from gittensor.constants import (
+        SERVING_AGGREGATE_DECODE_TPS_FALLBACK,
+        SERVING_GPU_HOUR_USD,
+        SERVING_PREFILL_TPS_FALLBACK,
+        SERVING_PROMPT_TEMPLATE_TOKENS,
+    )
     from gittensor.serving.loadout import load_serving_loadout
     from gittensor.validator.serving.scoring import (
         aggregate_decode_tps,
         card_equivalents,
+        paid_prompt_tokens,
         paid_tokens,
+        prefill_tps,
+        prompt_token_ceiling,
+        prompt_token_rate_usd,
         token_rate_usd,
     )
 
@@ -1864,10 +1873,13 @@ def test_token_pay_is_derived_from_the_release_speed(tmp_path):
     assert token_rate_usd(release) * hour == pytest.approx(SERVING_GPU_HOUR_USD)
     bare = _echo_release()
     assert aggregate_decode_tps(bare) == SERVING_AGGREGATE_DECODE_TPS_FALLBACK
-    raw = {'releases': [{'model_id': 'm', 'backend': 'echo', 'speed': {'aggregate_decode_tps': 400}}]}
+    raw = {
+        'releases': [{'model_id': 'm', 'backend': 'echo', 'speed': {'aggregate_decode_tps': 400, 'prefill_tps': 30000}}]
+    }
     path = tmp_path / 'loadout.json'
     path.write_text(json.dumps(raw))
     assert aggregate_decode_tps(load_serving_loadout(path).primary) == 400.0
+    assert prefill_tps(load_serving_loadout(path).primary) == 30000.0
     assert load_serving_loadout().primary.aggregate_decode_tps  # the shipped release self-prices
     # the gateway pays what it asked for at most: a runtime that streams past max_tokens is not paid for it
     req = _served(1, release)
@@ -1876,6 +1888,32 @@ def test_token_pay_is_derived_from_the_release_speed(tmp_path):
     assert paid_tokens(req) == 5
     req.tokens = None
     assert paid_tokens(req) == 0
+
+    # Prefill is the same card-time at the card's prefill rate: an hour of prompt tokens is one card-hour too, and
+    # a prompt-heavy request pays for the prefill it cost on top of its decode, not 1:1 with output.
+    release.prefill_tps = 24_000.0
+    assert prefill_tps(bare) == SERVING_PREFILL_TPS_FALLBACK
+    prefill_hour = int(24_000.0 * 3600)  # ~86M prompt tokens
+    assert card_equivalents(0, release, 3600.0, prefill_hour) == pytest.approx(1.0)
+    assert card_equivalents(hour, release, 3600.0, prefill_hour) == pytest.approx(2.0)
+    assert card_equivalents(150, release, 300.0, 30_000) == pytest.approx((150 / 280.0 + 30_000 / 24_000.0) / 300.0)
+    assert card_equivalents(150, release, 300.0, 30_000) > card_equivalents(150, release, 300.0)
+    assert card_equivalents(0, release, 300.0, 0) == 0.0 and card_equivalents(0, release, 0.0, 100) == 0.0
+    assert prompt_token_rate_usd(release) * 1e6 == pytest.approx(0.0081, abs=0.0001)  # $/M prompt: ~1/85 of output
+    assert token_rate_usd(release) / prompt_token_rate_usd(release) == pytest.approx(24_000.0 / 280.0)
+    # the count is miner-reported, so it is clamped to what the prompt could tokenize to: a runtime claiming a
+    # 100k-token prompt for 16 characters is paid one per character plus the template
+    req = _served(1, release)
+    req.prompt_tokens = 12
+    assert paid_prompt_tokens(req) == 12
+    req.prompt_tokens = 100_000
+    assert (
+        paid_prompt_tokens(req)
+        == prompt_token_ceiling(req.messages)
+        == 16 + len('user') + SERVING_PROMPT_TEMPLATE_TOKENS
+    )
+    req.prompt_tokens = -5
+    assert paid_prompt_tokens(req) == 0
 
 
 def test_pay_counts_gateway_tokens_the_reference_did_not_fail():
@@ -1892,11 +1930,15 @@ def test_pay_counts_gateway_tokens_the_reference_did_not_fail():
     baseline = _served(3, good)
     baseline.source = 'baseline'
     served.append(baseline)
+    for req in served:
+        req.prompt_tokens = 7  # the runtime's usage.prompt_tokens; every prompt here is 16 hex chars
     state = ServingState()
     summary: Dict[str, int] = {}
-    speeds, tokens = verify_served_round(state, ref, good, served, summary, rng=random.Random(0))
+    prompt: Dict[str, int] = {}
+    speeds, tokens = verify_served_round(state, ref, good, served, summary, rng=random.Random(0), prompt_tokens=prompt)
     assert summary['unsampled'] == 2 and len(speeds['hk1']) == 10
     assert tokens == {'hk1': 12 * 8, 'hk2': 8}  # hk2: one completion paid, the wrong one and the miss are not
+    assert prompt == {'hk1': 12 * 7, 'hk2': 7}  # prefill follows the same requests: nothing for the miss or baseline
     assert state.audits.verdict('hk2', good.release_id).quarantined_until > 0  # ... and the strike stands
 
     class Flaky:
@@ -1911,6 +1953,66 @@ def test_pay_counts_gateway_tokens_the_reference_did_not_fail():
     state = ServingState()
     _, tokens = verify_served_round(state, Flaky(), good, [_served(1, good)], {})  # type: ignore[arg-type]
     assert tokens == {'hk1': 8}
+
+
+def test_round_pays_prefill_as_card_time(monkeypatch):
+    """Two hotkeys serve the same completions; the one whose prompts were long is paid the prefill on top, at the
+    release's prefill rate, and the round report carries both token counts for the DB and the UI."""
+    from types import SimpleNamespace
+
+    from gittensor.validator.serving.scoring import card_equivalents
+
+    release = _echo_release()
+    release.prefill_tps = 24_000.0
+    dendrite, _ = _dendrite_echoing(release)
+    state = ServingState(settlement_rounds=1)
+    serving = [(1, 'hk1', SimpleNamespace(is_serving=True)), (2, 'hk2', SimpleNamespace(is_serving=True))]
+    for i in range(3):
+        state.enqueue_served(_served(1, release))
+        long = _served(2, release)  # the same honest echo completion, on a 4000-character prompt
+        long.messages = [{'role': 'user', 'content': f'{i}' + 'x' * 3999}]
+        ref = expected_completion(long.messages, release.max_tokens, release.model_id)
+        long.tokens, long.token_logprobs = list(ref.tokens or []), list(ref.token_logprobs or [])
+        long.completion = ' '.join(long.tokens)
+        long.prompt_tokens = 1000  # what the runtime reported; under the 4000 + template ceiling
+        state.enqueue_served(long)
+    scores = _round(state, dendrite, serving, release, monkeypatch)
+    assert scores['hk1'] == pytest.approx(card_equivalents(3 * 8, release, ROUND_S))
+    assert scores['hk2'] == pytest.approx(card_equivalents(3 * 8, release, ROUND_S, 3 * 1000))
+    assert scores['hk2'] > scores['hk1']
+    # 3000 prompt tokens at 24k tok/s is 0.125 s of card-time on top of 24 tokens' 0.086 s of decode
+    assert scores['hk2'] / scores['hk1'] == pytest.approx(1 + (3000 / 24_000.0) / (24 / 280.0))
+    windows = state.last_round['windows']
+    assert windows[1]['tokens'] == 24 and windows[1]['prompt_tokens'] == 0
+    assert windows[2]['tokens'] == 24 and windows[2]['prompt_tokens'] == 3000
+
+
+def test_round_rows_carry_prompt_tokens_and_both_rates():
+    """The persisted round carries the fleet's prompt tokens and the $/M prompt rate beside the output ones, and
+    each miner row its own prompt tokens — as many values as the INSERTs have placeholders."""
+    import datetime as dt
+
+    from gittensor.validator.serving.persist import round_rows
+    from gittensor.validator.storage.queries import BULK_INSERT_SERVING_MINER_ROUNDS, INSERT_SERVING_ROUND
+
+    release = _echo_release()
+    release.aggregate_decode_tps = 280.0
+    release.prefill_tps = 24_000.0
+    last_round = {
+        'served': 5,
+        'gateway': 4,
+        'baseline': 1,
+        'windows': {
+            1: {'hotkey': 'hk1', 'model_id': release.model_id, 'tokens': 800, 'prompt_tokens': 30_000, 'score': 0.1},
+            2: {'hotkey': 'hk2', 'model_id': release.model_id, 'tokens': 200, 'prompt_tokens': 0, 'score': 0.02},
+        },
+    }
+    summary, miners = round_rows('vali', dt.datetime.now(dt.timezone.utc), last_round, {}, None, release)
+    assert len(summary) == INSERT_SERVING_ROUND.count('%s')
+    assert all(len(row) == BULK_INSERT_SERVING_MINER_ROUNDS.count('%s') for row in miners)
+    assert summary[-4:-2] == (1000, pytest.approx(0.694, abs=0.001))  # output tokens, $/M output
+    assert summary[-2] == 30_000 and summary[-1] == pytest.approx(0.0081, abs=0.0001)  # prompt tokens, $/M prompt
+    assert sorted((row[2], row[-2], row[-1]) for row in miners) == [(1, 800, 30_000), (2, 200, 0)]
 
 
 def test_emission_pool_is_the_only_ceiling(monkeypatch):

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -38,6 +38,7 @@ ROUND = {
             'ttft_ms': 48.3,
             'decode_tps': 190.0,
             'tokens': 84_000,
+            'prompt_tokens': 2_400_000,
             'attested': True,
             'score': 1.0,
             'last_miss': '',
@@ -56,6 +57,7 @@ ROUND = {
             'ttft_ms': None,
             'decode_tps': None,
             'tokens': 0,
+            'prompt_tokens': 0,
             'attested': False,
             'score': 0.0,
             'last_miss': 'tokenization mismatch (3 vs 4)',
@@ -83,14 +85,16 @@ def test_round_rows_shape_and_pricing():
     assert summary[14:16] == (100.0, 1.0)
     assert summary[16:18] == (0.70, SERVING_EMISSION_SHARE_CAP)  # economics ride along so das never hard-codes them
     assert summary[18:25] == (None,) * 7
-    assert summary[25:] == (84_000, None)  # paid tokens across the fleet; no release -> no per-token rate
+    # paid output and prompt tokens across the fleet; no release -> no per-token rates
+    assert summary[25:] == (84_000, None, 2_400_000, None)
     assert len(miners) == 2
     ready = next(m for m in miners if m[2] == 16)
     assert ready[5] == 'qwen' and ready[6] == 'ready'  # release_id defaults to model_id
     assert ready[13] == 48.3 and ready[14] == 190.0 and ready[17] == 0.5 and ready[18] is None
     assert ready[15] == 1.0 and ready[19] == 84_000  # capacity carries admission only; tokens is what was paid
+    assert ready[20] == 2_400_000  # ... and prompt_tokens the prefill paid on the same requests
     quarantined = next(m for m in miners if m[2] == 27)
-    assert quarantined[6] == 'quarantined' and quarantined[15] == 0.0 and quarantined[19] == 0
+    assert quarantined[6] == 'quarantined' and quarantined[15] == 0.0 and quarantined[19:21] == (0, 0)
     assert quarantined[10] == dt.datetime.fromtimestamp(1_800_000_000.0, dt.timezone.utc)
     assert quarantined[18].startswith('tokenization mismatch')
 
@@ -118,6 +122,7 @@ def test_round_rows_carry_the_enforced_release():
         'entrius/gt-attest:v1',
     )
     assert summary[26] == pytest.approx(0.694, abs=0.001)  # $/M output tokens at the fallback 280 tok/s
+    assert summary[28] == pytest.approx(0.0081, abs=0.0001)  # $/M prompt tokens at the fallback 24k tok/s prefill
 
 
 def test_default_loadout_keeps_model_file():


### PR DESCRIPTION
## Summary
Compute miners are paid for the card-time they serve, not only for output tokens.

- `card_equivalents(tokens, release, seconds, prompt_tokens)` = `(tokens / aggregate_decode_tps + prompt_tokens / prefill_tps) / seconds`. One card-hour is $0.70 whether spent decoding or prefilling; the $/M prompt rate (~$0.008) falls out of the same card-hour as the $/M output rate ($0.694), so there is no hand-set ratio and no gain in shifting work between prompt and completion.
- `SERVING_PREFILL_TPS_FALLBACK = 24_000` (from the 2026-08-28 5090 TTFT readings, RTT included so it slightly overpays prefill). A release may carry `speed.prefill_tps`; `scripts/check_serving_runtime.py --speed-json` now measures it (long-prompt TTFT minus short-prompt TTFT over the extra prompt tokens, so RTT cancels).
- The prompt count is the miner runtime's `usage.prompt_tokens`, recorded on the served request by the gateway — the same number the product logs, so the two reconcile. Pay clamps it to `chars + 16 × messages` (`paid_prompt_tokens`), bounding a lying runtime to a few × of a rate that is already ~1/85 of an output token's.
- Round reports and persisted rows carry `prompt_tokens` per miner and per fleet plus `usd_per_m_prompt_tokens` (columns from entrius/gittensor-db#59). Log lines print both token volumes and both rates.

## Effect on emissions
Same card-hour price; prefill time now counts as card time. On prompt-heavy agentic traffic (yesterday's ratio: 1.48M prompt / 46k output) miners earn ~38% more; on chat-shaped traffic a few %. The compute pool is 0.01% of emission today, so OSS sees a rounding-error shift and the 5% cap stays ~350 cards away.

## Merge order
After entrius/gittensor-db#59. `ServingRoundStorage` swallows insert errors, so a validator on this code with the old schema logs a warning every round and persists nothing until the columns exist.

## Test plan
- `uv run pytest tests` — 789 passed (was 787): new `test_round_pays_prefill_as_card_time`, `test_round_rows_carry_prompt_tokens_and_both_rates`; pay/persist tests extended for prompt tokens, ceiling clamp and the prompt rate
- `ruff check` / `ruff format --check` clean
- On the box after deploy: the round log line reads `paid N output tokens at $0.694/M + M prompt tokens at $0.0081/M`

https://claude.ai/code/session_01Lpqs8q2BHEHSqs4DPq6JeT