### PR TITLE
serving: flip the blessed release to Qwen3.8-27B (multi-release plumbing, model-directory pin, thinking flag)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,12 @@ SERVING_ENABLED=false
 # The attest container beside the reference (compose service `attest`, image entrius/gt-attest:GT_ATTEST_TAG).
 # Default: the reference host on port 8081 — set it when the sidecar is a separate service or host.
 # SERVING_ATTEST_REFERENCE_URL=http://attest:8081
+# A second blessed release needs its own reference (the two models do not share a card): name it by release id,
+# upper-cased with non-alphanumerics as '_' (gittensor.serving.loadout.env_suffix). Same suffix for the api key
+# and the attest sidecar. The validator learns which release each miner serves from the miner itself.
+# SERVING_REFERENCE_URL__QWEN3_8_27B_NVFP4_SPARKINFER_ABC1234=http://reference-27b:8080
+# SERVING_REFERENCE_API_KEY__QWEN3_8_27B_NVFP4_SPARKINFER_ABC1234=<bearer>
+# SERVING_ATTEST_REFERENCE_URL__QWEN3_8_27B_NVFP4_SPARKINFER_ABC1234=http://attest-27b:8081
 # GT_ATTEST_TAG=v1
 # SPARKINFER_TAG=<commit>   # image tag for the reference sidecar = runtime_pin commit in the loadout
 # SPARKINFER_MODEL_SHA256=<model_sha256 from the loadout release>

--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,9 @@ SERVING_ENABLED=false
 # GT_ATTEST_TAG=v1
 # SPARKINFER_TAG=<commit>   # image tag for the reference sidecar = runtime_pin commit in the loadout
 # SPARKINFER_MODEL_SHA256=<model_sha256 from the loadout release>
+# A model-directory release instead: the loadout's model_dir block (repo / revision / sha256), plus SPARKINFER_CTX
+# for the KV pool the release was measured at. docker-compose.vali.yml passes each through to the reference.
+# SPARKINFER_MODEL_DIR_REPO=<model_dir.repo>
+# SPARKINFER_MODEL_DIR_REVISION=<model_dir.revision>
+# SPARKINFER_MODEL_DIR_SHA256=<model_dir.sha256: file=sha256,file=sha256>
+# SPARKINFER_CTX=<kv pool tokens>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ No clone, no build — every image is published on Docker Hub:
 
 ```bash
 # 1. The whole box (runtime + attest + neuron) from one compose file. Fill .env from the
-#    "Current release" card on gittensor.io/compute (images + model sha) plus wallet/network/port.
+#    "Current release" card on gittensor.io/compute (images + the model pin) plus wallet/network/port.
 curl -O https://raw.githubusercontent.com/entrius/gittensor/main/docker-compose.miner.yml
 curl -o .env https://raw.githubusercontent.com/entrius/gittensor/main/miner.env.example
 nano .env
@@ -73,7 +73,7 @@ docker compose -f docker-compose.miner.yml up -d
 
 # 2. Prove the box is conformant before you serve (model id from the same card)
 docker run --rm --network host entrius/gt-checker \
-  --base-url http://127.0.0.1:8080 --model-id qwen3.6-35b-a3b --attest-url http://127.0.0.1:8081
+  --base-url http://127.0.0.1:8080 --model-id qwen3.8-27b --attest-url http://127.0.0.1:8081
 ```
 
 Your status (READY / probation / quarantined, window, throughput, estimated payout, last miss reason) is on
