### PR TITLE
serving: audit the 27B on exact tokens only until sparkinfer's /v1/score logprobs are fixed

### DIFF
--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -46,6 +46,11 @@
         "iters": 3,
         "vram_model_reserved_bytes": 26400000000,
         "reference_wall_ms": 832.0
+      },
+      "audit": {
+        "min_prefix_agreement": 1.0,
+        "max_mean_abs_logprob_diff": 100.0,
+        "max_abs_logprob_diff": 100.0
       }
     }
   ]


### PR DESCRIPTION
First mainnet rounds on the 27B failed every honest miner with `reference disagreement: logprob drift`. Root cause, measured on compute3 (both cards, deterministic, repeatable): sparkinfer `19ef39ec2`'s `/v1/score` with `completion_token_ids` returns the correct argmax at every position (agreement 1.000 on every prompt tried) but a wrong logprob **value** at the first forced positions, ~20–30 nats off at position 1 on every call, position 0 on the first call after a generation, and occasionally a later position. Generation agrees bit-for-bit across the two servers (0.0 drift), so the model and pin are fine; the teacher-forced scoring path is not.

This keeps `min_prefix_agreement` 1.0 (miners must reproduce the reference's greedy tokens exactly, which is the strong half of the check) and lifts the two logprob bands to 100 nats for this release only, via the release's `audit` block. The validator is already running this as a loadout override (`SERVING_LOADOUT_PATH`). Upstream issue to follow; revert the bands when the scoring path is fixed and re-qualified.

https://claude.ai/code/session_01VjhStJbNW6WzxucTcwuw4y