### PR TITLE
serving: TTFT credit allows for the prompt's own prefill

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -242,12 +242,17 @@ SERVING_VERIFY_BUSY_RETRIES = 3
 # 5090 reports TTFT ~26 ms on-box (2026-08-27 conformance) and a 64-token answer in ~165 ms (2026-08-22/24); add
 # validator<->miner RTT and an honest miner anywhere on earth lands well under FULL. Credit is flat to FULL and
 # falls linearly to 0 at ZERO, so a miner proxying to a GPU in another region or queueing requests loses credit
-# in proportion. Generation length does not enter (mini-soak 2026-08-27: total latency of 64-512-token answers
+# in proportion. The prompt's own prefill is allowed for first: the time one honest card needs to prefill it
+# (prompt tokens / the release's prefill tok/s, ~1.5 s at 36k tokens) is subtracted from the observed TTFT before
+# the bands apply, so a long agentic prompt is not read as a slow card. The prompt token count is the reference's
+# own (from teacher-forced scoring) — never the miner's — with ~SERVING_CHARS_PER_TOKEN_ESTIMATE characters per
+# token as the fallback. Generation length does not enter (mini-soak 2026-08-27: total latency of 64-512-token answers
 # scored a perfect miner at 0.24). Same-region proxying is NOT visible here; that is the one-GPU-many-hotkeys
 # case, which pay-per-token makes pointless (the hotkeys split one card's tokens) and the decode floor catches
 # under load.
 SERVING_LATENCY_FULL_CREDIT_MS = 500.0
 SERVING_LATENCY_ZERO_CREDIT_MS = 1_500.0
+SERVING_CHARS_PER_TOKEN_ESTIMATE = 4  # the validator's own prompt-size estimate when the reference reports no count
 # Decode speed on served traffic. Each served request with at least SERVING_DECODE_MIN_TOKENS completion tokens
 # yields a validator-observed decode rate, tokens / (total - TTFT); it is compared with what one honest card does on
 # this runtime at the number of requests THIS validator had in flight to the miner (the release's blessing-time

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -100,6 +100,9 @@ class AuditVerdict:
     positional_overlap: float = 0.0
     max_abs_logprob_diff: float = float('inf')
     hard: bool = False  # a wrong answer (bands failed with aligned lengths), not a miss
+    # The reference's own count of the prompt's tokens (teacher-forced scoring reports it); None when it did not.
+    # Speed credit allows for prefilling this many tokens, so the number must never come from the miner.
+    prompt_tokens: Optional[int] = None
 
     @property
     def value(self) -> float:
