### PR TITLE
serving: a release carries its own attest wall-time budget; the 27B gets 2.0x

### DIFF
--- a/gittensor/constants.py
+++ b/gittensor/constants.py
@@ -217,7 +217,9 @@ SERVING_READY_TTL_S = 900.0  # gateway stops routing when the last audit round i
 # resident; a hotkey passes with any passing card. Never a strike: not READY that round, re-challenged next.
 SERVING_ATTEST_COHORT_FRACTION = 0.5
 SERVING_ATTEST_ITERS = 3
-SERVING_ATTEST_BUDGET_RATIO = 1.6
+SERVING_ATTEST_BUDGET_RATIO = (
+    1.6  # a release may carry its own attest.budget_ratio (the 27B: 2.0, dense decode saturates the card)
+)
 SERVING_ATTEST_MIN_FILL_RATIO = 0.6
 SERVING_ATTEST_TIMEOUT = 45.0  # seconds: fill + chain on a 5090 is ~1.5 s; queued challenges show up as slow
 SERVING_ATTEST_MEMORY_ROUNDS = 12  # a verdict older than this admits nothing until renewed

--- a/gittensor/serving/loadout.py
+++ b/gittensor/serving/loadout.py
@@ -90,6 +90,10 @@ class ServingRelease:
     attest_reference_url: Optional[str] = None
     attest_reference_api_key: Optional[str] = None  # bearer for a keyed reference sidecar (ATTEST_API_KEY there)
     attest_iters: Optional[int] = None
+    # Wall-time budget for the attest GEMM chain as a multiple of the reference's, for this release (None -> the
+    # constant). A dense model saturates the card under load, so its chain runs ~1.7x slower than idle while the
+    # MoE's stayed near 1.0x; the release carries what its own serving load leaves the sidecar.
+    attest_budget_ratio: Optional[float] = None
     vram_model_reserved_bytes: Optional[float] = None
     ttft_full_ms: Optional[float] = None  # validator-observed TTFT up to which latency credit is 1.0
     ttft_zero_ms: Optional[float] = None  # ... and at which it reaches 0.0
@@ -159,6 +163,7 @@ class ServingRelease:
             attest_reference_url=attest.get('reference_url') or _sidecar_url(raw.get('reference_url')),
             attest_reference_api_key=attest.get('reference_api_key'),
             attest_iters=int(attest['iters']) if attest.get('iters') else None,
+            attest_budget_ratio=_optional_float(attest.get('budget_ratio')),
             vram_model_reserved_bytes=_optional_float(attest.get('vram_model_reserved_bytes')),
             ttft_full_ms=_optional_float(speed.get('ttft_full_ms')),
             ttft_zero_ms=_optional_float(speed.get('ttft_zero_ms')),

--- a/gittensor/validator/serving/attest.py
+++ b/gittensor/validator/serving/attest.py
@@ -230,6 +230,8 @@ def judge(
         return AttestVerdict(False, f'no attestation ({detail or "timeout"})')
     if not response.devices:
         return AttestVerdict(False, 'no devices')
+    if release.attest_budget_ratio:  # the release's own budget wins over the constant (a dense model under load)
+        budget_ratio = release.attest_budget_ratio
     budget = budget_ratio * ref_wall_ms if ref_wall_ms > 0 else float('inf')
     if elapsed_ms is not None and elapsed_ms > budget + rtt_slack_ms:
         return AttestVerdict(False, f'too slow: {elapsed_ms:.0f} ms round trip > {budget + rtt_slack_ms:.0f} ms')

--- a/gittensor/validator/weights/serving_loadout.json
+++ b/gittensor/validator/weights/serving_loadout.json
@@ -45,7 +45,9 @@
         "image": "entrius/gt-attest:v1",
         "iters": 3,
         "vram_model_reserved_bytes": 26400000000,
-        "reference_wall_ms": 832.0
+        "reference_wall_ms": 832.0,
+        "budget_ratio": 2.0,
+        "budget_note": "2.0x: on mainnet 2026-09-08 the 27B card under 20+ concurrent gateway requests ran the attest chain at 1264-1280 ms vs the reference's 740 (1.7x) and failed the 1.6x constant on ~1 round in 7 while serving; idle it reads 720-795 ms"
       }
     }
   ]

--- a/tests/validator/test_serving.py
+++ b/tests/validator/test_serving.py
@@ -3704,3 +3704,25 @@ def test_release_pins_thinking_and_a_model_directory(monkeypatch):
 
 def _echo_release_openai() -> ServingRelease:
     return ServingRelease(model_id='echo-v0', backend='openai-compat', base_url='http://runtime:8080')
+
+
+def test_release_attest_budget_ratio_overrides_the_constant():
+    """A dense model under load runs the attest chain ~1.7x the reference; its release carries budget_ratio 2.0 and
+    the verdict uses it, while a release without one keeps the constant."""
+    from gittensor.constants import SERVING_ATTEST_BUDGET_RATIO
+    from gittensor.validator.serving.attest import judge
+
+    reply = _attest_reply(wall_ms=1270.0)
+    plain = _attest_release()
+    assert judge(reply, 'd', 740.0, plain).reason.startswith('too slow')  # 1270 > 1.6 x 740
+    dense = _attest_release()
+    dense.attest_budget_ratio = 2.0
+    assert judge(reply, 'd', 740.0, dense).passed  # 1270 < 2.0 x 740
+    assert (
+        ServingRelease.from_dict(
+            {'model_id': 'm', 'backend': 'echo', 'attest': {'budget_ratio': 2.0}}
+        ).attest_budget_ratio
+        == 2.0
+    )
+    shipped = load_serving_loadout().primary
+    assert shipped.attest_budget_ratio == 2.0 and SERVING_ATTEST_BUDGET_RATIO == 1.6


### PR DESCRIPTION
On mainnet 2026-09-08 our 27B card (UID 111) under 20+ concurrent gateway requests ran the attest GEMM chain at 1264–1280 ms against the reference's 740 ms (1.7×) and failed the 1.6× constant on ~1 round in 7 (19 of 127) while serving — and a failed attest zeroes that round's pay (one such round had 6,196 output tokens). Idle it reads 720–795 ms. The MoE's decode left the card idle enough for the chain to run at speed; a dense model saturates it.

`attest.budget_ratio` on the release now overrides `SERVING_ATTEST_BUDGET_RATIO` in `judge()`; the 27B release carries 2.0 with the measurement noted in the loadout. Constant unchanged for releases without one. Test added; 806 passed, lint clean.

Touches `serving_loadout.json`'s `attest` block only, so it merges beside #1760 (which edits the `audit` block).

https://claude.ai/code/session_01VjhStJbNW6WzxucTcwuw4y