@@ -100,8 +100,10 @@ See full guide **[here](https://docs.gittensor.io/validator.html)**
 `SERVING_ENABLED=true` plus the `reference` compose profile:
 
 ```bash
-SPARKINFER_TAG=<runtime_pin> SPARKINFER_MODEL_SHA256=<model_sha256> \
-  docker compose -f docker-compose.vali.yml --profile reference up -d
+# the release's artifact pins, from serving_loadout.json: a GGUF (SPARKINFER_MODEL_SHA256) or a pinned Hugging Face
+# model directory (SPARKINFER_MODEL_DIR_REPO / _REVISION / _SHA256) — docker-compose.vali.yml lists every variable
+SPARKINFER_TAG=<runtime_pin> SPARKINFER_MODEL_DIR_REPO=<model_dir.repo> SPARKINFER_MODEL_DIR_REVISION=<model_dir.revision> \
+  SPARKINFER_MODEL_DIR_SHA256=<model_dir.sha256> docker compose -f docker-compose.vali.yml --profile reference up -d
 ```
 
 Without a reference the validator still validates OSS and sends the serving cap to UID 0. All `SERVING_*`

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -13,7 +13,18 @@ services:
     container_name: gt-miner-runtime
     restart: unless-stopped
     environment:
-      MODEL_SHA256: ${MODEL_SHA256:?model sha256 from the Current release card on gittensor.io/compute}
+      # The release card names ONE artifact: a GGUF (MODEL_SHA256, optionally MODEL_REPO/MODEL_FILE) or a pinned
+      # Hugging Face model directory (MODEL_DIR_REPO + MODEL_DIR_REVISION + MODEL_DIR_SHA256). Copy exactly the
+      # values it shows; docker/sparkinfer-entrypoint.sh refuses to serve anything else.
+      MODEL_SHA256: ${MODEL_SHA256:-}
+      MODEL_REPO: ${MODEL_REPO:-}
+      MODEL_FILE: ${MODEL_FILE:-}
+      MODEL_DIR_REPO: ${MODEL_DIR_REPO:-}
+      MODEL_DIR_REVISION: ${MODEL_DIR_REVISION:-}
+      MODEL_DIR_SHA256: ${MODEL_DIR_SHA256:-}
+      TOK_REPO: ${TOK_REPO:-}
+      MODEL_NAME: ${MODEL_NAME:-}
+      CTX: ${CTX:-}
       # already baked into the image; repeated here so nobody turns it off by accident (contract D1)
       SPARKINFER_DETERMINISTIC: "1"
     ports:

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -43,8 +43,17 @@ services:
     restart: unless-stopped
     profiles: ["reference"]
     environment:
-      # model_sha256 from the release in serving_loadout.json (overrides upstream's reference.lock pin)
+      # The release's artifact, from serving_loadout.json: a GGUF (model_sha256) or a pinned Hugging Face model
+      # directory (model_dir.repo / revision / sha256) — docker/sparkinfer-entrypoint.sh. Same values a miner runs.
       MODEL_SHA256: ${SPARKINFER_MODEL_SHA256:-}
+      MODEL_REPO: ${SPARKINFER_MODEL_REPO:-}
+      MODEL_FILE: ${SPARKINFER_MODEL_FILE:-}
+      MODEL_DIR_REPO: ${SPARKINFER_MODEL_DIR_REPO:-}
+      MODEL_DIR_REVISION: ${SPARKINFER_MODEL_DIR_REVISION:-}
+      MODEL_DIR_SHA256: ${SPARKINFER_MODEL_DIR_SHA256:-}
+      TOK_REPO: ${SPARKINFER_TOK_REPO:-}
+      MODEL_NAME: ${SPARKINFER_MODEL_NAME:-}
+      CTX: ${SPARKINFER_CTX:-}
       # already baked into the image; repeated here so nobody turns it off by accident (contract D1)
       SPARKINFER_DETERMINISTIC: "1"
     deploy:

--- a/docker/sparkinfer-entrypoint.sh
+++ b/docker/sparkinfer-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Entrypoint of entrius/sparkinfer:<ref>: fetch the blessed model artifact, verify it against the loadout's digests,
+# start sparkinfer_server on it.
+#
+# Two artifact shapes, picked by env (docker-compose.miner.yml / the validator's reference profile pass them from the
+# release card):
+#   * one GGUF file (the default, e.g. Qwen3.6-35B-A3B UD-Q4_K_M): MODEL_REPO / MODEL_FILE / TOK_REPO / MODEL_NAME /
+#     MODEL_SHA256 as upstream's server/run.sh reads them; run.sh --download fetches and verifies the file.
+#   * a Hugging Face model DIRECTORY (compressed-tensors NVFP4/FP8 safetensors, e.g. Qwen3.8-27B-NVFP4-RTX5090):
+#     MODEL_DIR_REPO=<hf repo id>, MODEL_DIR_REVISION=<hf commit sha> (the repo is mutable; the revision is the pin),
+#     MODEL_DIR_SHA256="<file>=<sha256>[,<file>=<sha256>...]" for every weight shard the release lists. The directory is
+#     fetched at that revision into $MODELS_DIR/<repo name>, every listed file's sha256 is checked (a mismatch refuses to
+#     start, never re-downloads over it), then run.sh serves the directory: sparkinfer_server dispatches on `-m <dir>`.
+set -euo pipefail
+MODELS_DIR="${MODELS_DIR:-/opt/sparkinfer/models}"
+
+if [ -z "${MODEL_DIR_REPO:-}" ]; then
+  exec bash server/run.sh --download "$@"
+fi
+
+: "${MODEL_DIR_REVISION:?MODEL_DIR_REVISION (the Hugging Face commit sha of $MODEL_DIR_REPO) is the model pin; refusing to serve an unpinned directory}"
+: "${MODEL_DIR_SHA256:?MODEL_DIR_SHA256 (file=sha256,...) for the weight shards of the release is required}"
+DIR="$MODELS_DIR/$(basename "$MODEL_DIR_REPO")"
+mkdir -p "$MODELS_DIR"
+if [ ! -f "$DIR/.revision" ] || [ "$(cat "$DIR/.revision")" != "$MODEL_DIR_REVISION" ]; then
+  echo ">> downloading $MODEL_DIR_REPO@$MODEL_DIR_REVISION into $DIR ..." >&2
+  HF_HUB_DISABLE_XET=1 hf download "$MODEL_DIR_REPO" --revision "$MODEL_DIR_REVISION" --local-dir "$DIR" \
+    --exclude 'assets/*' >&2
+  printf '%s\n' "$MODEL_DIR_REVISION" > "$DIR/.revision"
+fi
+IFS=',' read -r -a pins <<< "$MODEL_DIR_SHA256"
+for pin in "${pins[@]}"; do
+  file="${pin%%=*}"; want="${pin#*=}"
+  got="$(sha256sum "$DIR/$file" 2>/dev/null | awk '{print $1}' || true)"
+  if [ "$got" != "$want" ]; then
+    echo ">> FATAL: $file sha256 MISMATCH (got ${got:-<missing>}, want $want). Not the pinned build; refusing to serve." >&2
+    exit 1
+  fi
+  echo ">> $file sha256 OK" >&2
+done
+# The directory carries its own tokenizer; run.sh still wants one under MODELS_DIR for --tokenizer.
+[ -f "$MODELS_DIR/tokenizer.json" ] || cp "$DIR/tokenizer.json" "$MODELS_DIR/tokenizer.json"
+export TOK_REPO="${TOK_REPO:-$MODEL_DIR_REPO}"
+exec bash server/run.sh "$DIR" "$@"

--- a/docker/sparkinfer.Dockerfile
+++ b/docker/sparkinfer.Dockerfile
@@ -83,6 +83,7 @@ LABEL org.opencontainers.image.source="https://github.com/gittensor-ai-lab/spark
 HEALTHCHECK --interval=30s --timeout=5s --start-period=600s --retries=5 \
     CMD curl -fsS http://127.0.0.1:8080/v1/models || exit 1
 
-# run.sh downloads the blessed model + tokenizer into MODELS_DIR on first start (--download) and execs the prebuilt
-# server binary.
-ENTRYPOINT ["bash", "server/run.sh", "--download"]
+# The entrypoint fetches + verifies the blessed artifact (one GGUF via run.sh --download, or a pinned Hugging Face
+# model directory via MODEL_DIR_*; see docker/sparkinfer-entrypoint.sh) and execs the prebuilt server binary.
+COPY docker/sparkinfer-entrypoint.sh /opt/sparkinfer/entrypoint.sh
+ENTRYPOINT ["bash", "/opt/sparkinfer/entrypoint.sh"]

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -182,7 +182,7 @@ SERVING_EMISSION_SHARE_CAP = 0.05
 SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 338.0
 # Prompt tok/s one card prefills on the blessed runtime, for a release without its own `speed.prefill_tps`. Prefill
 # is paid as card-time exactly like decode, so a 30k-token prompt with a 150-token answer pays for the ~4 s of
-# prefill it cost the card and not only the ~1.5 s of decode; at this rate a prompt token is worth ~1/45 of an output
+# prefill it cost the card and not only the ~1.5 s of decode; at this rate a prompt token is worth ~1/22 of an output
 # token, which is also why claiming prompt tokens is not worth lying about. Measured cold on Qwen3.8-27B NVFP4,
 # sparkinfer 19ef39ec2, deterministic mode, engine-reported ttft_ms: 7.6k tok/s at 10k prompt tokens, 9.7k at 41k,
 # 7.8k at 102k (2026-09-08); the 35B did ~24k. Re-measure per release and carry it on the release's `speed` block.

--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -162,8 +162,10 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 # =============================================================================
 # Serving miners are paid for the card-time the gateway saw them serve: output tokens at the decode rate and
 # prompt tokens (prefill) at the prefill rate, both derived from the card-hour target:
-# rate = SERVING_GPU_HOUR_USD / (one card's aggregate tok/s x 3600), so a 5090 flat out for an hour (~1M output
-# tokens on the current runtime, or ~86M prompt tokens) earns exactly the card-hour and an idle one earns nothing. A
+# rate = SERVING_GPU_HOUR_USD / (one card's aggregate tok/s x 3600), so a 5090 flat out for an hour (~1.2M output
+# tokens on the blessed Qwen3.8-27B release, or ~27M prompt tokens) earns exactly the card-hour and an idle one earns
+# nothing. Both rates come from the release's own measured `speed` block, so a pin or model change re-prices itself;
+# the constants below are only the fallback for a release that carries no measurement. A
 # round score is that card-time in card-equivalents ((tokens / decode tok/s + prompt tokens / prefill tok/s) /
 # round seconds); the settled mean is priced at
 # SERVING_GPU_HOUR_USD, converted to an emission share through the on-chain alpha/TAO price and a live TAO/USD
@@ -175,16 +177,16 @@ MAX_MAINTAINER_CUT = 0.5  # maintaining is only half of the problem to software,
 SERVING_GPU_HOUR_USD = 0.70
 SERVING_EMISSION_SHARE_CAP = 0.05
 # Output tok/s one card sustains under load on the blessed runtime, for a release without its own
-# `speed.aggregate_decode_tps` (sparkinfer 7498736 on a 5090: 279-282 at 16 concurrent, 2026-08-27).
-SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 280.0
+# `speed.aggregate_decode_tps` (Qwen3.8-27B NVFP4 on sparkinfer 19ef39ec2, 5090, 16 concurrent, logprobs on:
+# 334-343, 2026-09-08; the Qwen3.6-35B-A3B release before it did 280).
+SERVING_AGGREGATE_DECODE_TPS_FALLBACK = 338.0
 # Prompt tok/s one card prefills on the blessed runtime, for a release without its own `speed.prefill_tps`. Prefill
-# is paid as card-time exactly like decode, so a 30k-token prompt with a 150-token answer pays for the ~1.3 s of
-# prefill it cost the card and not only the 0.5 s of decode; at this rate a prompt token is worth ~1/85 of an output
-# token, which is also why claiming prompt tokens is not worth lying about. Derived from the 2026-08-28 5090 TTFT
-# readings behind SERVING_MAX_PROMPT_CHARS (8.9k prompt tokens in 403 ms, 35.6k in 1453 ms; RTT included, so this
-# understates the card). Re-measure with scripts/check_serving_runtime.py --speed-json (`prefill_tps`) and carry it
-# on the release.
-SERVING_PREFILL_TPS_FALLBACK = 24_000.0
+# is paid as card-time exactly like decode, so a 30k-token prompt with a 150-token answer pays for the ~4 s of
+# prefill it cost the card and not only the ~1.5 s of decode; at this rate a prompt token is worth ~1/45 of an output
+# token, which is also why claiming prompt tokens is not worth lying about. Measured cold on Qwen3.8-27B NVFP4,
+# sparkinfer 19ef39ec2, deterministic mode, engine-reported ttft_ms: 7.6k tok/s at 10k prompt tokens, 9.7k at 41k,
+# 7.8k at 102k (2026-09-08); the 35B did ~24k. Re-measure per release and carry it on the release's `speed` block.
+SERVING_PREFILL_TPS_FALLBACK = 7_500.0
 # The prompt token count is what the miner's runtime reported (usage.prompt_tokens). Pay is clamped to what the
 # prompt could honestly tokenize to: one token per character plus this many chat-template tokens per message.
 SERVING_PROMPT_TEMPLATE_TOKENS = 16
@@ -233,7 +235,9 @@ SERVING_ATTEST_PREFILL_DRAIN_S = 1.5
 # the reservation (a bare 5090 shows ~32 GB free, one holding the model ~8 GB). A spare card with nothing loaded is
 # not a serving card.
 SERVING_ATTEST_MODEL_RESIDENT_RATIO = 0.8
-SERVING_VRAM_MODEL_RESERVED_BYTES = 24e9  # what sparkinfer holds with the model loaded (7498736 on a 5090: 23.7 GB)
+SERVING_VRAM_MODEL_RESERVED_BYTES = (
+    26.4e9  # what sparkinfer holds with the model loaded (Qwen3.8-27B NVFP4 at CTX 131072 on a 5090: 25.1 GiB idle)
+)
 SERVING_VERIFY_WORKERS = 8  # concurrent /v1/score calls to the reference per round
 # A reference 429 is R6 backpressure (a conformant runtime refuses at capacity instead of queueing) — a fact about
 # the reference's load, never about the miner's answer. Retried with backoff this many times, then neutral.
@@ -265,7 +269,7 @@ SERVING_DECODE_FLOOR_RATIO = 0.5
 SERVING_DECODE_TOLERANCE_RATIO = 0.8  # full credit down to this fraction of expected: the curve is measured on-box, the
 # validator observes stream delivery over the WAN (soak 5: honest cards read 0.75-0.96x); credit = min(1, ratio / this)
 SERVING_DECODE_MIN_TOKENS = 32
-SERVING_DECODE_PER_REQUEST_FALLBACK = ((1, 440.0), (6, 46.0), (16, 19.0))  # (concurrent requests, tok/s each)
+SERVING_DECODE_PER_REQUEST_FALLBACK = ((1, 99.4), (6, 49.7), (16, 23.4))  # (concurrent requests, tok/s each)
 # Per-audit verdict. The blessed runtime is bit-reproducible (sparkinfer 7498736, SPARKINFER_DETERMINISTIC=1), so an
 # honest miner reproduces the reference's greedy tokens exactly and its logprobs to float noise; every planted
 # cheater differs on every prompt (measured 2026-08-24, internal serving-experiments notes: honest max |delta| 0.0000,
@@ -348,19 +352,20 @@ SERVING_BACKEND_CONCURRENCY = 16  # miner: concurrent backend generations (spark
 SERVING_GATEWAY_BUSY_RETRIES = 3
 SERVING_SEEN_NONCES = 10_000  # miner: replay guard size; covers many minutes of validator traffic
 SERVING_MAX_TOKENS = 4096  # hard cap per request (API and miner both enforce): the runtime's own max_output_tokens
-# Gateway: total characters across a request's messages — a denial-of-service backstop only (~0.25 MB of text; the
-# whole context window is ~150k characters). The prompt's real limit is the release's context window, checked in
+# Gateway: total characters across a request's messages — a denial-of-service backstop only (~0.5 MB of text; the
+# whole 64k context window is ~260k characters). The prompt's real limit is the release's context window, checked in
 # tokens at the door (SERVING_CONTEXT_TOKENS_FALLBACK / release.context_tokens, estimated at
 # SERVING_CHARS_PER_TOKEN_ESTIMATE) and enforced exactly by the runtime. This sat at 40k (~10k tokens) while two
 # things needed it: an honest prefill had to stay inside the full-credit TTFT band, and a runtime-rejected prompt
 # landed in the miner's window as a miss. The TTFT credit now allows for the prompt's prefill, and a
 # runtime-rejected request is checked against the reference before it counts, so neither holds.
-SERVING_MAX_PROMPT_CHARS = 262_144
+SERVING_MAX_PROMPT_CHARS = 524_288
 # The blessed release's context window in tokens, prompt and completion together, for a release without its own
-# `context_tokens` (sparkinfer 7498736 on a 5090, /v1/info: max_context 36864 = 32k prompt + 4k completion KV
+# `context_tokens` (Qwen3.8-27B on sparkinfer 19ef39ec2: 64k prompt + 4k completion on a 131k KV pool; the 35B
+# release before it: max_context 36864 = 32k prompt + 4k completion KV
 # pool). A request whose estimated prompt alone exceeds it is a 400 context_length_exceeded (OpenAI's shape, so
 # agent SDKs trim history and retry); one whose completion would overrun it has max_tokens clamped to what is left.
-SERVING_CONTEXT_TOKENS_FALLBACK = 36_864
+SERVING_CONTEXT_TOKENS_FALLBACK = 65_536
 SERVING_DB_RETENTION_DAYS = 7  # validator: per-round serving rows older than this are pruned on each write
 SERVING_REQUEST_LOG_SIZE = 5_000  # in-memory ring of recent API/audit requests (telemetry)
 

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -267,7 +267,7 @@ def build_app(
                 async def run(miner=miner, relay=relay, queue=queue) -> Optional[InferenceSynapse]:
                     try:
                         return await _dispatch(
-                            get_dendrite(), miner, messages, max_tokens, release, request_timeout, relay
+                            get_dendrite(), miner, messages, max_tokens, release, release.request_timeout, relay
                         )
                     finally:
                         await queue.put(_END)
@@ -305,7 +305,7 @@ def build_app(
                 return StreamingResponse(body_iter(), media_type='text/event-stream')
 
             try:
-                result = await _dispatch(get_dendrite(), miner, messages, max_tokens, release, request_timeout)
+                result = await _dispatch(get_dendrite(), miner, messages, max_tokens, release, release.request_timeout)
             except Exception:
                 result = None
             if _busy_refused(result):  # refused at capacity: try elsewhere

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -111,6 +111,13 @@ def build_app(
                     'model_id': release.model_id,
                     'runtime_pin': release.runtime_pin,
                     'model_sha256': release.model_sha256,
+                    'model_dir': {
+                        'repo': release.model_dir_repo,
+                        'revision': release.model_dir_revision,
+                        'sha256': release.model_dir_sha256,
+                    }
+                    if release.model_dir_repo
+                    else None,
                     # OpenRouter's fields: agent harnesses size their context compaction from these, so a client
                     # that reads them never has to hit the 400 context_length_exceeded
                     'context_length': release.context_tokens or SERVING_CONTEXT_TOKENS_FALLBACK,

--- a/gittensor/serving/api.py
+++ b/gittensor/serving/api.py
@@ -118,6 +118,7 @@ def build_app(
                     }
                     if release.model_dir_repo
                     else None,
+                    'runtime_env': release.runtime_env,
                     # OpenRouter's fields: agent harnesses size their context compaction from these, so a client
                     # that reads them never has to hit the 400 context_length_exceeded
                     'context_length': release.context_tokens or SERVING_CONTEXT_TOKENS_FALLBACK,

--- a/gittensor/serving/audit.py
+++ b/gittensor/serving/audit.py
@@ -330,10 +330,19 @@ class LiveReference:
         self.max_tokens = release.max_tokens
         self.timeout = release.request_timeout
         self.api_key = release.reference_api_key
+        self.enable_thinking = release.enable_thinking
 
     def case_for(self, messages: List[Message], max_tokens: Optional[int] = None) -> AuditCase:
         """Reference for an arbitrary prompt (audit, mirrored traffic, dispute)."""
-        ref = greedy(self.base_url, self.model_id, messages, max_tokens or self.max_tokens, self.timeout, self.api_key)
+        ref = greedy(
+            self.base_url,
+            self.model_id,
+            messages,
+            max_tokens or self.max_tokens,
+            self.timeout,
+            self.api_key,
+            enable_thinking=self.enable_thinking,
+        )
         return AuditCase(
             messages=messages,
             max_tokens=ref['max_tokens'],
@@ -359,6 +368,7 @@ class LiveReference:
             self.timeout,
             self.api_key,
             completion_token_ids=token_ids,
+            enable_thinking=self.enable_thinking,
         )
 
     def score_served(self, messages: List[Message], completion: str, token_ids: Optional[Sequence[int]] = None) -> dict:

--- a/gittensor/serving/backends.py
+++ b/gittensor/serving/backends.py
@@ -122,6 +122,7 @@ class OpenAICompatBackend:
         self.model_id = release.model_id
         self.base_url = release.base_url.rstrip('/')
         self.timeout = release.request_timeout
+        self.enable_thinking = release.enable_thinking
 
     def _body(self, messages: List[Message], max_tokens: int, logprobs: bool, stream: bool) -> Dict:
         body: Dict = {
@@ -136,6 +137,8 @@ class OpenAICompatBackend:
         if logprobs:
             body['logprobs'] = True
             body['top_logprobs'] = 1
+        if self.enable_thinking is not None:
+            body['enable_thinking'] = self.enable_thinking
         return body
 
     def stream(self, messages: List[Message], max_tokens: int, logprobs: bool = False) -> Iterator[bytes]:

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -55,12 +55,22 @@ class ServingRelease:
     runtime_image: Optional[str] = None  # the blessed image by digest (entrius/sparkinfer:<tag>@sha256:...)
     model_sha256: Optional[str] = None  # digest of the model file; runtime_pin + model_sha256 = the release
     model_file: Optional[str] = None  # HF path of the model file, informational (the digest is what is enforced)
+    # A release whose artifact is a Hugging Face model DIRECTORY (compressed-tensors NVFP4/FP8 safetensors) instead of
+    # one GGUF: the repo, the commit it is pinned at (HF repos are mutable) and "file=sha256,..." for its weight shards.
+    # docker/sparkinfer-entrypoint.sh fetches and verifies exactly this; model_sha256 is then None.
+    model_dir_repo: Optional[str] = None
+    model_dir_revision: Optional[str] = None
+    model_dir_sha256: Optional[str] = None
     audit_bank: Optional[str] = None  # validator side: snapshot reference, filename under weights/
     reference_url: Optional[str] = (
         None  # validator side: live reference runtime (own GPU or a rented one); wins over audit_bank
     )
     reference_api_key: Optional[str] = None  # bearer for a remote reference (sparkinfer --api-key)
     request_timeout: float = 60.0
+    # Whether the runtime renders the chat template with thinking on (None = the runtime's default). A hybrid-thinking
+    # model (Qwen3.8) thinks by default; a release that serves answers, not reasoning, pins False and the miner,
+    # the reference and the checker all send it, so served text and its teacher-forced score template identically.
+    enable_thinking: Optional[bool] = None
     # Speed of one honest card on this exact runtime, measured at blessing time (scripts/check_serving_runtime.py
     # --speed-json on the conformance GPU) and written by the pin-bump PR. The validator credits speed against the
     # curve and prices tokens against the aggregate, so the "one card" bar tracks the runtime as it gets faster and
@@ -113,6 +123,7 @@ class ServingRelease:
         speed = raw.get('speed') or {}
         attest = raw.get('attest') or {}
         audit = raw.get('audit') or {}
+        model_dir = raw.get('model_dir') or {}
         return cls(
             model_id=raw['model_id'],
             backend=raw['backend'],
@@ -126,10 +137,14 @@ class ServingRelease:
             runtime_image=raw.get('runtime_image'),
             model_file=raw.get('model_file'),
             model_sha256=raw.get('model_sha256'),
+            model_dir_repo=model_dir.get('repo'),
+            model_dir_revision=model_dir.get('revision'),
+            model_dir_sha256=model_dir.get('sha256'),
             audit_bank=raw.get('audit_bank'),
             reference_url=raw.get('reference_url'),
             reference_api_key=raw.get('reference_api_key'),
             request_timeout=float(raw.get('request_timeout', 60.0)),
+            enable_thinking=bool(raw['enable_thinking']) if raw.get('enable_thinking') is not None else None,
             context_tokens=int(raw['context_tokens']) if raw.get('context_tokens') else None,
             decode_per_request={int(k): float(v) for k, v in (speed.get('decode_per_request') or {}).items()} or None,
             aggregate_decode_tps=_optional_float(speed.get('aggregate_decode_tps')),

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -61,6 +61,9 @@ class ServingRelease:
     model_dir_repo: Optional[str] = None
     model_dir_revision: Optional[str] = None
     model_dir_sha256: Optional[str] = None
+    # Env the runtime container needs beyond the artifact pins (CTX, MODEL_NAME, TOK_REPO): informational for the release
+    # card and compose files; nothing enforces it.
+    runtime_env: Optional[Dict[str, str]] = None
     audit_bank: Optional[str] = None  # validator side: snapshot reference, filename under weights/
     reference_url: Optional[str] = (
         None  # validator side: live reference runtime (own GPU or a rented one); wins over audit_bank
@@ -140,6 +143,7 @@ class ServingRelease:
             model_dir_repo=model_dir.get('repo'),
             model_dir_revision=model_dir.get('revision'),
             model_dir_sha256=model_dir.get('sha256'),
+            runtime_env={str(k): str(v) for k, v in (raw.get('runtime_env') or {}).items()} or None,
             audit_bank=raw.get('audit_bank'),
             reference_url=raw.get('reference_url'),
             reference_api_key=raw.get('reference_api_key'),

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -24,6 +24,7 @@ traffic-driven schedule (Gepetto-lite) is the planned upgrade path.
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -192,6 +193,11 @@ class ServingLoadout:
         raise KeyError(f'release {release_id!r} not in serving loadout: {[r.release_id for r in self.releases]}')
 
 
+def env_suffix(release_id: str) -> str:
+    """``qwen3.8-27b-nvfp4`` -> ``QWEN3_8_27B_NVFP4``: how a non-primary release is named in env overrides."""
+    return re.sub(r'[^A-Za-z0-9]', '_', release_id).upper()
+
+
 def resolve_loadout_path(path: Optional[Path] = None) -> Path:
     if path is not None:
         return path
@@ -206,26 +212,37 @@ def load_serving_loadout(path: Optional[Path] = None) -> ServingLoadout:
     entries = raw['releases'] if isinstance(raw, dict) and 'releases' in raw else [raw]
     loadout = ServingLoadout(releases=[ServingRelease.from_dict(entry) for entry in entries])
 
+    # Miner side: the runtime/sidecar overrides apply to the release this miner serves (SERVING_RELEASE), else the
+    # primary. Validator side: SERVING_REFERENCE_URL & co. name the primary's reference; every other release's is
+    # SERVING_REFERENCE_URL__<RELEASE_ID> (release_id upper-cased, non-alphanumerics as '_'), same for the api keys
+    # and the attest sidecar, so a validator hosts one reference per release without committing its endpoints.
+    wanted = os.getenv('SERVING_RELEASE')
+    try:
+        mine = loadout.get(wanted) if wanted else loadout.primary
+    except KeyError:
+        mine = loadout.primary
     base_override = os.getenv('SERVING_BASE_URL')
     if base_override:
-        loadout.primary.base_url = base_override
-        loadout.primary.attest_url = _sidecar_url(base_override)
+        mine.base_url = base_override
+        mine.attest_url = _sidecar_url(base_override)
     attest_override = os.getenv('SERVING_ATTEST_URL')
     if attest_override:
-        loadout.primary.attest_url = attest_override
+        mine.attest_url = attest_override
 
-    reference_override = os.getenv('SERVING_REFERENCE_URL')
-    if reference_override:
-        loadout.primary.reference_url = reference_override
-        loadout.primary.attest_reference_url = os.getenv('SERVING_ATTEST_REFERENCE_URL') or _sidecar_url(
-            reference_override
-        )
-    key_override = os.getenv('SERVING_REFERENCE_API_KEY')
-    if key_override:
-        loadout.primary.reference_api_key = key_override
-    attest_key_override = os.getenv('SERVING_ATTEST_REFERENCE_API_KEY')
-    if attest_key_override:
-        loadout.primary.attest_reference_api_key = attest_key_override
+    for release in loadout.releases:
+        suffix = '' if release is loadout.primary else '__' + env_suffix(release.release_id)
+        reference_override = os.getenv('SERVING_REFERENCE_URL' + suffix)
+        if reference_override:
+            release.reference_url = reference_override
+            release.attest_reference_url = os.getenv('SERVING_ATTEST_REFERENCE_URL' + suffix) or _sidecar_url(
+                reference_override
+            )
+        key_override = os.getenv('SERVING_REFERENCE_API_KEY' + suffix)
+        if key_override:
+            release.reference_api_key = key_override
+        attest_key_override = os.getenv('SERVING_ATTEST_REFERENCE_API_KEY' + suffix)
+        if attest_key_override:
+            release.attest_reference_api_key = attest_key_override
 
     lines = [
         f'Serving release {release.release_id}: model={release.model_id} backend={release.backend} pin={release.runtime_pin} '

--- a/gittensor/serving/probe.py
+++ b/gittensor/serving/probe.py
@@ -82,6 +82,7 @@ def greedy(
     max_tokens: int,
     timeout: float,
     api_key: Optional[str] = None,
+    enable_thinking: Optional[bool] = None,
 ) -> dict:
     r = requests.post(
         f'{base_url.rstrip("/")}/v1/chat/completions',
@@ -94,6 +95,7 @@ def greedy(
             'stream': False,
             'logprobs': True,
             'top_logprobs': 1,
+            **({'enable_thinking': enable_thinking} if enable_thinking is not None else {}),
         },
         timeout=timeout,
     )
@@ -123,6 +125,7 @@ def score(
     api_key: Optional[str] = None,
     top_logprobs: int = 1,
     completion_token_ids: Optional[Sequence[int]] = None,
+    enable_thinking: Optional[bool] = None,
 ) -> dict:
     """Teacher-forced scoring (contract R8): per-token logprobs of ``completion`` under the model.
 
@@ -140,6 +143,7 @@ def score(
             'model': model_id,
             'messages': messages,
             'top_logprobs': top_logprobs,
+            **({'enable_thinking': enable_thinking} if enable_thinking is not None else {}),
             **(
                 {'completion_token_ids': list(completion_token_ids)}
                 if completion_token_ids

--- a/gittensor/serving/probe.py
+++ b/gittensor/serving/probe.py
@@ -109,6 +109,8 @@ def greedy(
         'messages': messages,
         'max_tokens': max_tokens,
         'reference_tokens': [e['token'] for e in content],
+        # sparkinfer reports token_id per entry (#925); a verifier forces these rather than re-tokenizing text
+        'reference_token_ids': [int(e['token_id']) for e in content] if all('token_id' in e for e in content) else None,
         'reference_logprobs': [float(e['logprob']) for e in content],
         'reference_completion': choice['message'].get('content') or '',
         'served_model': payload.get('model'),

--- a/gittensor/serving/state.py
+++ b/gittensor/serving/state.py
@@ -126,6 +126,9 @@ class ServingState:
     dormant_rounds: Dict[str, int] = field(default_factory=dict)  # audit thread only: hotkey -> rounds w/o completion
     attest_status: Dict[str, dict] = field(default_factory=dict)  # audit thread only: hotkey -> last attest verdict
     last_credit: Dict[str, float] = field(default_factory=dict)  # audit thread only: hotkey -> last measured credit
+    # audit thread only: hotkey -> the loadout release this miner declared it serves (learned from its refusal of
+    # a baseline prompt routed for another release, or from a completion it served); persisted by the validator
+    miner_release: Dict[str, str] = field(default_factory=dict)
     _sent_tokens: Dict[str, Deque[Tuple[float, int]]] = field(default_factory=dict)  # hotkey -> (ts, max_tokens)
     _busy: Dict[str, Deque[float]] = field(default_factory=dict)  # hotkey -> ts of each busy refusal
     attest_round: int = 0

--- a/gittensor/serving/store.py
+++ b/gittensor/serving/store.py
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS dormant (hotkey TEXT PRIMARY KEY, rounds INTEGER);
 CREATE TABLE IF NOT EXISTS attest (hotkey TEXT PRIMARY KEY, status TEXT);
 CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
 CREATE TABLE IF NOT EXISTS last_credit (hotkey TEXT PRIMARY KEY, credit REAL);
+CREATE TABLE IF NOT EXISTS miner_release (hotkey TEXT PRIMARY KEY, release_id TEXT);
 """
 
 
@@ -67,9 +68,11 @@ class ServingStore:
                 'attest',
                 'meta',
                 'last_credit',
+                'miner_release',
             ):
                 db.execute(f'DELETE FROM {table}')
             db.executemany('INSERT INTO last_credit VALUES (?, ?)', list(state.last_credit.items()))
+            db.executemany('INSERT INTO miner_release VALUES (?, ?)', list(state.miner_release.items()))
             db.execute('INSERT INTO meta VALUES (?, ?)', ('attest_round', str(int(state.attest_round))))
             db.execute('INSERT INTO meta VALUES (?, ?)', ('last_round_ts', repr(float(state.last_round_ts))))
             db.executemany(
@@ -121,6 +124,8 @@ class ServingStore:
                         state.last_round_ts = float(value)
                 for hk, credit in db.execute('SELECT hotkey, credit FROM last_credit'):
                     state.last_credit[str(hk)] = float(credit)
+                for hk, rid in db.execute('SELECT hotkey, release_id FROM miner_release'):
+                    state.miner_release[str(hk)] = str(rid)
         except sqlite3.Error:
             pass
         return state

--- a/gittensor/validator/serving/forward.py
+++ b/gittensor/validator/serving/forward.py
@@ -39,11 +39,12 @@ import hashlib
 import math
 import os
 import random
+import re
 import secrets
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import aiohttp
 import bittensor as bt
@@ -68,7 +69,7 @@ from gittensor.constants import (
 )
 from gittensor.serving.audit import AuditVerdict, Reference, reference_for, verify_served
 from gittensor.serving.baseline import baseline_max_tokens, make_baseline_prompt
-from gittensor.serving.loadout import ServingRelease, load_serving_loadout
+from gittensor.serving.loadout import ServingLoadout, ServingRelease, load_serving_loadout
 from gittensor.serving.state import ReadyMiner, RequestRecord, ServedRequest, ServingState, is_busy_detail
 from gittensor.serving.store import ServingStore
 from gittensor.serving.stream import consume_stream
@@ -328,28 +329,80 @@ def _mean(xs: List[float]) -> Optional[float]:
     return round(sum(xs) / len(xs), 1) if xs else None
 
 
+# A miner's own refusal of a request routed for another release (neurons/serving_miner.py, blacklist_caller), as it
+# lands in the axon status message. It names the release the miner does serve, which is how a validator learns it.
+_RELEASE_REFUSAL = re.compile(r'serving release (\S+), not (\S+)')
+
+
+def refused_release(detail: Optional[str]) -> Optional[str]:
+    """The release a miner declared in its refusal, or None when the detail is anything else."""
+    m = _RELEASE_REFUSAL.search(detail or '')
+    return m.group(1) if m else None
+
+
+def find_release(loadout: ServingLoadout, release_id: str) -> Optional[ServingRelease]:
+    """``ServingLoadout.get`` without the KeyError, over anything with a ``releases`` list."""
+    for release in loadout.releases:
+        if release.release_id == release_id:
+            return release
+    for release in loadout.releases:
+        if release.model_id == release_id:
+            return release
+    return None
+
+
+def release_for(state: ServingState, loadout: ServingLoadout, hotkey: str) -> ServingRelease:
+    """The loadout release this hotkey is known to serve; the primary until it has said otherwise (or a release it
+    named has since left the loadout)."""
+    known = state.miner_release.get(hotkey)
+    if known:
+        release = find_release(loadout, known)
+        if release is not None:
+            return release
+        state.miner_release.pop(hotkey, None)
+    return loadout.releases[0]
+
+
+def members(
+    state: ServingState, loadout: ServingLoadout, release: ServingRelease, active: Sequence[Tuple[int, str, Any]]
+) -> List[Tuple[int, str, Any]]:
+    """The active miners a release's round concerns: those known to serve it, plus every miner that has not yet
+    declared a release when this is the primary (it gets primary baseline prompts until it says otherwise)."""
+    return [
+        (uid, hotkey, axon)
+        for uid, hotkey, axon in active
+        if release_for(state, loadout, hotkey).release_id == release.release_id
+    ]
+
+
 async def baseline_round(
     state: ServingState,
     dendrite: bt.Dendrite,
     serving: Sequence[Tuple[int, str, bt.AxonInfo]],
-    release: ServingRelease,
+    loadout: Union[ServingLoadout, ServingRelease],
     window_s: float,
     per_miner: int = SERVING_BASELINE_PER_ROUND,
     rng: Optional[random.Random] = None,
 ) -> int:
     """Send every serving axon ``per_miner`` baseline prompts at random moments within ``window_s``.
 
-    The requests take the same path as user traffic and are queued as served requests, so the next round verifies
-    them like anything else. Quarantined and dormant hotkeys are skipped. Returns the number of requests sent.
+    Each miner is prompted for the release it is known to serve (``release_for``): the primary until it refuses
+    with the release it does run, which is recorded and targeted from the next round on — so a miner blessed for a
+    second release goes READY for that release instead of collecting misses on the primary's window. The requests
+    take the same path as user traffic and are queued as served requests, so the next round verifies them like
+    anything else. Quarantined and dormant hotkeys are skipped. Returns the number of requests sent.
     """
+    if isinstance(loadout, ServingRelease):
+        loadout = ServingLoadout(releases=[loadout])
     rng = rng or random.Random()
     targets = [
-        (uid, hotkey, axon)
+        (uid, hotkey, axon, release)
         for uid, hotkey, axon in serving
+        for release in [release_for(state, loadout, hotkey)]
         if state.audits.quarantined_until(hotkey, release.release_id) == 0.0 and not skip_baseline(state, hotkey)
     ]
 
-    async def one(uid: int, hotkey: str, axon: bt.AxonInfo, delay_s: float) -> None:
+    async def one(uid: int, hotkey: str, axon: bt.AxonInfo, release: ServingRelease, delay_s: float) -> None:
         await asyncio.sleep(delay_s)
         messages = make_baseline_prompt(rng)
         max_tokens = baseline_max_tokens(rng, min(SERVING_MAX_TOKENS, max(release.max_tokens, 512)))
@@ -375,6 +428,15 @@ async def baseline_round(
             err = ''
         ok = response is not None and response.completion is not None and response.served_model_id == release.model_id
         status = getattr(getattr(response, 'dendrite', None), 'status_message', None) if response is not None else None
+        if ok:
+            state.miner_release[hotkey] = release.release_id
+        declared = refused_release(status) if not ok else None
+        if declared and declared != release.release_id and find_release(loadout, declared) is not None:
+            # discovery, not a miss: next round's baseline prompts target the release it serves. A release we do
+            # not bless falls through and the refusal stands as this miner's miss.
+            state.miner_release[hotkey] = declared
+            bt.logging.info(f'Serving: UID {uid} serves release {declared}, not {release.release_id}; re-targeting')
+            return
         if (
             response is not None and not ok
         ):  # the axon answered but served nothing: not a compute miner (or a broken one)
@@ -411,8 +473,8 @@ async def baseline_round(
         )
 
     jobs = [
-        one(uid, hotkey, axon, rng.uniform(0.0, max(0.0, window_s)))
-        for uid, hotkey, axon in targets
+        one(uid, hotkey, axon, release, rng.uniform(0.0, max(0.0, window_s)))
+        for uid, hotkey, axon, release in targets
         for _ in range(per_miner)
     ]
     await asyncio.gather(*jobs)
@@ -441,6 +503,9 @@ async def audit_round(
     update_dormancy(state, serving, served)
     active = [(uid, hotkey, axon) for uid, hotkey, axon in serving if not is_dormant(state, hotkey)]
     dormant = len(serving) - len(active)
+    for req in served:  # a completion served for a release is that miner declaring it (gateway routes by release)
+        if req.ok and req.release_id:
+            state.miner_release[req.hotkey] = req.release_id
 
     # Per admitted hotkey, the release it is READY for: (pay, routing weight, release_id), best pay first.
     admitted: Dict[str, Tuple[float, float, str]] = {}
@@ -464,7 +529,7 @@ async def audit_round(
             state, reference, release, served, summary, last_miss, staked_caller=staked_caller, prompt_tokens=prompt
         )
         passing: List[Tuple[int, str, bt.AxonInfo, float]] = []
-        for uid, hotkey, axon in active:
+        for uid, hotkey, axon in members(state, loadout, release, active):
             window = state.audits.verdict(hotkey, release.release_id)
             round_speeds = speeds.get(hotkey) or []
             if round_speeds:
@@ -542,15 +607,19 @@ async def audit_round(
     quarantined = sum(1 for w in windows.values() if w['status'] == 'quarantined')
     summary.update(ready=len(ready), probation=len(probation), quarantined=quarantined, dormant=dormant)
     state.publish_round(ready, scores, list(probation.values()), {**summary, 'windows': windows})
+    paid = ' + '.join(
+        f'{release.release_id}: {sum(w["tokens"] for w in windows.values() if w["release_id"] == release.release_id)} '
+        f'output tokens at ${token_rate_usd(release) * 1e6:.3f}/M + '
+        f'{sum(w.get("prompt_tokens", 0) for w in windows.values() if w["release_id"] == release.release_id)} '
+        f'prompt tokens at ${prompt_token_rate_usd(release) * 1e6:.4f}/M'
+        for release in loadout.releases
+    )
     bt.logging.info(
         f'Serving round: served {summary.get("served", 0)} (gateway {summary.get("gateway", 0)} / baseline '
         f'{summary.get("baseline", 0)}) · pass {summary.get("pass", 0)} · miss {summary.get("miss", 0)} · '
         f'strike {summary.get("strike", 0)} · neutral {summary.get("neutral", 0)} · READY {len(ready)} '
         f'{[m.uid for m in ready]} · probation {len(probation)} · quarantined {quarantined} · dormant {dormant} · '
-        f'paid {sum(w["tokens"] for w in windows.values())} output tokens at '
-        f'${token_rate_usd(loadout.releases[0]) * 1e6:.3f}/M + '
-        f'{sum(w.get("prompt_tokens", 0) for w in windows.values())} prompt tokens at '
-        f'${prompt_token_rate_usd(loadout.releases[0]) * 1e6:.4f}/M'
+        f'paid {paid}'
     )
     return scores
 
@@ -584,12 +653,12 @@ def seed_ready_from_store(validator: 'Validator', state: ServingState, loadout=N
                 best[hotkey] = (credit, release.release_id)
     ready: List[ReadyMiner] = []
     probation: List[ReadyMiner] = []
-    fallback_release = loadout.primary.release_id
     for uid, hotkey, axon in active:
         credit, release_id = best.get(hotkey, (0.0, ''))
         if credit > 0.0:
             ready.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=credit, release_id=release_id))
         elif hotkey not in quarantined:
+            fallback_release = release_for(state, loadout, hotkey).release_id
             probation.append(ReadyMiner(uid=uid, hotkey=hotkey, axon=axon, score=0.0, release_id=fallback_release))
     if ready or probation:
         state.seed_ready(ready, probation)
@@ -726,10 +795,14 @@ class ServingAuditThread:
             # marks the round boundary; they are verified next round alongside any user traffic.
             remaining = max(0.0, self.interval_s - (time.monotonic() - started))
             try:
-                release = load_serving_loadout().primary
                 sent = loop.run_until_complete(
                     baseline_round(
-                        self.state, dendrite, serving, release, max(0.0, remaining - 5.0), self.baseline_per_round
+                        self.state,
+                        dendrite,
+                        serving,
+                        load_serving_loadout(),
+                        max(0.0, remaining - 5.0),
+                        self.baseline_per_round,
                     )
                 )
                 bt.logging.debug(f'Serving: sent {sent} baseline request(s)')

--- a/gittensor/validator/serving/persist.py
+++ b/gittensor/validator/serving/persist.py
@@ -12,6 +12,7 @@ and dropped — persistence must never stall or fail a round.
 """
 
 import datetime as dt
+import json
 from typing import Any, Dict, Optional
 
 import bittensor as bt
@@ -80,6 +81,9 @@ def round_rows(
         token_rate_usd(release) * 1e6 if release else None,
         sum(int(w.get('prompt_tokens', 0)) for w in windows.values()),
         prompt_token_rate_usd(release) * 1e6 if release else None,
+        # a model-directory release: its shard digests and the runtime env the card must show (JSON), else NULL
+        release.model_dir_sha256 if release else None,
+        json.dumps(release.runtime_env, sort_keys=True) if release and release.runtime_env else None,
     )
     miners = []
     for uid, w in windows.items():

--- a/gittensor/validator/storage/queries.py
+++ b/gittensor/validator/storage/queries.py
@@ -202,9 +202,10 @@ INSERT INTO serving_rounds (
     validator_hotkey, round_ts, served, gateway, baseline, passes, misses, strikes, neutral,
     ready, probation, quarantined, card_equivalents, pool_share, alpha_per_hour, alpha_usd,
     gpu_hour_usd, pool_cap, model_id, release_id, runtime_pin, model_sha256, model_file, runtime_image, attest_image,
-    tokens, usd_per_m_tokens, prompt_tokens, usd_per_m_prompt_tokens
+    tokens, usd_per_m_tokens, prompt_tokens, usd_per_m_prompt_tokens, model_dir_sha256, runtime_env
 ) VALUES (
-    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+    %s, %s
 )
 ON CONFLICT (validator_hotkey, round_ts) DO NOTHING
 """

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -1,42 +1,51 @@
 {
   "releases": [
     {
-      "release_id": "qwen3.6-35b-a3b-sparkinfer-7498736",
-      "model_id": "qwen3.6-35b-a3b",
+      "release_id": "qwen3.8-27b-nvfp4-sparkinfer-19ef39ec2",
+      "model_id": "qwen3.8-27b",
       "backend": "openai-compat",
       "base_url": "http://127.0.0.1:8080",
       "max_tokens": 64,
-      "context_tokens": 36864,
-      "end_of_turn_token_id": 151645,
+      "context_tokens": 65536,
+      "end_of_turn_token_id": 248046,
+      "enable_thinking": false,
       "request_timeout": 300,
-      "runtime_pin": "gittensor-ai-lab/sparkinfer@7498736",
-      "runtime_image": "entrius/sparkinfer:7498736@sha256:2ab51deb56af16d94ac0cd6c92756df5e5a42facb4c5ab8c5eb39224937e16a2",
-      "model_file": "unsloth/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-      "model_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
-      "audit_bank": "serving_audit_bank.json",
+      "runtime_pin": "gittensor-ai-lab/sparkinfer@19ef39ec2",
+      "runtime_image": "entrius/sparkinfer:19ef39ec2@sha256:d35719b03f320f7c30abcb7f6b495e64fb7edbe4187c8744775277dc661a23bb",
+      "model_file": "gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090@8e2c0cd25468ac5c1f85f621c2b8edb15ea1f03a",
+      "model_sha256": null,
+      "model_dir": {
+        "repo": "gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090",
+        "revision": "8e2c0cd25468ac5c1f85f621c2b8edb15ea1f03a",
+        "sha256": "model-00001-of-00002.safetensors=cdd37b0e61eccc8a3d7d08f9d1a4f52856a9d88e4e8b42089bd18a970e3a01ec,model-00002-of-00002.safetensors=713b84b8287e2193290214766c5384fa6475c5626a628e4021c2c9ca90aa61df"
+      },
+      "runtime_env": {
+        "CTX": "131072",
+        "MODEL_NAME": "qwen3.8-27b",
+        "TOK_REPO": "Qwen/Qwen3.8-27B"
+      },
       "speed": {
-        "single_stream_decode_tps": 443.6,
-        "aggregate_decode_tps": 280.0,
-        "measured_on": "gittensor-ai-lab/sparkinfer@7498736 on a rented RTX 5090 (Lium brave-fox-20), 2026-08-27: 16-concurrent x 64 tokens aggregate 279-282 tok/s (6: 255, 24: 268, 32: 275 \u2014 queues past 16, wall 3.7 s -> 7 s). Per-request points 2-12 re-measured on-box on compute3 card 1 (RTX 5090), 2026-09-05, 64 tokens x 3 reps, median: single 408.2, aggregate flat 285-289 from 2 up (#1753)",
+        "single_stream_decode_tps": 99.4,
+        "aggregate_decode_tps": 338.0,
+        "prefill_tps": 7500.0,
+        "measured_on": "gittensor-ai-lab/sparkinfer@19ef39ec2, NVFP4 directory, SPARKINFER_DETERMINISTIC=1, CTX=131072, enable_thinking=false, logprobs on every request, on two rented RTX 5090s (Lium, 2026-09-08 00:30-01:30 UTC), scripts/check_serving_runtime.py --parallel 16 --speed-json: single 99.6 / 99.2, 16-concurrent aggregate 334.1 / 342.6 tok/s, per-request points the mean of the two runs made monotone. prefill_tps from cold unique prompts, engine ttft_ms: 7.6k tok/s at 10k prompt tokens, 9.7k at 41k, 7.8k at 102k (deterministic mode; the runtime's own bench reports ~14k in default mode).",
         "decode_per_request": {
-          "1": 443.6,
-          "2": 144.3,
-          "3": 96.7,
-          "4": 72.6,
-          "5": 58.5,
-          "6": 50.2,
-          "8": 37.8,
-          "12": 25.5,
-          "16": 19.4,
-          "24": 19.4,
-          "32": 19.5
+          "1": 99.4,
+          "2": 92.1,
+          "3": 74.0,
+          "4": 56.8,
+          "5": 56.8,
+          "6": 49.7,
+          "8": 39.6,
+          "12": 24.8,
+          "16": 23.4
         }
       },
       "attest": {
         "image": "entrius/gt-attest:v1",
         "iters": 3,
-        "vram_model_reserved_bytes": 24000000000,
-        "reference_wall_ms": 846.8
+        "vram_model_reserved_bytes": 26400000000,
+        "reference_wall_ms": 832.0
       }
     }
   ]

--- a/miner.env.example
+++ b/miner.env.example
@@ -21,7 +21,10 @@ PORT=8099
 LOG_LEVEL=info
 # Neuron image: entrius/gittensor:latest tracks main (mainnet); entrius/gittensor:test tracks the test branch
 # GITTENSOR_IMAGE=entrius/gittensor:latest
-# Only once more than one release is blessed: the release id to serve (from the Current release card)
+# Once more than one release is blessed: the release id this box serves (from its release card). Default = the
+# primary. The validator learns it from you — a prompt for another release is refused naming this one — so a
+# box on the second release goes READY for that release, never for the primary. SERVING_BASE_URL/SERVING_ATTEST_URL
+# below apply to this release.
 # SERVING_RELEASE=
 
 # Host-side loopback ports for the runtime and attest containers, if 8080/8081 are already taken on the box.

--- a/miner.env.example
+++ b/miner.env.example
@@ -4,7 +4,12 @@
 
 RUNTIME_IMAGE=      # "Runtime image" on the Current release card (tag or tag@sha256)
 ATTEST_IMAGE=       # "Attest image" on the Current release card
-MODEL_SHA256=       # model sha256 on the Current release card
+# The model pin on the Current release card — it names ONE of the two shapes below; copy exactly what it shows.
+MODEL_SHA256=       # a GGUF release: the model file's sha256
+# MODEL_DIR_REPO=     # a Hugging Face model-directory release: repo id …
+# MODEL_DIR_REVISION= # … the commit sha it is pinned at …
+# MODEL_DIR_SHA256=   # … and file=sha256,file=sha256 for its weight shards
+# CTX=                # KV pool (tokens) the card mentions; leave unset for the runtime default
 
 WALLET_NAME=default
 HOTKEY_NAME=default

--- a/scripts/build_serving_audit_bank.py
+++ b/scripts/build_serving_audit_bank.py
@@ -8,7 +8,7 @@ Run on a team 5090 with the pinned runtime + model:
 
     ./server/run.sh --download --port 8080            # in the sparkinfer checkout
     uv run python scripts/build_serving_audit_bank.py \\
-        --base-url http://127.0.0.1:8080 --model-id qwen3.6-35b-a3b \\
+        --base-url http://127.0.0.1:8080 --model-id qwen3.8-27b \\
         --runtime-pin gittensor-ai-lab/sparkinfer@<commit> --count 500 --max-tokens 64 \\
         --out gittensor/validator/weights/serving_audit_bank.json
 

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -6,7 +6,7 @@
 
 Point it at a running runtime and it exercises every MUST/SHOULD in the contract:
 
-    uv run python scripts/check_serving_runtime.py --base-url http://127.0.0.1:8080 --model-id qwen3.6-35b-a3b
+    uv run python scripts/check_serving_runtime.py --base-url http://127.0.0.1:8080 --model-id qwen3.8-27b
 
 Prints PASS/FAIL/WARN per check, the measured greedy-stability distribution (D1) and whether the
 server 429s under overload instead of queueing (R6). Exit code 1 if any MUST fails. Runtime
@@ -57,6 +57,7 @@ def get_json(url: str, timeout: float, api_key: Optional[str] = None) -> Tuple[O
 
 
 API_KEY: Optional[str] = None
+THINKING: Optional[bool] = None  # --thinking on|off: sent as `enable_thinking` on every request, as the release will
 
 
 def chat(base_url: str, body: Dict, timeout: float) -> requests.Response:
@@ -91,6 +92,7 @@ def check_completion_shape(rep: Report, base_url: str, model_id: str, max_tokens
         'messages': [{'role': 'user', 'content': 'Explain TCP congestion control in two sentences.'}],
         'max_tokens': max_tokens,
         'temperature': 0,
+        **({'enable_thinking': THINKING} if THINKING is not None else {}),
         'stream': False,
         'logprobs': True,
         'top_logprobs': 1,
@@ -182,7 +184,9 @@ def check_score(rep: Report, base_url: str, model_id: str, max_tokens: int, time
     messages = make_prompts(1, seed=11)[0]
     gen = greedy(base_url, model_id, messages, max_tokens, timeout, API_KEY)
     try:
-        sc = score(base_url, model_id, messages, gen['reference_completion'], timeout, API_KEY)
+        sc = score(
+            base_url, model_id, messages, gen['reference_completion'], timeout, API_KEY, enable_thinking=THINKING
+        )
     except requests.HTTPError as e:
         rep.add('R8 POST /v1/score', MUST, False, f'HTTP {e.response.status_code if e.response else "?"}')
         return
@@ -231,6 +235,7 @@ def check_overload(rep: Report, base_url: str, model_id: str, parallel: int, max
         'messages': [{'role': 'user', 'content': 'Write a long essay about the history of computing.'}],
         'max_tokens': max_tokens,
         'temperature': 0,
+        **({'enable_thinking': THINKING} if THINKING is not None else {}),
         'stream': False,
     }
 
@@ -273,6 +278,7 @@ def _stream_once(base_url: str, model_id: str, messages, max_tokens: int, timeou
         'messages': messages,
         'max_tokens': max_tokens,
         'temperature': 0,
+        **({'enable_thinking': THINKING} if THINKING is not None else {}),
         'stream': True,
         'stream_options': {'include_usage': True},
     }
@@ -302,6 +308,7 @@ def _prefill_once(base_url: str, model_id: str, messages, timeout: float) -> Tup
         'messages': messages,
         'max_tokens': 1,
         'temperature': 0,
+        **({'enable_thinking': THINKING} if THINKING is not None else {}),
         'stream': True,
         'stream_options': {'include_usage': True},
     }
@@ -459,6 +466,12 @@ def main() -> int:
     )
     ap.add_argument('--overload-max-tokens', type=int, default=512)
     ap.add_argument('--api-key', default=None, help='bearer for a remote runtime (sparkinfer --api-key)')
+    ap.add_argument(
+        '--thinking',
+        choices=('runtime', 'on', 'off'),
+        default='runtime',
+        help="send enable_thinking on every request (the release's `enable_thinking`); runtime = the server default",
+    )
     ap.add_argument('--attest-url', default=None, help='the attest container (default: the runtime host, port 8081)')
     ap.add_argument(
         '--speed-json',
@@ -472,6 +485,8 @@ def main() -> int:
     args = ap.parse_args()
     global API_KEY
     API_KEY = args.api_key
+    global THINKING
+    THINKING = {'on': True, 'off': False}.get(args.thinking)
     base_url = args.base_url.rstrip('/')
 
     rep = Report()

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -219,14 +219,27 @@ def check_score(rep: Report, base_url: str, model_id: str, max_tokens: int, time
         enable_thinking=THINKING,
     )
     ref = LiveReference(release)
+    # As the validator does on served traffic: force the runtime's own token ids, never re-tokenized text.
     verdict = verify_served(
-        ref, messages, gen['reference_completion'], gen['reference_tokens'], gen['reference_logprobs']
+        ref,
+        messages,
+        gen['reference_completion'],
+        gen['reference_tokens'],
+        gen['reference_logprobs'],
+        token_ids=gen.get('reference_token_ids'),
     )
     rep.add("R8 verify_served passes the model's own greedy output", MUST, verdict.passed, verdict.reason)
     for i in range(3):  # and on longer, traffic-shaped prompts
         msgs = make_baseline_prompt(random.Random(100 + i))
         g = greedy(base_url, model_id, msgs, 256, timeout, API_KEY, enable_thinking=THINKING)
-        v = verify_served(ref, msgs, g['reference_completion'], g['reference_tokens'], g['reference_logprobs'])
+        v = verify_served(
+            ref,
+            msgs,
+            g['reference_completion'],
+            g['reference_tokens'],
+            g['reference_logprobs'],
+            token_ids=g.get('reference_token_ids'),
+        )
         rep.add(
             f'R8 verify_served on baseline prompt #{i + 1} ({len(g["reference_tokens"])} tok)', MUST, v.passed, v.reason
         )

--- a/scripts/check_serving_runtime.py
+++ b/scripts/check_serving_runtime.py
@@ -182,13 +182,16 @@ def check_determinism(
 def check_score(rep: Report, base_url: str, model_id: str, max_tokens: int, timeout: float) -> None:
     """R8: /v1/score must exist and reproduce, for the model's own greedy output, the logprobs generation reported."""
     messages = make_prompts(1, seed=11)[0]
-    gen = greedy(base_url, model_id, messages, max_tokens, timeout, API_KEY)
+    gen = greedy(base_url, model_id, messages, max_tokens, timeout, API_KEY, enable_thinking=THINKING)
     try:
         sc = score(
             base_url, model_id, messages, gen['reference_completion'], timeout, API_KEY, enable_thinking=THINKING
         )
     except requests.HTTPError as e:
-        rep.add('R8 POST /v1/score', MUST, False, f'HTTP {e.response.status_code if e.response else "?"}')
+        # `if e.response` is False for any 4xx/5xx (Response.__bool__ is .ok): test for None, and show the body.
+        r = e.response
+        detail = f'HTTP {r.status_code}: {r.text[:300]!r}' if r is not None else repr(e)
+        rep.add('R8 POST /v1/score', MUST, False, detail)
         return
     rep.add('R8 POST /v1/score', MUST, True, f'{len(sc["tokens"])} tokens')
     same_tok = sc['tokens'] == gen['reference_tokens']
@@ -213,6 +216,7 @@ def check_score(rep: Report, base_url: str, model_id: str, max_tokens: int, time
         reference_url=base_url,
         reference_api_key=API_KEY,
         request_timeout=timeout,
+        enable_thinking=THINKING,
     )
     ref = LiveReference(release)
     verdict = verify_served(
@@ -221,7 +225,7 @@ def check_score(rep: Report, base_url: str, model_id: str, max_tokens: int, time
     rep.add("R8 verify_served passes the model's own greedy output", MUST, verdict.passed, verdict.reason)
     for i in range(3):  # and on longer, traffic-shaped prompts
         msgs = make_baseline_prompt(random.Random(100 + i))
-        g = greedy(base_url, model_id, msgs, 256, timeout, API_KEY)
+        g = greedy(base_url, model_id, msgs, 256, timeout, API_KEY, enable_thinking=THINKING)
         v = verify_served(ref, msgs, g['reference_completion'], g['reference_tokens'], g['reference_logprobs'])
         rep.add(
             f'R8 verify_served on baseline prompt #{i + 1} ({len(g["reference_tokens"])} tok)', MUST, v.passed, v.reason

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -14,8 +14,17 @@ set -euo pipefail
 REF="${1:?sparkinfer ref (image tag)}"
 OUT="${2:-serving-conformance-$REF}"
 LOADOUT="$(dirname "$0")/../gittensor/validator/weights/serving_loadout.json"
-MODEL_ID=$(jq -r '.releases[0].model_id' "$LOADOUT")
+# Measuring a release other than the loadout's primary (a candidate second model): CONFORMANCE_MODEL_ID is what the
+# runtime will report in /v1/models, CONFORMANCE_MODEL_ENV the space-separated KEY=VALUE pairs the runtime pod needs
+# for that artifact (MODEL_REPO/MODEL_FILE/TOK_REPO/MODEL_NAME/MODEL_SHA256 for a GGUF; MODEL_DIR_REPO/
+# MODEL_DIR_REVISION/MODEL_DIR_SHA256/TOK_REPO/MODEL_NAME for a Hugging Face directory — docker/sparkinfer-entrypoint.sh).
+MODEL_ID="${CONFORMANCE_MODEL_ID:-$(jq -r '.releases[0].model_id' "$LOADOUT")}"
 MODEL_SHA=$(jq -r '.releases[0].model_sha256' "$LOADOUT")
+MODEL_ENV=(-e "MODEL_SHA256=$MODEL_SHA")
+if [ -n "${CONFORMANCE_MODEL_ENV:-}" ]; then
+  MODEL_ENV=()
+  for kv in $CONFORMANCE_MODEL_ENV; do MODEL_ENV+=(-e "$kv"); done
+fi
 ATTEST_IMAGE="${CONFORMANCE_ATTEST_IMAGE:-$(jq -r '.releases[0].attest.image' "$LOADOUT")}"
 POD="conf-${REF:0:7}-$RANDOM"
 ATTEST_POD="$POD-attest"
@@ -59,7 +68,7 @@ for ((i = 0; i < RENT_WAIT_MIN; i++)); do
 done
 [ -n "${NODE:-}" ] && [ -n "${ATTEST_NODE:-}" ] || { echo "two 1x$GPU executors did not become available in ${RENT_WAIT_MIN} min"; exit 2; }
 lium up "$NODE" --name "$POD" --image "entrius/sparkinfer:$REF" --internal-ports 22,8080 \
-  -e "MODEL_SHA256=$MODEL_SHA" -e SPARKINFER_DETERMINISTIC=1 --ttl 3h -y --no-ssh
+  "${MODEL_ENV[@]}" -e SPARKINFER_DETERMINISTIC=1 --ttl 3h -y --no-ssh
 lium up "$ATTEST_NODE" --name "$ATTEST_POD" --image "$ATTEST_IMAGE" --internal-ports 22,8081 --ttl 3h -y --no-ssh
 
 # public URL of a pod's internal port, empty until the pod is RUNNING with the port mapped

--- a/scripts/serving_conformance_on_lium.sh
+++ b/scripts/serving_conformance_on_lium.sh
@@ -60,9 +60,10 @@ free_node() {
 }
 
 echo "renting 2x 1x$GPU: entrius/sparkinfer:$REF + $ATTEST_IMAGE (waiting up to ${RENT_WAIT_MIN} min for free cards)"
+# CONFORMANCE_SKIP_NODES: executor ids to leave alone (space-separated), e.g. one whose pod just CREATION_FAILED.
 for ((i = 0; i < RENT_WAIT_MIN; i++)); do
-  NODE=$(free_node "")
-  ATTEST_NODE=$([ -n "$NODE" ] && free_node "$NODE" || true)
+  NODE=$(free_node "${CONFORMANCE_SKIP_NODES:-}")
+  ATTEST_NODE=$([ -n "$NODE" ] && free_node "${CONFORMANCE_SKIP_NODES:-} $NODE" || true)
   [ -n "$NODE" ] && [ -n "$ATTEST_NODE" ] && break
   sleep 60
 done
@@ -130,8 +131,10 @@ done
 echo "checker reaches the runtime through ssh root@$SSH_HOST:$SSH_PORT (tunnel $TUNNEL)"
 
 set +e
+# CONFORMANCE_CHECKER_ARGS: extra checker flags, e.g. "--thinking off" for a release that pins enable_thinking.
 uv run python scripts/check_serving_runtime.py --base-url "$TUNNEL" --model-id "$MODEL_ID" --attest-url "$ATTEST" \
-  --determinism-count 30 --repeat 3 --parallel 16 --speed-json "$OUT/speed.json" 2>&1 | tee "$OUT/conformance.txt"
+  --determinism-count 30 --repeat 3 --parallel 16 --speed-json "$OUT/speed.json" ${CONFORMANCE_CHECKER_ARGS:-} \
+  2>&1 | tee "$OUT/conformance.txt"
 RC=${PIPESTATUS[0]}
 set -e
 echo "checker exit $RC (report: $OUT/conformance.txt)"

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -12,11 +12,14 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gittensor.constants import (
+    SERVING_AGGREGATE_DECODE_TPS_FALLBACK,
     SERVING_AUDIT_MAX_ABS_LOGPROB_DIFF,
     SERVING_AUDIT_MAX_MEAN_ABS_LOGPROB_DIFF,
     SERVING_AUDIT_MIN_PREFIX_AGREEMENT,
     SERVING_AUDIT_WINDOW,
     SERVING_AUDIT_WINDOW_THRESHOLDS,
+    SERVING_DECODE_PER_REQUEST_FALLBACK,
+    SERVING_PREFILL_TPS_FALLBACK,
     SERVING_PRICING_MAX_AGE_S,
 )
 from gittensor.serving.api import build_app, parse_api_keys
@@ -349,7 +352,7 @@ def test_gateway_requires_key(monkeypatch):
     assert r.status_code == 200 and set(r.json()['data'][0]) >= {'id', 'runtime_pin', 'model_sha256'}
     # OpenRouter's context fields: a harness reads these to size its compaction instead of hitting the 400
     model = r.json()['data'][0]
-    assert model['context_length'] == 36_864 and model['max_output_tokens'] == 4096
+    assert model['context_length'] == 65_536 and model['max_output_tokens'] == 4096
     assert client.get('/health').status_code == 200
 
 
@@ -953,10 +956,10 @@ def test_gateway_limits_the_prompt_by_context_window_not_characters(monkeypatch)
 
     monkeypatch.setattr(api_module, '_dispatch', dispatch)
     context = SERVING_CONTEXT_TOKENS_FALLBACK
-    long_prompt = [{'role': 'user', 'content': 'x' * (30_000 * 4)}]  # ~30k tokens: fits, with ~6.8k left
+    long_prompt = [{'role': 'user', 'content': 'x' * ((context - 6_800) * 4)}]  # fits, with ~6.8k tokens left
     r = client.post('/v1/chat/completions', headers=headers, json={'messages': long_prompt, 'max_tokens': 4096})
     assert r.status_code == 200 and seen['max_tokens'] == 4096
-    nearly_full = [{'role': 'user', 'content': 'x' * (35_000 * 4)}]  # ~35k tokens: the completion is clamped
+    nearly_full = [{'role': 'user', 'content': 'x' * ((context - 1_800) * 4)}]  # ~1.8k left: the completion is clamped
     r = client.post('/v1/chat/completions', headers=headers, json={'messages': nearly_full, 'max_tokens': 4096})
     assert r.status_code == 200 and seen['max_tokens'] == context - prompt_token_estimate(nearly_full)
     assert len(state.drain_served()) == 2  # both routed and recorded
@@ -1901,7 +1904,7 @@ def test_decode_speed_prices_served_requests_against_the_blessing_curve():
     # between points the aggregate (per-request x n) is interpolated, then divided by n: 6 -> 276, 16 -> 304 tok/s
     assert expected_decode_tps(curve, 11) == pytest.approx((276.0 + (304.0 - 276.0) * 0.5) / 11)
     assert expected_decode_tps(curve, 3) == pytest.approx((440.0 + (276.0 - 440.0) * 0.4) / 3)  # 124.8, not 282.4
-    assert expected_decode_tps(None, 6) == 46.0  # constants' fallback curve
+    assert expected_decode_tps(None, 6) == pytest.approx(SERVING_DECODE_PER_REQUEST_FALLBACK[1][1])  # fallback curve
     assert decode_credit(440.0, 440.0) == 1.0 and decode_credit(600.0, 440.0) == 1.0  # never more than one card
     assert decode_credit(352.0, 440.0) == 1.0  # 0.8x: inside the tolerance for WAN-observed decode
     assert decode_credit(264.0, 440.0) == pytest.approx(0.75)  # 0.6x -> 0.6 / 0.8
@@ -1965,9 +1968,7 @@ def test_token_pay_is_derived_from_the_release_speed(tmp_path):
     """Only the card-hour target is hand-set: the per-token rate is that target over what one card decodes in an
     hour, so a card flat out earns exactly the card-hour, 1.5 cards' worth of tokens earns 1.5, an idle card 0."""
     from gittensor.constants import (
-        SERVING_AGGREGATE_DECODE_TPS_FALLBACK,
         SERVING_GPU_HOUR_USD,
-        SERVING_PREFILL_TPS_FALLBACK,
         SERVING_PROMPT_TEMPLATE_TOKENS,
     )
     from gittensor.serving.loadout import load_serving_loadout
@@ -2101,8 +2102,12 @@ def test_round_pays_prefill_as_card_time(monkeypatch):
     assert scores['hk1'] == pytest.approx(card_equivalents(3 * 8, release, ROUND_S))
     assert scores['hk2'] == pytest.approx(card_equivalents(3 * 8, release, ROUND_S, 3 * 1000))
     assert scores['hk2'] > scores['hk1']
-    # 3000 prompt tokens at 24k tok/s is 0.125 s of card-time on top of 24 tokens' 0.086 s of decode
-    assert scores['hk2'] / scores['hk1'] == pytest.approx(1 + (3000 / 24_000.0) / (24 / 280.0))
+    # 3000 prompt tokens at the release's prefill rate is card-time on top of 24 tokens' decode at its aggregate rate
+    from gittensor.validator.serving.scoring import aggregate_decode_tps, prefill_tps
+
+    assert scores['hk2'] / scores['hk1'] == pytest.approx(
+        1 + (3000 / prefill_tps(release)) / (24 / aggregate_decode_tps(release))
+    )
     windows = state.last_round['windows']
     assert windows[1]['tokens'] == 24 and windows[1]['prompt_tokens'] == 0
     assert windows[2]['tokens'] == 24 and windows[2]['prompt_tokens'] == 3000
@@ -2131,8 +2136,12 @@ def test_round_rows_carry_prompt_tokens_and_both_rates():
     summary, miners = round_rows('vali', dt.datetime.now(dt.timezone.utc), last_round, {}, None, release)
     assert len(summary) == INSERT_SERVING_ROUND.count('%s')
     assert all(len(row) == BULK_INSERT_SERVING_MINER_ROUNDS.count('%s') for row in miners)
-    assert summary[-4:-2] == (1000, pytest.approx(0.694, abs=0.001))  # output tokens, $/M output
-    assert summary[-2] == 30_000 and summary[-1] == pytest.approx(0.0081, abs=0.0001)  # prompt tokens, $/M prompt
+    from gittensor.validator.serving.scoring import aggregate_decode_tps, prefill_tps
+
+    out_rate = 0.70 / (aggregate_decode_tps(release) * 3600) * 1e6
+    prompt_rate = 0.70 / (prefill_tps(release) * 3600) * 1e6
+    assert summary[25:27] == (1000, pytest.approx(out_rate))  # output tokens, $/M output
+    assert summary[27] == 30_000 and summary[28] == pytest.approx(prompt_rate)  # prompt tokens, $/M prompt
     assert sorted((row[2], row[-2], row[-1]) for row in miners) == [(1, 800, 30_000), (2, 200, 0)]
 
 

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -125,7 +125,7 @@ def test_live_reference_wins_over_bank(monkeypatch):
     assert isinstance(ref, audit.LiveReference)
     captured = {}
 
-    def fake_greedy(base_url, model_id, messages, max_tokens, timeout, api_key=None):
+    def fake_greedy(base_url, model_id, messages, max_tokens, timeout, api_key=None, **kw):
         captured['base_url'] = base_url
         captured['api_key'] = api_key
         return {
@@ -3631,3 +3631,60 @@ def test_loadout_env_overrides_target_each_release(monkeypatch, tmp_path):
     monkeypatch.delenv('SERVING_RELEASE')
     a, b = load_serving_loadout(path).releases
     assert a.base_url == 'http://runtime:8080' and b.base_url is None  # no SERVING_RELEASE: the primary, as before
+
+
+def test_release_pins_thinking_and_a_model_directory(monkeypatch):
+    """A release's enable_thinking rides on every request the miner, the reference and the checker send, so served
+    text and its teacher-forced score template identically; a model-directory artifact is pinned by HF revision
+    plus per-shard digests and surfaces on /v1/models for the release card."""
+    from gittensor.serving import probe
+    from gittensor.serving.audit import LiveReference
+    from gittensor.serving.backends import OpenAICompatBackend
+
+    raw = {
+        'model_id': 'qwen3.8-27b',
+        'backend': 'openai-compat',
+        'base_url': 'http://runtime:8080',
+        'reference_url': 'http://ref:8080',
+        'enable_thinking': False,
+        'model_dir': {'repo': 'org/Model-NVFP4', 'revision': 'abc123', 'sha256': 'a.safetensors=00,b.safetensors=11'},
+    }
+    release = ServingRelease.from_dict(raw)
+    assert release.enable_thinking is False and release.model_sha256 is None
+    assert (release.model_dir_repo, release.model_dir_revision) == ('org/Model-NVFP4', 'abc123')
+    assert ServingRelease.from_dict({'model_id': 'x', 'backend': 'echo'}).enable_thinking is None
+
+    body = OpenAICompatBackend(release)._body(MSGS, 8, logprobs=True, stream=False)
+    assert body['enable_thinking'] is False
+    assert 'enable_thinking' not in OpenAICompatBackend(_echo_release_openai())._body(MSGS, 8, False, False)
+
+    sent = []
+
+    class _R:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                'choices': [{'message': {'content': 'x'}, 'logprobs': {'content': [{'token': 'x', 'logprob': -0.1}]}}],
+                'usage': {'completion_tokens': 1},
+                'tokens': ['x'],
+                'logprobs': [-0.1],
+            }
+
+    monkeypatch.setattr(probe.requests, 'post', lambda url, **kw: (sent.append((url, kw['json'])), _R())[1])
+    ref = LiveReference(release)
+    ref.case_for(MSGS)
+    ref.score(MSGS, 'x')
+    assert [u.rsplit('/', 1)[1] for u, _ in sent] == ['completions', 'score']
+    assert all(j['enable_thinking'] is False for _, j in sent)
+
+    with TestClient(build_app(ServingState(), ServingLoadout(releases=[release]), {'k'}, lambda: None, 60.0)) as c:
+        model = c.get('/v1/models', headers={'Authorization': 'Bearer k'}).json()['data'][0]
+    assert model['model_dir'] == raw['model_dir'] and model['model_sha256'] is None
+
+
+def _echo_release_openai() -> ServingRelease:
+    return ServingRelease(model_id='echo-v0', backend='openai-compat', base_url='http://runtime:8080')

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -3449,3 +3449,185 @@ def test_shipped_curve_pays_an_honest_card_in_full_at_2_to_5_concurrent():
     assert expected_decode_tps(release.decode_per_request, 64) == 19.5
     # a card genuinely shared between two hotkeys still reads under the floor at 1 in flight
     assert decode_credit(144.3, expected_decode_tps(release.decode_per_request, 1)) == 0.0
+
+
+# ---------------------------------------------------------------------------------------------------------------
+# Two blessed releases at once (serving/multi-release): a miner runs one, the validator learns which and audits,
+# pays and routes it for that release only.
+
+
+def _two_release_dendrite(by_axon: Dict[int, ServingRelease]):
+    """Fake streaming dendrite for miners on different releases: an axon echoes its own release's completion when
+    asked for it and refuses like ``blacklist_caller`` does when asked for another. Counts calls per axon."""
+    from gittensor.serving.stream import result_to_sse
+
+    calls: Dict[int, list] = {}
+
+    async def call_stream(target_axon, synapse, timeout, deserialize):
+        mine = by_axon[id(target_axon)]
+        calls.setdefault(id(target_axon), []).append(synapse.release_id)
+        final = synapse.model_copy()
+        if synapse.release_id and synapse.release_id != mine.release_id:
+            final.dendrite.status_code = 403
+            final.dendrite.status_message = f'serving release {mine.release_id}, not {synapse.release_id}'
+            yield final
+            return
+        ref = expected_completion(synapse.messages, synapse.max_tokens, mine.model_id)
+        ref.model_id = mine.model_id
+        for chunk in result_to_sse(ref, 'chatcmpl-miner', 0, logprobs=True):
+            yield chunk
+        final.dendrite.process_time = 0.05
+        yield final
+
+    return SimpleNamespace(call_stream=call_stream), calls
+
+
+def test_refused_release_parses_the_miners_own_refusal():
+    from gittensor.validator.serving.forward import refused_release
+
+    assert refused_release('Forbidden. Key is blacklisted: serving release b-v0, not a-v0') == 'b-v0'
+    assert refused_release('busy: all backend slots in use') is None
+    assert refused_release(None) is None
+
+
+def test_baseline_discovers_a_miners_release_from_its_refusal_and_retargets():
+    """Round 1: every undeclared miner gets primary prompts; the second-release miner refuses naming its release,
+    which is recorded as discovery (no miss). Round 2: it is prompted for its own release and serves."""
+    from gittensor.validator.serving import forward as fwd
+
+    a = ServingRelease(model_id='echo-a', backend='echo', max_tokens=8, release_id='a-v0')
+    b = ServingRelease(model_id='echo-b', backend='echo', max_tokens=8, release_id='b-v0')
+    loadout = ServingLoadout(releases=[a, b])
+    ax1, ax2, ax3 = (SimpleNamespace(is_serving=True) for _ in range(3))
+    dendrite, calls = _two_release_dendrite(
+        {id(ax1): a, id(ax2): b, id(ax3): ServingRelease(model_id='x', backend='echo', release_id='not-blessed')}
+    )
+    serving = [(1, 'hk1', ax1), (2, 'hk2', ax2), (3, 'hk3', ax3)]
+    state = ServingState()
+
+    sent = asyncio.run(fwd.baseline_round(state, dendrite, serving, loadout, 0.0, per_miner=1, rng=random.Random(1)))  # type: ignore[arg-type]
+    assert sent == 3 and calls[id(ax1)] == ['a-v0'] and calls[id(ax2)] == ['a-v0'] and calls[id(ax3)] == ['a-v0']
+    assert state.miner_release == {'hk1': 'a-v0', 'hk2': 'b-v0'}  # hk3 named a release we do not bless
+    served = state.drain_served()
+    assert {req.hotkey: (req.ok, req.release_id) for req in served} == {'hk1': (True, 'a-v0'), 'hk3': (False, 'a-v0')}
+    assert 'not-blessed' in served[-1].detail  # the unblessed refusal is that miner's miss, nothing is hidden
+
+    asyncio.run(fwd.baseline_round(state, dendrite, serving, loadout, 0.0, per_miner=1, rng=random.Random(2)))  # type: ignore[arg-type]
+    assert calls[id(ax2)] == ['a-v0', 'b-v0']
+    assert {(req.hotkey, req.ok, req.release_id) for req in state.drain_served()} >= {
+        ('hk2', True, 'b-v0'),
+        ('hk1', True, 'a-v0'),
+    }
+
+    # a miner that switches releases is rediscovered from its next refusal, not stranded on the stale mapping
+    by_axon = {id(ax1): b, id(ax2): b, id(ax3): a}
+    dendrite2, calls2 = _two_release_dendrite(by_axon)
+    asyncio.run(fwd.baseline_round(state, dendrite2, serving, loadout, 0.0, per_miner=1, rng=random.Random(3)))  # type: ignore[arg-type]
+    assert state.miner_release == {'hk1': 'b-v0', 'hk2': 'b-v0', 'hk3': 'a-v0'}
+    assert all(req.ok for req in state.drain_served())  # discovery rounds carry no misses
+
+    # release_for falls back to the primary when a declared release leaves the loadout
+    assert fwd.release_for(state, ServingLoadout(releases=[a]), 'hk2') is a and 'hk2' not in state.miner_release
+
+
+def test_audit_round_settles_two_live_releases_independently(monkeypatch):
+    """Miners on two blessed releases in one round: each is verified against its own reference, reported and paid
+    under its own release, READY for it alone; an undeclared miner sits in probation on the primary; a served
+    completion for a release declares the miner for it without a baseline refusal."""
+    from gittensor.validator.serving import forward as fwd
+
+    a = ServingRelease(model_id='echo-a', backend='echo', max_tokens=8, release_id='a-v0')
+    b = ServingRelease(model_id='echo-b', backend='echo', max_tokens=8, release_id='b-v0', request_timeout=123.0)
+    loadout = ServingLoadout(releases=[a, b])
+    ax1, ax2, ax3 = (SimpleNamespace(is_serving=True) for _ in range(3))
+    dendrite, _ = _two_release_dendrite({id(ax1): a, id(ax2): b, id(ax3): a})
+    state = ServingState(settlement_rounds=1)
+    state.miner_release['hk1'] = 'a-v0'  # hk2 is undeclared: its served completion for b-v0 declares it below
+    for uid, release in ((1, a), (2, b), (1, a), (2, b)):
+        req = _served(uid, release)
+        req.release_id = release.release_id  # as the gateway and baseline stamp it
+        state.enqueue_served(req)
+
+    scores = asyncio.run(
+        fwd.audit_round(state, dendrite, [(1, 'hk1', ax1), (2, 'hk2', ax2), (3, 'hk3', ax3)], loadout, round_s=ROUND_S)  # type: ignore[arg-type]
+    )
+    assert scores == {'hk1': pytest.approx(_pay(16, a)), 'hk2': pytest.approx(_pay(16, b)), 'hk3': 0.0}
+    assert state.miner_release == {'hk1': 'a-v0', 'hk2': 'b-v0'}
+    ready = {m.uid: m.release_id for m in state.ready_miners()}
+    assert ready == {1: 'a-v0', 2: 'b-v0'}
+    windows = state.last_round['windows']
+    assert windows[1]['release_id'] == 'a-v0' and windows[1]['status'] == 'ready' and windows[1]['tokens'] == 16
+    assert windows[2]['release_id'] == 'b-v0' and windows[2]['status'] == 'ready' and windows[2]['tokens'] == 16
+    assert windows[3]['release_id'] == 'a-v0' and windows[3]['status'] == 'probation'  # undeclared -> primary
+    assert state.audits.verdict('hk2', 'a-v0').n_audits == 0  # nothing of hk2's landed in the primary's window
+    # routing: each release acquires only its own miner; probation for the primary holds the undeclared one
+    assert state.acquire('a-v0').uid == 1 and state.acquire('b-v0').uid == 2  # type: ignore[union-attr]
+    assert state.acquire('a-v0', probation=True).uid == 3  # type: ignore[union-attr]
+    # the round's per-miner DB rows carry each miner's own release and rate
+    import datetime as dt
+
+    from gittensor.validator.serving.persist import round_rows
+
+    now = dt.datetime.now(dt.timezone.utc)
+    summary, miners = round_rows('vali', now, state.last_round, state.settled_scores(), None, a)
+    by_uid = {row[2]: row for row in miners}
+    assert by_uid[1][5] == 'a-v0' and by_uid[2][5] == 'b-v0' and by_uid[3][5] == 'a-v0'
+
+
+def test_serving_store_round_trips_miner_releases(tmp_path):
+    from gittensor.serving.store import ServingStore
+
+    store = ServingStore(tmp_path / 'serving.db')
+    state = ServingState()
+    state.miner_release = {'hk1': 'a-v0', 'hk2': 'b-v0'}
+    store.save(state)
+    assert store.load(ServingState()).miner_release == {'hk1': 'a-v0', 'hk2': 'b-v0'}
+    state.miner_release.pop('hk2')
+    store.save(state)
+    assert store.load(ServingState()).miner_release == {'hk1': 'a-v0'}  # replaced, never appended
+
+
+def test_seeded_probation_uses_the_miners_known_release(monkeypatch):
+    from gittensor.validator.serving import forward as fwd
+
+    a = ServingRelease(model_id='echo-a', backend='echo', max_tokens=8, release_id='a-v0')
+    b = ServingRelease(model_id='echo-b', backend='echo', max_tokens=8, release_id='b-v0')
+    state = ServingState()
+    state.last_round_ts = time.time()
+    state.miner_release['hk2'] = 'b-v0'
+    ax1, ax2 = SimpleNamespace(is_serving=True), SimpleNamespace(is_serving=True)
+    monkeypatch.setattr(fwd, 'get_serving_axons', lambda v: [(1, 'hk1', ax1), (2, 'hk2', ax2)])
+    fwd.seed_ready_from_store(SimpleNamespace(), state, ServingLoadout(releases=[a, b]))  # type: ignore[arg-type]
+    assert state.acquire('a-v0', probation=True).uid == 1 and state.acquire('b-v0', probation=True).uid == 2  # type: ignore[union-attr]
+
+
+def test_loadout_env_overrides_target_each_release(monkeypatch, tmp_path):
+    """SERVING_REFERENCE_URL names the primary's reference; SERVING_REFERENCE_URL__<RELEASE_ID> a second release's;
+    the miner-side SERVING_BASE_URL applies to the release named by SERVING_RELEASE."""
+    from gittensor.serving.loadout import env_suffix
+
+    path = tmp_path / 'loadout.json'
+    path.write_text(
+        json.dumps(
+            {
+                'releases': [
+                    {'model_id': 'echo-a', 'backend': 'echo', 'release_id': 'a-v0'},
+                    {'model_id': 'echo-b', 'backend': 'echo', 'release_id': 'qwen3.8-27b-nvfp4-sparkinfer-abc'},
+                ]
+            }
+        )
+    )
+    assert env_suffix('qwen3.8-27b-nvfp4-sparkinfer-abc') == 'QWEN3_8_27B_NVFP4_SPARKINFER_ABC'
+    monkeypatch.setenv('SERVING_REFERENCE_URL', 'http://ref-a:8080')
+    monkeypatch.setenv('SERVING_REFERENCE_URL__QWEN3_8_27B_NVFP4_SPARKINFER_ABC', 'http://ref-b:8080')
+    monkeypatch.setenv('SERVING_REFERENCE_API_KEY__QWEN3_8_27B_NVFP4_SPARKINFER_ABC', 'kb')
+    monkeypatch.setenv('SERVING_RELEASE', 'qwen3.8-27b-nvfp4-sparkinfer-abc')
+    monkeypatch.setenv('SERVING_BASE_URL', 'http://runtime:8080')
+    a, b = load_serving_loadout(path).releases
+    assert a.reference_url == 'http://ref-a:8080' and a.attest_reference_url == 'http://ref-a:8081'
+    assert a.reference_api_key is None and a.base_url is None
+    assert b.reference_url == 'http://ref-b:8080' and b.attest_reference_url == 'http://ref-b:8081'
+    assert b.reference_api_key == 'kb' and b.base_url == 'http://runtime:8080' and b.attest_url == 'http://runtime:8081'
+    monkeypatch.delenv('SERVING_RELEASE')
+    a, b = load_serving_loadout(path).releases
+    assert a.base_url == 'http://runtime:8080' and b.base_url is None  # no SERVING_RELEASE: the primary, as before

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -69,9 +69,15 @@ def test_echo_backend_matches_expected_completion():
 def test_default_loadout_targets_sparkinfer():
     release = load_serving_loadout().primary
     assert release.backend == 'openai-compat'
-    assert release.base_url and release.audit_bank
+    assert release.base_url and release.runtime_pin and release.runtime_image and '@sha256:' in release.runtime_image
     assert release.reference_url is None  # validators point SERVING_REFERENCE_URL at their own/rented runtime
     assert release.max_tokens > 0
+    # Qwen3.8-27B: a pinned model directory (HF commit + per-shard digests), thinking off, 64k prompts
+    assert release.model_id == 'qwen3.8-27b' and release.model_sha256 is None
+    assert release.model_dir_repo and len(release.model_dir_revision or '') == 40
+    assert (release.model_dir_sha256 or '').count('=') == 2
+    assert release.enable_thinking is False and release.end_of_turn_token_id == 248046
+    assert release.context_tokens == 65_536 and (release.runtime_env or {}).get('CTX') == '131072'
 
 
 def test_echo_loadout_loads_via_env(monkeypatch):
@@ -929,7 +935,7 @@ def test_gateway_limits_the_prompt_by_context_window_not_characters(monkeypatch)
 
     assert SERVING_MAX_TOKENS == 4096 and SERVING_MAX_PROMPT_CHARS >= 4 * SERVING_CONTEXT_TOKENS_FALLBACK
     shipped = load_serving_loadout().primary
-    assert shipped.context_tokens == 36_864 and shipped.request_timeout >= 300.0  # 4096 tokens at ~19 tok/s fits
+    assert shipped.context_tokens == 65_536 and shipped.request_timeout >= 300.0  # 4096 tokens at ~23 tok/s fits
 
     good = _echo_release()
     state = ServingState()
@@ -3431,24 +3437,25 @@ def test_inference_stream_clears_the_prefill_mark_at_the_first_content_delta():
 def test_shipped_curve_pays_an_honest_card_in_full_at_2_to_5_concurrent():
     """#1753: the blessed curve had points at 1 and 6 only, and the straight line between them sat far above what a
     5090 does at 2-5 streams, so an honest card read 0.32-0.48x expected there — under the floor, zero credit. The
-    curve now carries measured points 2-12 and interpolates on aggregate rate. The rows are the issue's on-box
-    measurement of an unshared, correctly pinned card."""
+    curve carries measured points 1-16 and interpolates on aggregate rate. The rows are the first of the two
+    2026-09-08 checker runs on Qwen3.8-27B NVFP4 (the loadout curve is the mean of both, made monotone)."""
     from gittensor.validator.serving.scoring import decode_credit, expected_decode_tps
 
     release = load_serving_loadout().primary
     assert release.decode_per_request is not None
-    miner_measured = {1: 426.8, 2: 148.2, 3: 91.8, 4: 74.7, 5: 59.9, 6: 49.6, 8: 37.5}
+    miner_measured = {1: 99.6, 2: 89.4, 3: 72.3, 4: 57.3, 5: 53.6, 6: 49.4, 8: 39.5, 12: 24.9, 16: 23.2}
     for n, observed in miner_measured.items():
         expected = expected_decode_tps(release.decode_per_request, n)
         assert observed / expected >= 0.8, (n, observed, expected)  # inside the WAN tolerance: full credit
         assert decode_credit(observed, expected) == 1.0
-    # and between the sparse tail points a queued stream is still expected at the last measured rate, not below it
-    assert expected_decode_tps(release.decode_per_request, 20) == pytest.approx(
-        (16 * 19.4 + (24 * 19.4 - 16 * 19.4) * 0.5) / 20
-    )
-    assert expected_decode_tps(release.decode_per_request, 64) == 19.5
-    # a card genuinely shared between two hotkeys still reads under the floor at 1 in flight
-    assert decode_credit(144.3, expected_decode_tps(release.decode_per_request, 1)) == 0.0
+    # past the last measured point a queued stream is still expected at the last measured rate, not below it
+    assert expected_decode_tps(release.decode_per_request, 20) == 23.4
+    assert expected_decode_tps(release.decode_per_request, 64) == 23.4
+    # A dense 27B barely slows at 2 streams (92 vs 99 tok/s), so two hotkeys on one card are NOT caught by decode
+    # speed the way the MoE's 144-vs-440 was; the same-instant attest fill is what catches sharing now. Four
+    # hotkeys on one card still read under the tolerance at 1 in flight.
+    assert decode_credit(92.1, expected_decode_tps(release.decode_per_request, 1)) == 1.0
+    assert decode_credit(56.8, expected_decode_tps(release.decode_per_request, 1)) < 0.8
 
 
 # ---------------------------------------------------------------------------------------------------------------

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -86,7 +86,8 @@ def test_round_rows_shape_and_pricing():
     assert summary[16:18] == (0.70, SERVING_EMISSION_SHARE_CAP)  # economics ride along so das never hard-codes them
     assert summary[18:25] == (None,) * 7
     # paid output and prompt tokens across the fleet; no release -> no per-token rates
-    assert summary[25:] == (84_000, None, 2_400_000, None)
+    assert summary[25:29] == (84_000, None, 2_400_000, None)
+    assert summary[29:] == (None, None)  # no release -> no directory digests, no runtime env
     assert len(miners) == 2
     ready = next(m for m in miners if m[2] == 16)
     assert ready[5] == 'qwen' and ready[6] == 'ready'  # release_id defaults to model_id
@@ -109,9 +110,13 @@ def test_round_rows_carry_the_enforced_release():
             'model_file': 'org/model.gguf',
             'runtime_image': 'entrius/sparkinfer:abc@sha256:00',
             'attest': {'image': 'entrius/gt-attest:v1'},
+            'model_dir': {'repo': 'org/m', 'revision': 'r', 'sha256': 'a.safetensors=00,b.safetensors=11'},
+            'runtime_env': {'MODEL_NAME': 'qwen', 'CTX': 131072},
         }
     )
     summary, _ = persist.round_rows('vali', dt.datetime.now(dt.timezone.utc), ROUND, {}, None, release)
+    assert summary[29] == 'a.safetensors=00,b.safetensors=11'
+    assert summary[30] == '{"CTX": "131072", "MODEL_NAME": "qwen"}'  # JSON, keys sorted, values as strings
     assert summary[18:25] == (
         'qwen',
         'qwen',  # release_id defaults to model_id
@@ -121,8 +126,11 @@ def test_round_rows_carry_the_enforced_release():
         'entrius/sparkinfer:abc@sha256:00',
         'entrius/gt-attest:v1',
     )
-    assert summary[26] == pytest.approx(0.694, abs=0.001)  # $/M output tokens at the fallback 280 tok/s
-    assert summary[28] == pytest.approx(0.0081, abs=0.0001)  # $/M prompt tokens at the fallback 24k tok/s prefill
+    from gittensor.constants import SERVING_AGGREGATE_DECODE_TPS_FALLBACK, SERVING_PREFILL_TPS_FALLBACK
+
+    # $/M output tokens at the fallback aggregate decode rate; $/M prompt tokens at the fallback prefill rate
+    assert summary[26] == pytest.approx(0.70 / (SERVING_AGGREGATE_DECODE_TPS_FALLBACK * 3600) * 1e6, rel=1e-6)
+    assert summary[28] == pytest.approx(0.70 / (SERVING_PREFILL_TPS_FALLBACK * 3600) * 1e6, rel=1e-6)
 
 
 def test_default_loadout_keeps_model_file():

--- a/tests/validator/test_serving_persist.py
+++ b/tests/validator/test_serving_persist.py
@@ -126,7 +126,13 @@ def test_round_rows_carry_the_enforced_release():
 
 
 def test_default_loadout_keeps_model_file():
-    assert loadout.load_serving_loadout().primary.model_file.endswith('.gguf')
+    """The serving_rounds row carries model_file: a GGUF path, or for a model-directory release '<repo>@<commit>'."""
+    release = loadout.load_serving_loadout().primary
+    assert release.model_file
+    if release.model_dir_repo:
+        assert release.model_file == f'{release.model_dir_repo}@{release.model_dir_revision}'
+    else:
+        assert release.model_file.endswith('.gguf')
 
 
 def test_round_rows_report_the_share_that_will_actually_be_paid():


### PR DESCRIPTION
## What

Flips the serving release from Qwen3.6-35B-A3B to **Qwen3.8-27B** (NVFP4, sparkinfer `19ef39ec2`) as the single loadout entry, with everything the validator, miner image and compose files need for it, and re-prices the fallbacks so a card still earns $0.70 per hour. Decision 2026-09-07: flip outright; two models later.

Commits, in order:

1. **Multi-release plumbing** — validator learns which release each miner serves from the miner's own refusal / served completions; audits, pay, probation, reports and routing per release; `SERVING_REFERENCE_URL__<RELEASE_ID>`; gateway timeout per release. Not needed for the flip, but it makes a second release later a loadout entry plus a reference.
2. **Model-directory artifact** — `docker/sparkinfer-entrypoint.sh` serves either one GGUF (unchanged) or an HF model directory pinned by commit + per-shard sha256 (`MODEL_DIR_*`), refusing to start on any mismatch.
3. **Release schema** — `enable_thinking` (sent by the miner backend, the live reference on chat and `/v1/score`, and the checker), `model_dir`, `runtime_env`; both compose files pass either artifact's pins through; env examples and README updated.
4. **Checker fixes** found while qualifying — R8 failures print status+body, thinking rides on every R8 request, `verify_served` forces the runtime's own token ids like production.
5. **The loadout entry** — `qwen3.8-27b-nvfp4-sparkinfer-19ef39ec2`: `gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090@8e2c0cd2` (both shard digests), `entrius/sparkinfer:19ef39ec2@sha256:d35719b0…`, thinking off, `context_tokens` 65536 on a 131k KV pool, end-of-turn 248046.
6. **Pay re-priced** — pay is derived from the release's measured speeds, so the flip re-prices itself: $0.70 per card-hour is now ~**$0.58 per million output tokens** and ~**$0.026 per million prompt tokens** (one card flat out ≈ 1.2M output tokens or ≈ 27M prompt tokens an hour; was ~1M / ~86M). The constants only back a release without measurements; they and their comments now describe the 27B (aggregate 338, prefill 7,500, curve 99.4/49.7/23.4 at 1/6/16, 26.4 GB resident, 64k context). The prompt-size DoS backstop doubles to 0.5 MB so a full 64k prompt fits. `serving_rounds` gains `model_dir_sha256` + `runtime_env` for the release card.

## Measured (rented RTX 5090s, 2026-09-08, `scripts/check_serving_runtime.py`, deterministic mode, logprobs on every request)

- Every MUST passes: D1 prefix agreement 1.000 / drift 0.0000 (30×3), `/v1/score` exact (max |Δ| 0), 429-not-queue at 16, attest 832 ms.
- Decode: single-stream 99.4 tok/s; 16-concurrent aggregate ~338; per-request 99.4 / 92.1 / 74.0 / 56.8 / 56.8 / 49.7 / 39.6 / 24.8 / 23.4 at 1/2/3/4/5/6/8/12/16 (mean of two runs, monotone).
- Prefill, cold unique prompts, engine `ttft_ms`: 7.6k tok/s at 10k tokens, 9.7k at 41k, 7.8k at 102k (carried as 7,500).
- Resident VRAM 25.1 GiB idle at CTX 131072 → `vram_model_reserved_bytes` 26.4e9.
- Caveat: a dense 27B barely slows at 2 streams (92 vs 99), so two hotkeys on one card are no longer exposed by the decode curve the way the MoE's 144-vs-440 was; the same-instant attest fill carries that check.

Full readout in the team run-log (2026-09-08 entry).

## Companion PRs (merge order)

1. entrius/gittensor-db#61 — the two columns
2. this PR — validator writes them, new release
3. entrius/das-gittensor#103 — release object passes them through
4. entrius/gittensor-ui#1377 — Current release card for the directory shape
5. entrius/gittensor-docs-ui (compute pages) and e35VenturaLabs/gittensor-app#10 (default model, 64k context) — independent

## Tests

805 passed; pre-commit + pre-push (ruff, format, pyright, vulture) clean.

## Before mainnet

Testnet soak with real cards on the new image; miner announcement (flag day: new image, new artifact); validator reference switched to the 27B (`SPARKINFER_MODEL_DIR_*`, `SPARKINFER_CTX` in `.env`).

https://claude.ai/code/session_01VjhStJbNW6WzxucTcwuw4y