@@ -476,6 +479,8 @@ def verify_served(
     # there must be the end-of-turn, which is what makes an early stop the model's own decision and not the miner's.
     ref = reference.score_served(messages, completion, mine_ids)
     argmax, ref_lp = list(ref.get('argmax') or []), list(ref.get('logprobs') or [])
+    reported = (ref.get('usage') or {}).get('prompt_tokens')
+    prompt_tokens = int(reported) if isinstance(reported, int) and reported > 0 else None
     if appended:
         if len(argmax) == len(mine) + 1 and argmax[-1] not in end_of_turn:
             return AuditVerdict(False, 0.0, float('inf'), 'stopped early: the model would have continued', hard=True)
@@ -494,16 +499,19 @@ def verify_served(
             return AuditVerdict(False, 0.0, float('inf'), 'token ids do not spell the completion')
     case = AuditCase(messages=list(messages), max_tokens=len(mine), reference_tokens=argmax, reference_logprobs=ref_lp)
     if release is None:
-        return verify_response(case, mine, mine_lp, aligned=True)
-    return verify_response(
-        case,
-        mine,
-        mine_lp,
-        release.min_prefix_agreement,
-        release.max_mean_abs_logprob_diff,
-        release.max_abs_logprob_diff,
-        aligned=True,
-    )
+        verdict = verify_response(case, mine, mine_lp, aligned=True)
+    else:
+        verdict = verify_response(
+            case,
+            mine,
+            mine_lp,
+            release.min_prefix_agreement,
+            release.max_mean_abs_logprob_diff,
+            release.max_abs_logprob_diff,
+            aligned=True,
+        )
+    verdict.prompt_tokens = prompt_tokens
+    return verdict
 
 
 def spells(ref_bytes: bytes, completion: str) -> bool:

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -302,10 +302,13 @@ def verify_served_round(
         else:
             state.audits.record(req.hotkey, release.release_id, verdict.value)
             bump('pass' if verdict.passed else 'miss')
-        # Speed is priced on served traffic: time to first token and decode rate against the blessing's curve at
-        # the load this validator had in flight to the miner (gittensor/validator/serving/scoring.py).
+        # Speed is priced on served traffic: time to first token (less the prompt's own prefill, sized by the
+        # reference's token count) and decode rate against the blessing's curve at the load this validator had in
+        # flight to the miner (gittensor/validator/serving/scoring.py).
         speeds.setdefault(req.hotkey, []).append(
-            request_speed(req, release) if verdict.passed else RequestSpeed(credit=0.0)
+            request_speed(req, release, prompt_tokens=verdict.prompt_tokens)
+            if verdict.passed
+            else RequestSpeed(credit=0.0)
         )
         state.record(
             RequestRecord(

--- a/gittensor/validator/serving/scoring.py
+++ b/gittensor/validator/serving/scoring.py
@@ -25,6 +25,7 @@ from typing import Dict, Optional, Sequence, Tuple
 from gittensor.classes import RequestSpeed
 from gittensor.constants import (
     SERVING_AGGREGATE_DECODE_TPS_FALLBACK,
+    SERVING_CHARS_PER_TOKEN_ESTIMATE,
     SERVING_DECODE_FLOOR_RATIO,
     SERVING_DECODE_MIN_TOKENS,
     SERVING_DECODE_PER_REQUEST_FALLBACK,
@@ -134,12 +135,32 @@ def decode_credit(
     return 0.0 if ratio < floor_ratio else min(1.0, ratio / tolerance_ratio)
 
 
-def request_speed(req: ServedRequest, release: ServingRelease) -> RequestSpeed:
-    """Speed of one verified served request: TTFT band × decode band (decode only when measurable)."""
+def prompt_token_estimate(messages: Sequence[Dict[str, str]]) -> int:
+    """The validator's own count of a prompt's tokens when the reference reported none: ~4 characters each."""
+    chars = sum(len(m.get('content') or '') + len(m.get('role') or '') for m in messages)
+    return chars // SERVING_CHARS_PER_TOKEN_ESTIMATE
+
+
+def prefill_allowance_ms(prompt_tokens: int, release: ServingRelease) -> float:
+    """Time one honest card needs to prefill ``prompt_tokens`` on ``release``. Subtracted from the observed TTFT
+    before the latency bands apply, so a 30k-token prompt that took 1.4 s to first token reads as a fast card, not a
+    slow one; the bands then measure what they were set for — network, queue and the card's own overhead."""
+    return 1000.0 * max(prompt_tokens, 0) / prefill_tps(release)
+
+
+def request_speed(req: ServedRequest, release: ServingRelease, prompt_tokens: Optional[int] = None) -> RequestSpeed:
+    """Speed of one verified served request: TTFT band × decode band (decode only when measurable).
+
+    ``prompt_tokens`` is the reference's count of the prompt (``AuditVerdict.prompt_tokens``); None falls back to
+    the validator's own estimate from the prompt text. The miner-reported ``req.prompt_tokens`` is deliberately not
+    used here: a miner could inflate it to buy TTFT slack.
+    """
     speed_ms = req.ttft_ms if req.ttft_ms is not None else req.latency_ms
     if speed_ms is None:
         return RequestSpeed(credit=0.0)
-    credit = latency_credit(speed_ms, release.ttft_full_ms, release.ttft_zero_ms)
+    n = prompt_tokens if prompt_tokens is not None else prompt_token_estimate(req.messages)
+    residual_ms = max(0.0, speed_ms - prefill_allowance_ms(n, release))
+    credit = latency_credit(residual_ms, release.ttft_full_ms, release.ttft_zero_ms)
     tokens = len(req.tokens or [])
     decode_tps = None
     if (

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -1729,8 +1729,60 @@ def test_latency_credit_uses_time_to_first_token_not_total_latency(monkeypatch):
     state.enqueue_served(prompt)
     state.enqueue_served(slow)
     scores = _round(state, dendrite, [(1, 'hk1', axon), (2, 'hk2', axon)], good, monkeypatch)
-    assert _weights(state) == {1: 1.0, 2: pytest.approx(0.5)}
+    assert _weights(state) == {
+        1: 1.0,
+        2: pytest.approx(0.5, abs=1e-3),
+    }  # a 16-char prompt earns a sub-ms prefill allowance
     assert scores['hk1'] == scores['hk2'] == pytest.approx(_pay(8, good))  # speed routes; tokens pay
+
+
+def test_ttft_credit_allows_for_the_prompts_own_prefill():
+    """A 30k-token prompt takes an honest 5090 ~1.25 s to prefill, so a 1.4 s TTFT on it is a fast card; the same
+    1.4 s on a 100-token prompt is a slow one. The allowance is sized by the reference's token count, never the
+    miner's; without a reference count the validator estimates from the prompt text."""
+    from gittensor.validator.serving.scoring import (
+        prefill_allowance_ms,
+        prompt_token_estimate,
+        request_speed,
+    )
+
+    release = _echo_release()
+    release.prefill_tps = 24_000.0
+    assert prefill_allowance_ms(30_000, release) == pytest.approx(1250.0)
+    assert prefill_allowance_ms(0, release) == 0.0 and prefill_allowance_ms(-5, release) == 0.0
+
+    req = _served(1, release, latency_ms=1500.0)
+    req.ttft_ms = 1400.0
+    assert request_speed(req, release, prompt_tokens=30_000).credit == 1.0  # 150 ms residual: inside FULL
+    assert request_speed(req, release, prompt_tokens=100).credit == pytest.approx(0.1, abs=0.01)  # ~1.4 s residual
+    # the miner's own claim buys nothing: only the reference's count (or the validator's estimate) enters
+    req.prompt_tokens = 1_000_000
+    assert request_speed(req, release, prompt_tokens=100).credit == pytest.approx(0.1, abs=0.01)
+    # no reference count: ~4 characters per token from the prompt text
+    long = _served(1, release, latency_ms=1500.0)
+    long.ttft_ms = 1400.0
+    long.messages = [{'role': 'user', 'content': 'x' * 120_000}]  # ~30k tokens
+    assert prompt_token_estimate(long.messages) == 30_001
+    assert request_speed(long, release).credit == 1.0
+    assert request_speed(req, release).credit == pytest.approx(0.1, abs=0.01)  # a 16-char prompt: no allowance
+
+
+def test_verify_served_carries_the_references_prompt_token_count():
+    """Teacher-forced scoring reports the prompt's token count; the verdict carries it for the speed credit and
+    reads None when the reference reports nothing (echo, bank)."""
+    from gittensor.serving.audit import EchoReference, verify_served
+
+    good = _echo_release()
+    req = _served(1, good)
+
+    class Counting(EchoReference):
+        def score_served(self, messages, completion, token_ids=None):
+            return {**super().score_served(messages, completion, token_ids), 'usage': {'prompt_tokens': 4321}}
+
+    plain = verify_served(EchoReference(good), req.messages, req.completion, req.tokens, req.token_logprobs)
+    assert plain.passed and plain.prompt_tokens is None
+    counted = verify_served(Counting(good), req.messages, req.completion, req.tokens, req.token_logprobs)
+    assert counted.passed and counted.prompt_tokens == 4321
 
 
 def test_ready_miner_misses_are_logged_with_a_reason(monkeypatch):
@@ -1829,7 +1881,7 @@ def test_decode_speed_prices_served_requests_against_the_blessing_curve():
     short = req(8, 100.0, 5_000.0)  # too few tokens to measure decode: TTFT band only
     assert request_speed(short, release).credit == 1.0 and request_speed(short, release).decode_tps is None
     slow_ttft = req(64, 1_000.0, 1_000.0 + 64 / 440.0 * 1000.0)
-    assert request_speed(slow_ttft, release).credit == pytest.approx(0.5)
+    assert request_speed(slow_ttft, release).credit == pytest.approx(0.5, abs=1e-3)
 
 
 def test_gateway_and_baseline_record_inflight_at_dispatch(monkeypatch):


### PR DESCRIPTION
## Summary
Speed credit no longer punishes an honest card for a long prompt.

- `request_speed` subtracts `prefill_allowance_ms(prompt_tokens, release)` = `prompt_tokens / prefill_tps × 1000` from the observed TTFT before the 500/1500 ms bands apply. A 30k-token prompt that took 1.4 s to first token now reads as 150 ms of residual (full credit); the same 1.4 s on a 100-token prompt still scores ~0.1.
- The prompt token count is the **reference's own**: `/v1/score` reports `usage.prompt_tokens`, `verify_served` carries it on `AuditVerdict.prompt_tokens`, and `verify_served_round` hands it to `request_speed`. When the reference reports none (echo, bank), the validator estimates ~4 characters per token from the prompt text (`SERVING_CHARS_PER_TOKEN_ESTIMATE`). The miner-reported `req.prompt_tokens` is deliberately not used for speed, so it cannot be inflated to buy TTFT slack.
- Uses `prefill_tps` from #1755; no new release fields.

## Why
The TTFT bands were calibrated for network + queue + the card's overhead on ~≤10k-token prompts, which is also why `SERVING_MAX_PROMPT_CHARS` sits at 40k characters. With the prompt's prefill allowed for separately, the bands measure what they were set for and the character cap stops being load-bearing for speed credit, which is the prerequisite for lifting it toward the context window for agent traffic.

## Not in this PR
- The 40k-character prompt cap and the 1024 `max_tokens` cap are unchanged. Raising the prompt cap should wait on confirming the pinned runtime's documented int8-KV prefill defect above ~2048 prompt tokens does not break audit reproducibility in deterministic mode (see discussion).

## Test plan
- `uv run pytest tests` — 797 passed (was 789): `test_ttft_credit_allows_for_the_prompts_own_prefill`, `test_verify_served_carries_the_references_prompt_token_count`; two existing exact-0.5 credit asserts loosened to ±1e-3 because a 16-character test prompt now earns a sub-millisecond allowance
- `ruff check` / `ruff format --check` clean

https://claude.ai/code/session_01Lpqs8q2BHEHSqs4DPq6JeT